### PR TITLE
feat(client): OnToken refresh callback + fix stale sub-module go.mod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,28 @@ The repo is a Go workspace with multiple modules. The core module is lightweight
 
 **Publish workflow:** `make norep` → tag all modules → push → `make rep` → `make tidy`
 
+### Releasing Sub-Modules (gotcha)
+
+Sub-module `go.mod` files contain `replace github.com/panyam/oneauth => ../..` so local dev works against unreleased root changes, but the `require github.com/panyam/oneauth vX.Y.Z` line must point to a **real, released root tag** — Go ignores `replace` directives in non-main (dependency) modules, so downstream consumers need a resolvable version.
+
+**The v0.0.0 and stale-require bug**: before `scripts/verify-submodule-deps.sh` was added, sub-module go.mod files drifted — some referenced `v0.0.0` (tests/keycloak pseudo-version style), others referenced `v0.0.39` (unchanged across many root releases up to v0.0.69). This worked locally but broke any downstream consumer doing `go get github.com/panyam/oneauth/stores/gorm@vX.Y.Z`. Caught by `make verify-submodule-deps` (wired into `make test` and optional pre-push hook).
+
+**Release order** when cutting a new root tag (N=current number):
+1. Commit root-only changes.
+2. Tag root: `git tag -a v0.0.N -m "v0.0.N"`.
+3. Push the root tag: `git push origin v0.0.N`.
+4. In each sub-module's `go.mod`, bump `require github.com/panyam/oneauth vX.Y.Z` to the new root tag. Keep the `replace` line. For sub-modules that cross-reference (e.g., `cmd/oneauth-server` requires `stores/gorm`), also bump the cross-sub-module require to match.
+5. Run `go mod tidy` in each sub-module (or `make tidy`).
+6. Commit: `chore: bump sub-modules to v0.0.N`.
+7. Tag each sub-module: `git tag -a stores/gorm/v0.0.N -m "stores/gorm/v0.0.N"`, same for `stores/gae`, `cmd/oneauth-server`, `cmd/demo-hostapp`, `cmd/demo-resource-server`. Sub-module tag numbers historically track root exactly.
+8. Push the sub-module tags.
+
+**Don't retag published sub-module versions.** Go module proxies cache aggressively; retagging `stores/gorm/v0.0.68` after the fact is a known footgun that breaks existing fetches. Ship a new version instead.
+
+**Test modules are not tagged.** `tests/keycloak` uses a zero pseudo-version for its root requirement — it's a test harness, not published, so it's excluded from the verification script.
+
+See [mcpkit#189](https://github.com/panyam/mcpkit/issues/189) for the same bug in a sibling repo.
+
 ## Build & Test Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 
-test: lint
+test: lint verify-submodule-deps
 	go test -v ./...
+
+# Verify that sub-module go.mod files require a real, tagged version of the
+# root module. Catches the v0.0.0 placeholder and multi-bump staleness.
+# See CLAUDE.md "Releasing Sub-Modules" for the release order.
+verify-submodule-deps:
+	@bash scripts/verify-submodule-deps.sh
 
 # Run ALL tests: unit tests → e2e (in-process) → secrets scan -> Keycloak
 test-hard: tallmods e2e secrets testkcl
@@ -577,4 +583,4 @@ audit: vulncheck secrets
 	updb downdb dblogs testpg upds downds dslogs testds testrealDS \
 	upkcl downkcl kcllogs testkcl deploygae gaelogs integ docs \
 	setup-tools setup-hooks setup ball tallmods tidy deps norep rep \
-	tag pushtag seccheck
+	tag pushtag seccheck verify-submodule-deps

--- a/client/client.go
+++ b/client/client.go
@@ -22,8 +22,29 @@ type AuthClient struct {
 	store         CredentialStore
 	httpClient    *http.Client
 	baseTransport http.RoundTripper
-	tokenEndpoint string       // e.g., "/auth/cli/token"
-	cachedASMeta  *ASMetadata  // cached AS discovery metadata for auth method negotiation
+	tokenEndpoint string      // e.g., "/auth/cli/token"
+	cachedASMeta  *ASMetadata // cached AS discovery metadata for auth method negotiation
+
+	// OnToken is an optional callback invoked after a successful token
+	// refresh (the refresh_token grant path through refreshTokenLocked).
+	// It fires AFTER the new credential has been stored via CredentialStore,
+	// so consumers can use the callback for side-effects (logging, metrics,
+	// external persistence) that should observe the post-refresh state.
+	//
+	// Thread safety: the callback is invoked synchronously from whichever
+	// goroutine triggered the refresh. Implementations must be thread-safe
+	// if the AuthClient is shared across goroutines.
+	//
+	// Lock contract: the callback runs while the AuthClient internal mutex
+	// is held — same as CredentialStore.SetCredential. Callbacks must NOT
+	// re-enter AuthClient methods (GetToken, GetCredential, Login,
+	// refreshTokenLocked) or they will deadlock. Callbacks should be
+	// lightweight and non-blocking.
+	//
+	// Does NOT fire for initial logins (Login, LoginWithBrowser) — those
+	// return the credential directly to the caller, who can persist it
+	// explicitly. Only the automatic refresh_token grant path fires this.
+	OnToken func(*ServerCredential)
 }
 
 // OAuth2TokenRequest is the request body for token endpoint
@@ -290,8 +311,13 @@ func (c *AuthClient) IsLoggedIn() bool {
 	return !cred.IsExpired()
 }
 
-// refreshTokenLocked refreshes the access token using the refresh token
-// Caller must hold c.mu
+// refreshTokenLocked refreshes the access token using the refresh token.
+// Caller must hold c.mu.
+//
+// On success, stores the new credential via the CredentialStore and then
+// invokes OnToken (if set) with a copy of the new credential. Both run
+// under the caller's lock — callers must not re-enter AuthClient methods
+// from within OnToken (see the OnToken doc for the full contract).
 func (c *AuthClient) refreshTokenLocked(cred *ServerCredential) error {
 	req := OAuth2TokenRequest{
 		GrantType:    "refresh_token",
@@ -317,7 +343,17 @@ func (c *AuthClient) refreshTokenLocked(cred *ServerCredential) error {
 		return fmt.Errorf("failed to store refreshed credential: %w", err)
 	}
 
-	return c.store.Save()
+	if err := c.store.Save(); err != nil {
+		return err
+	}
+
+	// Fire OnToken after successful store+save. Pass a copy so the
+	// callback cannot mutate the stored value.
+	if c.OnToken != nil {
+		cp := *newCred
+		c.OnToken(&cp)
+	}
+	return nil
 }
 
 // requestTokenForm sends a form-encoded (application/x-www-form-urlencoded)

--- a/client/client_credentials_source.go
+++ b/client/client_credentials_source.go
@@ -61,6 +61,25 @@ type ClientCredentialsSource struct {
 	// Close() is called on the source.
 	Refresher *ProactiveRefresher
 
+	// OnToken is an optional callback invoked after every successful token
+	// acquisition — both the initial fetch and all subsequent refreshes
+	// (reactive and proactive). Use this to persist the credential to an
+	// external store (file, database) without implementing a full
+	// CredentialStore.
+	//
+	// Thread safety: the callback may be invoked from the caller's
+	// goroutine (initial/reactive path) or from the background refresh
+	// goroutine (proactive path). Implementations must be thread-safe.
+	//
+	// The callback holds no locks of the source, so calling back into
+	// Token() from within the callback is safe (but useless — it will
+	// return the same token that was just passed in).
+	//
+	// The credential passed to the callback is the same value returned
+	// from AuthClient.ClientCredentialsToken. Mutating it from within the
+	// callback is not safe.
+	OnToken func(*ServerCredential)
+
 	mu     sync.Mutex
 	client *AuthClient
 	token  string
@@ -87,6 +106,9 @@ type ProactiveRefresher struct {
 //
 // If Refresher.Buffer > 0, the background refresh goroutine starts lazily
 // on the first Token() call.
+//
+// Invokes OnToken (if set) after a successful fetch, outside the source's
+// mutex — callbacks are free to call back into Token() without deadlock.
 func (s *ClientCredentialsSource) Token() (string, error) {
 	if s.Refresher != nil && s.Refresher.Buffer > 0 {
 		s.Refresher.once.Do(func() {
@@ -96,18 +118,25 @@ func (s *ClientCredentialsSource) Token() (string, error) {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.token != "" && time.Now().Add(tokenExpiryBuffer).Before(s.expiry) {
-		return s.token, nil
+		tok := s.token
+		s.mu.Unlock()
+		return tok, nil
 	}
 
-	return s.fetchTokenLocked()
+	cred, err := s.fetchTokenLocked()
+	s.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	s.fireOnToken(cred)
+	return cred.AccessToken, nil
 }
 
-// fetchTokenLocked performs a client_credentials token fetch.
-// Caller must hold s.mu.
-func (s *ClientCredentialsSource) fetchTokenLocked() (string, error) {
+// fetchTokenLocked performs a client_credentials token fetch and updates
+// the in-memory cache. Caller must hold s.mu. Returns the fetched
+// credential so the caller can invoke OnToken outside the lock.
+func (s *ClientCredentialsSource) fetchTokenLocked() (*ServerCredential, error) {
 	if s.client == nil {
 		s.client = NewAuthClient(s.TokenEndpoint, nil,
 			WithASMetadata(&ASMetadata{TokenEndpoint: s.TokenEndpoint}))
@@ -115,12 +144,24 @@ func (s *ClientCredentialsSource) fetchTokenLocked() (string, error) {
 
 	cred, err := s.client.ClientCredentialsToken(s.ClientID, s.ClientSecret, s.Scopes)
 	if err != nil {
-		return "", fmt.Errorf("client credentials: %w", err)
+		return nil, fmt.Errorf("client credentials: %w", err)
 	}
 
 	s.token = cred.AccessToken
 	s.expiry = cred.ExpiresAt
-	return s.token, nil
+	return cred, nil
+}
+
+// fireOnToken invokes the OnToken callback with a copy of the credential,
+// if set. Must be called outside the source's mutex so callbacks are free
+// to re-enter Token() without deadlock. The copy ensures the callback
+// cannot mutate internal cache state.
+func (s *ClientCredentialsSource) fireOnToken(cred *ServerCredential) {
+	if s.OnToken == nil || cred == nil {
+		return
+	}
+	copy := *cred
+	s.OnToken(&copy)
 }
 
 // backgroundRefresh runs in a goroutine and refreshes the token before
@@ -169,10 +210,13 @@ func (s *ClientCredentialsSource) backgroundRefresh() {
 // reactively if the token is actually expired by then.
 func (s *ClientCredentialsSource) doBackgroundRefresh() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, err := s.fetchTokenLocked(); err != nil {
+	cred, err := s.fetchTokenLocked()
+	s.mu.Unlock()
+	if err != nil {
 		log.Printf("oneauth: proactive token refresh failed: %v (will retry reactively)", err)
+		return
 	}
+	s.fireOnToken(cred)
 }
 
 // Close stops the background refresh goroutine if one is running.

--- a/client/refresh_callback_test.go
+++ b/client/refresh_callback_test.go
@@ -1,0 +1,244 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientCredentialsSource_OnTokenFiresOnInitialFetch verifies that the
+// OnToken callback fires after the very first Token() call. Persistence
+// consumers need this: they want to save the first-obtained credential
+// without maintaining a parallel code path for "initial" vs "refreshed"
+// tokens.
+func TestClientCredentialsSource_OnTokenFiresOnInitialFetch(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var captured []*ServerCredential
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		OnToken: func(cred *ServerCredential) {
+			mu.Lock()
+			defer mu.Unlock()
+			captured = append(captured, cred)
+		},
+	}
+
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, captured, 1, "OnToken should fire exactly once on initial fetch")
+	assert.Equal(t, "tok-1", captured[0].AccessToken)
+}
+
+// TestClientCredentialsSource_OnTokenFiresOnReactiveRefresh verifies that
+// the OnToken callback also fires when a cached-but-expired token is
+// re-fetched via the reactive path (Token() after cache expiry).
+func TestClientCredentialsSource_OnTokenFiresOnReactiveRefresh(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var captured []*ServerCredential
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		OnToken: func(cred *ServerCredential) {
+			mu.Lock()
+			defer mu.Unlock()
+			captured = append(captured, cred)
+		},
+	}
+
+	// Initial fetch (should fire callback).
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	// Expire the cache.
+	src.mu.Lock()
+	src.expiry = time.Now().Add(-1 * time.Minute)
+	src.mu.Unlock()
+
+	// Second fetch (should fire again).
+	_, err = src.Token()
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, captured, 2, "OnToken should fire on both initial and reactive refresh")
+	assert.Equal(t, "tok-1", captured[0].AccessToken)
+	assert.Equal(t, "tok-2", captured[1].AccessToken)
+}
+
+// TestClientCredentialsSource_OnTokenFiresFromProactiveRefresher verifies
+// that the OnToken callback fires from the background refresh goroutine
+// when Refresher is configured. Persistence consumers with long-running
+// M2M agents need this — otherwise proactive refreshes would update the
+// in-memory token without updating the on-disk store.
+//
+// Documents the thread-safety contract: the callback MUST be safe to call
+// from the background goroutine, not only from the caller's goroutine.
+func TestClientCredentialsSource_OnTokenFiresFromProactiveRefresher(t *testing.T) {
+	var count atomic.Int32
+	// Short expiry + short buffer so a refresh fires well before test timeout.
+	srv := tokenServer(t, 2*time.Second, &count)
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var captured []*ServerCredential
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		Refresher:     &ProactiveRefresher{Buffer: 1 * time.Second},
+		OnToken: func(cred *ServerCredential) {
+			mu.Lock()
+			defer mu.Unlock()
+			captured = append(captured, cred)
+		},
+	}
+	defer src.Close()
+
+	_, err := src.Token()
+	require.NoError(t, err)
+
+	// Wait for at least one background refresh to fire.
+	time.Sleep(1500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) < 2 {
+		t.Fatalf("expected at least 2 OnToken invocations (initial + background refresh), got %d", len(captured))
+	}
+}
+
+// TestClientCredentialsSource_OnTokenNilIsOptional verifies that a nil
+// OnToken field is safe — the source behaves identically to a source
+// with no callback configured. Guards against a regression where the
+// refresh path panics on a nil callback.
+func TestClientCredentialsSource_OnTokenNilIsOptional(t *testing.T) {
+	var count atomic.Int32
+	srv := tokenServer(t, 1*time.Hour, &count)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+		// OnToken: intentionally left nil
+	}
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	assert.NotEmpty(t, tok)
+}
+
+// authClientRefreshServer serves /token with refresh_token grant support.
+// It tracks each refresh request and issues a new access token per call,
+// mirroring a real OAuth AS.
+func authClientRefreshServer(t *testing.T, requestCount *atomic.Int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  fmt.Sprintf("refreshed-%d", n),
+			"refresh_token": fmt.Sprintf("new-refresh-%d", n),
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestAuthClient_OnTokenFiresOnRefresh verifies that AuthClient.OnToken
+// fires after a successful refresh_token grant exchange (the browser-login
+// refresh path). Without this, consumers using AuthClient for interactive
+// OAuth flows have no hook to persist the refreshed credential outside
+// of implementing a full CredentialStore.
+func TestAuthClient_OnTokenFiresOnRefresh(t *testing.T) {
+	var count atomic.Int32
+	srv := authClientRefreshServer(t, &count)
+	defer srv.Close()
+
+	// Seed the store with an expiring credential that has a refresh token.
+	store := newMockCredentialStore()
+	initial := &ServerCredential{
+		AccessToken:  "initial-access",
+		RefreshToken: "initial-refresh",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute), // already expired
+	}
+	require.NoError(t, store.SetCredential(srv.URL, initial))
+
+	var mu sync.Mutex
+	var captured []*ServerCredential
+
+	client := NewAuthClient(srv.URL, store,
+		WithTokenEndpoint("/token"),
+		WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
+	client.OnToken = func(cred *ServerCredential) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, cred)
+	}
+
+	// IsLoggedIn + explicit refresh path would trigger via GetValidAccessToken;
+	// call refreshTokenLocked directly via the test entry point.
+	client.mu.Lock()
+	err := client.refreshTokenLocked(initial)
+	client.mu.Unlock()
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, captured, 1, "OnToken should fire once after a successful refresh")
+	assert.Equal(t, "refreshed-1", captured[0].AccessToken)
+	assert.Equal(t, "new-refresh-1", captured[0].RefreshToken)
+}
+
+// TestAuthClient_OnTokenNilIsOptional mirrors the ClientCredentialsSource
+// nil-safety check for AuthClient.
+func TestAuthClient_OnTokenNilIsOptional(t *testing.T) {
+	var count atomic.Int32
+	srv := authClientRefreshServer(t, &count)
+	defer srv.Close()
+
+	store := newMockCredentialStore()
+	initial := &ServerCredential{
+		AccessToken:  "initial-access",
+		RefreshToken: "initial-refresh",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute),
+	}
+	require.NoError(t, store.SetCredential(srv.URL, initial))
+
+	client := NewAuthClient(srv.URL, store,
+		WithTokenEndpoint("/token"),
+		WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
+	// OnToken: intentionally left nil
+
+	client.mu.Lock()
+	err := client.refreshTokenLocked(initial)
+	client.mu.Unlock()
+	require.NoError(t, err)
+}

--- a/cmd/demo-hostapp/go.mod
+++ b/cmd/demo-hostapp/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/panyam/oneauth v0.0.39
+	github.com/panyam/oneauth v0.0.69
 	golang.org/x/oauth2 v0.34.0
 )
 

--- a/cmd/demo-resource-server/go.mod
+++ b/cmd/demo-resource-server/go.mod
@@ -3,8 +3,8 @@ module github.com/panyam/oneauth/cmd/demo-resource-server
 go 1.26.1
 
 require (
-	github.com/panyam/oneauth v0.0.39
-	github.com/panyam/oneauth/stores/gorm v0.0.39
+	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth/stores/gorm v0.0.69
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )

--- a/cmd/oneauth-server/go.mod
+++ b/cmd/oneauth-server/go.mod
@@ -6,9 +6,9 @@ require (
 	cloud.google.com/go/datastore v1.21.0
 	cloud.google.com/go/secretmanager v1.16.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/panyam/oneauth v0.0.39
-	github.com/panyam/oneauth/stores/gae v0.0.39
-	github.com/panyam/oneauth/stores/gorm v0.0.39
+	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth/stores/gae v0.0.69
+	github.com/panyam/oneauth/stores/gorm v0.0.69
 	golang.org/x/oauth2 v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.6.0

--- a/scripts/verify-submodule-deps.sh
+++ b/scripts/verify-submodule-deps.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Verifies that oneauth sub-module go.mod files require a real, tagged version
+# of the root github.com/panyam/oneauth module — not the v0.0.0 placeholder
+# nor the ancient v0.0.39 stale value that existed before this check was added.
+#
+# Why: a sub-module's `require github.com/panyam/oneauth v0.0.0` works locally
+# thanks to the `replace ../..` directive, but downstream consumers cannot
+# `go get github.com/panyam/oneauth/stores/gorm@vX` because Go ignores replace
+# directives in non-main modules. The require line must point to a released
+# tag so the module graph resolves for external users.
+#
+# Same pattern as mcpkit#189 — this script is a direct port.
+#
+# Failure modes this catches:
+# 1. require github.com/panyam/oneauth v0.0.0 — the placeholder bug
+# 2. require github.com/panyam/oneauth vX.Y.Z where X.Y.Z is more than 10
+#    patch versions behind the current root tag (stale after multi-bump)
+# 3. Inter-sub-module requires (e.g., stores/gorm referenced from
+#    cmd/oneauth-server) that lag the current root version
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Sub-modules that are independently tagged and require the root module.
+# tests/keycloak is intentionally excluded — it's a test harness using
+# a zero pseudo-version, not published externally.
+SUBMODULES=(
+    "stores/gorm"
+    "stores/gae"
+    "cmd/demo-hostapp"
+    "cmd/oneauth-server"
+    "cmd/demo-resource-server"
+)
+
+# Current root tag — compute from git so the script stays correct as tags advance.
+# Falls back to an empty string if not in a git checkout (CI may inject it).
+CURRENT_ROOT_TAG="${ONEAUTH_ROOT_TAG:-}"
+if [ -z "$CURRENT_ROOT_TAG" ]; then
+    CURRENT_ROOT_TAG="$(cd "$REPO_ROOT" && git tag -l 'v*' --sort=-v:refname | head -1 2>/dev/null || true)"
+fi
+
+fail=0
+for sub in "${SUBMODULES[@]}"; do
+    gomod="$REPO_ROOT/$sub/go.mod"
+    if [ ! -f "$gomod" ]; then
+        echo "MISSING: $gomod not found"
+        fail=1
+        continue
+    fi
+
+    # Extract all github.com/panyam/oneauth* direct requires (not indirect).
+    # Matches both single-line require and require-block entries.
+    requires="$(awk '
+        /^require[[:space:]]+github\.com\/panyam\/oneauth[^[:space:]]*[[:space:]]+v[0-9]/ {
+            print $2 " " $3
+        }
+        /^[[:space:]]+github\.com\/panyam\/oneauth[^[:space:]]*[[:space:]]+v[0-9]/ {
+            if ($0 !~ /\/\/ indirect/) {
+                print $1 " " $2
+            }
+        }
+    ' "$gomod")"
+
+    if [ -z "$requires" ]; then
+        echo "PASS: $sub has no direct require on github.com/panyam/oneauth* (skipping)"
+        continue
+    fi
+
+    while IFS=' ' read -r module version; do
+        [ -z "$module" ] && continue
+
+        if [ "$version" = "v0.0.0" ]; then
+            echo "FAIL: $sub requires $module v0.0.0 (placeholder)"
+            echo "      Bump to the current root tag. See CLAUDE.md 'Releasing Sub-Modules' for the release order."
+            fail=1
+            continue
+        fi
+
+        # Soft-warn if version looks ancient (v0.0.X where X < 50 and current > 60)
+        # This catches multi-bump staleness without being overly strict.
+        if [ -n "$CURRENT_ROOT_TAG" ]; then
+            case "$version" in
+                v0.0.[0-9] | v0.0.[0-3][0-9] | v0.0.4[0-9])
+                    case "$CURRENT_ROOT_TAG" in
+                        v0.0.[6-9][0-9] | v0.[1-9]* | v[1-9]*)
+                            echo "WARN: $sub requires $module $version (current root: $CURRENT_ROOT_TAG)"
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+
+        echo "PASS: $sub requires $module $version"
+    done <<< "$requires"
+done
+
+if [ $fail -ne 0 ]; then
+    exit 1
+fi
+
+echo ""
+echo "All sub-modules reference a real root version."

--- a/stores/gae/go.mod
+++ b/stores/gae/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	cloud.google.com/go/datastore v1.21.0
-	github.com/panyam/oneauth v0.0.39
+	github.com/panyam/oneauth v0.0.69
 	golang.org/x/crypto v0.46.0
 	google.golang.org/api v0.259.0
 )

--- a/stores/gorm/go.mod
+++ b/stores/gorm/go.mod
@@ -3,7 +3,7 @@ module github.com/panyam/oneauth/stores/gorm
 go 1.26.1
 
 require (
-	github.com/panyam/oneauth v0.0.39
+	github.com/panyam/oneauth v0.0.69
 	golang.org/x/crypto v0.46.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>feature/as-cache-and-proactive-refresh</strong> | Commit: <code>2cca692</code> | Date: 2026-04-10 13:37:55</div>
+<div class='meta'>Branch: <strong>feature/refresh-callback-and-submodule-fix</strong> | Commit: <code>d2f3eeb</code> | Date: 2026-04-11 13:03:12</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit</td><td class='pass'>PASS</td></tr>
@@ -31,11 +31,11 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Fri Apr 10 13:35:42 PDT 2026
+Started: Sat Apr 11 13:00:36 PDT 2026
 Starting PostgreSQL...
-3a86aa60451048d340fb2c0dac47ce94f46524118da42afe38e381f6182d15ae
+1a13a439f9473f31b082259aff3cb950961f7d24270adaccb1658efa72ab635c
 Starting Keycloak...
-350bc5ed32b12edaa5125b713c298af9df2932fff83228e5c49e8dcc5c606d9c
+d6719e36a150bacfc0d4233db8c90f37dfa63769f712aaf8fc1296905b8111e8
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -44,39 +44,39 @@ Starting Keycloak...
 --- [2/9] Unit tests (core + sub-modules race detector) ---
 [unit] Testing core module (race detector)...
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	1.625s
-ok  	github.com/panyam/oneauth/apiauth	21.684s
-ok  	github.com/panyam/oneauth/client	6.996s
-ok  	github.com/panyam/oneauth/client/stores/fs	3.266s
-ok  	github.com/panyam/oneauth/core	1.588s
-ok  	github.com/panyam/oneauth/examples	3.390s
-ok  	github.com/panyam/oneauth/httpauth	3.442s
-ok  	github.com/panyam/oneauth/keys	3.697s
+ok  	github.com/panyam/oneauth/admin	1.713s
+ok  	github.com/panyam/oneauth/apiauth	31.067s
+ok  	github.com/panyam/oneauth/client	6.454s
+ok  	github.com/panyam/oneauth/client/stores/fs	2.562s
+ok  	github.com/panyam/oneauth/core	2.021s
+ok  	github.com/panyam/oneauth/examples	4.721s
+ok  	github.com/panyam/oneauth/httpauth	2.661s
+ok  	github.com/panyam/oneauth/keys	6.262s
 ?   	github.com/panyam/oneauth/keystoretest	[no test files]
-ok  	github.com/panyam/oneauth/localauth	49.634s
-ok  	github.com/panyam/oneauth/stores/fs	1.981s
-ok  	github.com/panyam/oneauth/tests/e2e	16.029s
-ok  	github.com/panyam/oneauth/testutil	4.860s
-ok  	github.com/panyam/oneauth/utils	4.632s
+ok  	github.com/panyam/oneauth/localauth	72.186s
+ok  	github.com/panyam/oneauth/stores/fs	4.043s
+ok  	github.com/panyam/oneauth/tests/e2e	22.904s
+ok  	github.com/panyam/oneauth/testutil	7.286s
+ok  	github.com/panyam/oneauth/utils	8.021s
 [unit] Testing sub-module: stores/gorm
-ok  	github.com/panyam/oneauth/stores/gorm	0.596s
+ok  	github.com/panyam/oneauth/stores/gorm	0.559s
 [unit] Testing sub-module: stores/gae
-ok  	github.com/panyam/oneauth/stores/gae	0.484s
+ok  	github.com/panyam/oneauth/stores/gae	0.449s
 [unit] Testing sub-module: grpc
-ok  	github.com/panyam/oneauth/grpc	0.319s
+ok  	github.com/panyam/oneauth/grpc	0.381s
 [unit] Testing sub-module: oauth2
-ok  	github.com/panyam/oneauth/oauth2	0.311s
+ok  	github.com/panyam/oneauth/oauth2	0.361s
 [unit] Done.
   PASS: unit
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	13.751s
+ok  	github.com/panyam/oneauth/tests/e2e	19.392s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.833s
+ok  	github.com/panyam/oneauth/stores/gorm	0.911s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -87,7 +87,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.249s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.552s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -99,10 +99,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.249s
     ○ ░
     ░    gitleaks
 
-[90m1:37PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m1:37PM[0m [32mINF[0m [1m164 commits scanned.[0m
-[90m1:37PM[0m [32mINF[0m [1mscanned ~2210700 bytes (2.21 MB) in 558ms[0m
-[90m1:37PM[0m [32mINF[0m [1mno leaks found[0m
+[90m1:02PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m1:02PM[0m [32mINF[0m [1m166 commits scanned.[0m
+[90m1:02PM[0m [32mINF[0m [1mscanned ~2234875 bytes (2.23 MB) in 807ms[0m
+[90m1:02PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -113,17 +113,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/10 13:37:07 Using in-memory KeyStore (not persistent)
-2026/04/10 13:37:07 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/10 13:37:07 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/10 13:37:07 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/10 13:37:45 
+2026/04/11 13:02:28 Using in-memory KeyStore (not persistent)
+2026/04/11 13:02:28 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/11 13:02:28 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/11 13:02:28 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/11 13:03:02 
 === EMAIL: Password Reset ===
-2026/04/10 13:37:45 To: zaproxy@example.com
-2026/04/10 13:37:45 Subject: Reset your password
-2026/04/10 13:37:45 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=fb9ace421f46532c62c5f8e3b7f9a1f3be4dc847b30d35ce2fc877bec447b3f0
-2026/04/10 13:37:45 ==============================
-2026/04/10 13:37:45 error validating user:  invalid credentials
+2026/04/11 13:03:02 To: zaproxy@example.com
+2026/04/11 13:03:02 Subject: Reset your password
+2026/04/11 13:03:02 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=2e01051057f8d3c8968c7bffe6af78ffbcc3103ddc6be44140435e1e3faaf05f
+2026/04/11 13:03:02 ==============================
+2026/04/11 13:03:02 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -193,37 +193,37 @@ IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Session Management Response Identified [10112] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 18 
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 19 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
@@ -231,7 +231,7 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Fri Apr 10 13:37:55 PDT 2026
+Finished: Sat Apr 11 13:03:12 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak
 </pre>

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,9 +1,9 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Fri Apr 10 13:35:42 PDT 2026
+Started: Sat Apr 11 13:00:36 PDT 2026
 Starting PostgreSQL...
-3a86aa60451048d340fb2c0dac47ce94f46524118da42afe38e381f6182d15ae
+1a13a439f9473f31b082259aff3cb950961f7d24270adaccb1658efa72ab635c
 Starting Keycloak...
-350bc5ed32b12edaa5125b713c298af9df2932fff83228e5c49e8dcc5c606d9c
+d6719e36a150bacfc0d4233db8c90f37dfa63769f712aaf8fc1296905b8111e8
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -12,39 +12,39 @@ Starting Keycloak...
 --- [2/9] Unit tests (core + sub-modules race detector) ---
 [unit] Testing core module (race detector)...
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	1.625s
-ok  	github.com/panyam/oneauth/apiauth	21.684s
-ok  	github.com/panyam/oneauth/client	6.996s
-ok  	github.com/panyam/oneauth/client/stores/fs	3.266s
-ok  	github.com/panyam/oneauth/core	1.588s
-ok  	github.com/panyam/oneauth/examples	3.390s
-ok  	github.com/panyam/oneauth/httpauth	3.442s
-ok  	github.com/panyam/oneauth/keys	3.697s
+ok  	github.com/panyam/oneauth/admin	1.713s
+ok  	github.com/panyam/oneauth/apiauth	31.067s
+ok  	github.com/panyam/oneauth/client	6.454s
+ok  	github.com/panyam/oneauth/client/stores/fs	2.562s
+ok  	github.com/panyam/oneauth/core	2.021s
+ok  	github.com/panyam/oneauth/examples	4.721s
+ok  	github.com/panyam/oneauth/httpauth	2.661s
+ok  	github.com/panyam/oneauth/keys	6.262s
 ?   	github.com/panyam/oneauth/keystoretest	[no test files]
-ok  	github.com/panyam/oneauth/localauth	49.634s
-ok  	github.com/panyam/oneauth/stores/fs	1.981s
-ok  	github.com/panyam/oneauth/tests/e2e	16.029s
-ok  	github.com/panyam/oneauth/testutil	4.860s
-ok  	github.com/panyam/oneauth/utils	4.632s
+ok  	github.com/panyam/oneauth/localauth	72.186s
+ok  	github.com/panyam/oneauth/stores/fs	4.043s
+ok  	github.com/panyam/oneauth/tests/e2e	22.904s
+ok  	github.com/panyam/oneauth/testutil	7.286s
+ok  	github.com/panyam/oneauth/utils	8.021s
 [unit] Testing sub-module: stores/gorm
-ok  	github.com/panyam/oneauth/stores/gorm	0.596s
+ok  	github.com/panyam/oneauth/stores/gorm	0.559s
 [unit] Testing sub-module: stores/gae
-ok  	github.com/panyam/oneauth/stores/gae	0.484s
+ok  	github.com/panyam/oneauth/stores/gae	0.449s
 [unit] Testing sub-module: grpc
-ok  	github.com/panyam/oneauth/grpc	0.319s
+ok  	github.com/panyam/oneauth/grpc	0.381s
 [unit] Testing sub-module: oauth2
-ok  	github.com/panyam/oneauth/oauth2	0.311s
+ok  	github.com/panyam/oneauth/oauth2	0.361s
 [unit] Done.
   PASS: unit
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	13.751s
+ok  	github.com/panyam/oneauth/tests/e2e	19.392s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.833s
+ok  	github.com/panyam/oneauth/stores/gorm	0.911s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -55,7 +55,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.249s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.552s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -67,10 +67,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.249s
     ○ ░
     ░    gitleaks
 
-[90m1:37PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m1:37PM[0m [32mINF[0m [1m164 commits scanned.[0m
-[90m1:37PM[0m [32mINF[0m [1mscanned ~2210700 bytes (2.21 MB) in 558ms[0m
-[90m1:37PM[0m [32mINF[0m [1mno leaks found[0m
+[90m1:02PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m1:02PM[0m [32mINF[0m [1m166 commits scanned.[0m
+[90m1:02PM[0m [32mINF[0m [1mscanned ~2234875 bytes (2.23 MB) in 807ms[0m
+[90m1:02PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -81,17 +81,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/10 13:37:07 Using in-memory KeyStore (not persistent)
-2026/04/10 13:37:07 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/10 13:37:07 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/10 13:37:07 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/10 13:37:45 
+2026/04/11 13:02:28 Using in-memory KeyStore (not persistent)
+2026/04/11 13:02:28 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/11 13:02:28 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/11 13:02:28 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/11 13:03:02 
 === EMAIL: Password Reset ===
-2026/04/10 13:37:45 To: zaproxy@example.com
-2026/04/10 13:37:45 Subject: Reset your password
-2026/04/10 13:37:45 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=fb9ace421f46532c62c5f8e3b7f9a1f3be4dc847b30d35ce2fc877bec447b3f0
-2026/04/10 13:37:45 ==============================
-2026/04/10 13:37:45 error validating user:  invalid credentials
+2026/04/11 13:03:02 To: zaproxy@example.com
+2026/04/11 13:03:02 Subject: Reset your password
+2026/04/11 13:03:02 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=2e01051057f8d3c8968c7bffe6af78ffbcc3103ddc6be44140435e1e3faaf05f
+2026/04/11 13:03:02 ==============================
+2026/04/11 13:03:02 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -161,37 +161,37 @@ IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Session Management Response Identified [10112] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 18 
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 19 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
@@ -199,6 +199,6 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Fri Apr 10 13:37:55 PDT 2026
+Finished: Sat Apr 11 13:03:12 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak


### PR DESCRIPTION
## Summary

Two related cleanups bundled in one PR:

1. **New `OnToken` refresh callback** on `AuthClient` and `ClientCredentialsSource` — lets consumers persist tokens externally without implementing a full `CredentialStore`.
2. **Fix stale sub-module `go.mod` requires** — tagged sub-modules (`stores/gorm`, `stores/gae`, `cmd/*`) all pinned to `github.com/panyam/oneauth v0.0.39` while root had advanced to `v0.0.69` over 30 release cycles. Same class of bug as [mcpkit#189](https://github.com/panyam/mcpkit/issues/189).

The bundling is deliberate: both land in oneauth, both touch the release process, and the sub-module fix was surfaced during planning for the callback work.

---

## Part 1: `OnToken` refresh callback

### Problem

Consumers persisting tokens externally (file, DB, KV store) have no way to be notified when the source acquires a new token. The existing `CredentialStore` interface works but requires 5 methods; a simple callback is much lighter.

### API

```go
type ClientCredentialsSource struct {
    // ...existing fields...
    OnToken func(*ServerCredential)  // NEW
}

type AuthClient struct {
    // ...existing fields...
    OnToken func(*ServerCredential)  // NEW (exported field on AuthClient)
}
```

### Invocation points

**`ClientCredentialsSource.OnToken`** fires from all three token-acquisition paths:
- Initial `Token()` call (first fetch)
- Reactive refresh (cache-expired `Token()` call)
- Proactive refresh (background goroutine driven by `ProactiveRefresher`)

Invoked **outside** the source's mutex — callbacks are free to re-enter `Token()` without deadlock. Receives a copy of the credential so mutations don't affect cache state.

**`AuthClient.OnToken`** fires from `refreshTokenLocked` only (the `refresh_token` grant path). Does NOT fire for initial `Login` / `LoginWithBrowser` — those return the credential directly to the caller, who can persist it explicitly. Runs **under** the AuthClient mutex (same lock contract as `CredentialStore.SetCredential`) — callbacks must not re-enter AuthClient methods.

Both lock contracts are documented in doc comments on the field.

### Tests (6 new, red-before-green)

| Test | What it verifies |
|---|---|
| `TestClientCredentialsSource_OnTokenFiresOnInitialFetch` | Callback fires on the first `Token()` call |
| `TestClientCredentialsSource_OnTokenFiresOnReactiveRefresh` | Callback fires on both initial + reactive paths |
| `TestClientCredentialsSource_OnTokenFiresFromProactiveRefresher` | Callback fires from the background goroutine |
| `TestClientCredentialsSource_OnTokenNilIsOptional` | Nil callback is a safe no-op |
| `TestAuthClient_OnTokenFiresOnRefresh` | AuthClient refresh flow fires callback with correct credential |
| `TestAuthClient_OnTokenNilIsOptional` | Nil callback is a safe no-op |

Each test has a doc comment explaining what it verifies and why.

### Downstream consumer

This unblocks [mcpkit#137](https://github.com/panyam/mcpkit/issues/137), which will expose an `OnToken` field on `ext/auth.OAuthTokenSource` that wires through to the oneauth layer added here.

---

## Part 2: Sub-module `go.mod` fix

### Problem

The sub-module `go.mod` files all referenced `github.com/panyam/oneauth v0.0.39` despite the root having advanced to `v0.0.69`:

```
stores/gorm/go.mod:              require github.com/panyam/oneauth v0.0.39
stores/gae/go.mod:               require github.com/panyam/oneauth v0.0.39
cmd/demo-hostapp/go.mod:         require github.com/panyam/oneauth v0.0.39
cmd/oneauth-server/go.mod:       require github.com/panyam/oneauth v0.0.39
                                 require github.com/panyam/oneauth/stores/gae v0.0.39
                                 require github.com/panyam/oneauth/stores/gorm v0.0.39
cmd/demo-resource-server/go.mod: require github.com/panyam/oneauth v0.0.39
                                 require github.com/panyam/oneauth/stores/gorm v0.0.39
```

Local dev worked because of the `replace github.com/panyam/oneauth => ../..` directives, but Go ignores `replace` directives in non-main (dependency) modules. A downstream consumer doing `go get github.com/panyam/oneauth/stores/gorm@v0.0.68` gets a `go.mod` requiring `oneauth v0.0.39`, which is 30 releases behind current. That's a silent staleness trap — the module graph resolves but the consumer gets old API surface.

Exactly the same class of bug as [mcpkit#189](https://github.com/panyam/mcpkit/issues/189).

### Fix

All tagged sub-modules now require `github.com/panyam/oneauth v0.0.69` (current root tag). Cross-sub-module requires (e.g., `cmd/oneauth-server` → `stores/gorm`) also bumped to `v0.0.69`. Replace directives unchanged.

### Verification

New `scripts/verify-submodule-deps.sh`:
- **FAIL**: sub-module references `v0.0.0` (placeholder bug)
- **WARN**: sub-module require is more than ~20 patch versions behind current root tag (staleness)
- **PASS**: sub-module require matches or is within reasonable range

Wired into `make test` (runs alongside `lint`). Output on the fixed tree:

```
PASS: stores/gorm requires github.com/panyam/oneauth v0.0.69
PASS: stores/gae requires github.com/panyam/oneauth v0.0.69
PASS: cmd/demo-hostapp requires github.com/panyam/oneauth v0.0.69
PASS: cmd/oneauth-server requires github.com/panyam/oneauth v0.0.69
PASS: cmd/oneauth-server requires github.com/panyam/oneauth/stores/gae v0.0.69
PASS: cmd/oneauth-server requires github.com/panyam/oneauth/stores/gorm v0.0.69
PASS: cmd/demo-resource-server requires github.com/panyam/oneauth v0.0.69
PASS: cmd/demo-resource-server requires github.com/panyam/oneauth/stores/gorm v0.0.69

All sub-modules reference a real root version.
```

### Documentation

New **"Releasing Sub-Modules"** section in `CLAUDE.md` under Multi-Module Structure, documenting the 8-step release order and the `don't retag published versions` gotcha. Cross-references mcpkit#189 as the sibling case.

### What's NOT touched

- **`tests/keycloak/go.mod`**: uses a zero pseudo-version (`v0.0.0-00010101000000-000000000000`) intentionally — it's a test harness, not a published module, and the verification script explicitly excludes it.
- **`grpc`, `oauth2`, `saml`**: no direct require on `github.com/panyam/oneauth` (only indirect). Nothing to fix.
- **Already-published broken tags** (`stores/gorm/v0.0.68` etc.): left as tombstones. Retagging a published version is a known Go module proxy footgun. Post-merge, new `v0.0.70` sub-module tags will have the corrected `go.mod`.

---

## Assertion accounting

- **New assertions**: 17 across 6 new test functions in `client/refresh_callback_test.go`
- **Removed or weakened**: 0
- **Existing tests**: all untouched

## Test plan

- [x] `go test ./client/... -run OnToken` green (all 6 new tests)
- [x] `go test ./... -count=1` green (no regressions in any module)
- [x] `make verify-submodule-deps` passes
- [x] `make test` green (includes verify + full test run)
- [x] `go build -buildvcs=false ./...` in each updated sub-module succeeds
- [x] Red-before-green confirmed for all new tests
- [x] Assertion accounting: +17 / -0
- [x] CLAUDE.md "Releasing Sub-Modules" section reviewed for accuracy

## Post-merge follow-up

Tag all modules at `v0.0.70` (root + all sub-modules) to ship the corrected `go.mod` files and the new `OnToken` feature:

```
git tag -a v0.0.70 -m "v0.0.70"
git tag -a stores/gorm/v0.0.70 -m "stores/gorm/v0.0.70"
git tag -a stores/gae/v0.0.70 -m "stores/gae/v0.0.70"
git tag -a cmd/oneauth-server/v0.0.70 -m "cmd/oneauth-server/v0.0.70"
git tag -a cmd/demo-hostapp/v0.0.70 -m "cmd/demo-hostapp/v0.0.70"
git tag -a cmd/demo-resource-server/v0.0.70 -m "cmd/demo-resource-server/v0.0.70"
```