### PR TITLE
Add OAuth redirect tests with HTTP mocks

### DIFF
--- a/oauth2/github.go
+++ b/oauth2/github.go
@@ -1,20 +1,24 @@
 package oauth2
 
 import (
-	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
 
-	ghttp "github.com/panyam/servicekit/http"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 )
 
 type GithubOAuth2 struct {
 	*BaseOAuth2
+
+	// UserInfoURL is the URL to fetch user info from. Defaults to GitHub's API.
+	// Can be overridden for testing.
+	UserInfoURL string
 }
 
 func NewGithubOAuth2(clientId string, clientSecret string, callbackUrl string, handleUser HandleUserFunc) *GithubOAuth2 {
@@ -29,7 +33,8 @@ func NewGithubOAuth2(clientId string, clientSecret string, callbackUrl string, h
 	}
 
 	out := GithubOAuth2{
-		BaseOAuth2: NewBaseOAuth2(clientId, clientSecret, callbackUrl, handleUser),
+		BaseOAuth2:  NewBaseOAuth2(clientId, clientSecret, callbackUrl, handleUser),
+		UserInfoURL: "https://api.github.com/user",
 	}
 	out.BaseOAuth2.oauthConfig.Endpoint = github.Endpoint
 	out.BaseOAuth2.oauthConfig.Scopes = []string{
@@ -63,13 +68,13 @@ func (g *GithubOAuth2) handleCallback(w http.ResponseWriter, r *http.Request) {
 	var userInfo map[string]any
 	code := r.FormValue("code")
 	// token, err := getAuthTokens(oauthConfig, code)
-	token, err := g.oauthConfig.Exchange(context.Background(), code)
+	token, err := g.oauthConfig.Exchange(g.ExchangeContext(), code)
 	if err != nil {
 		slog.Info("Invalid code exchange", "err", err)
 	} else {
 		// log.Println("Received Token Type: ", reflect.TypeOf(token))
 		// log.Println("Received Token: ", token)
-		userInfo, err = validateGithubAccessTokenToken(token)
+		userInfo, err = g.validateAccessToken(token)
 		if err == nil {
 			g.HandleUser("oauth", "github", token, userInfo, w, r)
 		}
@@ -80,27 +85,41 @@ func (g *GithubOAuth2) handleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func validateGithubAccessTokenToken(token *oauth2.Token) (userInfo map[string]any, err error) {
+func (g *GithubOAuth2) validateAccessToken(token *oauth2.Token) (userInfo map[string]any, err error) {
 	log.Println("Validating Token: ", token)
-	response, err := getUserDataFromGithub(token)
-	if err == nil {
-		if userInfo, ok := response.(map[string]any); !ok {
-			return nil, nil
-		} else {
-			return userInfo, nil
-		}
-	}
+	userInfo, err = g.getUserData(token)
 	if err != nil {
 		slog.Info("error validating tokens", "err", err)
 	}
 	return
 }
 
-func getUserDataFromGithub(token *oauth2.Token) (any, error) {
+func (g *GithubOAuth2) getUserData(token *oauth2.Token) (map[string]any, error) {
 	// Use code to get token and get user info from Github.
 	log.Println("Getting User data from github....")
-	req, _ := ghttp.NewRequest("GET", "https://api.github.com/user", nil)
-	req.Header.Set("Authorization", token.AccessToken)
-	// response, err := http.Get(oauthGithubUrlAPI + token.AccessToken)
-	return ghttp.Call(req, nil)
+	req, err := http.NewRequest("GET", g.UserInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %s", err.Error())
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	req.Header.Set("Accept", "application/json")
+
+	// Use injectable client if set
+	client := g.getHTTPClient()
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting user info from github: %s", err.Error())
+	}
+	defer response.Body.Close()
+
+	contents, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed read response: %s", err.Error())
+	}
+
+	var userInfo map[string]any
+	if err := json.Unmarshal(contents, &userInfo); err != nil {
+		return nil, fmt.Errorf("failed to parse user info: %s", err.Error())
+	}
+	return userInfo, nil
 }

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -1,0 +1,653 @@
+package oauth2_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/oauth2"
+	oauth2lib "golang.org/x/oauth2"
+)
+
+// mockOAuthServer creates a mock OAuth provider server that handles:
+// - /token endpoint for token exchange
+// - /userinfo endpoint for user data retrieval
+type mockOAuthServer struct {
+	server           *httptest.Server
+	tokenEndpoint    string
+	userInfoEndpoint string
+
+	// Configuration for responses
+	tokenResponse    map[string]any
+	userInfoResponse map[string]any
+	tokenError       bool
+	userInfoError    bool
+}
+
+func newMockOAuthServer() *mockOAuthServer {
+	mock := &mockOAuthServer{
+		tokenResponse: map[string]any{
+			"access_token":  "mock_access_token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"refresh_token": "mock_refresh_token",
+		},
+		userInfoResponse: map[string]any{
+			"id":    "12345",
+			"email": "testuser@example.com",
+			"name":  "Test User",
+		},
+	}
+
+	mux := http.NewServeMux()
+
+	// Token endpoint
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if mock.tokenError {
+			http.Error(w, "token exchange failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(mock.tokenResponse)
+	})
+
+	// User info endpoint
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if mock.userInfoError {
+			http.Error(w, "user info failed", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(mock.userInfoResponse)
+	})
+
+	mock.server = httptest.NewServer(mux)
+	mock.tokenEndpoint = mock.server.URL + "/token"
+	mock.userInfoEndpoint = mock.server.URL + "/userinfo"
+
+	return mock
+}
+
+func (m *mockOAuthServer) Close() {
+	m.server.Close()
+}
+
+// TestOauthRedirector tests the OAuth redirect handler
+func TestOauthRedirector(t *testing.T) {
+	config := &oauth2lib.Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost:8080/callback",
+		Scopes:       []string{"email", "profile"},
+		Endpoint: oauth2lib.Endpoint{
+			AuthURL:  "https://provider.example.com/auth",
+			TokenURL: "https://provider.example.com/token",
+		},
+	}
+
+	redirector := oauth2.OauthRedirector(config)
+
+	t.Run("redirects to OAuth provider", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		redirector(rr, req)
+
+		if rr.Code != http.StatusFound {
+			t.Errorf("Expected status %d, got %d", http.StatusFound, rr.Code)
+		}
+
+		location := rr.Header().Get("Location")
+		if !strings.HasPrefix(location, "https://provider.example.com/auth") {
+			t.Errorf("Expected redirect to OAuth provider, got: %s", location)
+		}
+
+		// Check that location contains required OAuth parameters
+		parsedURL, err := url.Parse(location)
+		if err != nil {
+			t.Fatalf("Failed to parse redirect URL: %v", err)
+		}
+		query := parsedURL.Query()
+		if query.Get("client_id") != "test-client-id" {
+			t.Errorf("Expected client_id in URL")
+		}
+		if query.Get("redirect_uri") != "http://localhost:8080/callback" {
+			t.Errorf("Expected redirect_uri in URL")
+		}
+		if query.Get("response_type") != "code" {
+			t.Errorf("Expected response_type=code in URL")
+		}
+		if query.Get("state") == "" {
+			t.Errorf("Expected state parameter in URL")
+		}
+	})
+
+	t.Run("sets oauthstate cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		redirector(rr, req)
+
+		cookies := rr.Result().Cookies()
+		var oauthStateCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == "oauthstate" {
+				oauthStateCookie = c
+				break
+			}
+		}
+
+		if oauthStateCookie == nil {
+			t.Error("Expected oauthstate cookie to be set")
+		} else if oauthStateCookie.Value == "" {
+			t.Error("Expected oauthstate cookie to have a value")
+		}
+	})
+
+	t.Run("sets callback URL cookie when provided", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?callbackURL=/dashboard", nil)
+		rr := httptest.NewRecorder()
+
+		redirector(rr, req)
+
+		cookies := rr.Result().Cookies()
+		var callbackCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == "oauthCallbackURL" {
+				callbackCookie = c
+				break
+			}
+		}
+
+		if callbackCookie == nil {
+			t.Error("Expected oauthCallbackURL cookie to be set")
+		} else if callbackCookie.Value != "/dashboard" {
+			t.Errorf("Expected callback URL '/dashboard', got '%s'", callbackCookie.Value)
+		}
+	})
+
+	t.Run("state in URL matches cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		redirector(rr, req)
+
+		// Get state from cookie
+		cookies := rr.Result().Cookies()
+		var cookieState string
+		for _, c := range cookies {
+			if c.Name == "oauthstate" {
+				cookieState = c.Value
+				break
+			}
+		}
+
+		// Get state from redirect URL
+		location := rr.Header().Get("Location")
+		parsedURL, _ := url.Parse(location)
+		urlState := parsedURL.Query().Get("state")
+
+		if cookieState != urlState {
+			t.Errorf("State mismatch: cookie=%s, url=%s", cookieState, urlState)
+		}
+	})
+}
+
+// TestGoogleOAuth2Callback tests the Google OAuth callback handler
+func TestGoogleOAuth2Callback(t *testing.T) {
+	mock := newMockOAuthServer()
+	defer mock.Close()
+
+	// Track HandleUser calls
+	var handledProvider string
+	var handledUserInfo map[string]any
+	var handledCalled bool
+
+	googleAuth := oauth2.NewGoogleOAuth2(
+		"test-client-id",
+		"test-client-secret",
+		"http://localhost:8080/callback",
+		func(authtype, provider string, token *oauth2lib.Token, userInfo map[string]any, w http.ResponseWriter, r *http.Request) {
+			handledCalled = true
+			handledProvider = provider
+			handledUserInfo = userInfo
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+
+	// Override endpoints and client for testing
+	googleAuth.UserInfoURL = mock.userInfoEndpoint
+	googleAuth.SetHTTPClient(mock.server.Client())
+	// Override the oauth config endpoint for token exchange
+	googleAuth.BaseOAuth2.SetOAuthEndpoint(oauth2lib.Endpoint{
+		AuthURL:  mock.server.URL + "/auth",
+		TokenURL: mock.tokenEndpoint,
+	})
+
+	t.Run("rejects missing state cookie", func(t *testing.T) {
+		handledCalled = false
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=test_code&state=test_state", nil)
+		rr := httptest.NewRecorder()
+
+		googleAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("Expected status %d, got %d", http.StatusBadRequest, rr.Code)
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called without state cookie")
+		}
+	})
+
+	t.Run("rejects mismatched state", func(t *testing.T) {
+		handledCalled = false
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=test_code&state=wrong_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "correct_state"})
+		rr := httptest.NewRecorder()
+
+		googleAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("Expected status %d, got %d", http.StatusBadRequest, rr.Code)
+		}
+		if !strings.Contains(rr.Body.String(), "invalid oauth") {
+			t.Errorf("Expected invalid oauth error, got: %s", rr.Body.String())
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called with mismatched state")
+		}
+	})
+
+	t.Run("successful callback flow", func(t *testing.T) {
+		handledCalled = false
+		handledProvider = ""
+		handledUserInfo = nil
+
+		mock.userInfoResponse = map[string]any{
+			"id":    "google123",
+			"email": "user@gmail.com",
+			"name":  "Google User",
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=valid_code&state=valid_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "valid_state"})
+		rr := httptest.NewRecorder()
+
+		googleAuth.Handler().ServeHTTP(rr, req)
+
+		if !handledCalled {
+			t.Error("HandleUser should have been called")
+		}
+		if handledProvider != "google" {
+			t.Errorf("Expected provider 'google', got '%s'", handledProvider)
+		}
+		if handledUserInfo["email"] != "user@gmail.com" {
+			t.Errorf("Expected email 'user@gmail.com', got '%v'", handledUserInfo["email"])
+		}
+	})
+
+	t.Run("redirects on token exchange failure", func(t *testing.T) {
+		handledCalled = false
+		mock.tokenError = true
+		defer func() { mock.tokenError = false }()
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=bad_code&state=valid_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "valid_state"})
+		rr := httptest.NewRecorder()
+
+		googleAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusTemporaryRedirect {
+			t.Errorf("Expected redirect status, got %d", rr.Code)
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called on token exchange failure")
+		}
+	})
+
+	t.Run("redirects on user info failure", func(t *testing.T) {
+		handledCalled = false
+		mock.userInfoError = true
+		defer func() { mock.userInfoError = false }()
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=valid_code&state=valid_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "valid_state"})
+		rr := httptest.NewRecorder()
+
+		googleAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusTemporaryRedirect {
+			t.Errorf("Expected redirect status, got %d", rr.Code)
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called on user info failure")
+		}
+	})
+}
+
+// TestGithubOAuth2Callback tests the GitHub OAuth callback handler
+func TestGithubOAuth2Callback(t *testing.T) {
+	mock := newMockOAuthServer()
+	defer mock.Close()
+
+	// Track HandleUser calls
+	var handledProvider string
+	var handledUserInfo map[string]any
+	var handledCalled bool
+
+	githubAuth := oauth2.NewGithubOAuth2(
+		"test-client-id",
+		"test-client-secret",
+		"http://localhost:8080/callback",
+		func(authtype, provider string, token *oauth2lib.Token, userInfo map[string]any, w http.ResponseWriter, r *http.Request) {
+			handledCalled = true
+			handledProvider = provider
+			handledUserInfo = userInfo
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+
+	// Override endpoints and client for testing
+	githubAuth.UserInfoURL = mock.userInfoEndpoint
+	githubAuth.SetHTTPClient(mock.server.Client())
+	// Override the oauth config endpoint for token exchange
+	githubAuth.BaseOAuth2.SetOAuthEndpoint(oauth2lib.Endpoint{
+		AuthURL:  mock.server.URL + "/auth",
+		TokenURL: mock.tokenEndpoint,
+	})
+
+	t.Run("rejects missing state cookie", func(t *testing.T) {
+		handledCalled = false
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=test_code&state=test_state", nil)
+		rr := httptest.NewRecorder()
+
+		githubAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("Expected status %d, got %d", http.StatusBadRequest, rr.Code)
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called without state cookie")
+		}
+	})
+
+	t.Run("rejects mismatched state", func(t *testing.T) {
+		handledCalled = false
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=test_code&state=wrong_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "correct_state"})
+		rr := httptest.NewRecorder()
+
+		githubAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("Expected status %d, got %d", http.StatusBadRequest, rr.Code)
+		}
+		if !strings.Contains(rr.Body.String(), "invalid oauth") {
+			t.Errorf("Expected invalid oauth error, got: %s", rr.Body.String())
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called with mismatched state")
+		}
+	})
+
+	t.Run("successful callback flow", func(t *testing.T) {
+		handledCalled = false
+		handledProvider = ""
+		handledUserInfo = nil
+
+		mock.userInfoResponse = map[string]any{
+			"id":    "github456",
+			"login": "githubuser",
+			"email": "user@github.com",
+			"name":  "GitHub User",
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=valid_code&state=valid_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "valid_state"})
+		rr := httptest.NewRecorder()
+
+		githubAuth.Handler().ServeHTTP(rr, req)
+
+		if !handledCalled {
+			t.Error("HandleUser should have been called")
+		}
+		if handledProvider != "github" {
+			t.Errorf("Expected provider 'github', got '%s'", handledProvider)
+		}
+		if handledUserInfo["login"] != "githubuser" {
+			t.Errorf("Expected login 'githubuser', got '%v'", handledUserInfo["login"])
+		}
+	})
+
+	t.Run("redirects on token exchange failure", func(t *testing.T) {
+		handledCalled = false
+		mock.tokenError = true
+		defer func() { mock.tokenError = false }()
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=bad_code&state=valid_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "valid_state"})
+		rr := httptest.NewRecorder()
+
+		githubAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusTemporaryRedirect {
+			t.Errorf("Expected redirect status, got %d", rr.Code)
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called on token exchange failure")
+		}
+	})
+
+	t.Run("redirects on user info failure", func(t *testing.T) {
+		handledCalled = false
+		mock.userInfoError = true
+		defer func() { mock.userInfoError = false }()
+
+		req := httptest.NewRequest(http.MethodGet, "/callback/?code=valid_code&state=valid_state", nil)
+		req.AddCookie(&http.Cookie{Name: "oauthstate", Value: "valid_state"})
+		rr := httptest.NewRecorder()
+
+		githubAuth.Handler().ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusTemporaryRedirect {
+			t.Errorf("Expected redirect status, got %d", rr.Code)
+		}
+		if handledCalled {
+			t.Error("HandleUser should not be called on user info failure")
+		}
+	})
+}
+
+// TestOAuthStateGeneration tests that OAuth state is properly generated and validated
+func TestOAuthStateGeneration(t *testing.T) {
+	config := &oauth2lib.Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost:8080/callback",
+		Scopes:       []string{"email"},
+		Endpoint: oauth2lib.Endpoint{
+			AuthURL:  "https://provider.example.com/auth",
+			TokenURL: "https://provider.example.com/token",
+		},
+	}
+
+	redirector := oauth2.OauthRedirector(config)
+
+	t.Run("generates unique state for each request", func(t *testing.T) {
+		states := make(map[string]bool)
+
+		for i := 0; i < 10; i++ {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rr := httptest.NewRecorder()
+
+			redirector(rr, req)
+
+			cookies := rr.Result().Cookies()
+			for _, c := range cookies {
+				if c.Name == "oauthstate" {
+					if states[c.Value] {
+						t.Errorf("Duplicate state generated: %s", c.Value)
+					}
+					states[c.Value] = true
+					break
+				}
+			}
+		}
+
+		if len(states) != 10 {
+			t.Errorf("Expected 10 unique states, got %d", len(states))
+		}
+	})
+
+	t.Run("state cookie has appropriate expiration", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+
+		redirector(rr, req)
+
+		cookies := rr.Result().Cookies()
+		for _, c := range cookies {
+			if c.Name == "oauthstate" {
+				// Cookie should expire in about 30 days
+				expectedExpiry := time.Now().Add(30 * 24 * time.Hour)
+				if c.Expires.Before(expectedExpiry.Add(-1*time.Hour)) || c.Expires.After(expectedExpiry.Add(1*time.Hour)) {
+					t.Errorf("Cookie expiry not within expected range: %v", c.Expires)
+				}
+				break
+			}
+		}
+	})
+}
+
+// TestBaseOAuth2HTTPClient tests the HTTP client injection functionality
+func TestBaseOAuth2HTTPClient(t *testing.T) {
+	t.Run("uses default client when none set", func(t *testing.T) {
+		googleAuth := oauth2.NewGoogleOAuth2(
+			"test-client-id",
+			"test-client-secret",
+			"http://localhost:8080/callback",
+			nil,
+		)
+
+		// The getHTTPClient is not exported, but we can test behavior indirectly
+		// by checking that the HTTPClient field is nil
+		if googleAuth.HTTPClient != nil {
+			t.Error("Expected HTTPClient to be nil by default")
+		}
+	})
+
+	t.Run("uses custom client when set", func(t *testing.T) {
+		googleAuth := oauth2.NewGoogleOAuth2(
+			"test-client-id",
+			"test-client-secret",
+			"http://localhost:8080/callback",
+			nil,
+		)
+
+		customClient := &http.Client{Timeout: 5 * time.Second}
+		googleAuth.SetHTTPClient(customClient)
+
+		if googleAuth.HTTPClient != customClient {
+			t.Error("Expected HTTPClient to be the custom client")
+		}
+	})
+}
+
+// TestOAuthEndpointConfiguration tests that OAuth endpoints can be configured
+func TestOAuthEndpointConfiguration(t *testing.T) {
+	t.Run("Google uses default endpoints", func(t *testing.T) {
+		googleAuth := oauth2.NewGoogleOAuth2(
+			"test-client-id",
+			"test-client-secret",
+			"http://localhost:8080/callback",
+			nil,
+		)
+
+		// Default Google UserInfoURL should be set
+		expectedURL := "https://www.googleapis.com/oauth2/v2/userinfo"
+		if googleAuth.UserInfoURL != expectedURL {
+			t.Errorf("Expected default UserInfoURL '%s', got '%s'", expectedURL, googleAuth.UserInfoURL)
+		}
+	})
+
+	t.Run("GitHub uses default endpoints", func(t *testing.T) {
+		githubAuth := oauth2.NewGithubOAuth2(
+			"test-client-id",
+			"test-client-secret",
+			"http://localhost:8080/callback",
+			nil,
+		)
+
+		// Default GitHub UserInfoURL should be set
+		expectedURL := "https://api.github.com/user"
+		if githubAuth.UserInfoURL != expectedURL {
+			t.Errorf("Expected default UserInfoURL '%s', got '%s'", expectedURL, githubAuth.UserInfoURL)
+		}
+	})
+
+	t.Run("UserInfoURL can be overridden", func(t *testing.T) {
+		googleAuth := oauth2.NewGoogleOAuth2(
+			"test-client-id",
+			"test-client-secret",
+			"http://localhost:8080/callback",
+			nil,
+		)
+
+		customURL := "http://mock.example.com/userinfo"
+		googleAuth.UserInfoURL = customURL
+
+		if googleAuth.UserInfoURL != customURL {
+			t.Errorf("Expected UserInfoURL '%s', got '%s'", customURL, googleAuth.UserInfoURL)
+		}
+	})
+}
+
+// TestEnvironmentVariableDefaults tests that OAuth config falls back to environment variables
+func TestEnvironmentVariableDefaults(t *testing.T) {
+	t.Run("Google OAuth reads from environment when empty", func(t *testing.T) {
+		// This test verifies the behavior exists - we don't actually set env vars
+		// because it would affect other tests
+		googleAuth := oauth2.NewGoogleOAuth2("", "", "", nil)
+
+		// With no env vars set, these should be empty
+		if googleAuth.ClientId != "" {
+			t.Error("Expected empty ClientId when env var not set")
+		}
+	})
+
+	t.Run("GitHub OAuth reads from environment when empty", func(t *testing.T) {
+		githubAuth := oauth2.NewGithubOAuth2("", "", "", nil)
+
+		// With no env vars set, these should be empty
+		if githubAuth.ClientId != "" {
+			t.Error("Expected empty ClientId when env var not set")
+		}
+	})
+
+	t.Run("explicit values override environment", func(t *testing.T) {
+		googleAuth := oauth2.NewGoogleOAuth2(
+			"explicit-client-id",
+			"explicit-secret",
+			"http://explicit-callback.com",
+			nil,
+		)
+
+		if googleAuth.ClientId != "explicit-client-id" {
+			t.Errorf("Expected explicit ClientId, got '%s'", googleAuth.ClientId)
+		}
+		if googleAuth.ClientSecret != "explicit-secret" {
+			t.Errorf("Expected explicit ClientSecret, got '%s'", googleAuth.ClientSecret)
+		}
+		if googleAuth.CallbackURL != "http://explicit-callback.com" {
+			t.Errorf("Expected explicit CallbackURL, got '%s'", googleAuth.CallbackURL)
+		}
+	})
+}


### PR DESCRIPTION
- Add HTTPClient field to BaseOAuth2 for injectable HTTP clients
- Add SetHTTPClient and SetOAuthEndpoint methods for testing
- Add ExchangeContext to use injectable client for token exchange
- Make Google/GitHub UserInfoURL configurable for mock servers
- Refactor getUserData methods to use injectable HTTP client
- Add comprehensive OAuth test suite with mock HTTP server:
  - OauthRedirector tests (state, cookies, redirect URL)
  - Google OAuth callback tests (state validation, token exchange, user data)
  - GitHub OAuth callback tests (state validation, token exchange, user data)
  - Error handling tests (invalid state, failed exchanges)