### PR TITLE
build: add tidy-all and bump-root Makefile targets, align submodules to v0.0.70

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,26 @@ tidy:
 	go mod tidy
 	@for mod in $(SUBMODULES); do (cd $$mod && go mod tidy) || exit 1; done
 
+# Alias for consistency with other projects (mcpkit uses this name).
+tidy-all: tidy
+
+# Bump each sub-module's require github.com/panyam/oneauth to a specific tag.
+# Usage: make bump-root V=v0.0.70
+#
+# Only touches the root self-reference. Cross-sub-module references
+# (e.g. stores/gorm referenced from cmd/oneauth-server) have their own
+# independent timelines and must be bumped manually when needed.
+bump-root:
+	@if [ -z "$(V)" ]; then echo "Usage: make bump-root V=v0.0.70"; exit 1; fi
+	@for mod in $(SUBMODULES); do \
+		if [ ! -f "$$mod/go.mod" ]; then continue; fi; \
+		if ! grep -q "github.com/panyam/oneauth v" "$$mod/go.mod"; then continue; fi; \
+		echo "==> $$mod/go.mod: require github.com/panyam/oneauth $(V)"; \
+		(cd $$mod && go mod edit -require=github.com/panyam/oneauth@$(V)) || exit 1; \
+	done
+	@$(MAKE) -s tidy
+	@$(MAKE) -s verify-submodule-deps
+
 # Dep count for core module
 deps:
 	@echo "Direct: $$(grep -c '^\t' go.mod) | Transitive: $$(go list -m all 2>/dev/null | wc -l | tr -d ' ')"
@@ -582,5 +602,5 @@ audit: vulncheck secrets
 	unit postgres datastore keycloak zap lint secrets vulncheck \
 	updb downdb dblogs testpg upds downds dslogs testds testrealDS \
 	upkcl downkcl kcllogs testkcl deploygae gaelogs integ docs \
-	setup-tools setup-hooks setup ball tallmods tidy deps norep rep \
-	tag pushtag seccheck verify-submodule-deps
+	setup-tools setup-hooks setup ball tallmods tidy tidy-all bump-root \
+	deps norep rep tag pushtag seccheck verify-submodule-deps

--- a/cmd/demo-hostapp/go.mod
+++ b/cmd/demo-hostapp/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth v0.0.70
 	golang.org/x/oauth2 v0.34.0
 )
 

--- a/cmd/demo-resource-server/go.mod
+++ b/cmd/demo-resource-server/go.mod
@@ -3,7 +3,7 @@ module github.com/panyam/oneauth/cmd/demo-resource-server
 go 1.26.1
 
 require (
-	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth v0.0.70
 	github.com/panyam/oneauth/stores/gorm v0.0.69
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1

--- a/cmd/oneauth-server/go.mod
+++ b/cmd/oneauth-server/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/datastore v1.21.0
 	cloud.google.com/go/secretmanager v1.16.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth v0.0.70
 	github.com/panyam/oneauth/stores/gae v0.0.69
 	github.com/panyam/oneauth/stores/gorm v0.0.69
 	golang.org/x/oauth2 v0.34.0

--- a/oauth2/go.mod
+++ b/oauth2/go.mod
@@ -2,6 +2,14 @@ module github.com/panyam/oneauth/oauth2
 
 go 1.26.1
 
-require golang.org/x/oauth2 v0.34.0
+require (
+	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.34.0
+)
 
-require cloud.google.com/go/compute/metadata v0.3.0 // indirect
+require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/oauth2/go.sum
+++ b/oauth2/go.sum
@@ -1,4 +1,14 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/stores/gae/go.mod
+++ b/stores/gae/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	cloud.google.com/go/datastore v1.21.0
-	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth v0.0.70
 	golang.org/x/crypto v0.46.0
 	google.golang.org/api v0.259.0
 )

--- a/stores/gorm/go.mod
+++ b/stores/gorm/go.mod
@@ -3,7 +3,7 @@ module github.com/panyam/oneauth/stores/gorm
 go 1.26.1
 
 require (
-	github.com/panyam/oneauth v0.0.69
+	github.com/panyam/oneauth v0.0.70
 	golang.org/x/crypto v0.46.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0


### PR DESCRIPTION
## Summary

Two small related changes codifying the sub-module release workflow from PR #82:

1. **New Makefile targets** — `tidy-all` (alias for existing `tidy`) and `bump-root V=vX.Y.Z` which automates the \"update sub-module go.mod to a specific root tag\" dance that I was doing by hand in PR #82.

2. **Realign sub-modules to v0.0.70** — after PR #82 tagged v0.0.70, sub-modules were still pinned to v0.0.69 (the pre-PR bump). Ran \`make bump-root V=v0.0.70\` on this branch to demonstrate the target works.

## `bump-root` usage

```bash
make bump-root V=v0.0.70
```

Replaces the manual:

```bash
cd stores/gorm && go mod edit -require=github.com/panyam/oneauth@v0.0.70 && go mod tidy && cd -
cd stores/gae  && go mod edit -require=github.com/panyam/oneauth@v0.0.70 && go mod tidy && cd -
# ...and so on for every sub-module
```

Only touches the root self-reference. Cross-sub-module requires (e.g. \`cmd/oneauth-server\` needing \`stores/gorm\`) have their own independent tag timelines and must still be bumped manually when those sub-modules are re-released.

## Incidental: oauth2 tidy drift

\`make tidy\` picked up a pre-existing drift in \`oauth2/go.mod\`: it was missing \`github.com/stretchr/testify\` even though \`oauth2/pkce_test.go\` imports it. Tests still ran because \`go test\` resolves imports on its own, but the go.mod was out of sync. Folded into this PR since it surfaced via the same tidy run.

## Test plan

- [x] \`make bump-root V=v0.0.70\` runs successfully end-to-end
- [x] \`make verify-submodule-deps\` passes
- [x] \`make tallmods\` green across every module (including stores/gorm, stores/gae, oauth2, grpc, cmd/*)

## Follow-up

mcpkit gets the equivalent \`bump-root\` / \`tidy-all\` targets in its parallel PR (sibling bundle for mcpkit#72 and mcpkit#137).