### PR TITLE
Add CustomClaimsFunc, KeyStore, and multi-tenant JWT validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -112,6 +112,41 @@ Client → GET /api/resource (Bearer token) → APIMiddleware → Handler
 - Prefixed with `oa_` for identification
 - User-manageable
 
+## Multi-Tenant JWT and KeyStore
+
+For federated systems where multiple Hosts mint JWTs verified by a shared Relay, oneauth supports multi-tenant signing key management:
+
+### KeyStore Interface
+
+```go
+type KeyStore interface {
+    GetVerifyKey(clientID string) (any, error)    // []byte for HMAC, crypto.PublicKey for asymmetric
+    GetSigningKey(clientID string) (any, error)
+    GetExpectedAlg(clientID string) (string, error)  // algorithm confusion prevention
+}
+```
+
+### Custom Claims
+
+`APIAuth.CustomClaimsFunc` injects custom claims into JWTs at minting time (e.g., `client_id`, `max_rooms`). Standard claims (`sub`, `iss`, `aud`, `exp`, `iat`, `type`, `scopes`) cannot be overridden.
+
+`APIAuth.ValidateAccessTokenFull()` returns custom claims separately from standard claims for downstream extraction.
+
+### Multi-Tenant Validation Flow
+
+When `APIMiddleware.KeyStore` is set:
+1. Extract `client_id` from unverified JWT claims
+2. Look up expected algorithm via `KeyStore.GetExpectedAlg(clientID)` — prevents algorithm confusion
+3. Look up verification key via `KeyStore.GetVerifyKey(clientID)`
+4. Verify JWT signature with the per-client key
+
+When `KeyStore` is nil, falls back to single `JWTSecretKey` (backwards-compatible).
+
+### Implementations
+
+- `InMemoryKeyStore` — thread-safe map, for testing and simple deployments
+- FS/GORM/GAE KeyStore — planned (#5)
+
 ## Store Architecture
 
 ```
@@ -119,6 +154,7 @@ Client → GET /api/resource (Bearer token) → APIMiddleware → Handler
 │                    Store Interfaces                     │
 │  UserStore | IdentityStore | ChannelStore | TokenStore  │
 │  RefreshTokenStore | APIKeyStore | UsernameStore (opt)  │
+│  KeyStore (multi-tenant JWT)                            │
 └─────────────────────────────┬───────────────────────────┘
                               │
         ┌─────────────────────┼─────────────────────┐

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1126,6 +1126,126 @@ newToken, err := refreshTokenStore.RotateRefreshToken(token, expiry)
 4. **API Key Storage**: Store API keys securely. They cannot be recovered if lost.
 5. **Scope Validation**: Always validate scopes in your handlers for defense-in-depth.
 
+### Custom Claims
+
+You can inject application-specific claims into JWTs using `CustomClaimsFunc`. This is useful for embedding metadata like tenant IDs, quotas, or client identifiers:
+
+```go
+apiAuth := &oneauth.APIAuth{
+    JWTSecretKey: os.Getenv("JWT_SECRET"),
+    JWTIssuer:    "yourapp.com",
+    CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+        // Look up application-specific data for this user
+        tenant := getTenantForUser(userID)
+        return map[string]any{
+            "tenant_id":  tenant.ID,
+            "plan":       tenant.Plan,
+            "max_seats":  tenant.MaxSeats,
+        }, nil
+    },
+}
+```
+
+**Important**: Standard JWT claims (`sub`, `iss`, `aud`, `exp`, `iat`, `type`, `scopes`) cannot be overridden. If `CustomClaimsFunc` returns keys that collide with standard claims, they are logged and silently ignored.
+
+To extract custom claims on the validation side, use `ValidateAccessTokenFull`:
+
+```go
+userID, scopes, customClaims, err := apiAuth.ValidateAccessTokenFull(tokenString)
+if err != nil {
+    // handle error
+}
+tenantID := customClaims["tenant_id"].(string)
+```
+
+If `CustomClaimsFunc` is nil, behavior is identical to before (backwards-compatible). If the callback returns an error, `CreateAccessToken` fails and the error propagates.
+
+### Multi-Tenant JWT Validation (KeyStore)
+
+For architectures where multiple clients (hosts, tenants) each mint their own JWTs — such as federated relay systems — use a `KeyStore` for per-client key lookup instead of a single shared secret.
+
+#### The Problem
+
+With a single `JWTSecretKey`, all token issuers share one secret. This means:
+- You can't revoke access for one issuer without rotating the key for all
+- A compromised secret affects all clients
+- You can't have different clients use different signing algorithms
+
+#### The Solution: KeyStore Interface
+
+```go
+type KeyStore interface {
+    GetVerifyKey(clientID string) (any, error)    // verification key for this client
+    GetSigningKey(clientID string) (any, error)    // signing key for this client
+    GetExpectedAlg(clientID string) (string, error) // expected algorithm
+}
+```
+
+#### Setting Up Multi-Tenant Validation
+
+```go
+// 1. Create a KeyStore and register client keys
+keyStore := oneauth.NewInMemoryKeyStore()
+keyStore.RegisterKey("host-alpha", []byte("alpha-secret-key"), "HS256")
+keyStore.RegisterKey("host-beta",  []byte("beta-secret-key"),  "HS256")
+
+// 2. Configure middleware with KeyStore (replaces JWTSecretKey)
+middleware := &oneauth.APIMiddleware{
+    KeyStore:    keyStore,
+    JWTIssuer:   "relay.example.com", // optional: still validates issuer
+    APIKeyStore: apiKeyStore,         // optional: API keys still work
+}
+
+// 3. Protect endpoints — tokens are verified per-client
+mux.Handle("/api/resource", middleware.ValidateToken(handler))
+```
+
+#### How It Works
+
+When a JWT arrives, the middleware:
+
+1. Parses the token without verifying the signature
+2. Extracts the `client_id` claim from the unverified payload
+3. Calls `KeyStore.GetExpectedAlg(clientID)` — if the JWT's `alg` header doesn't match, the token is rejected (prevents algorithm confusion attacks)
+4. Calls `KeyStore.GetVerifyKey(clientID)` — returns the key material for this client
+5. Verifies the JWT signature with the client-specific key
+
+If `KeyStore` is nil, the middleware falls back to single `JWTSecretKey` behavior (backwards-compatible).
+
+#### Minting Tokens for Multi-Tenant Systems
+
+On the host/client side, use `CustomClaimsFunc` to embed the `client_id`:
+
+```go
+hostAuth := &oneauth.APIAuth{
+    JWTSecretKey: hostSharedSecret,  // the secret registered with the relay
+    JWTIssuer:    "relay.example.com",
+    CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+        return map[string]any{
+            "client_id":     "host-alpha",
+            "client_domain": "alpha.example.com",
+            "max_rooms":     10,
+            "max_msg_rate":  30.0,
+        }, nil
+    },
+}
+
+// Mint a relay-scoped token for a user
+token, _, err := hostAuth.CreateAccessToken("user-123", []string{"read", "write"})
+```
+
+#### Algorithm Confusion Prevention
+
+The `KeyStore.GetExpectedAlg()` method prevents algorithm confusion attacks. For example, if a client is registered with `HS256` but sends a token with `alg: none` or `alg: RS256`, the token is rejected before signature verification.
+
+#### Future: Asymmetric Keys
+
+The `KeyStore` interface is designed for forward compatibility with asymmetric signing:
+- `GetVerifyKey` can return `*rsa.PublicKey` or `*ecdsa.PublicKey` for RS256/ES256
+- `GetSigningKey` can return `*rsa.PrivateKey` or `*ecdsa.PrivateKey`
+- Per-client algorithm choice: some clients use HS256, others use RS256
+- Both modes coexist on the same middleware
+
 ## gRPC Authentication
 
 OneAuth provides gRPC authentication utilities in the `grpc` subpackage for integrating authentication with gRPC services.
@@ -1364,6 +1484,8 @@ Complete example applications are planned for a future release. For now, refer t
 
 - Test files: `local_test.go`, `auth_flows_test.go` show complete browser auth patterns
 - Test files: `api_auth_test.go` for API authentication with JWT, refresh tokens, and API keys
+- Test files: `custom_claims_test.go` for custom claims injection and multi-tenant JWT validation
+- Test files: `keystore_test.go` for KeyStore interface and InMemoryKeyStore usage
 - Test files: `grpc/context_test.go`, `grpc/interceptor_test.go` for gRPC patterns
 - Quick Start section above for basic integration
 - Helper functions section for common patterns

--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -80,6 +80,15 @@
 
 ## Short-term
 
+### Federated Auth (Relay + Host)
+
+- [x] **P0** `[BLOCKER]` `CustomClaimsFunc` + multi-tenant `KeyStore` interface (#2) ✅
+- [ ] **P0** `[BLOCKER]` Host registration API + service component (#3)
+  > `HostStore` interface, HTTP handlers for Host CRUD, `MintRelayToken` helper
+- [ ] **P1** Asymmetric signing support — RS256/ES256 (#4)
+  > Compatible extension: per-host algorithm choice, both HS256 and asymmetric coexist
+- [ ] **P1** Persistent `KeyStore` implementations — FS, GORM, GAE (#5)
+
 ### Phase 3: OAuth Integration for API
 
 - [ ] **P0** `[BLOCKER]` Add API mode to OAuth callbacks (return tokens instead of session)
@@ -284,10 +293,10 @@ Currently each store implementation redeclares model types (FSUser, GORMUser, GA
   >
   > **Requires**: Organization support (for org-scoped roles)
 
-- [ ] **P2** `[DX]` Custom claims in JWT
-  > **Scenario**: App needs tenant_id in every token. Configure: `JWTClaims: func(user) { return map{"tenant_id": user.TenantID} }`. All tokens include custom claim.
-  >
-  > **Urgency**: Flexibility feature. Workaround: fetch from user store on each request.
+- [x] **P2** `[DX]` Custom claims in JWT ✅ **COMPLETED (oneauth#2)**
+  > `CustomClaimsFunc` on `APIAuth` + `ValidateAccessTokenFull` for extraction.
+  > Multi-tenant `KeyStore` interface with `InMemoryKeyStore` implementation.
+  > `APIMiddleware` supports per-client key lookup via `KeyStore`.
 
 - [ ] **P2** `[DX]` Device management UI components
   > **Scenario**: User views "Active Sessions" page: "Chrome on MacBook (current), Safari on iPhone, Firefox on Windows". Can click "Sign out" on any device.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Go authentication library providing unified local and OAuth-based authenticati
 - **Unified authentication**: Password and OAuth through a single interface
 - **Multi-provider support**: One account accessible via password, Google, GitHub, etc.
 - **API authentication**: JWT access tokens, refresh tokens, and API keys for programmatic access
+- **Multi-tenant JWT**: KeyStore interface for per-client signing keys, custom claims injection, algorithm confusion prevention
 - **Separation of concerns**: Users, identities, and authentication channels as distinct concepts
 - **Flexible storage**: Database-agnostic store interfaces with file-based, GORM, and GAE/Datastore implementations
 - **Email workflows**: Built-in email verification and password reset flows
@@ -209,11 +210,41 @@ mux.Handle("/api/logout", http.HandlerFunc(apiAuth.HandleLogout))
 mux.Handle("/api/keys", http.HandlerFunc(apiAuth.HandleAPIKeys))
 ```
 
+### Custom Claims
+
+Inject application-specific claims into JWTs at minting time:
+
+```go
+apiAuth := &oneauth.APIAuth{
+    JWTSecretKey: "your-secret-key",
+    JWTIssuer:    "yourapp.com",
+    // Inject custom claims into every token
+    CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+        return map[string]any{
+            "client_id":     "my-host-id",
+            "client_domain": "myapp.com",
+            "max_rooms":     10,
+        }, nil
+    },
+}
+
+// Mint a token with custom claims
+token, expiresIn, err := apiAuth.CreateAccessToken("user-123", []string{"read", "write"})
+
+// Validate and extract custom claims
+userID, scopes, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+// customClaims["client_id"] == "my-host-id"
+// customClaims["max_rooms"] == 10
+```
+
+Standard claims (`sub`, `iss`, `aud`, `exp`, `iat`, `type`, `scopes`) cannot be overridden by custom claims. Attempts are logged and ignored.
+
 ### API Middleware
 
 Protect your API endpoints with JWT validation:
 
 ```go
+// Single-tenant (backwards-compatible)
 middleware := &oneauth.APIMiddleware{
     JWTSecretKey: "your-secret-key",
     JWTIssuer:    "yourapp.com",
@@ -229,6 +260,33 @@ mux.Handle("/api/write", middleware.RequireScopes("write")(writeHandler))
 // Optional authentication
 mux.Handle("/api/public", middleware.Optional(publicHandler))
 ```
+
+### Multi-Tenant JWT Validation
+
+For systems where multiple hosts mint JWTs (e.g., federated relay architectures), use a `KeyStore` for per-client key lookup:
+
+```go
+// Register signing keys for each host
+keyStore := oneauth.NewInMemoryKeyStore()
+keyStore.RegisterKey("host-alpha", []byte("alpha-secret"), "HS256")
+keyStore.RegisterKey("host-beta", []byte("beta-secret"), "HS256")
+
+// Middleware uses KeyStore instead of a single secret
+middleware := &oneauth.APIMiddleware{
+    KeyStore: keyStore,  // per-client key lookup
+}
+
+// Tokens are verified using the key for their client_id claim
+mux.Handle("/api/resource", middleware.ValidateToken(handler))
+```
+
+When `KeyStore` is set, the middleware:
+1. Extracts `client_id` from the JWT's unverified claims
+2. Looks up the expected algorithm and signing key for that client
+3. Validates the algorithm matches (prevents algorithm confusion attacks)
+4. Verifies the JWT signature with the client-specific key
+
+When `KeyStore` is nil, falls back to single `JWTSecretKey` (backwards-compatible).
 
 ### API Requests
 
@@ -344,6 +402,20 @@ type APIKeyStore interface {
     ListUserAPIKeys(userID string) ([]*APIKey, error)
 }
 ```
+
+### KeyStore
+
+Manages per-client signing keys for multi-tenant JWT validation.
+
+```go
+type KeyStore interface {
+    GetVerifyKey(clientID string) (any, error)
+    GetSigningKey(clientID string) (any, error)
+    GetExpectedAlg(clientID string) (string, error)
+}
+```
+
+`InMemoryKeyStore` is provided for testing and simple deployments. Persistent implementations (FS, GORM, GAE) are planned.
 
 ## Store Implementations
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,6 +11,7 @@ OneAuth is a Go authentication library providing unified local and OAuth-based a
 - **Multi-provider**: Single account accessible via password, Google, GitHub, etc. with channel linking
 - **Flexible Storage**: File-based, GORM (SQL), and GAE/Datastore implementations
 - **Scope-based Access**: Fine-grained permissions for API endpoints
+- **Multi-tenant JWT**: KeyStore interface for per-client signing keys, custom claims, algorithm confusion prevention
 - **Policy-Based Validation**: Configurable signup requirements (SignupPolicy)
 - **Username Support**: Optional username uniqueness with username-based login
 
@@ -120,5 +121,7 @@ oneauth.HandleLinkOAuthCallback(config, linkingUserID, "google", userInfo, w, r)
 ```
 
 ## Current Version
+
+v0.0.29 - Added `CustomClaimsFunc` on `APIAuth` for injecting custom claims into JWTs. Added `KeyStore` interface and `InMemoryKeyStore` for multi-tenant JWT validation. Added `ValidateAccessTokenFull` for extracting custom claims. `APIMiddleware` supports per-client key lookup via `KeyStore` with algorithm confusion prevention. Backwards-compatible — existing single-key setups work unchanged.
 
 v0.0.28 - Added optimistic locking fields (`Version`, `UpdatedAt`) to Identity and Channel models. Added `ExpiresAt` field to Channel for tracking when OAuth tokens or auth sessions need re-authentication. Added `IsExpired()` helper method to Channel. Updated all store implementations (GAE, FS, GORM).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -324,6 +324,15 @@ API tokens have scopes that limit what they can access:
 
 When creating API keys, request only the scopes you need.
 
+**Federated Access**
+
+Some applications use OneAuth in a federated model where you authenticate with one service (your "host") and the token grants access to another (e.g., a relay server). In this case:
+
+- You log in to your host application normally
+- The host mints a short-lived token scoped for the relay
+- Your client uses this token to connect to the relay
+- If the token expires, your client reconnects automatically with a fresh token from the host
+
 ### Browser Requirements
 
 OneAuth works with modern browsers that support:

--- a/api_auth.go
+++ b/api_auth.go
@@ -34,6 +34,12 @@ type APIAuth struct {
 	OnLoginSuccess      func(userID string, r *http.Request) // Optional: for logging/analytics
 	OnLoginFailure      func(username string, r *http.Request, err error) // Optional: for logging/analytics
 
+	// CustomClaimsFunc is called during token creation to inject additional claims
+	// into the JWT (e.g., client_id, max_rooms for relay-scoped tokens).
+	// Standard claims (sub, iss, aud, exp, iat, type, scopes) cannot be overridden.
+	// If nil, no custom claims are added (backwards-compatible).
+	CustomClaimsFunc func(userID string, scopes []string) (map[string]any, error)
+
 	// Rate limiting (optional)
 	RateLimiter RateLimiter
 }
@@ -132,7 +138,7 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
 	}
 
 	// Create access token (JWT)
-	accessToken, expiresIn, err := a.createAccessToken(user.Id(), grantedScopes)
+	accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes)
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -193,7 +199,7 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	}
 
 	// Create new access token
-	accessToken, expiresIn, err := a.createAccessToken(refreshToken.UserID, refreshToken.Scopes)
+	accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.UserID, refreshToken.Scopes)
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -303,8 +309,15 @@ func (a *APIAuth) HandleListSessions(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// createAccessToken creates a signed JWT access token
-func (a *APIAuth) createAccessToken(userID string, scopes []string) (string, int64, error) {
+// standardClaims is the set of JWT claim keys that cannot be overridden by CustomClaimsFunc.
+var standardClaims = map[string]bool{
+	"sub": true, "iss": true, "aud": true, "exp": true,
+	"iat": true, "type": true, "scopes": true,
+}
+
+// CreateAccessToken creates a signed JWT access token. If CustomClaimsFunc is set,
+// its returned claims are merged into the token (standard claims cannot be overridden).
+func (a *APIAuth) CreateAccessToken(userID string, scopes []string) (string, int64, error) {
 	expiry := a.AccessTokenExpiry
 	if expiry == 0 {
 		expiry = TokenExpiryAccessToken
@@ -326,6 +339,21 @@ func (a *APIAuth) createAccessToken(userID string, scopes []string) (string, int
 	}
 	if a.JWTAudience != "" {
 		claims["aud"] = a.JWTAudience
+	}
+
+	// Merge custom claims (cannot override standard claims)
+	if a.CustomClaimsFunc != nil {
+		custom, err := a.CustomClaimsFunc(userID, scopes)
+		if err != nil {
+			return "", 0, fmt.Errorf("custom claims func failed: %w", err)
+		}
+		for k, v := range custom {
+			if standardClaims[k] {
+				log.Printf("Warning: CustomClaimsFunc attempted to override standard claim %q (ignored)", k)
+			} else {
+				claims[k] = v
+			}
+		}
 	}
 
 	signingMethod := jwt.SigningMethodHS256
@@ -408,6 +436,68 @@ func (a *APIAuth) ValidateAccessToken(tokenString string) (userID string, scopes
 	}
 
 	return userID, scopes, nil
+}
+
+// ValidateAccessTokenFull validates a JWT access token and returns the standard claims
+// plus any custom claims (non-standard keys) as a separate map.
+func (a *APIAuth) ValidateAccessTokenFull(tokenString string) (userID string, scopes []string, customClaims map[string]any, err error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(a.JWTSecretKey), nil
+	})
+
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	if !token.Valid {
+		return "", nil, nil, fmt.Errorf("invalid token")
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", nil, nil, fmt.Errorf("invalid claims")
+	}
+
+	// Verify token type
+	if tokenType, ok := claims["type"].(string); !ok || tokenType != "access" {
+		return "", nil, nil, fmt.Errorf("invalid token type")
+	}
+
+	// Verify issuer if configured
+	if a.JWTIssuer != "" {
+		if iss, ok := claims["iss"].(string); !ok || iss != a.JWTIssuer {
+			return "", nil, nil, fmt.Errorf("invalid issuer")
+		}
+	}
+
+	// Extract user ID
+	userID, ok = claims["sub"].(string)
+	if !ok || userID == "" {
+		return "", nil, nil, fmt.Errorf("missing subject")
+	}
+
+	// Extract scopes
+	if scopesRaw, ok := claims["scopes"].([]any); ok {
+		scopes = make([]string, 0, len(scopesRaw))
+		for _, s := range scopesRaw {
+			if str, ok := s.(string); ok {
+				scopes = append(scopes, str)
+			}
+		}
+	}
+
+	// Extract custom claims (everything that's not a standard JWT claim)
+	customClaims = make(map[string]any)
+	for k, v := range claims {
+		if !standardClaims[k] {
+			customClaims[k] = v
+		}
+	}
+
+	return userID, scopes, customClaims, nil
 }
 
 // tokenResponse sends a successful token response
@@ -651,6 +741,11 @@ type APIMiddleware struct {
 	JWTAudience   string
 	JWTSigningAlg string
 
+	// KeyStore for multi-tenant JWT validation. When set, the middleware extracts
+	// client_id from unverified JWT claims and looks up the signing key per-client.
+	// When nil, falls back to JWTSecretKey (single-tenant, backwards-compatible).
+	KeyStore KeyStore
+
 	// API key validation (optional)
 	APIKeyStore APIKeyStore
 
@@ -795,7 +890,31 @@ func (m *APIMiddleware) validateRequest(r *http.Request) (userID string, scopes 
 // validateJWT validates a JWT access token
 func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes []string, authType string, err error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
-		// Validate signing method
+		// If KeyStore is configured, use multi-tenant key lookup
+		if m.KeyStore != nil {
+			// Extract client_id from unverified claims to look up the key
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				return nil, fmt.Errorf("invalid claims")
+			}
+			clientID, _ := claims["client_id"].(string)
+			if clientID == "" {
+				return nil, fmt.Errorf("missing client_id claim")
+			}
+
+			// Validate algorithm matches what we expect for this client
+			expectedAlg, err := m.KeyStore.GetExpectedAlg(clientID)
+			if err != nil {
+				return nil, fmt.Errorf("unknown client: %w", err)
+			}
+			if token.Header["alg"] != expectedAlg {
+				return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", expectedAlg, token.Header["alg"])
+			}
+
+			return m.KeyStore.GetVerifyKey(clientID)
+		}
+
+		// Fallback: single-key validation (backwards-compatible)
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}

--- a/custom_claims_test.go
+++ b/custom_claims_test.go
@@ -1,0 +1,370 @@
+package oneauth_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	oa "github.com/panyam/oneauth"
+)
+
+// TestCustomClaimsFunc_RoundTrip tests that custom claims are embedded in the JWT
+// and can be extracted after validation.
+func TestCustomClaimsFunc_RoundTrip(t *testing.T) {
+	apiAuth := &oa.APIAuth{
+		JWTSecretKey: "test-secret-key",
+		JWTIssuer:    "test-issuer",
+		CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+			return map[string]any{
+				"client_id":     "host-excaliframe",
+				"client_domain": "excaliframe.com",
+				"max_rooms":     float64(10),
+				"max_msg_rate":  float64(30.0),
+			}, nil
+		},
+	}
+
+	// Mint a token using the exported method
+	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read", "write"})
+	if err != nil {
+		t.Fatalf("CreateAccessToken failed: %v", err)
+	}
+
+	// Validate and extract custom claims
+	userID, scopes, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	if err != nil {
+		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
+	}
+
+	if userID != "user-123" {
+		t.Errorf("Expected userID user-123, got %s", userID)
+	}
+	if len(scopes) != 2 {
+		t.Errorf("Expected 2 scopes, got %d", len(scopes))
+	}
+
+	// Check custom claims
+	if customClaims["client_id"] != "host-excaliframe" {
+		t.Errorf("Expected client_id host-excaliframe, got %v", customClaims["client_id"])
+	}
+	if customClaims["client_domain"] != "excaliframe.com" {
+		t.Errorf("Expected client_domain excaliframe.com, got %v", customClaims["client_domain"])
+	}
+	if customClaims["max_rooms"] != float64(10) {
+		t.Errorf("Expected max_rooms 10, got %v", customClaims["max_rooms"])
+	}
+	if customClaims["max_msg_rate"] != float64(30.0) {
+		t.Errorf("Expected max_msg_rate 30, got %v", customClaims["max_msg_rate"])
+	}
+}
+
+// TestCustomClaimsFunc_Nil tests that nil callback preserves existing behavior
+func TestCustomClaimsFunc_Nil(t *testing.T) {
+	apiAuth := &oa.APIAuth{
+		JWTSecretKey: "test-secret-key",
+		JWTIssuer:    "test-issuer",
+		// CustomClaimsFunc is nil
+	}
+
+	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"})
+	if err != nil {
+		t.Fatalf("CreateAccessToken failed: %v", err)
+	}
+
+	userID, scopes, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	if err != nil {
+		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
+	}
+
+	if userID != "user-123" {
+		t.Errorf("Expected userID user-123, got %s", userID)
+	}
+	if len(scopes) != 1 || scopes[0] != "read" {
+		t.Errorf("Expected scopes [read], got %v", scopes)
+	}
+	// No custom claims should be present
+	if len(customClaims) != 0 {
+		t.Errorf("Expected no custom claims, got %v", customClaims)
+	}
+}
+
+// TestCustomClaimsFunc_Error tests that callback error propagates
+func TestCustomClaimsFunc_Error(t *testing.T) {
+	apiAuth := &oa.APIAuth{
+		JWTSecretKey: "test-secret-key",
+		CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+			return nil, oa.ErrInvalidGrant
+		},
+	}
+
+	_, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"})
+	if err == nil {
+		t.Fatal("Expected error from CreateAccessToken when CustomClaimsFunc fails")
+	}
+}
+
+// TestCustomClaimsFunc_NoOverrideStandard tests that custom claims cannot override standard claims
+func TestCustomClaimsFunc_NoOverrideStandard(t *testing.T) {
+	apiAuth := &oa.APIAuth{
+		JWTSecretKey: "test-secret-key",
+		JWTIssuer:    "real-issuer",
+		CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+			return map[string]any{
+				"sub":       "evil-user",       // should NOT override
+				"iss":       "evil-issuer",     // should NOT override
+				"type":      "refresh",         // should NOT override
+				"client_id": "legit-host",      // custom claim, should be kept
+			}, nil
+		},
+	}
+
+	token, _, err := apiAuth.CreateAccessToken("real-user", []string{"read"})
+	if err != nil {
+		t.Fatalf("CreateAccessToken failed: %v", err)
+	}
+
+	userID, _, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	if err != nil {
+		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
+	}
+
+	// Standard claims should NOT be overridden
+	if userID != "real-user" {
+		t.Errorf("sub should not be overridden: expected real-user, got %s", userID)
+	}
+
+	// Custom claims should be present
+	if customClaims["client_id"] != "legit-host" {
+		t.Errorf("Expected client_id legit-host, got %v", customClaims["client_id"])
+	}
+}
+
+// TestMultiTenantValidation_DifferentHosts tests that tokens from different hosts
+// are verified with their respective secrets via KeyStore.
+func TestMultiTenantValidation_DifferentHosts(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+	ks.RegisterKey("host-alpha", []byte("alpha-secret"), "HS256")
+	ks.RegisterKey("host-beta", []byte("beta-secret"), "HS256")
+
+	// Mint token for host-alpha
+	alphaToken := mintTestToken(t, "user-1", "host-alpha", "alpha-secret")
+	// Mint token for host-beta
+	betaToken := mintTestToken(t, "user-2", "host-beta", "beta-secret")
+
+	middleware := &oa.APIMiddleware{
+		KeyStore: ks,
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID := oa.GetUserIDFromAPIContext(r.Context())
+		json.NewEncoder(w).Encode(map[string]any{"user_id": userID})
+	})
+
+	// alpha token should pass
+	t.Run("host-alpha token accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+		req.Header.Set("Authorization", "Bearer "+alphaToken)
+		rr := httptest.NewRecorder()
+		middleware.ValidateToken(testHandler).ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200, got %d. Body: %s", rr.Code, rr.Body.String())
+		}
+		var resp map[string]any
+		json.NewDecoder(rr.Body).Decode(&resp)
+		if resp["user_id"] != "user-1" {
+			t.Errorf("Expected user_id user-1, got %v", resp["user_id"])
+		}
+	})
+
+	// beta token should pass
+	t.Run("host-beta token accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+		req.Header.Set("Authorization", "Bearer "+betaToken)
+		rr := httptest.NewRecorder()
+		middleware.ValidateToken(testHandler).ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200, got %d. Body: %s", rr.Code, rr.Body.String())
+		}
+		var resp map[string]any
+		json.NewDecoder(rr.Body).Decode(&resp)
+		if resp["user_id"] != "user-2" {
+			t.Errorf("Expected user_id user-2, got %v", resp["user_id"])
+		}
+	})
+}
+
+// TestMultiTenantValidation_WrongSecret tests that a token signed with wrong secret is rejected
+func TestMultiTenantValidation_WrongSecret(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+	ks.RegisterKey("host-alpha", []byte("alpha-secret"), "HS256")
+
+	// Mint token claiming to be from host-alpha but signed with wrong secret
+	wrongToken := mintTestToken(t, "user-1", "host-alpha", "wrong-secret")
+
+	middleware := &oa.APIMiddleware{
+		KeyStore: ks,
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+wrongToken)
+	rr := httptest.NewRecorder()
+	middleware.ValidateToken(testHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for wrong secret, got %d", rr.Code)
+	}
+}
+
+// TestMultiTenantValidation_UnknownClientID tests that a token with unregistered client_id is rejected
+func TestMultiTenantValidation_UnknownClientID(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+	// No hosts registered
+
+	token := mintTestToken(t, "user-1", "unknown-host", "some-secret")
+
+	middleware := &oa.APIMiddleware{
+		KeyStore: ks,
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	middleware.ValidateToken(testHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for unknown client_id, got %d", rr.Code)
+	}
+}
+
+// TestMultiTenantValidation_AlgorithmConfusion tests that a HS256 token is rejected
+// when the KeyStore says the client uses HS512
+func TestMultiTenantValidation_AlgorithmConfusion(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+	ks.RegisterKey("host-alpha", []byte("shared-secret"), "HS512") // registered as HS512
+
+	// Mint with HS256 (algorithm mismatch)
+	token := mintTestToken(t, "user-1", "host-alpha", "shared-secret")
+
+	middleware := &oa.APIMiddleware{
+		KeyStore: ks,
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	middleware.ValidateToken(testHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for algorithm confusion, got %d", rr.Code)
+	}
+}
+
+// TestMultiTenantValidation_FallbackToSingleKey tests that when KeyStore is nil,
+// the middleware falls back to the single JWTSecretKey (backwards compat).
+func TestMultiTenantValidation_FallbackToSingleKey(t *testing.T) {
+	secret := "single-secret-key"
+
+	// Mint token without client_id (old-style)
+	claims := jwt.MapClaims{
+		"sub":    "user-1",
+		"type":   "access",
+		"scopes": []string{"read"},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := tok.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("Failed to mint token: %v", err)
+	}
+
+	middleware := &oa.APIMiddleware{
+		JWTSecretKey: secret,
+		// KeyStore is nil — should fall back to single key
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID := oa.GetUserIDFromAPIContext(r.Context())
+		json.NewEncoder(w).Encode(map[string]any{"user_id": userID})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+	rr := httptest.NewRecorder()
+	middleware.ValidateToken(testHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected 200 with single-key fallback, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestValidateAccessTokenFull_StandardClaimsExcluded tests that standard JWT claims
+// are not included in the customClaims return value
+func TestValidateAccessTokenFull_StandardClaimsExcluded(t *testing.T) {
+	apiAuth := &oa.APIAuth{
+		JWTSecretKey: "test-secret",
+		JWTIssuer:    "test-issuer",
+		CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+			return map[string]any{
+				"client_id": "my-host",
+				"max_rooms": float64(5),
+			}, nil
+		},
+	}
+
+	token, _, err := apiAuth.CreateAccessToken("user-1", []string{"read"})
+	if err != nil {
+		t.Fatalf("CreateAccessToken failed: %v", err)
+	}
+
+	_, _, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	if err != nil {
+		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
+	}
+
+	// Standard claims should NOT be in customClaims
+	for _, stdClaim := range []string{"sub", "iss", "aud", "exp", "iat", "type", "scopes"} {
+		if _, exists := customClaims[stdClaim]; exists {
+			t.Errorf("Standard claim %q should not be in customClaims", stdClaim)
+		}
+	}
+
+	// Custom claims should be present
+	if customClaims["client_id"] != "my-host" {
+		t.Errorf("Expected client_id my-host, got %v", customClaims["client_id"])
+	}
+	if customClaims["max_rooms"] != float64(5) {
+		t.Errorf("Expected max_rooms 5, got %v", customClaims["max_rooms"])
+	}
+}
+
+// mintTestToken creates a HS256 JWT with client_id claim for testing multi-tenant validation
+func mintTestToken(t *testing.T, userID, clientID, secret string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"sub":       userID,
+		"type":      "access",
+		"client_id": clientID,
+		"scopes":    []string{"read", "write"},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := tok.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("Failed to mint test token: %v", err)
+	}
+	return tokenString
+}

--- a/keystore.go
+++ b/keystore.go
@@ -1,0 +1,101 @@
+package oneauth
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Common errors for key operations
+var (
+	ErrKeyNotFound      = fmt.Errorf("signing key not found")
+	ErrAlgorithmMismatch = fmt.Errorf("algorithm mismatch")
+)
+
+// KeyStore provides multi-tenant signing key lookup for JWT verification and minting.
+// For HS256 keys, GetVerifyKey and GetSigningKey return []byte (shared secret).
+// For RS256/ES256 (future), GetVerifyKey returns crypto.PublicKey and GetSigningKey returns crypto.PrivateKey.
+type KeyStore interface {
+	// GetVerifyKey returns the key material for verifying a JWT from the given client.
+	GetVerifyKey(clientID string) (any, error)
+
+	// GetSigningKey returns the key material for signing a JWT on behalf of the given client.
+	GetSigningKey(clientID string) (any, error)
+
+	// GetExpectedAlg returns the expected signing algorithm for the given client.
+	// Used to prevent algorithm confusion attacks.
+	GetExpectedAlg(clientID string) (string, error)
+}
+
+// keyEntry stores key material and metadata for a single client.
+type keyEntry struct {
+	Key       any    // []byte for HMAC, crypto.PublicKey for asymmetric (future)
+	Algorithm string // "HS256", "HS384", "HS512", "RS256", "ES256"
+}
+
+// InMemoryKeyStore is a thread-safe in-memory KeyStore implementation.
+// Suitable for testing and simple single-process deployments.
+type InMemoryKeyStore struct {
+	mu   sync.RWMutex
+	keys map[string]*keyEntry
+}
+
+// NewInMemoryKeyStore creates a new empty InMemoryKeyStore.
+func NewInMemoryKeyStore() *InMemoryKeyStore {
+	return &InMemoryKeyStore{
+		keys: make(map[string]*keyEntry),
+	}
+}
+
+// RegisterKey adds or overwrites a signing key for the given client_id.
+func (s *InMemoryKeyStore) RegisterKey(clientID string, key any, algorithm string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys[clientID] = &keyEntry{Key: key, Algorithm: algorithm}
+	return nil
+}
+
+// DeleteKey removes the signing key for the given client_id.
+func (s *InMemoryKeyStore) DeleteKey(clientID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.keys[clientID]; !ok {
+		return ErrKeyNotFound
+	}
+	delete(s.keys, clientID)
+	return nil
+}
+
+// GetVerifyKey returns the verification key for the given client_id.
+// For HMAC algorithms, this is the same shared secret used for signing.
+func (s *InMemoryKeyStore) GetVerifyKey(clientID string) (any, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.keys[clientID]
+	if !ok {
+		return nil, ErrKeyNotFound
+	}
+	return entry.Key, nil
+}
+
+// GetSigningKey returns the signing key for the given client_id.
+// For HMAC algorithms, this is the same shared secret used for verification.
+func (s *InMemoryKeyStore) GetSigningKey(clientID string) (any, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.keys[clientID]
+	if !ok {
+		return nil, ErrKeyNotFound
+	}
+	return entry.Key, nil
+}
+
+// GetExpectedAlg returns the expected signing algorithm for the given client_id.
+func (s *InMemoryKeyStore) GetExpectedAlg(clientID string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.keys[clientID]
+	if !ok {
+		return "", ErrKeyNotFound
+	}
+	return entry.Algorithm, nil
+}

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -1,0 +1,165 @@
+package oneauth_test
+
+import (
+	"testing"
+
+	oa "github.com/panyam/oneauth"
+)
+
+// TestInMemoryKeyStore_RegisterAndGet tests basic registration and retrieval
+func TestInMemoryKeyStore_RegisterAndGet(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+
+	secret := []byte("host-secret-123")
+	err := ks.RegisterKey("host-abc", secret, "HS256")
+	if err != nil {
+		t.Fatalf("RegisterKey failed: %v", err)
+	}
+
+	// GetVerifyKey should return the secret
+	key, err := ks.GetVerifyKey("host-abc")
+	if err != nil {
+		t.Fatalf("GetVerifyKey failed: %v", err)
+	}
+	keyBytes, ok := key.([]byte)
+	if !ok {
+		t.Fatalf("Expected []byte, got %T", key)
+	}
+	if string(keyBytes) != string(secret) {
+		t.Errorf("Expected secret %q, got %q", secret, keyBytes)
+	}
+
+	// GetSigningKey should return the same secret for HS256
+	sigKey, err := ks.GetSigningKey("host-abc")
+	if err != nil {
+		t.Fatalf("GetSigningKey failed: %v", err)
+	}
+	sigKeyBytes, ok := sigKey.([]byte)
+	if !ok {
+		t.Fatalf("Expected []byte, got %T", sigKey)
+	}
+	if string(sigKeyBytes) != string(secret) {
+		t.Errorf("Expected signing key %q, got %q", secret, sigKeyBytes)
+	}
+
+	// GetExpectedAlg should return HS256
+	alg, err := ks.GetExpectedAlg("host-abc")
+	if err != nil {
+		t.Fatalf("GetExpectedAlg failed: %v", err)
+	}
+	if alg != "HS256" {
+		t.Errorf("Expected alg HS256, got %s", alg)
+	}
+}
+
+// TestInMemoryKeyStore_NotFound tests error on unknown client_id
+func TestInMemoryKeyStore_NotFound(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+
+	_, err := ks.GetVerifyKey("nonexistent")
+	if err != oa.ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound, got %v", err)
+	}
+
+	_, err = ks.GetSigningKey("nonexistent")
+	if err != oa.ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound, got %v", err)
+	}
+
+	_, err = ks.GetExpectedAlg("nonexistent")
+	if err != oa.ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound, got %v", err)
+	}
+}
+
+// TestInMemoryKeyStore_MultipleHosts tests multiple hosts with different keys
+func TestInMemoryKeyStore_MultipleHosts(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+
+	secret1 := []byte("secret-for-host-1")
+	secret2 := []byte("secret-for-host-2")
+
+	if err := ks.RegisterKey("host-1", secret1, "HS256"); err != nil {
+		t.Fatalf("RegisterKey host-1 failed: %v", err)
+	}
+	if err := ks.RegisterKey("host-2", secret2, "HS256"); err != nil {
+		t.Fatalf("RegisterKey host-2 failed: %v", err)
+	}
+
+	key1, err := ks.GetVerifyKey("host-1")
+	if err != nil {
+		t.Fatalf("GetVerifyKey host-1 failed: %v", err)
+	}
+	key2, err := ks.GetVerifyKey("host-2")
+	if err != nil {
+		t.Fatalf("GetVerifyKey host-2 failed: %v", err)
+	}
+
+	if string(key1.([]byte)) != string(secret1) {
+		t.Errorf("host-1 key mismatch")
+	}
+	if string(key2.([]byte)) != string(secret2) {
+		t.Errorf("host-2 key mismatch")
+	}
+	if string(key1.([]byte)) == string(key2.([]byte)) {
+		t.Error("host-1 and host-2 should have different keys")
+	}
+}
+
+// TestInMemoryKeyStore_DeleteKey tests key removal
+func TestInMemoryKeyStore_DeleteKey(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+
+	if err := ks.RegisterKey("host-abc", []byte("secret"), "HS256"); err != nil {
+		t.Fatalf("RegisterKey failed: %v", err)
+	}
+
+	// Should exist
+	if _, err := ks.GetVerifyKey("host-abc"); err != nil {
+		t.Fatalf("Key should exist: %v", err)
+	}
+
+	// Delete
+	if err := ks.DeleteKey("host-abc"); err != nil {
+		t.Fatalf("DeleteKey failed: %v", err)
+	}
+
+	// Should not exist
+	if _, err := ks.GetVerifyKey("host-abc"); err != oa.ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound after delete, got %v", err)
+	}
+}
+
+// TestInMemoryKeyStore_DeleteNonexistent tests deleting a key that doesn't exist
+func TestInMemoryKeyStore_DeleteNonexistent(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+
+	err := ks.DeleteKey("nonexistent")
+	if err != oa.ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound, got %v", err)
+	}
+}
+
+// TestInMemoryKeyStore_OverwriteKey tests that re-registering overwrites
+func TestInMemoryKeyStore_OverwriteKey(t *testing.T) {
+	ks := oa.NewInMemoryKeyStore()
+
+	if err := ks.RegisterKey("host-abc", []byte("old-secret"), "HS256"); err != nil {
+		t.Fatalf("RegisterKey failed: %v", err)
+	}
+
+	// Overwrite with new secret and alg
+	if err := ks.RegisterKey("host-abc", []byte("new-secret"), "HS512"); err != nil {
+		t.Fatalf("RegisterKey overwrite failed: %v", err)
+	}
+
+	key, _ := ks.GetVerifyKey("host-abc")
+	if string(key.([]byte)) != "new-secret" {
+		t.Error("Expected overwritten secret")
+	}
+
+	alg, _ := ks.GetExpectedAlg("host-abc")
+	if alg != "HS512" {
+		t.Errorf("Expected overwritten alg HS512, got %s", alg)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CustomClaimsFunc` on `APIAuth` for injecting custom claims into JWTs (standard claims cannot be overridden; attempts are logged)
- Add `KeyStore` interface and `InMemoryKeyStore` for multi-tenant signing key lookup
- Add `KeyStore` field on `APIMiddleware` — per-client JWT verification with algorithm confusion prevention
- Export `CreateAccessToken` and add `ValidateAccessTokenFull` for custom claims extraction
- Falls back to single `JWTSecretKey` when `KeyStore` is nil (fully backwards-compatible)
- 16 new tests, all existing tests pass
- Updated README, DEVELOPER_GUIDE, USER_GUIDE, ARCHITECTURE, NEXTSTEPS, SUMMARY

Closes #2

## Test plan

- [x] `go test ./...` — all tests pass (existing + 16 new)
- [x] Custom claims round-trip (mint with custom claims, validate, extract)
- [x] Custom claims nil callback — existing behavior unchanged
- [x] Custom claims error propagation
- [x] Standard claim override prevention (logged and ignored)
- [x] Multi-tenant: two hosts with different secrets, both verified correctly
- [x] Multi-tenant: wrong secret rejected
- [x] Multi-tenant: unknown client_id rejected
- [x] Algorithm confusion: HS256 token rejected when client registered as HS512
- [x] Single-key fallback when KeyStore is nil
- [x] InMemoryKeyStore CRUD (register, get, delete, overwrite, not-found)