### PR TITLE
feat: AS metadata cache + proactive token refresh

### DIFF
--- a/client/as_cache.go
+++ b/client/as_cache.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultASCacheTTL is the default time-to-live for cached AS metadata entries.
+// AS metadata changes rarely (endpoint rotations, scope additions), so a 1-hour
+// TTL balances freshness against redundant HTTP fetches.
+const DefaultASCacheTTL = 1 * time.Hour
+
+// ASMetadataStore caches OAuth Authorization Server metadata by issuer URL.
+// Implementations must be safe for concurrent use by multiple goroutines.
+//
+// A store is typically shared across multiple [OAuthTokenSource] instances in
+// the same process, so that N resource servers sharing one AS only trigger one
+// discovery fetch instead of N.
+//
+// The store is a hot-path optimization: discovery is cheap (one HTTP fetch) but
+// redundant across concurrent token sources. Callers opt in by passing a store
+// to [WithASMetadataStore].
+type ASMetadataStore interface {
+	// Get returns the cached metadata for an issuer if present and not expired.
+	// Returns (nil, false) on cache miss or expiry.
+	Get(issuer string) (*ASMetadata, bool)
+
+	// Put stores metadata for an issuer with the given TTL. A TTL of 0 means
+	// use the store's default. Put replaces any existing entry for the issuer.
+	Put(issuer string, md *ASMetadata, ttl time.Duration)
+}
+
+// MemoryASMetadataStore is an in-memory [ASMetadataStore] backed by a
+// sync.RWMutex-protected map. Suitable for single-process deployments where
+// all token sources run in the same binary.
+//
+// Entries expire lazily on Get — there is no background eviction goroutine.
+// Expired entries stay in the map until a Get or Put touches them, which
+// is fine for bounded-size workloads (one entry per unique issuer URL).
+type MemoryASMetadataStore struct {
+	mu         sync.RWMutex
+	cache      map[string]*cachedAS
+	defaultTTL time.Duration
+}
+
+// cachedAS wraps metadata with an expiry time for lazy TTL eviction.
+type cachedAS struct {
+	md     *ASMetadata
+	expiry time.Time
+}
+
+// NewMemoryASMetadataStore creates a new in-memory AS metadata store.
+// If defaultTTL is 0, [DefaultASCacheTTL] is used.
+func NewMemoryASMetadataStore(defaultTTL time.Duration) *MemoryASMetadataStore {
+	if defaultTTL <= 0 {
+		defaultTTL = DefaultASCacheTTL
+	}
+	return &MemoryASMetadataStore{
+		cache:      make(map[string]*cachedAS),
+		defaultTTL: defaultTTL,
+	}
+}
+
+// Get returns cached metadata for an issuer if present and not expired.
+// Expired entries are removed lazily on access.
+func (s *MemoryASMetadataStore) Get(issuer string) (*ASMetadata, bool) {
+	s.mu.RLock()
+	entry, ok := s.cache[issuer]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiry) {
+		// Expired — remove and return miss
+		s.mu.Lock()
+		delete(s.cache, issuer)
+		s.mu.Unlock()
+		return nil, false
+	}
+	return entry.md, true
+}
+
+// Put stores metadata for an issuer with the given TTL. If ttl is 0, the
+// store's default TTL is used.
+func (s *MemoryASMetadataStore) Put(issuer string, md *ASMetadata, ttl time.Duration) {
+	if ttl <= 0 {
+		ttl = s.defaultTTL
+	}
+	s.mu.Lock()
+	s.cache[issuer] = &cachedAS{
+		md:     md,
+		expiry: time.Now().Add(ttl),
+	}
+	s.mu.Unlock()
+}
+
+// Compile-time interface compliance check.
+var _ ASMetadataStore = (*MemoryASMetadataStore)(nil)

--- a/client/as_cache_test.go
+++ b/client/as_cache_test.go
@@ -1,0 +1,195 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestMemoryASMetadataStorePutGet verifies basic round-trip: Put stores
+// metadata, Get returns it within the TTL window. This is the foundation
+// for caching AS discovery across multiple consumers.
+func TestMemoryASMetadataStorePutGet(t *testing.T) {
+	store := NewMemoryASMetadataStore(0) // use default TTL
+
+	md := &ASMetadata{
+		Issuer:        "https://auth.example.com",
+		TokenEndpoint: "https://auth.example.com/token",
+	}
+	store.Put("https://auth.example.com", md, 0)
+
+	got, ok := store.Get("https://auth.example.com")
+	if !ok {
+		t.Fatal("expected cache hit, got miss")
+	}
+	if got.Issuer != md.Issuer {
+		t.Errorf("Issuer mismatch: got %q, want %q", got.Issuer, md.Issuer)
+	}
+	if got.TokenEndpoint != md.TokenEndpoint {
+		t.Errorf("TokenEndpoint mismatch: got %q, want %q", got.TokenEndpoint, md.TokenEndpoint)
+	}
+}
+
+// TestMemoryASMetadataStoreMiss verifies that Get returns (nil, false) for
+// issuers that haven't been Put, ensuring no false positives for cold cache.
+func TestMemoryASMetadataStoreMiss(t *testing.T) {
+	store := NewMemoryASMetadataStore(0)
+	md, ok := store.Get("https://never-cached.example.com")
+	if ok {
+		t.Error("expected cache miss, got hit")
+	}
+	if md != nil {
+		t.Error("expected nil metadata on miss")
+	}
+}
+
+// TestMemoryASMetadataStoreExpiry verifies that entries expire after their
+// TTL and are evicted on the next Get. This is the lazy eviction contract:
+// no background goroutine, expiry happens on access.
+func TestMemoryASMetadataStoreExpiry(t *testing.T) {
+	store := NewMemoryASMetadataStore(0)
+
+	md := &ASMetadata{Issuer: "https://auth.example.com"}
+	store.Put("https://auth.example.com", md, 10*time.Millisecond)
+
+	// Immediate Get should hit
+	if _, ok := store.Get("https://auth.example.com"); !ok {
+		t.Error("expected immediate hit")
+	}
+
+	// Wait for expiry
+	time.Sleep(20 * time.Millisecond)
+
+	// Should be a miss (and evicted)
+	if _, ok := store.Get("https://auth.example.com"); ok {
+		t.Error("expected miss after TTL expiry")
+	}
+}
+
+// TestMemoryASMetadataStoreDefaultTTL verifies that Put with ttl=0 uses
+// the store's default TTL, allowing callers to opt out of per-call TTL.
+func TestMemoryASMetadataStoreDefaultTTL(t *testing.T) {
+	store := NewMemoryASMetadataStore(50 * time.Millisecond)
+
+	md := &ASMetadata{Issuer: "https://auth.example.com"}
+	store.Put("https://auth.example.com", md, 0) // use default
+
+	// Should hit immediately
+	if _, ok := store.Get("https://auth.example.com"); !ok {
+		t.Error("expected hit with default TTL")
+	}
+
+	// Should expire after default TTL
+	time.Sleep(100 * time.Millisecond)
+	if _, ok := store.Get("https://auth.example.com"); ok {
+		t.Error("expected miss after default TTL expiry")
+	}
+}
+
+// TestDiscoverASUsesCache verifies that DiscoverAS with WithASMetadataStore
+// hits the cache on the second call instead of making an HTTP request.
+// This is the primary value of the cache: avoiding redundant discovery
+// fetches across multiple resource servers sharing one AS.
+func TestDiscoverASUsesCache(t *testing.T) {
+	var fetchCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"issuer":"http://test","token_endpoint":"http://test/token"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	store := NewMemoryASMetadataStore(0)
+
+	// First call — should fetch
+	md1, err := DiscoverAS(ts.URL, WithASMetadataStore(store))
+	if err != nil {
+		t.Fatalf("first DiscoverAS failed: %v", err)
+	}
+	if md1.Issuer != "http://test" {
+		t.Errorf("unexpected issuer: %q", md1.Issuer)
+	}
+	if got := fetchCount.Load(); got != 1 {
+		t.Errorf("expected 1 fetch after first call, got %d", got)
+	}
+
+	// Second call — should hit cache
+	md2, err := DiscoverAS(ts.URL, WithASMetadataStore(store))
+	if err != nil {
+		t.Fatalf("second DiscoverAS failed: %v", err)
+	}
+	if md2.Issuer != "http://test" {
+		t.Errorf("unexpected issuer on second call: %q", md2.Issuer)
+	}
+	if got := fetchCount.Load(); got != 1 {
+		t.Errorf("expected still 1 fetch (cache hit), got %d", got)
+	}
+}
+
+// TestDiscoverASCacheMissOnExpiry verifies that expired cache entries
+// trigger a fresh HTTP fetch, ensuring stale metadata doesn't persist
+// beyond its TTL.
+func TestDiscoverASCacheMissOnExpiry(t *testing.T) {
+	var fetchCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"issuer":"http://test","token_endpoint":"http://test/token"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	store := NewMemoryASMetadataStore(10 * time.Millisecond)
+
+	// First call fetches and caches
+	_, err := DiscoverAS(ts.URL, WithASMetadataStore(store))
+	if err != nil {
+		t.Fatalf("first DiscoverAS failed: %v", err)
+	}
+	if got := fetchCount.Load(); got != 1 {
+		t.Errorf("expected 1 fetch, got %d", got)
+	}
+
+	// Wait for cache expiry
+	time.Sleep(20 * time.Millisecond)
+
+	// Second call should fetch again (cache expired)
+	_, err = DiscoverAS(ts.URL, WithASMetadataStore(store))
+	if err != nil {
+		t.Fatalf("second DiscoverAS failed: %v", err)
+	}
+	if got := fetchCount.Load(); got != 2 {
+		t.Errorf("expected 2 fetches after expiry, got %d", got)
+	}
+}
+
+// TestDiscoverASNoCache verifies that DiscoverAS without a store continues
+// to fetch on every call, preserving backward compatibility for callers
+// that don't opt into caching.
+func TestDiscoverASNoCache(t *testing.T) {
+	var fetchCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"issuer":"http://test","token_endpoint":"http://test/token"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	_, _ = DiscoverAS(ts.URL)
+	_, _ = DiscoverAS(ts.URL)
+	_, _ = DiscoverAS(ts.URL)
+
+	if got := fetchCount.Load(); got != 3 {
+		t.Errorf("expected 3 fetches without cache, got %d", got)
+	}
+}

--- a/client/client_credentials_source.go
+++ b/client/client_credentials_source.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -51,15 +52,49 @@ type ClientCredentialsSource struct {
 	// Audience is the resource server's canonical URI (RFC 8707 resource indicator).
 	Audience string
 
+	// Refresher enables proactive token refresh before expiry. When nil or
+	// Refresher.Buffer == 0, refresh is reactive — happens on the next
+	// Token() call after expiry.
+	//
+	// Typical values: Buffer of 30s-60s for tokens with 5-15 minute lifetimes.
+	// The goroutine starts lazily on the first Token() call and runs until
+	// Close() is called on the source.
+	Refresher *ProactiveRefresher
+
 	mu     sync.Mutex
 	client *AuthClient
 	token  string
 	expiry time.Time
 }
 
+// ProactiveRefresher configures and manages background token refresh before
+// expiry. It bundles the refresh policy (Buffer) with the runtime state
+// needed to coordinate the background goroutine lifecycle.
+type ProactiveRefresher struct {
+	// Buffer is how long before token expiry to refresh. Must be positive
+	// to enable proactive refresh. A buffer of 30s means the refresh fires
+	// 30 seconds before the token would have expired reactively.
+	Buffer time.Duration
+
+	// Runtime state — do not set these; managed internally.
+	once   sync.Once
+	stop   chan struct{}
+	closed bool
+}
+
 // Token returns a cached access token if still valid, or fetches a new one
 // via the client_credentials grant.
+//
+// If Refresher.Buffer > 0, the background refresh goroutine starts lazily
+// on the first Token() call.
 func (s *ClientCredentialsSource) Token() (string, error) {
+	if s.Refresher != nil && s.Refresher.Buffer > 0 {
+		s.Refresher.once.Do(func() {
+			s.Refresher.stop = make(chan struct{})
+			go s.backgroundRefresh()
+		})
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -67,6 +102,12 @@ func (s *ClientCredentialsSource) Token() (string, error) {
 		return s.token, nil
 	}
 
+	return s.fetchTokenLocked()
+}
+
+// fetchTokenLocked performs a client_credentials token fetch.
+// Caller must hold s.mu.
+func (s *ClientCredentialsSource) fetchTokenLocked() (string, error) {
 	if s.client == nil {
 		s.client = NewAuthClient(s.TokenEndpoint, nil,
 			WithASMetadata(&ASMetadata{TokenEndpoint: s.TokenEndpoint}))
@@ -80,6 +121,79 @@ func (s *ClientCredentialsSource) Token() (string, error) {
 	s.token = cred.AccessToken
 	s.expiry = cred.ExpiresAt
 	return s.token, nil
+}
+
+// backgroundRefresh runs in a goroutine and refreshes the token before
+// its expiry. It sleeps until (expiry - Refresher.Buffer), refreshes, and
+// repeats. If the token is not yet fetched, it polls briefly.
+//
+// On refresh failure, it logs and retries after a short backoff — the
+// next Token() call will trigger a reactive refresh if the current token
+// has actually expired by then.
+func (s *ClientCredentialsSource) backgroundRefresh() {
+	// Minimum wait between iterations to prevent tight-loops when refresh
+	// fails or when we're already past the refresh time.
+	const minWait = 500 * time.Millisecond
+
+	for {
+		s.mu.Lock()
+		expiry := s.expiry
+		s.mu.Unlock()
+
+		var wait time.Duration
+		switch {
+		case expiry.IsZero():
+			// Token not yet fetched — poll briefly and re-check.
+			wait = minWait
+		default:
+			refreshAt := expiry.Add(-s.Refresher.Buffer)
+			wait = time.Until(refreshAt)
+			if wait < minWait {
+				wait = minWait
+			}
+		}
+
+		select {
+		case <-s.Refresher.stop:
+			return
+		case <-time.After(wait):
+			if !expiry.IsZero() && time.Now().After(expiry.Add(-s.Refresher.Buffer)) {
+				s.doBackgroundRefresh()
+			}
+		}
+	}
+}
+
+// doBackgroundRefresh fetches a new token and updates the cache under lock.
+// Failures are logged and swallowed — the next Token() call will retry
+// reactively if the token is actually expired by then.
+func (s *ClientCredentialsSource) doBackgroundRefresh() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.fetchTokenLocked(); err != nil {
+		log.Printf("oneauth: proactive token refresh failed: %v (will retry reactively)", err)
+	}
+}
+
+// Close stops the background refresh goroutine if one is running.
+// Safe to call multiple times. Returns nil always (io.Closer compliance).
+// After Close, subsequent Token() calls still work reactively.
+func (s *ClientCredentialsSource) Close() error {
+	if s.Refresher == nil {
+		return nil
+	}
+	// Guard against double-close: the stop channel may not exist if
+	// Token() was never called.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Refresher.closed {
+		return nil
+	}
+	s.Refresher.closed = true
+	if s.Refresher.stop != nil {
+		close(s.Refresher.stop)
+	}
+	return nil
 }
 
 // TokenForScopes invalidates the cached token, merges the requested scopes

--- a/client/client_credentials_source_test.go
+++ b/client/client_credentials_source_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -222,6 +223,125 @@ func TestClientCredentialsSource_CloseIdempotent(t *testing.T) {
 	// Double close — should not panic
 	require.NoError(t, src.Close())
 	require.NoError(t, src.Close())
+}
+
+// TestClientCredentialsSource_TokenForScopesConcurrent verifies that
+// concurrent calls to TokenForScopes from multiple goroutines correctly
+// accumulate scopes via core.UnionScopes without losing any. The mutex
+// on the source ensures serial execution of the update, so the final
+// Scopes set should contain the union of all requested scopes (#138).
+func TestClientCredentialsSource_TokenForScopesConcurrent(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Scopes:        []string{"base"},
+	}
+
+	// Fetch initial token
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	// 5 goroutines each requesting different scopes
+	var wg sync.WaitGroup
+	scopeRequests := [][]string{
+		{"read"},
+		{"write"},
+		{"admin"},
+		{"delete"},
+		{"audit"},
+	}
+	for _, scopes := range scopeRequests {
+		wg.Add(1)
+		go func(s []string) {
+			defer wg.Done()
+			_, err := src.TokenForScopes(s)
+			if err != nil {
+				t.Errorf("TokenForScopes(%v) failed: %v", s, err)
+			}
+		}(scopes)
+	}
+	wg.Wait()
+
+	// All 5 scopes + initial "base" should be present in src.Scopes
+	expected := []string{"admin", "audit", "base", "delete", "read", "write"}
+	src.mu.Lock()
+	got := src.Scopes
+	src.mu.Unlock()
+	assert.ElementsMatch(t, expected, got,
+		"concurrent TokenForScopes should accumulate all scopes via union")
+}
+
+// TestClientCredentialsSource_TokenForScopesEmptySlice verifies that
+// calling TokenForScopes with an empty slice does NOT clear the existing
+// scope set (union with empty leaves current unchanged). This preserves
+// accumulated scopes in the edge case where a caller passes nil or []
+// defensively (#138).
+func TestClientCredentialsSource_TokenForScopesEmptySlice(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Scopes:        []string{"read", "write"},
+	}
+
+	// Establish scope set
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	// Call TokenForScopes with empty slice
+	_, err = src.TokenForScopes([]string{})
+	require.NoError(t, err)
+
+	// Scopes should be unchanged
+	src.mu.Lock()
+	got := src.Scopes
+	src.mu.Unlock()
+	assert.ElementsMatch(t, []string{"read", "write"}, got,
+		"empty slice should not clear existing scopes")
+}
+
+// TestClientCredentialsSource_TokenForScopesTriggersRefetch verifies that
+// calling TokenForScopes invalidates the cached token and triggers a
+// fresh fetch with the accumulated scopes (#138). Without cache
+// invalidation, a step-up call could return the stale narrow-scope token.
+func TestClientCredentialsSource_TokenForScopesTriggersRefetch(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Scopes:        []string{"read"},
+	}
+
+	// Initial fetch
+	tok1, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), count.Load())
+
+	// Another Token() call — should return cached
+	tok2, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, tok1, tok2)
+	assert.Equal(t, int32(1), count.Load())
+
+	// TokenForScopes should invalidate cache and refetch
+	tok3, err := src.TokenForScopes([]string{"write"})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), count.Load(), "TokenForScopes should trigger refetch")
+	// The returned token should differ from the cached one (fresh fetch)
+	assert.NotEqual(t, tok1, tok3)
 }
 
 // TestClientCredentialsSource_CloseWithoutRefresher verifies that Close()

--- a/client/client_credentials_source_test.go
+++ b/client/client_credentials_source_test.go
@@ -125,3 +125,118 @@ func TestClientCredentialsSource_TokenForScopes(t *testing.T) {
 	// Scopes should be merged (union) and sorted
 	assert.Equal(t, []string{"read", "write"}, src.Scopes)
 }
+
+// TestClientCredentialsSource_ProactiveRefresh verifies that when Refresher
+// is configured with a positive Buffer, a background goroutine refreshes
+// the token before its natural expiry. This avoids latency spikes on the
+// hot path for long-running M2M agents.
+func TestClientCredentialsSource_ProactiveRefresh(t *testing.T) {
+	var count atomic.Int32
+	// Token expires in 2s, refresh 1s before expiry = refresh fires at ~1s
+	// (minWait between iterations is 500ms, so this is comfortably above it)
+	srv := tokenServer(t, 2*time.Second, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Refresher: &ProactiveRefresher{
+			Buffer: 1 * time.Second,
+		},
+	}
+	defer src.Close()
+
+	// First Token() call fetches + starts background refresh
+	_, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), count.Load())
+
+	// Wait long enough for at least one background refresh to fire
+	// (first refresh at +1s, next at +2s)
+	time.Sleep(1500 * time.Millisecond)
+
+	// Count should have increased due to background refresh
+	if got := count.Load(); got < 2 {
+		t.Errorf("expected at least 2 token fetches (initial + background), got %d", got)
+	}
+}
+
+// TestClientCredentialsSource_CloseStopsRefresher verifies that Close()
+// stops the background refresh goroutine. After Close, no further token
+// fetches should occur from the background goroutine.
+func TestClientCredentialsSource_CloseStopsRefresher(t *testing.T) {
+	var count atomic.Int32
+	// Long-lived token so reactive path doesn't fire
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Refresher: &ProactiveRefresher{
+			Buffer: 30 * time.Second,
+		},
+	}
+
+	// Start the refresher
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	// Close before any background refresh fires
+	require.NoError(t, src.Close())
+
+	// Capture count after close
+	beforeClose := count.Load()
+
+	// Wait long enough that background refresh would have fired if still running
+	time.Sleep(1 * time.Second)
+
+	// Count should not have increased
+	afterWait := count.Load()
+	if afterWait != beforeClose {
+		t.Errorf("expected no fetches after Close, got %d -> %d", beforeClose, afterWait)
+	}
+}
+
+// TestClientCredentialsSource_CloseIdempotent verifies that Close() can be
+// called multiple times without panicking or returning an error.
+func TestClientCredentialsSource_CloseIdempotent(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Refresher: &ProactiveRefresher{
+			Buffer: 30 * time.Second,
+		},
+	}
+
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	// Double close — should not panic
+	require.NoError(t, src.Close())
+	require.NoError(t, src.Close())
+}
+
+// TestClientCredentialsSource_CloseWithoutRefresher verifies that Close()
+// is safe to call when no Refresher is configured (reactive-only mode).
+func TestClientCredentialsSource_CloseWithoutRefresher(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		// No Refresher
+	}
+
+	require.NoError(t, src.Close()) // should be no-op
+}

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -40,6 +40,8 @@ type DiscoveryOption func(*discoveryConfig)
 
 type discoveryConfig struct {
 	httpClient *http.Client
+	store      ASMetadataStore
+	cacheTTL   time.Duration
 }
 
 // WithHTTPClientForDiscovery sets a custom HTTP client for the discovery request.
@@ -47,6 +49,33 @@ type discoveryConfig struct {
 func WithHTTPClientForDiscovery(client *http.Client) DiscoveryOption {
 	return func(cfg *discoveryConfig) {
 		cfg.httpClient = client
+	}
+}
+
+// WithASMetadataStore enables caching of AS metadata via the given store.
+// When set, DiscoverAS checks the store first and returns the cached value
+// on hit. On miss, it fetches from the well-known endpoint and stores the
+// result with the configured TTL (or the store's default).
+//
+// Typical usage is to share a single store across multiple token sources
+// in the same process:
+//
+//	cache := client.NewMemoryASMetadataStore(0)
+//	md1, _ := client.DiscoverAS("https://auth.example.com", client.WithASMetadataStore(cache))
+//	md2, _ := client.DiscoverAS("https://auth.example.com", client.WithASMetadataStore(cache))
+//	// md2 returned from cache; no second HTTP fetch.
+func WithASMetadataStore(store ASMetadataStore) DiscoveryOption {
+	return func(cfg *discoveryConfig) {
+		cfg.store = store
+	}
+}
+
+// WithASCacheTTL sets a custom TTL for cache writes during discovery.
+// Only applies when a store is also provided via WithASMetadataStore.
+// A TTL of 0 uses the store's default TTL.
+func WithASCacheTTL(ttl time.Duration) DiscoveryOption {
+	return func(cfg *discoveryConfig) {
+		cfg.cacheTTL = ttl
 	}
 }
 
@@ -76,6 +105,13 @@ func DiscoverAS(issuerURL string, opts ...DiscoveryOption) (*ASMetadata, error) 
 	// Normalize: strip trailing slash
 	issuerURL = strings.TrimRight(issuerURL, "/")
 
+	// Check cache first if configured
+	if cfg.store != nil {
+		if md, ok := cfg.store.Get(issuerURL); ok {
+			return md, nil
+		}
+	}
+
 	// Build discovery URLs based on whether the issuer has a path
 	urls := buildDiscoveryURLs(issuerURL)
 
@@ -83,6 +119,10 @@ func DiscoverAS(issuerURL string, opts ...DiscoveryOption) (*ASMetadata, error) 
 	for _, u := range urls {
 		meta, err := fetchMetadata(cfg.httpClient, u)
 		if err == nil {
+			// Store in cache if configured
+			if cfg.store != nil {
+				cfg.store.Put(issuerURL, meta, cfg.cacheTTL)
+			}
 			return meta, nil
 		}
 		lastErr = err

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>claude/mcpkit-issue-158-gR17h</strong> | Commit: <code>2b7c6dd</code> | Date: 2026-04-09 00:33:21</div>
+<div class='meta'>Branch: <strong>feature/as-cache-and-proactive-refresh</strong> | Commit: <code>2cca692</code> | Date: 2026-04-10 13:37:55</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit</td><td class='pass'>PASS</td></tr>
@@ -31,11 +31,11 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Thu Apr  9 00:30:53 PDT 2026
+Started: Fri Apr 10 13:35:42 PDT 2026
 Starting PostgreSQL...
-dab022e8b616a81577cc06acd83e2471e7f402cfeebf23aeca0462b80b6a25b5
+3a86aa60451048d340fb2c0dac47ce94f46524118da42afe38e381f6182d15ae
 Starting Keycloak...
-39aa6d87d57315a576ab2ae2a968f29fdffc17ec9a1bb530861abb8c3e54b8b2
+350bc5ed32b12edaa5125b713c298af9df2932fff83228e5c49e8dcc5c606d9c
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -44,39 +44,39 @@ Starting Keycloak...
 --- [2/9] Unit tests (core + sub-modules race detector) ---
 [unit] Testing core module (race detector)...
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	1.947s
-ok  	github.com/panyam/oneauth/apiauth	30.213s
-ok  	github.com/panyam/oneauth/client	2.592s
-ok  	github.com/panyam/oneauth/client/stores/fs	2.248s
-ok  	github.com/panyam/oneauth/core	2.817s
-ok  	github.com/panyam/oneauth/examples	4.606s
-ok  	github.com/panyam/oneauth/httpauth	3.469s
-ok  	github.com/panyam/oneauth/keys	5.816s
+ok  	github.com/panyam/oneauth/admin	1.625s
+ok  	github.com/panyam/oneauth/apiauth	21.684s
+ok  	github.com/panyam/oneauth/client	6.996s
+ok  	github.com/panyam/oneauth/client/stores/fs	3.266s
+ok  	github.com/panyam/oneauth/core	1.588s
+ok  	github.com/panyam/oneauth/examples	3.390s
+ok  	github.com/panyam/oneauth/httpauth	3.442s
+ok  	github.com/panyam/oneauth/keys	3.697s
 ?   	github.com/panyam/oneauth/keystoretest	[no test files]
-ok  	github.com/panyam/oneauth/localauth	72.801s
-ok  	github.com/panyam/oneauth/stores/fs	2.692s
-ok  	github.com/panyam/oneauth/tests/e2e	23.444s
-ok  	github.com/panyam/oneauth/testutil	7.151s
-ok  	github.com/panyam/oneauth/utils	7.683s
+ok  	github.com/panyam/oneauth/localauth	49.634s
+ok  	github.com/panyam/oneauth/stores/fs	1.981s
+ok  	github.com/panyam/oneauth/tests/e2e	16.029s
+ok  	github.com/panyam/oneauth/testutil	4.860s
+ok  	github.com/panyam/oneauth/utils	4.632s
 [unit] Testing sub-module: stores/gorm
-ok  	github.com/panyam/oneauth/stores/gorm	0.480s
+ok  	github.com/panyam/oneauth/stores/gorm	0.596s
 [unit] Testing sub-module: stores/gae
-ok  	github.com/panyam/oneauth/stores/gae	0.432s
+ok  	github.com/panyam/oneauth/stores/gae	0.484s
 [unit] Testing sub-module: grpc
-ok  	github.com/panyam/oneauth/grpc	0.380s
+ok  	github.com/panyam/oneauth/grpc	0.319s
 [unit] Testing sub-module: oauth2
-ok  	github.com/panyam/oneauth/oauth2	0.359s
+ok  	github.com/panyam/oneauth/oauth2	0.311s
 [unit] Done.
   PASS: unit
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	19.278s
+ok  	github.com/panyam/oneauth/tests/e2e	13.751s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.924s
+ok  	github.com/panyam/oneauth/stores/gorm	0.833s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -87,7 +87,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.388s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.249s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -99,10 +99,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.388s
     ○ ░
     ░    gitleaks
 
-[90m12:32AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m12:32AM[0m [32mINF[0m [1m161 commits scanned.[0m
-[90m12:32AM[0m [32mINF[0m [1mscanned ~2172454 bytes (2.17 MB) in 643ms[0m
-[90m12:32AM[0m [32mINF[0m [1mno leaks found[0m
+[90m1:37PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m1:37PM[0m [32mINF[0m [1m164 commits scanned.[0m
+[90m1:37PM[0m [32mINF[0m [1mscanned ~2210700 bytes (2.21 MB) in 558ms[0m
+[90m1:37PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -113,17 +113,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/09 00:32:45 Using in-memory KeyStore (not persistent)
-2026/04/09 00:32:45 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/09 00:32:45 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/09 00:32:45 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/09 00:33:11 
+2026/04/10 13:37:07 Using in-memory KeyStore (not persistent)
+2026/04/10 13:37:07 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/10 13:37:07 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/10 13:37:07 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/10 13:37:45 
 === EMAIL: Password Reset ===
-2026/04/09 00:33:11 To: zaproxy@example.com
-2026/04/09 00:33:11 Subject: Reset your password
-2026/04/09 00:33:11 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=33b4c7612c426530c55d3ef3b3193d72ecfac49d6a96e0e9ae672067dd938505
-2026/04/09 00:33:11 ==============================
-2026/04/09 00:33:11 error validating user:  invalid credentials
+2026/04/10 13:37:45 To: zaproxy@example.com
+2026/04/10 13:37:45 Subject: Reset your password
+2026/04/10 13:37:45 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=fb9ace421f46532c62c5f8e3b7f9a1f3be4dc847b30d35ce2fc877bec447b3f0
+2026/04/10 13:37:45 ==============================
+2026/04/10 13:37:45 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -193,45 +193,45 @@ IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/ (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Session Management Response Identified [10112] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
-	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 11 
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 18 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/robots.txt (404 Not Found)
-	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Thu Apr  9 00:33:20 PDT 2026
+Finished: Fri Apr 10 13:37:55 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak
 </pre>

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,9 +1,9 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Thu Apr  9 00:30:53 PDT 2026
+Started: Fri Apr 10 13:35:42 PDT 2026
 Starting PostgreSQL...
-dab022e8b616a81577cc06acd83e2471e7f402cfeebf23aeca0462b80b6a25b5
+3a86aa60451048d340fb2c0dac47ce94f46524118da42afe38e381f6182d15ae
 Starting Keycloak...
-39aa6d87d57315a576ab2ae2a968f29fdffc17ec9a1bb530861abb8c3e54b8b2
+350bc5ed32b12edaa5125b713c298af9df2932fff83228e5c49e8dcc5c606d9c
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -12,39 +12,39 @@ Starting Keycloak...
 --- [2/9] Unit tests (core + sub-modules race detector) ---
 [unit] Testing core module (race detector)...
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	1.947s
-ok  	github.com/panyam/oneauth/apiauth	30.213s
-ok  	github.com/panyam/oneauth/client	2.592s
-ok  	github.com/panyam/oneauth/client/stores/fs	2.248s
-ok  	github.com/panyam/oneauth/core	2.817s
-ok  	github.com/panyam/oneauth/examples	4.606s
-ok  	github.com/panyam/oneauth/httpauth	3.469s
-ok  	github.com/panyam/oneauth/keys	5.816s
+ok  	github.com/panyam/oneauth/admin	1.625s
+ok  	github.com/panyam/oneauth/apiauth	21.684s
+ok  	github.com/panyam/oneauth/client	6.996s
+ok  	github.com/panyam/oneauth/client/stores/fs	3.266s
+ok  	github.com/panyam/oneauth/core	1.588s
+ok  	github.com/panyam/oneauth/examples	3.390s
+ok  	github.com/panyam/oneauth/httpauth	3.442s
+ok  	github.com/panyam/oneauth/keys	3.697s
 ?   	github.com/panyam/oneauth/keystoretest	[no test files]
-ok  	github.com/panyam/oneauth/localauth	72.801s
-ok  	github.com/panyam/oneauth/stores/fs	2.692s
-ok  	github.com/panyam/oneauth/tests/e2e	23.444s
-ok  	github.com/panyam/oneauth/testutil	7.151s
-ok  	github.com/panyam/oneauth/utils	7.683s
+ok  	github.com/panyam/oneauth/localauth	49.634s
+ok  	github.com/panyam/oneauth/stores/fs	1.981s
+ok  	github.com/panyam/oneauth/tests/e2e	16.029s
+ok  	github.com/panyam/oneauth/testutil	4.860s
+ok  	github.com/panyam/oneauth/utils	4.632s
 [unit] Testing sub-module: stores/gorm
-ok  	github.com/panyam/oneauth/stores/gorm	0.480s
+ok  	github.com/panyam/oneauth/stores/gorm	0.596s
 [unit] Testing sub-module: stores/gae
-ok  	github.com/panyam/oneauth/stores/gae	0.432s
+ok  	github.com/panyam/oneauth/stores/gae	0.484s
 [unit] Testing sub-module: grpc
-ok  	github.com/panyam/oneauth/grpc	0.380s
+ok  	github.com/panyam/oneauth/grpc	0.319s
 [unit] Testing sub-module: oauth2
-ok  	github.com/panyam/oneauth/oauth2	0.359s
+ok  	github.com/panyam/oneauth/oauth2	0.311s
 [unit] Done.
   PASS: unit
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	19.278s
+ok  	github.com/panyam/oneauth/tests/e2e	13.751s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.924s
+ok  	github.com/panyam/oneauth/stores/gorm	0.833s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -55,7 +55,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.388s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.249s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -67,10 +67,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.388s
     ○ ░
     ░    gitleaks
 
-[90m12:32AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m12:32AM[0m [32mINF[0m [1m161 commits scanned.[0m
-[90m12:32AM[0m [32mINF[0m [1mscanned ~2172454 bytes (2.17 MB) in 643ms[0m
-[90m12:32AM[0m [32mINF[0m [1mno leaks found[0m
+[90m1:37PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m1:37PM[0m [32mINF[0m [1m164 commits scanned.[0m
+[90m1:37PM[0m [32mINF[0m [1mscanned ~2210700 bytes (2.21 MB) in 558ms[0m
+[90m1:37PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -81,17 +81,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/09 00:32:45 Using in-memory KeyStore (not persistent)
-2026/04/09 00:32:45 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/09 00:32:45 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/09 00:32:45 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/09 00:33:11 
+2026/04/10 13:37:07 Using in-memory KeyStore (not persistent)
+2026/04/10 13:37:07 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/10 13:37:07 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/10 13:37:07 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/10 13:37:45 
 === EMAIL: Password Reset ===
-2026/04/09 00:33:11 To: zaproxy@example.com
-2026/04/09 00:33:11 Subject: Reset your password
-2026/04/09 00:33:11 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=33b4c7612c426530c55d3ef3b3193d72ecfac49d6a96e0e9ae672067dd938505
-2026/04/09 00:33:11 ==============================
-2026/04/09 00:33:11 error validating user:  invalid credentials
+2026/04/10 13:37:45 To: zaproxy@example.com
+2026/04/10 13:37:45 Subject: Reset your password
+2026/04/10 13:37:45 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=fb9ace421f46532c62c5f8e3b7f9a1f3be4dc847b30d35ce2fc877bec447b3f0
+2026/04/10 13:37:45 ==============================
+2026/04/10 13:37:45 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -161,44 +161,44 @@ IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/ (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Session Management Response Identified [10112] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
-	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 11 
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 18 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/robots.txt (404 Not Found)
-	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Thu Apr  9 00:33:20 PDT 2026
+Finished: Fri Apr 10 13:37:55 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak


### PR DESCRIPTION
## Summary

Two opt-in auth features driven by mcpkit's #47 and #48:

- **AS metadata cache**: `ASMetadataStore` interface + `MemoryASMetadataStore` impl. `DiscoverAS` accepts `WithASMetadataStore(store)` option. Enables N resource servers sharing one AS to trigger only one discovery HTTP fetch.
- **Proactive token refresh**: New `ProactiveRefresher` type bundles Buffer config + runtime state. `ClientCredentialsSource.Refresher` enables background refresh before token expiry. Implements `io.Closer` to stop the refresh goroutine.

## API

### AS metadata cache
```go
cache := client.NewMemoryASMetadataStore(0) // default TTL 1h

md1, _ := client.DiscoverAS("https://auth.example.com", client.WithASMetadataStore(cache))
md2, _ := client.DiscoverAS("https://auth.example.com", client.WithASMetadataStore(cache))
// md2 returned from cache; no second HTTP fetch.
```

### Proactive refresh
```go
src := &client.ClientCredentialsSource{
    TokenEndpoint: "https://auth.example.com/token",
    ClientID:      "my-client",
    ClientSecret:  "secret",
    Refresher: &client.ProactiveRefresher{
        Buffer: 30 * time.Second, // refresh 30s before expiry
    },
}
defer src.Close() // stop background goroutine

tok, _ := src.Token() // fetches + lazily starts refresh goroutine
```

## Design notes

- Both features are **opt-in** — existing consumers see zero behavior change.
- `ProactiveRefresher` combines configuration (`Buffer`) with runtime state (`once`, `stop`, `closed`) into a single struct so all refresh-related fields are co-located. `ClientCredentialsSource.Refresher` reads cleanly as "configure proactive refresh here".
- `Close()` is idempotent and safe to call without a refresher (no-op).
- Background goroutine uses a min-wait of 500ms to prevent tight-loop on refresh failures. Failures are logged and fall back to reactive refresh on the next `Token()` call.

## Test plan
- [x] 7 new cache tests (put/get, miss, expiry, default TTL, DiscoverAS uses cache, cache miss on expiry, no cache)
- [x] 4 new proactive refresh tests (fires before expiry, Close stops goroutine, Close idempotent, Close safe without refresher)
- [x] All existing tests pass (0 regressions)
- [x] No existing assertions relaxed