### PR TITLE
feat: RFC 9396 Rich Authorization Requests — full implementation + interop tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ demo/data/
 .gcloudignore
 .playwright-mcp/
 cmd/oneauth-server/oneauth-server
+rar-test-issuer

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ cmd/oneauth-server/oneauth-server
 /01-client-credentials
 /02-resource-token-hs256
 /03-resource-token-rs256-jwks
+/04-discovery
+/05-introspection
+/06-dynamic-client-registration
+/07-client-sdk
+/08-rich-authorization-requests
+/09-key-rotation
+/10-security

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,8 @@ demo/data/
 .gcloudignore
 .playwright-mcp/
 cmd/oneauth-server/oneauth-server
-rar-test-issuer
+# Built binaries from examples and cmd
+/rar-test-issuer
+/01-client-credentials
+/02-resource-token-hs256
+/03-resource-token-rs256-jwks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ In-process e2e tests using `httptest.NewServer`. Auth server + 2 resource server
 
 | What | Import |
 |---|---|
-| User, Identity, Channel, store interfaces, tokens, credentials, scopes, UnionScopes | `"github.com/panyam/oneauth/core"` |
+| User, Identity, Channel, store interfaces, tokens, credentials, scopes, UnionScopes, AuthorizationDetail (RFC 9396) | `"github.com/panyam/oneauth/core"` |
 | KeyStorage, KeyRecord, InMemoryKeyStore, EncryptedKeyStorage, JWKSHandler | `"github.com/panyam/oneauth/keys"` |
 | AdminAuth, AppRegistrar, MintResourceToken, AppQuota | `"github.com/panyam/oneauth/admin"` |
 | APIAuth, APIMiddleware, IntrospectionHandler, ProtectedResourceMetadata, ASServerMetadata | `"github.com/panyam/oneauth/apiauth"` |
@@ -297,4 +297,5 @@ Design lessons and feedback from past sessions are in `memories/`. See `memories
 - **`make lint`** uses `GOFLAGS=-buildvcs=false` to work in worktrees.
 - **PKCE functions in `client/`** are inlined (not imported from `oauth2/` sub-module) to avoid cross-module dependency. The `oauth2/` sub-module has heavy deps (`golang.org/x/oauth2`).
 - **Token endpoint accepts both form-encoded and JSON** — `APIAuth.ServeHTTP` routes on `Content-Type`: `application/x-www-form-urlencoded` (RFC 6749 standard) or JSON (legacy/convenience). Standard OAuth clients (Keycloak, Auth0, testutil helpers) send form-encoded.
+- **RFC 9396 Rich Authorization Requests** — `authorization_details` parameter is supported on token requests (both form-encoded as a JSON string, and JSON body). The granted details are returned in the token response and embedded in the JWT as an `authorization_details` claim. Introspection responses also include it. `CreateAccessToken` takes `authzDetails []core.AuthorizationDetail` as a third parameter. `standardClaims` guard prevents `CustomClaimsFunc` from overriding it.
 - **Legacy `/api/token` JSON endpoint** — retained for `Login` and `refreshTokenLocked` backward compat. E2E tests now have `/oauth/token` (form-encoded, standards-compliant) for auth code and client_credentials flows. The legacy JSON path (`requestToken`) can be removed once the CLI client (`cmd/oneauth-cli`) migrates to form-encoded requests — tracked as a future cleanup item.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,8 @@ Design lessons and feedback from past sessions are in `memories/`. See `memories
 - PostgreSQL test container: `arm64v8/postgres:18.1` on port 5433
 - Datastore test credentials: `~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json`
 - **Security tests must include `// See:` links** to the relevant RFC, CVE, CWE, or OWASP reference in each test function's doc comment. This makes it easy to trace why a test exists and what attack it prevents. Example: `// See: https://nvd.nist.gov/vuln/detail/CVE-2015-9235`
-- Keycloak interop tests: `quay.io/keycloak/keycloak:26.0` on port 8180, realm config at `tests/keycloak/realm.json`
+- Keycloak interop tests: `quay.io/keycloak/keycloak:26.6` on port 8180, realm config at `tests/keycloak/realm.json`
+- RAR test issuer (`cmd/rar-test-issuer`): port 8181, RFC 9396 interop tests. See `cmd/rar-test-issuer/main.go` header and `tests/keycloak/rar_interop_test.go` for details and KC migration path.
 - **`type: "access"` claim is OneAuth-specific** — external IdP tokens (Keycloak, Auth0) don't have it. The check accepts tokens without the claim; only rejects tokens with `type` set to something other than `"access"` (e.g., refresh tokens).
 - **`aud` claim may be string or array** (RFC 7519 §4.1.3) — `matchesAudience()` helper handles both. Keycloak/Auth0/Azure AD send arrays.
 - **Separate Go modules** (`tests/keycloak/`, `stores/gorm/`, `stores/gae/`, etc.) need `GOWORK=off` or `cd` into the module dir when running outside `go.work`.

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ testrealDS:
 # =============================================================================
 KC_CONTAINER_NAME := oneauth-test-keycloak
 KC_PORT := 8180
-KC_IMAGE := quay.io/keycloak/keycloak:26.0
+KC_IMAGE := quay.io/keycloak/keycloak:26.6
 
 # Start a Keycloak instance using Docker for interop testing
 upkcl:
@@ -459,10 +459,59 @@ testkcl:
 		until curl -sf http://localhost:$(KC_PORT)/realms/oneauth-test > /dev/null 2>&1; do sleep 2; done; \
 		echo "Keycloak ready."; \
 	fi
+	@if ! docker ps --format '{{.Names}}' | grep -q '^$(RAR_CONTAINER_NAME)$$'; then \
+		echo "Building and starting RAR test issuer..."; \
+		docker build -f cmd/rar-test-issuer/Dockerfile -t $(RAR_IMAGE) . > /dev/null 2>&1; \
+		docker run --rm -d --name $(RAR_CONTAINER_NAME) -p $(RAR_PORT):8181 $(RAR_IMAGE); \
+		until curl -sf http://localhost:$(RAR_PORT)/_ah/health > /dev/null 2>&1; do sleep 1; done; \
+		echo "RAR test issuer ready."; \
+	fi
 	cd tests/keycloak && \
 	KEYCLOAK_URL=http://localhost:$(KC_PORT) \
+	RAR_ISSUER_URL=http://localhost:$(RAR_PORT) \
 	GOWORK=off \
 	go test -v -race -count=1 ./...
+
+# =============================================================================
+# RAR Test Issuer — RFC 9396 interop testing
+# =============================================================================
+# A minimal OneAuth-based AS that supports Rich Authorization Requests.
+# Used for interop testing: proves OneAuth resource servers can validate
+# RAR tokens issued by an external AS over real HTTP.
+#
+# Migration path: when Keycloak adds RFC 9396 RAR support on standard OAuth
+# flows (tracked: keycloak/keycloak#29340), migrate these tests to use
+# Keycloak and retire this binary. The tests in tests/keycloak/rar_interop_test.go
+# are structured to make this migration straightforward — swap the URL and
+# client credentials, keep the assertions.
+RAR_CONTAINER_NAME := oneauth-rar-test-issuer
+RAR_PORT := 8181
+RAR_IMAGE := oneauth-rar-test-issuer
+
+# Build the RAR test issuer Docker image
+buildrar:
+	@echo "Building RAR test issuer image..."
+	@docker build -f cmd/rar-test-issuer/Dockerfile -t $(RAR_IMAGE) .
+
+# Start the RAR test issuer container
+uprar: buildrar
+	@echo "Starting RAR test issuer container..."
+	@docker run --rm -d \
+		--name $(RAR_CONTAINER_NAME) \
+		-p $(RAR_PORT):8181 \
+		$(RAR_IMAGE)
+	@echo "Waiting for RAR test issuer to be ready..."
+	@until curl -sf http://localhost:$(RAR_PORT)/_ah/health > /dev/null 2>&1; do sleep 1; done
+	@echo ""
+	@echo "RAR test issuer is running!"
+	@echo "  Discovery: http://localhost:$(RAR_PORT)/.well-known/openid-configuration"
+	@echo "  JWKS:      http://localhost:$(RAR_PORT)/.well-known/jwks.json"
+	@echo "To stop: make downrar"
+
+# Stop the RAR test issuer container
+downrar:
+	@echo "Stopping RAR test issuer container..."
+	@docker stop $(RAR_CONTAINER_NAME) 2>/dev/null || echo "Container not running"
 
 # =============================================================================
 # GAE deployment
@@ -629,7 +678,7 @@ audit: vulncheck secrets
 .PHONY: test test-hard testall test-report e2e audit \
 	unit postgres datastore keycloak zap lint secrets vulncheck \
 	updb downdb dblogs testpg upds downds dslogs testds testrealDS \
-	upkcl downkcl kcllogs testkcl deploygae gaelogs integ docs \
+	upkcl downkcl kcllogs testkcl buildrar uprar downrar deploygae gaelogs integ docs \
 	setup-tools setup-hooks setup ball tallmods tidy tidy-all bump-root \
 	deps norep rep tag pushtag seccheck verify-submodule-deps \
 	cover cover-html cover-func cover-all

--- a/admin/dcr.go
+++ b/admin/dcr.go
@@ -48,6 +48,9 @@ type DCRRequest struct {
 	// Authentication method
 	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
 
+	// RFC 9396 — authorization details types this client intends to use
+	AuthorizationDetailsTypes []string `json:"authorization_details_types,omitempty"`
+
 	// Keys — for asymmetric auth methods (private_key_jwt)
 	JWKS *utils.JWKSet `json:"jwks,omitempty"`
 }
@@ -62,9 +65,10 @@ type DCRResponse struct {
 	ClientName              string   `json:"client_name,omitempty"`
 	ClientURI               string   `json:"client_uri,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris,omitempty"`
-	GrantTypes              []string `json:"grant_types,omitempty"`
-	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
-	Scope                   string   `json:"scope,omitempty"`
+	GrantTypes                []string `json:"grant_types,omitempty"`
+	TokenEndpointAuthMethod   string   `json:"token_endpoint_auth_method,omitempty"`
+	Scope                     string   `json:"scope,omitempty"`
+	AuthorizationDetailsTypes []string `json:"authorization_details_types,omitempty"` // RFC 9396
 }
 
 // ServeHTTP handles POST /register per RFC 7591.
@@ -113,15 +117,16 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := DCRResponse{
-		ClientID:                clientID,
-		ClientIDIssuedAt:        time.Now().Unix(),
-		ClientSecretExpiresAt:   0, // never expires
-		ClientName:              req.ClientName,
-		ClientURI:               req.ClientURI,
-		RedirectURIs:            req.RedirectURIs,
-		GrantTypes:              req.GrantTypes,
-		TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
-		Scope:                   req.Scope,
+		ClientID:                  clientID,
+		ClientIDIssuedAt:          time.Now().Unix(),
+		ClientSecretExpiresAt:     0, // never expires
+		ClientName:                req.ClientName,
+		ClientURI:                 req.ClientURI,
+		RedirectURIs:              req.RedirectURIs,
+		GrantTypes:                req.GrantTypes,
+		TokenEndpointAuthMethod:   req.TokenEndpointAuthMethod,
+		Scope:                     req.Scope,
+		AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
 	}
 
 	if utils.IsAsymmetricAlg(signingAlg) {
@@ -165,10 +170,11 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			domain = req.ClientName
 		}
 		reg := &AppRegistration{
-			ClientID:     clientID,
-			ClientDomain: domain,
-			SigningAlg:   signingAlg,
-			CreatedAt:    time.Now(),
+			ClientID:                  clientID,
+			ClientDomain:              domain,
+			SigningAlg:                signingAlg,
+			AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
+			CreatedAt:                 time.Now(),
 		}
 		h.Registrar.mu.Lock()
 		h.Registrar.apps[clientID] = reg

--- a/admin/mint.go
+++ b/admin/mint.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/utils"
 )
 
@@ -18,8 +19,8 @@ type AppQuota struct {
 
 // MintResourceToken creates a resource-scoped JWT for a user on behalf of a registered App,
 // signed with the app's shared secret (HS256). This is the backwards-compatible API.
-func MintResourceToken(userID, appClientID, appSecret string, quota AppQuota, scopes []string) (string, error) {
-	return MintResourceTokenWithKey(userID, appClientID, []byte(appSecret), quota, scopes)
+func MintResourceToken(userID, appClientID, appSecret string, quota AppQuota, scopes []string, authzDetails []core.AuthorizationDetail) (string, error) {
+	return MintResourceTokenWithKey(userID, appClientID, []byte(appSecret), quota, scopes, authzDetails)
 }
 
 // MintResourceTokenWithKey creates a resource-scoped JWT signed with the provided key.
@@ -27,7 +28,7 @@ func MintResourceToken(userID, appClientID, appSecret string, quota AppQuota, sc
 //   - []byte → HS256
 //   - *rsa.PrivateKey → RS256
 //   - *ecdsa.PrivateKey → ES256
-func MintResourceTokenWithKey(userID, appClientID string, signingKey any, quota AppQuota, scopes []string) (string, error) {
+func MintResourceTokenWithKey(userID, appClientID string, signingKey any, quota AppQuota, scopes []string, authzDetails []core.AuthorizationDetail) (string, error) {
 	method, err := signingMethodFromKey(signingKey)
 	if err != nil {
 		return "", err
@@ -41,6 +42,10 @@ func MintResourceTokenWithKey(userID, appClientID string, signingKey any, quota 
 		"scopes":    scopes,
 		"iat":       now.Unix(),
 		"exp":       now.Add(15 * time.Minute).Unix(),
+	}
+
+	if len(authzDetails) > 0 {
+		claims["authorization_details"] = authzDetails
 	}
 
 	if quota.MaxRooms > 0 {

--- a/admin/mint_test.go
+++ b/admin/mint_test.go
@@ -17,7 +17,7 @@ func TestMintResourceToken_Basic(t *testing.T) {
 	token, err := admin.MintResourceToken("user-123", "app-abc", "my-secret", admin.AppQuota{
 		MaxRooms:   10,
 		MaxMsgRate: 30.0,
-	}, []string{"read", "write"})
+	}, []string{"read", "write"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceToken failed: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestMintResourceToken_Basic(t *testing.T) {
 
 // TestMintResourceToken_NoQuota verifies that zero-value quota fields are omitted from JWT claims.
 func TestMintResourceToken_NoQuota(t *testing.T) {
-	token, err := admin.MintResourceToken("user-1", "app-1", "secret", admin.AppQuota{}, []string{"read"})
+	token, err := admin.MintResourceToken("user-1", "app-1", "secret", admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceToken failed: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestMintResourceToken_VerifiableByMiddleware(t *testing.T) {
 	clientID := "app-excaliframe"
 
 	// App mints token
-	token, err := admin.MintResourceToken("user-42", clientID, secret, admin.AppQuota{}, []string{"read"})
+	token, err := admin.MintResourceToken("user-42", clientID, secret, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceToken failed: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestMintResourceToken_VerifiableByMiddleware(t *testing.T) {
 // TestMintResourceToken_WrongSecretRejected verifies that a token signed with one secret
 // is rejected when verified with a different secret.
 func TestMintResourceToken_WrongSecretRejected(t *testing.T) {
-	token, _ := admin.MintResourceToken("user-1", "app-1", "correct-secret", admin.AppQuota{}, []string{"read"})
+	token, _ := admin.MintResourceToken("user-1", "app-1", "correct-secret", admin.AppQuota{}, []string{"read"}, nil)
 
 	// Verify with wrong secret should fail
 	_, err := jwt.Parse(token, func(t *jwt.Token) (any, error) {

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -16,13 +16,14 @@ import (
 
 // AppRegistration holds metadata about a registered App.
 type AppRegistration struct {
-	ClientID     string    `json:"client_id"`
-	ClientDomain string    `json:"client_domain"`
-	SigningAlg   string    `json:"signing_alg"`
-	MaxRooms     int       `json:"max_rooms,omitempty"`
-	MaxMsgRate   float64   `json:"max_msg_rate,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	Revoked      bool      `json:"revoked"`
+	ClientID                  string    `json:"client_id"`
+	ClientDomain              string    `json:"client_domain"`
+	SigningAlg                string    `json:"signing_alg"`
+	MaxRooms                  int       `json:"max_rooms,omitempty"`
+	MaxMsgRate                float64   `json:"max_msg_rate,omitempty"`
+	AuthorizationDetailsTypes []string  `json:"authorization_details_types,omitempty"` // RFC 9396
+	CreatedAt                 time.Time `json:"created_at"`
+	Revoked                   bool      `json:"revoked"`
 }
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.

--- a/apiauth/SUMMARY.md
+++ b/apiauth/SUMMARY.md
@@ -10,6 +10,7 @@ JWT-based API authentication: token issuance (login/refresh/client_credentials),
 - **protected_resource.go** — `ProtectedResourceMetadata` struct + `NewProtectedResourceHandler` for RFC 9728 discovery
 
 ## Recent Changes
+- **RFC 9396 Rich Authorization Requests** — Token endpoint accepts `authorization_details` parameter (JSON body or form-encoded JSON string). Granted details are embedded in JWT claims and returned in token/introspection responses. `CreateAccessToken` signature: `(userID, scopes, authzDetails)`. `standardClaims` guard blocks `CustomClaimsFunc` from overriding `authorization_details`.
 - **client_credentials grant** — `APIAuth.ClientKeyStore` enables machine-to-machine auth via `grant_type=client_credentials` (RFC 6749 §4.4). Supports `client_secret_post` and `client_secret_basic`.
 - **Protected Resource Metadata** — `NewProtectedResourceHandler` serves RFC 9728 metadata at `/.well-known/oauth-protected-resource`, enabling clients to auto-discover resource server capabilities
 - **Audience validation** — `ValidateAccessToken` checks `aud` claim against expected audiences; handles both string and array formats (RFC 7519 §4.1.3, #52)

--- a/apiauth/as_metadata.go
+++ b/apiauth/as_metadata.go
@@ -32,7 +32,8 @@ type ASServerMetadata struct {
 	UserinfoEndpoint      string `json:"userinfo_endpoint,omitempty"`
 
 	// Supported features
-	ScopesSupported               []string `json:"scopes_supported,omitempty"`
+	AuthorizationDetailsTypesSupported []string `json:"authorization_details_types_supported,omitempty"` // RFC 9396
+	ScopesSupported                    []string `json:"scopes_supported,omitempty"`
 	ResponseTypesSupported        []string `json:"response_types_supported,omitempty"`
 	GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
 	TokenEndpointAuthMethods      []string `json:"token_endpoint_auth_methods_supported,omitempty"`

--- a/apiauth/asymmetric_jwt_test.go
+++ b/apiauth/asymmetric_jwt_test.go
@@ -146,7 +146,7 @@ func TestAPIAuth_RS256_Signing(t *testing.T) {
 		JWTIssuer:     "test",
 	}
 
-	tokenStr, _, err := auth.CreateAccessToken("user-rsa", []string{"read"})
+	tokenStr, _, err := auth.CreateAccessToken("user-rsa", []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("CreateAccessToken: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestAPIAuth_ES256_Signing(t *testing.T) {
 		JWTVerifyKey:  pubKey,
 	}
 
-	tokenStr, _, err := auth.CreateAccessToken("user-ec", []string{"write"})
+	tokenStr, _, err := auth.CreateAccessToken("user-ec", []string{"write"}, nil)
 	if err != nil {
 		t.Fatalf("CreateAccessToken: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestAPIAuth_RS256_RejectsHMAC(t *testing.T) {
 	}
 
 	// Create a valid RS256 token, then try to validate with HMAC-configured auth
-	tokenStr, _, _ := auth.CreateAccessToken("user-1", []string{"read"})
+	tokenStr, _, _ := auth.CreateAccessToken("user-1", []string{"read"}, nil)
 
 	hmacAuth := &apiauth.APIAuth{JWTSecretKey: "some-secret"}
 	_, _, err := hmacAuth.ValidateAccessToken(tokenStr)
@@ -232,7 +232,7 @@ func TestAPIAuth_ValidateAccessTokenFull_RS256(t *testing.T) {
 		},
 	}
 
-	tokenStr, _, _ := auth.CreateAccessToken("user-1", []string{"read"})
+	tokenStr, _, _ := auth.CreateAccessToken("user-1", []string{"read"}, nil)
 	userID, _, custom, err := auth.ValidateAccessTokenFull(tokenStr)
 	if err != nil {
 		t.Fatalf("ValidateAccessTokenFull: %v", err)

--- a/apiauth/asymmetric_jwt_test.go
+++ b/apiauth/asymmetric_jwt_test.go
@@ -32,7 +32,7 @@ func TestMintResourceTokenWithKey_RS256(t *testing.T) {
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 	pubKey, _ := utils.ParsePublicKeyPEM(pubPEM)
 
-	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{MaxRooms: 5}, []string{"read"})
+	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{MaxRooms: 5}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceTokenWithKey: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestMintResourceTokenWithKey_ES256(t *testing.T) {
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 	pubKey, _ := utils.ParsePublicKeyPEM(pubPEM)
 
-	tokenStr, err := admin.MintResourceTokenWithKey("user-2", "app-ec", privKey, admin.AppQuota{}, []string{"write"})
+	tokenStr, err := admin.MintResourceTokenWithKey("user-2", "app-ec", privKey, admin.AppQuota{}, []string{"write"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceTokenWithKey: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestMintResourceTokenWithKey_WrongKey(t *testing.T) {
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 	otherPub, _ := utils.ParsePublicKeyPEM(otherPubPEM)
 
-	tokenStr, _ := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Verify with wrong public key — should fail
 	_, err := jwt.Parse(tokenStr, func(token *jwt.Token) (any, error) {
@@ -109,7 +109,7 @@ func TestMintResourceTokenWithKey_WrongKey(t *testing.T) {
 // (HS256) API still works correctly alongside the new asymmetric key API.
 func TestMintResourceTokenWithKey_BackwardsCompat(t *testing.T) {
 	// MintResourceToken (old API) should still work
-	tokenStr, err := admin.MintResourceToken("user-1", "app-hs", "my-secret", admin.AppQuota{MaxRooms: 3}, []string{"read"})
+	tokenStr, err := admin.MintResourceToken("user-1", "app-hs", "my-secret", admin.AppQuota{MaxRooms: 3}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceToken: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestAPIMiddleware_RS256_MultiTenant(t *testing.T) {
 	ks.RegisterKey("app-rsa", pubPEM, "RS256")
 
 	// Mint a token with the private key
-	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"})
+	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceTokenWithKey: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestAPIMiddleware_ES256_MultiTenant(t *testing.T) {
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 	ks.RegisterKey("app-ec", pubPEM, "ES256")
 
-	tokenStr, _ := admin.MintResourceTokenWithKey("user-2", "app-ec", privKey, admin.AppQuota{}, []string{"write"})
+	tokenStr, _ := admin.MintResourceTokenWithKey("user-2", "app-ec", privKey, admin.AppQuota{}, []string{"write"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -395,7 +395,7 @@ func TestAPIMiddleware_AlgorithmConfusion(t *testing.T) {
 
 func mustMintHS256(t *testing.T, userID, clientID, secret string) string {
 	t.Helper()
-	tok, err := admin.MintResourceToken(userID, clientID, secret, admin.AppQuota{}, []string{"read"})
+	tok, err := admin.MintResourceToken(userID, clientID, secret, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceToken: %v", err)
 	}
@@ -404,7 +404,7 @@ func mustMintHS256(t *testing.T, userID, clientID, secret string) string {
 
 func mustMintWithKey(t *testing.T, userID, clientID string, key any) string {
 	t.Helper()
-	tok, err := admin.MintResourceTokenWithKey(userID, clientID, key, admin.AppQuota{}, []string{"read"})
+	tok, err := admin.MintResourceTokenWithKey(userID, clientID, key, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("MintResourceTokenWithKey: %v", err)
 	}

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -116,6 +116,13 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ClientID:     r.FormValue("client_id"),
 			ClientSecret: r.FormValue("client_secret"),
 		}
+		// RFC 9396 §6.1: authorization_details is a JSON-encoded string in form params
+		if adStr := r.FormValue("authorization_details"); adStr != "" {
+			if err := json.Unmarshal([]byte(adStr), &req.AuthorizationDetails); err != nil {
+				a.errorResponse(w, "invalid_authorization_details", "Invalid authorization_details JSON", http.StatusBadRequest)
+				return
+			}
+		}
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			a.errorResponse(w, "invalid_request", "Invalid request body", http.StatusBadRequest)
@@ -199,8 +206,14 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
+	// Validate authorization_details if present (RFC 9396)
+	if err := core.ValidateAll(req.AuthorizationDetails); err != nil {
+		a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Create access token (JWT)
-	accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes)
+	accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -213,7 +226,7 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
 	}
 
 	// Return token pair
-	a.tokenResponse(w, accessToken, expiresIn, refreshToken.Token, grantedScopes)
+	a.tokenResponse(w, accessToken, expiresIn, refreshToken.Token, grantedScopes, req.AuthorizationDetails)
 }
 
 // handleRefreshTokenGrant handles the refresh_token grant type
@@ -264,8 +277,8 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Create new access token
-	accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.UserID, refreshToken.Scopes)
+	// Create new access token (carry forward authorization_details from original grant)
+	accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.UserID, refreshToken.Scopes, refreshToken.AuthorizationDetails)
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -273,7 +286,7 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	}
 
 	// Return new token pair
-	a.tokenResponse(w, accessToken, expiresIn, newRefreshToken.Token, refreshToken.Scopes)
+	a.tokenResponse(w, accessToken, expiresIn, newRefreshToken.Token, refreshToken.Scopes, refreshToken.AuthorizationDetails)
 }
 
 // handleClientCredentialsGrant handles the client_credentials grant type (RFC 6749 §4.4).
@@ -330,8 +343,14 @@ func (a *APIAuth) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Re
 		scopes = strings.Split(req.Scope, " ")
 	}
 
+	// Validate authorization_details if present (RFC 9396)
+	if err := core.ValidateAll(req.AuthorizationDetails); err != nil {
+		a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Create access token with sub=client_id (no user context)
-	accessToken, expiresIn, err := a.CreateAccessToken(clientID, scopes)
+	accessToken, expiresIn, err := a.CreateAccessToken(clientID, scopes, req.AuthorizationDetails)
 	if err != nil {
 		log.Printf("Error creating client_credentials token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -339,7 +358,7 @@ func (a *APIAuth) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Re
 	}
 
 	// Return access token only — no refresh token for client_credentials
-	a.tokenResponse(w, accessToken, expiresIn, "", scopes)
+	a.tokenResponse(w, accessToken, expiresIn, "", scopes, req.AuthorizationDetails)
 }
 
 // constantTimeEqual performs a constant-time string comparison to prevent
@@ -460,11 +479,13 @@ func (a *APIAuth) HandleListSessions(w http.ResponseWriter, r *http.Request) {
 var standardClaims = map[string]bool{
 	"sub": true, "iss": true, "aud": true, "exp": true,
 	"iat": true, "type": true, "scopes": true, "jti": true,
+	"authorization_details": true, // RFC 9396
 }
 
 // CreateAccessToken creates a signed JWT access token. If CustomClaimsFunc is set,
 // its returned claims are merged into the token (standard claims cannot be overridden).
-func (a *APIAuth) CreateAccessToken(userID string, scopes []string) (string, int64, error) {
+// authzDetails is an optional RFC 9396 authorization_details array embedded in the JWT.
+func (a *APIAuth) CreateAccessToken(userID string, scopes []string, authzDetails []core.AuthorizationDetail) (string, int64, error) {
 	expiry := a.AccessTokenExpiry
 	if expiry == 0 {
 		expiry = core.TokenExpiryAccessToken
@@ -486,6 +507,10 @@ func (a *APIAuth) CreateAccessToken(userID string, scopes []string) (string, int
 		"jti":    jti,
 		"iat":    now.Unix(),
 		"exp":    expiresAt.Unix(),
+	}
+
+	if len(authzDetails) > 0 {
+		claims["authorization_details"] = authzDetails
 	}
 
 	if a.JWTIssuer != "" {
@@ -722,13 +747,14 @@ func (a *APIAuth) jwtKeyFunc(token *jwt.Token) (any, error) {
 }
 
 // tokenResponse sends a successful token response
-func (a *APIAuth) tokenResponse(w http.ResponseWriter, accessToken string, expiresIn int64, refreshToken string, scopes []string) {
+func (a *APIAuth) tokenResponse(w http.ResponseWriter, accessToken string, expiresIn int64, refreshToken string, scopes []string, authzDetails []core.AuthorizationDetail) {
 	resp := core.TokenPair{
-		AccessToken:  accessToken,
-		TokenType:    "Bearer",
-		ExpiresIn:    expiresIn,
-		RefreshToken: refreshToken,
-		Scope:        core.JoinScopes(scopes),
+		AccessToken:          accessToken,
+		TokenType:            "Bearer",
+		ExpiresIn:            expiresIn,
+		RefreshToken:         refreshToken,
+		Scope:                core.JoinScopes(scopes),
+		AuthorizationDetails: authzDetails,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -975,10 +975,11 @@ func (a *APIAuth) HandleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 type apiContextKey string
 
 const (
-	contextKeyUserID   apiContextKey = "api_user_id"
-	contextKeyScopes   apiContextKey = "api_scopes"
-	contextKeyAuthType    apiContextKey = "api_auth_type" // "jwt" or "api_key"
-	contextKeyCustomClaims apiContextKey = "api_custom_claims"
+	contextKeyUserID               apiContextKey = "api_user_id"
+	contextKeyScopes               apiContextKey = "api_scopes"
+	contextKeyAuthType             apiContextKey = "api_auth_type" // "jwt" or "api_key"
+	contextKeyCustomClaims         apiContextKey = "api_custom_claims"
+	contextKeyAuthorizationDetails apiContextKey = "api_authorization_details" // RFC 9396
 )
 
 // APIMiddleware provides middleware for validating API tokens
@@ -1063,6 +1064,17 @@ func GetCustomClaimsFromContext(ctx context.Context) map[string]any {
 	return nil
 }
 
+// GetAuthorizationDetailsFromContext retrieves the RFC 9396 authorization_details from context.
+// Returns nil if no authorization details are present (e.g., API key auth or token without RAR).
+func GetAuthorizationDetailsFromContext(ctx context.Context) []core.AuthorizationDetail {
+	if v := ctx.Value(contextKeyAuthorizationDetails); v != nil {
+		if details, ok := v.([]core.AuthorizationDetail); ok {
+			return details
+		}
+	}
+	return nil
+}
+
 // ValidateToken middleware validates Bearer tokens (JWT or API key) and sets user info in context
 func (m *APIMiddleware) ValidateToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1072,15 +1084,7 @@ func (m *APIMiddleware) ValidateToken(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := r.Context()
-		ctx = context.WithValue(ctx, contextKeyUserID, userID)
-		ctx = context.WithValue(ctx, contextKeyScopes, scopes)
-		ctx = context.WithValue(ctx, contextKeyAuthType, authType)
-		if customClaims != nil {
-			ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
-		}
-		ctx = core.SetUserIDInContext(ctx, userID)
-
+		ctx := setAuthContext(r.Context(), userID, scopes, authType, customClaims)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -1100,15 +1104,7 @@ func (m *APIMiddleware) RequireScopes(requiredScopes ...string) func(http.Handle
 				return
 			}
 
-			ctx := r.Context()
-			ctx = context.WithValue(ctx, contextKeyUserID, userID)
-			ctx = context.WithValue(ctx, contextKeyScopes, grantedScopes)
-			ctx = context.WithValue(ctx, contextKeyAuthType, authType)
-			if customClaims != nil {
-				ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
-			}
-			ctx = core.SetUserIDInContext(ctx, userID)
-
+			ctx := setAuthContext(r.Context(), userID, grantedScopes, authType, customClaims)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -1119,14 +1115,7 @@ func (m *APIMiddleware) Optional(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userID, scopes, authType, customClaims, err := m.validateRequest(r)
 		if err == nil && userID != "" {
-			ctx := r.Context()
-			ctx = context.WithValue(ctx, contextKeyUserID, userID)
-			ctx = context.WithValue(ctx, contextKeyScopes, scopes)
-			ctx = context.WithValue(ctx, contextKeyAuthType, authType)
-			if customClaims != nil {
-				ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
-			}
-			ctx = core.SetUserIDInContext(ctx, userID)
+			ctx := setAuthContext(r.Context(), userID, scopes, authType, customClaims)
 			r = r.WithContext(ctx)
 		}
 		next.ServeHTTP(w, r)
@@ -1298,6 +1287,15 @@ func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes [
 		}
 	}
 
+	// Extract authorization_details (RFC 9396) from JWT claims.
+	// Stored under a private key in customClaims so context-setting code can extract it.
+	if adRaw, ok := claims["authorization_details"].([]any); ok {
+		authzDetails := parseAuthorizationDetailsFromClaims(adRaw)
+		if len(authzDetails) > 0 {
+			customClaims["__authz_details"] = authzDetails
+		}
+	}
+
 	// Check blacklist if configured
 	if m.Blacklist != nil {
 		if jti, ok := claims["jti"].(string); ok && jti != "" {
@@ -1365,4 +1363,123 @@ func getClientIP(r *http.Request) string {
 		ip = ip[:colonIdx]
 	}
 	return ip
+}
+
+// =============================================================================
+// RFC 9396 helpers
+// =============================================================================
+
+// standardADFields are the RFC 9396 §2 common field names used when parsing
+// authorization_details from JWT claims to separate known fields from extensions.
+var standardADFields = map[string]bool{
+	"type": true, "locations": true, "actions": true,
+	"datatypes": true, "identifier": true, "privileges": true,
+}
+
+// parseAuthorizationDetailsFromClaims converts raw JWT claim data ([]any of
+// map[string]any) into typed AuthorizationDetail structs.
+func parseAuthorizationDetailsFromClaims(raw []any) []core.AuthorizationDetail {
+	var result []core.AuthorizationDetail
+	for _, item := range raw {
+		adMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		ad := core.AuthorizationDetail{
+			Type:       stringFromMap(adMap, "type"),
+			Identifier: stringFromMap(adMap, "identifier"),
+			Locations:  toStringSlice(anySliceFromMap(adMap, "locations")),
+			Actions:    toStringSlice(anySliceFromMap(adMap, "actions")),
+			DataTypes:  toStringSlice(anySliceFromMap(adMap, "datatypes")),
+			Privileges: toStringSlice(anySliceFromMap(adMap, "privileges")),
+		}
+		for k, v := range adMap {
+			if !standardADFields[k] {
+				if ad.Extra == nil {
+					ad.Extra = make(map[string]any)
+				}
+				ad.Extra[k] = v
+			}
+		}
+		result = append(result, ad)
+	}
+	return result
+}
+
+func stringFromMap(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func anySliceFromMap(m map[string]any, key string) []any {
+	if v, ok := m[key].([]any); ok {
+		return v
+	}
+	return nil
+}
+
+func toStringSlice(raw []any) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// setAuthContext sets all standard auth context values on the request context.
+func setAuthContext(ctx context.Context, userID string, scopes []string, authType string, customClaims map[string]any) context.Context {
+	ctx = context.WithValue(ctx, contextKeyUserID, userID)
+	ctx = context.WithValue(ctx, contextKeyScopes, scopes)
+	ctx = context.WithValue(ctx, contextKeyAuthType, authType)
+	if customClaims != nil {
+		// Extract authorization_details from the private key and set in dedicated context
+		if authzDetails, ok := customClaims["__authz_details"].([]core.AuthorizationDetail); ok {
+			ctx = context.WithValue(ctx, contextKeyAuthorizationDetails, authzDetails)
+			delete(customClaims, "__authz_details")
+		}
+		ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
+	}
+	ctx = core.SetUserIDInContext(ctx, userID)
+	return ctx
+}
+
+// RequireAuthorizationDetails middleware ensures the token contains
+// authorization_details matching all required types. For each required type,
+// there must be at least one authorization_details entry with that type.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+func (m *APIMiddleware) RequireAuthorizationDetails(requiredTypes ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID, scopes, authType, customClaims, err := m.validateRequest(r)
+			if err != nil {
+				m.handleAuthError(w, r, err)
+				return
+			}
+
+			ctx := setAuthContext(r.Context(), userID, scopes, authType, customClaims)
+			granted := GetAuthorizationDetailsFromContext(ctx)
+
+			// Check that all required types are present
+			grantedTypes := make(map[string]bool)
+			for _, ad := range granted {
+				grantedTypes[ad.Type] = true
+			}
+			for _, reqType := range requiredTypes {
+				if !grantedTypes[reqType] {
+					m.handleAuthError(w, r, fmt.Errorf("missing required authorization_details type: %s", reqType))
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }

--- a/apiauth/auth_rar_test.go
+++ b/apiauth/auth_rar_test.go
@@ -1,0 +1,362 @@
+package apiauth_test
+
+// Tests for RFC 9396 Rich Authorization Requests support in the token endpoint
+// and introspection handler.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRARAuth creates an APIAuth with a registered client for RAR testing.
+func setupRARAuth(t *testing.T) (*apiauth.APIAuth, *keys.InMemoryKeyStore) {
+	t.Helper()
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{
+		ClientID:  "test-client",
+		Key:       []byte("test-client-secret"),
+		Algorithm: "HS256",
+	})
+
+	auth := &apiauth.APIAuth{
+		JWTSecretKey:   "rar-test-jwt-secret-32chars-min!",
+		JWTIssuer:      "test-issuer",
+		ClientKeyStore: ks,
+	}
+	return auth, ks
+}
+
+// TestTokenEndpoint_ClientCredentials_WithRAR verifies that client_credentials
+// tokens carry authorization_details in both the response body and the JWT.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5
+func TestTokenEndpoint_ClientCredentials_WithRAR(t *testing.T) {
+	auth, _ := setupRARAuth(t)
+
+	details := []core.AuthorizationDetail{
+		{
+			Type:      "payment_initiation",
+			Actions:   []string{"initiate"},
+			Locations: []string{"https://bank.example.com/payments"},
+			Extra: map[string]any{
+				"instructedAmount": map[string]any{
+					"currency": "EUR",
+					"amount":   "45.00",
+				},
+			},
+		},
+	}
+	detailsJSON, _ := json.Marshal(details)
+
+	body := map[string]any{
+		"grant_type":            "client_credentials",
+		"client_id":             "test-client",
+		"client_secret":         "test-client-secret",
+		"authorization_details": details,
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	auth.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "response: %s", rr.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Token response must include authorization_details
+	ad, ok := resp["authorization_details"]
+	require.True(t, ok, "response missing authorization_details")
+	adArray, ok := ad.([]any)
+	require.True(t, ok, "authorization_details should be an array")
+	assert.Len(t, adArray, 1)
+
+	adObj := adArray[0].(map[string]any)
+	assert.Equal(t, "payment_initiation", adObj["type"])
+
+	// Decode the JWT and verify the claim is embedded
+	tokenStr := resp["access_token"].(string)
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	require.NoError(t, err)
+	claims := token.Claims.(jwt.MapClaims)
+
+	jwtAD, ok := claims["authorization_details"]
+	require.True(t, ok, "JWT missing authorization_details claim")
+	jwtADArray, ok := jwtAD.([]any)
+	require.True(t, ok)
+	assert.Len(t, jwtADArray, 1)
+
+	_ = detailsJSON // used implicitly via body
+}
+
+// TestTokenEndpoint_ClientCredentials_InvalidRAR verifies that a missing type
+// field in authorization_details produces the invalid_authorization_details
+// error code per RFC 9396 §5.2.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5.2
+func TestTokenEndpoint_ClientCredentials_InvalidRAR(t *testing.T) {
+	auth, _ := setupRARAuth(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     "test-client",
+		"client_secret": "test-client-secret",
+		"authorization_details": []map[string]any{
+			{"actions": []string{"read"}}, // missing "type"
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	auth.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "invalid_authorization_details", resp["error"])
+}
+
+// TestTokenEndpoint_FormEncoded_RAR verifies that authorization_details can be
+// sent as a JSON-encoded string in form-encoded requests per RFC 9396 §6.1.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-6.1
+func TestTokenEndpoint_FormEncoded_RAR(t *testing.T) {
+	auth, _ := setupRARAuth(t)
+
+	details := []core.AuthorizationDetail{
+		{Type: "account_information", Actions: []string{"list_accounts"}},
+	}
+	detailsJSON, _ := json.Marshal(details)
+
+	form := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_id":             {"test-client"},
+		"client_secret":         {"test-client-secret"},
+		"authorization_details": {string(detailsJSON)},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	auth.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "response: %s", rr.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	ad, ok := resp["authorization_details"]
+	require.True(t, ok, "response missing authorization_details")
+	adArray := ad.([]any)
+	assert.Len(t, adArray, 1)
+	assert.Equal(t, "account_information", adArray[0].(map[string]any)["type"])
+}
+
+// TestTokenEndpoint_FormEncoded_InvalidRARJSON verifies that malformed JSON in
+// the authorization_details form parameter produces an error.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-6.1
+func TestTokenEndpoint_FormEncoded_InvalidRARJSON(t *testing.T) {
+	auth, _ := setupRARAuth(t)
+
+	form := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_id":             {"test-client"},
+		"client_secret":         {"test-client-secret"},
+		"authorization_details": {"not valid json"},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	auth.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "invalid_authorization_details", resp["error"])
+}
+
+// TestCreateAccessToken_StandardClaimsGuard_RAR verifies that CustomClaimsFunc
+// cannot override the authorization_details claim.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestCreateAccessToken_StandardClaimsGuard_RAR(t *testing.T) {
+	auth := &apiauth.APIAuth{
+		JWTSecretKey: "rar-guard-test-secret-32chars-m!",
+		CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {
+			return map[string]any{
+				"authorization_details": []map[string]any{
+					{"type": "injected", "actions": []string{"admin"}},
+				},
+			}, nil
+		},
+	}
+
+	details := []core.AuthorizationDetail{
+		{Type: "legitimate", Actions: []string{"read"}},
+	}
+
+	token, _, err := auth.CreateAccessToken("user-1", []string{"read"}, details)
+	require.NoError(t, err)
+
+	// Parse JWT and verify the custom claim was blocked
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	require.NoError(t, err)
+	claims := parsed.Claims.(jwt.MapClaims)
+
+	ad := claims["authorization_details"].([]any)
+	adObj := ad[0].(map[string]any)
+	assert.Equal(t, "legitimate", adObj["type"], "CustomClaimsFunc should not override authorization_details")
+}
+
+// TestIntrospection_WithRAR verifies that the introspection response includes
+// authorization_details when the token contains them.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
+func TestIntrospection_WithRAR(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{
+		ClientID:  "resource-server",
+		Key:       []byte("rs-secret"),
+		Algorithm: "HS256",
+	})
+
+	auth := &apiauth.APIAuth{
+		JWTSecretKey:   "introspect-rar-secret-32chars-m!",
+		JWTIssuer:      "test-issuer",
+		ClientKeyStore: ks,
+	}
+
+	handler := &apiauth.IntrospectionHandler{
+		Auth:           auth,
+		ClientKeyStore: ks,
+	}
+
+	details := []core.AuthorizationDetail{
+		{
+			Type:    "payment_initiation",
+			Actions: []string{"initiate"},
+			Extra:   map[string]any{"creditorName": "Merchant A"},
+		},
+	}
+
+	token, _, err := auth.CreateAccessToken("user-rar", []string{"payments"}, details)
+	require.NoError(t, err)
+
+	// Introspect the token
+	rr := postIntrospect(t, handler, token, "resource-server", "rs-secret")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["active"])
+
+	// authorization_details must be present
+	ad, ok := resp["authorization_details"]
+	require.True(t, ok, "introspection response missing authorization_details")
+	adArray, ok := ad.([]any)
+	require.True(t, ok)
+	assert.Len(t, adArray, 1)
+	assert.Equal(t, "payment_initiation", adArray[0].(map[string]any)["type"])
+}
+
+// TestIntrospection_WithoutRAR verifies that the introspection response does
+// not include authorization_details when the token has none.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
+func TestIntrospection_WithoutRAR(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{
+		ClientID:  "resource-server",
+		Key:       []byte("rs-secret"),
+		Algorithm: "HS256",
+	})
+
+	auth := &apiauth.APIAuth{
+		JWTSecretKey:   "introspect-norar-secret-32ch-m!",
+		JWTIssuer:      "test-issuer",
+		ClientKeyStore: ks,
+	}
+
+	handler := &apiauth.IntrospectionHandler{
+		Auth:           auth,
+		ClientKeyStore: ks,
+	}
+
+	token, _, err := auth.CreateAccessToken("user-normal", []string{"read"}, nil)
+	require.NoError(t, err)
+
+	rr := postIntrospect(t, handler, token, "resource-server", "rs-secret")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["active"])
+
+	_, ok := resp["authorization_details"]
+	assert.False(t, ok, "authorization_details should not appear when token has none")
+}
+
+// TestTokenEndpoint_NoRAR_Unchanged verifies that existing token requests
+// without authorization_details continue to work exactly as before.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5
+func TestTokenEndpoint_NoRAR_Unchanged(t *testing.T) {
+	auth, _ := setupRARAuth(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     "test-client",
+		"client_secret": "test-client-secret",
+		"scope":         "read write",
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	auth.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// authorization_details should not be present
+	_, ok := resp["authorization_details"]
+	assert.False(t, ok, "authorization_details should not appear when not requested")
+
+	// Normal fields should still work
+	assert.NotEmpty(t, resp["access_token"])
+	assert.Equal(t, "Bearer", resp["token_type"])
+	assert.Equal(t, "read write", resp["scope"])
+}

--- a/apiauth/blacklist_test.go
+++ b/apiauth/blacklist_test.go
@@ -80,10 +80,10 @@ func TestInMemoryBlacklist_Cleanup(t *testing.T) {
 func TestBlacklist_JTIInAccessToken(t *testing.T) {
 	auth := &apiauth.APIAuth{JWTSecretKey: "test-secret"}
 
-	token1, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token1, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	require.NoError(t, err)
 
-	token2, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token2, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	require.NoError(t, err)
 
 	// Parse tokens to extract jti
@@ -116,7 +116,7 @@ func TestBlacklist_RevokedTokenRejected(t *testing.T) {
 		Blacklist:    bl,
 	}
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	require.NoError(t, err)
 
 	// Token should work before revocation
@@ -145,7 +145,7 @@ func TestBlacklist_NonRevokedTokenAccepted(t *testing.T) {
 		Blacklist:    bl,
 	}
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	require.NoError(t, err)
 
 	// Revoke a DIFFERENT token
@@ -163,7 +163,7 @@ func TestBlacklist_NoBlacklistConfigured(t *testing.T) {
 	auth := &apiauth.APIAuth{JWTSecretKey: "test-secret"}
 	// No Blacklist field set
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	require.NoError(t, err)
 
 	userID, _, err := auth.ValidateAccessToken(token)
@@ -196,7 +196,7 @@ func TestBlacklist_MiddlewareChecksBlacklist(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token, _, _ := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, _ := auth.CreateAccessToken("user1", []string{"read"}, nil)
 
 	// Should work before revocation
 	rr := httptest.NewRecorder()
@@ -229,7 +229,7 @@ func TestBlacklist_ValidateAccessTokenFull_ChecksBlacklist(t *testing.T) {
 		Blacklist:    bl,
 	}
 
-	token, _, _ := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, _ := auth.CreateAccessToken("user1", []string{"read"}, nil)
 
 	// Extract and revoke
 	parser := jwt.NewParser()

--- a/apiauth/custom_claims_test.go
+++ b/apiauth/custom_claims_test.go
@@ -31,7 +31,7 @@ func TestCustomClaimsFunc_RoundTrip(t *testing.T) {
 	}
 
 	// Mint a token using the exported method
-	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read", "write"})
+	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read", "write"}, nil)
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestCustomClaimsFunc_Nil(t *testing.T) {
 		// CustomClaimsFunc is nil
 	}
 
-	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"})
+	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestCustomClaimsFunc_Error(t *testing.T) {
 		},
 	}
 
-	_, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"})
+	_, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"}, nil)
 	if err == nil {
 		t.Fatal("Expected error from CreateAccessToken when CustomClaimsFunc fails")
 	}
@@ -124,7 +124,7 @@ func TestCustomClaimsFunc_NoOverrideStandard(t *testing.T) {
 		},
 	}
 
-	token, _, err := apiAuth.CreateAccessToken("real-user", []string{"read"})
+	token, _, err := apiAuth.CreateAccessToken("real-user", []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestValidateAccessTokenFull_StandardClaimsExcluded(t *testing.T) {
 		},
 	}
 
-	token, _, err := apiAuth.CreateAccessToken("user-1", []string{"read"})
+	token, _, err := apiAuth.CreateAccessToken("user-1", []string{"read"}, nil)
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}

--- a/apiauth/introspection.go
+++ b/apiauth/introspection.go
@@ -95,6 +95,11 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	// Include authorization_details if present (RFC 9396 §9.1)
+	if ad, ok := rawClaims["authorization_details"]; ok {
+		resp["authorization_details"] = ad
+	}
+
 	h.jsonResponse(w, http.StatusOK, resp)
 }
 

--- a/apiauth/introspection_test.go
+++ b/apiauth/introspection_test.go
@@ -81,7 +81,7 @@ func postIntrospect(t *testing.T, handler http.Handler, token, clientID, clientS
 // mintIntrospectionToken creates a signed access token for testing.
 func mintIntrospectionToken(t *testing.T, auth *apiauth.APIAuth, userID string, scopes []string) string {
 	t.Helper()
-	token, _, err := auth.CreateAccessToken(userID, scopes)
+	token, _, err := auth.CreateAccessToken(userID, scopes, nil)
 	require.NoError(t, err)
 	return token
 }

--- a/apiauth/security_test.go
+++ b/apiauth/security_test.go
@@ -136,7 +136,7 @@ func TestSecurity_ExpiredToken_Rejected(t *testing.T) {
 	secret := "test-secret-key-for-jwt"
 	auth := &apiauth.APIAuth{JWTSecretKey: secret}
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	require.NoError(t, err)
 
 	// Validate immediately — should work
@@ -241,7 +241,7 @@ func TestSecurity_EmptySigningKey_Errors(t *testing.T) {
 	// CreateAccessToken with empty key should still produce a token
 	// (jwt library allows it), but validation should use the same empty key.
 	// The real risk is key misconfiguration — this documents current behavior.
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"})
+	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
 	if err != nil {
 		// If it errors on creation, that's fine — fail-safe
 		return

--- a/apiauth/security_test.go
+++ b/apiauth/security_test.go
@@ -261,7 +261,7 @@ func TestSecurity_EmptySigningKey_Errors(t *testing.T) {
 // TestSecurity_NilKey_MintResourceToken proves that MintResourceTokenWithKey
 // returns an error when given a nil signing key.
 func TestSecurity_NilKey_MintResourceToken(t *testing.T) {
-	_, err := admin.MintResourceTokenWithKey("user1", "app1", nil, admin.AppQuota{}, []string{"read"})
+	_, err := admin.MintResourceTokenWithKey("user1", "app1", nil, admin.AppQuota{}, []string{"read"}, nil)
 	assert.Error(t, err, "nil signing key must return error")
 }
 
@@ -348,7 +348,7 @@ func TestSecurity_ScopeEscalation_Prevented(t *testing.T) {
 
 	// Mint with admin scope
 	token, _ := admin.MintResourceToken("user1", "app1", "secret",
-		admin.AppQuota{}, []string{"admin"})
+		admin.AppQuota{}, []string{"admin"}, nil)
 
 	// RequireScopes("admin") allows it
 	mw := &apiauth.APIMiddleware{KeyStore: ks}

--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/panyam/oneauth/core"
 )
 
 // RefreshThreshold is how long before expiry to proactively refresh
@@ -63,13 +65,14 @@ type OAuth2TokenRequest struct {
 
 // OAuth2TokenResponse is the response from token endpoint
 type OAuth2TokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`
-	ExpiresIn    int64  `json:"expires_in"`
-	RefreshToken string `json:"refresh_token,omitempty"`
-	Scope        string `json:"scope,omitempty"`
-	Error        string `json:"error,omitempty"`
-	ErrorDesc    string `json:"error_description,omitempty"`
+	AccessToken          string `json:"access_token"`
+	TokenType            string `json:"token_type"`
+	ExpiresIn            int64  `json:"expires_in"`
+	RefreshToken         string `json:"refresh_token,omitempty"`
+	Scope                string `json:"scope,omitempty"`
+	AuthorizationDetails []any  `json:"authorization_details,omitempty"` // RFC 9396 (raw JSON)
+	Error                string `json:"error,omitempty"`
+	ErrorDesc            string `json:"error_description,omitempty"`
 }
 
 // ClientOption configures an AuthClient
@@ -414,14 +417,16 @@ func (c *AuthClient) requestTokenForm(tokenEndpoint string, data url.Values, aut
 
 	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
-	return &ServerCredential{
+	cred := &ServerCredential{
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 		TokenType:    tokenResp.TokenType,
 		Scope:        tokenResp.Scope,
 		ExpiresAt:    expiresAt,
 		CreatedAt:    time.Now(),
-	}, nil
+	}
+	cred.AuthorizationDetails = parseAuthzDetailsFromRaw(tokenResp.AuthorizationDetails)
+	return cred, nil
 }
 
 // requestToken makes a token request to the server using JSON encoding.
@@ -465,14 +470,16 @@ func (c *AuthClient) requestToken(req OAuth2TokenRequest) (*ServerCredential, er
 
 	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
-	return &ServerCredential{
+	cred := &ServerCredential{
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 		TokenType:    tokenResp.TokenType,
 		Scope:        tokenResp.Scope,
 		ExpiresAt:    expiresAt,
 		CreatedAt:    time.Now(),
-	}, nil
+	}
+	cred.AuthorizationDetails = parseAuthzDetailsFromRaw(tokenResp.AuthorizationDetails)
+	return cred, nil
 }
 
 // refreshTransport is an http.RoundTripper that adds auth and handles refresh
@@ -527,4 +534,21 @@ func (t *refreshTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	return resp, nil
+}
+
+// parseAuthzDetailsFromRaw converts raw JSON authorization_details ([]any from
+// token response) into typed AuthorizationDetail structs via JSON re-marshal.
+func parseAuthzDetailsFromRaw(raw []any) []core.AuthorizationDetail {
+	if len(raw) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var details []core.AuthorizationDetail
+	if err := json.Unmarshal(data, &details); err != nil {
+		return nil
+	}
+	return details
 }

--- a/client/client_credentials_source.go
+++ b/client/client_credentials_source.go
@@ -49,6 +49,9 @@ type ClientCredentialsSource struct {
 	// Scopes to request.
 	Scopes []string
 
+	// AuthorizationDetails to request (RFC 9396). Sent alongside scopes.
+	AuthorizationDetails []core.AuthorizationDetail
+
 	// Audience is the resource server's canonical URI (RFC 8707 resource indicator).
 	Audience string
 

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -4,18 +4,21 @@ package client
 
 import (
 	"time"
+
+	"github.com/panyam/oneauth/core"
 )
 
 // ServerCredential holds authentication info for a single server
 type ServerCredential struct {
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token,omitempty"`
-	TokenType    string    `json:"token_type,omitempty"`
-	UserID       string    `json:"user_id,omitempty"`
-	UserEmail    string    `json:"user_email,omitempty"`
-	Scope        string    `json:"scope,omitempty"`
-	ExpiresAt    time.Time `json:"expires_at"`
-	CreatedAt    time.Time `json:"created_at"`
+	AccessToken          string                     `json:"access_token"`
+	RefreshToken         string                     `json:"refresh_token,omitempty"`
+	TokenType            string                     `json:"token_type,omitempty"`
+	UserID               string                     `json:"user_id,omitempty"`
+	UserEmail            string                     `json:"user_email,omitempty"`
+	Scope                string                     `json:"scope,omitempty"`
+	AuthorizationDetails []core.AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
+	ExpiresAt            time.Time                  `json:"expires_at"`
+	CreatedAt            time.Time                  `json:"created_at"`
 }
 
 // IsExpired returns true if the access token has expired

--- a/cmd/demo-hostapp/main.go
+++ b/cmd/demo-hostapp/main.go
@@ -175,7 +175,7 @@ func main() {
 			creds.ClientID,
 			creds.ClientSecret,
 			admin.AppQuota{MaxRooms: 10, MaxMsgRate: 100},
-			[]string{"collab"},
+			[]string{"collab"}, nil,
 		)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")

--- a/cmd/rar-test-issuer/Dockerfile
+++ b/cmd/rar-test-issuer/Dockerfile
@@ -1,0 +1,11 @@
+# Build from repo root: docker build -f cmd/rar-test-issuer/Dockerfile -t rar-test-issuer .
+FROM golang:1.24-alpine AS builder
+WORKDIR /src
+COPY . .
+WORKDIR /src/cmd/rar-test-issuer
+RUN CGO_ENABLED=0 GOWORK=off go build -o /rar-test-issuer .
+
+FROM alpine:3.21
+COPY --from=builder /rar-test-issuer /usr/local/bin/
+EXPOSE 8181
+CMD ["rar-test-issuer"]

--- a/cmd/rar-test-issuer/go.mod
+++ b/cmd/rar-test-issuer/go.mod
@@ -1,0 +1,14 @@
+module github.com/panyam/oneauth/cmd/rar-test-issuer
+
+go 1.26.2
+
+require github.com/panyam/oneauth v0.0.70
+
+require (
+	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/oauth2 v0.34.0 // indirect
+)
+
+replace github.com/panyam/oneauth => ../..

--- a/cmd/rar-test-issuer/go.sum
+++ b/cmd/rar-test-issuer/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611 h1:JwYtKJ/DVEoIA5dH45OEU7uoryZY/gjd/BQiwwAOImM=
+github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611/go.mod h1:zHMNeYgqrTpKyjawjitDg0Osd1P/FmeA0SZLYK3RfLQ=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
+golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
+golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
+golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/rar-test-issuer/main.go
+++ b/cmd/rar-test-issuer/main.go
@@ -1,0 +1,147 @@
+// cmd/rar-test-issuer is a minimal OAuth 2.0 Authorization Server that supports
+// RFC 9396 Rich Authorization Requests. It is designed as a test fixture for
+// interop testing — proving that OneAuth resource servers can validate RAR tokens
+// issued by an external AS over real HTTP.
+//
+// This server fills a gap: no open-source IdP (Keycloak, Curity, etc.) currently
+// supports RFC 9396 on standard OAuth flows (client_credentials, authorization_code).
+// When Keycloak adds RAR support (tracked: keycloak/keycloak#29340), the interop
+// tests should be migrated to use Keycloak and this binary can be retired.
+//
+// Endpoints:
+//
+//	POST /api/token                          — token endpoint (client_credentials + RAR)
+//	POST /oauth/introspect                   — token introspection (RFC 7662)
+//	GET  /.well-known/openid-configuration   — AS metadata (RFC 8414 + RFC 9396 §10)
+//	GET  /.well-known/jwks.json              — JWKS (RFC 7517)
+//	GET  /_ah/health                         — health check
+//
+// Pre-registered clients:
+//
+//	client_id: rar-test-client       secret: rar-test-secret
+//	client_id: rar-introspect-client secret: rar-introspect-secret
+//
+// Usage:
+//
+//	go run ./cmd/rar-test-issuer                    # default :8181
+//	RAR_ISSUER_PORT=9090 go run ./cmd/rar-test-issuer
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+const (
+	defaultPort = "8181"
+
+	// Pre-registered test clients
+	testClientID     = "rar-test-client"
+	testClientSecret = "rar-test-secret"
+
+	introClientID     = "rar-introspect-client"
+	introClientSecret = "rar-introspect-secret"
+)
+
+// Supported authorization_details types — advertised in AS metadata.
+// Tests request these types to verify the full RAR flow.
+var supportedRARTypes = []string{
+	"payment_initiation",
+	"account_information",
+	"signing_service",
+}
+
+func main() {
+	port := os.Getenv("RAR_ISSUER_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+	baseURL := fmt.Sprintf("http://localhost:%s", port)
+
+	// Generate RS256 key pair
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	// Key store with the server's public key + pre-registered clients
+	ks := keys.NewInMemoryKeyStore()
+
+	pubPEM, err := utils.EncodePublicKeyPEM(&privKey.PublicKey)
+	if err != nil {
+		log.Fatalf("Failed to encode public key: %v", err)
+	}
+	kid, err := utils.ComputeKid(&privKey.PublicKey, "RS256")
+	if err != nil {
+		log.Fatalf("Failed to compute kid: %v", err)
+	}
+	ks.PutKey(&keys.KeyRecord{ClientID: "rar-test-issuer", Key: pubPEM, Algorithm: "RS256", Kid: kid})
+
+	// Register test clients
+	ks.PutKey(&keys.KeyRecord{ClientID: testClientID, Key: []byte(testClientSecret), Algorithm: "HS256"})
+	ks.PutKey(&keys.KeyRecord{ClientID: introClientID, Key: []byte(introClientSecret), Algorithm: "HS256"})
+
+	// API Auth (token endpoint)
+	apiAuth := &apiauth.APIAuth{
+		JWTSigningAlg:  "RS256",
+		JWTSigningKey:  privKey,
+		JWTVerifyKey:   &privKey.PublicKey,
+		JWTIssuer:      baseURL,
+		ClientKeyStore: ks,
+	}
+
+	// Introspection
+	introspection := &apiauth.IntrospectionHandler{
+		Auth:           apiAuth,
+		ClientKeyStore: ks,
+	}
+
+	// JWKS
+	jwksHandler := &keys.JWKSHandler{KeyStore: ks}
+
+	// AS Metadata with authorization_details_types_supported (RFC 9396 §10)
+	asMeta := apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+		Issuer:                             baseURL,
+		TokenEndpoint:                      baseURL + "/api/token",
+		JWKSURI:                            baseURL + "/.well-known/jwks.json",
+		IntrospectionEndpoint:              baseURL + "/oauth/introspect",
+		ScopesSupported:                    []string{"read", "write", "payments", "accounts"},
+		GrantTypesSupported:                []string{"client_credentials"},
+		ResponseTypesSupported:             []string{"token"},
+		TokenEndpointAuthMethods:           []string{"client_secret_post", "client_secret_basic"},
+		AuthorizationDetailsTypesSupported: supportedRARTypes,
+	})
+
+	// App registration (for DCR tests)
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	// Routes
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_ah/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+	mux.Handle("POST /oauth/introspect", introspection)
+	mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+	mux.Handle("GET /.well-known/openid-configuration", asMeta)
+	mux.Handle("/apps/", registrar.Handler())
+
+	log.Printf("rar-test-issuer listening on :%s", port)
+	log.Printf("  Clients: %s, %s", testClientID, introClientID)
+	log.Printf("  RAR types: %v", supportedRARTypes)
+	log.Printf("  JWKS: %s/.well-known/jwks.json", baseURL)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
+}

--- a/core/SUMMARY.md
+++ b/core/SUMMARY.md
@@ -12,6 +12,7 @@ Foundation types and interfaces for the OneAuth authentication framework. Every 
 - **context.go** — `GetUserIDFromContext()`, `SetUserIDInContext()`, `DefaultUserParamName`
 
 ## Recent Additions
+- **authorization_details.go** — `AuthorizationDetail` struct (RFC 9396), custom JSON marshal/unmarshal with extension flattening, `ValidateAll()`, `FilterByType()`, `ErrInvalidAuthorizationDetails`
 - **blacklist.go** — `TokenBlacklist` interface and `InMemoryBlacklist` for jti-based JWT revocation
 - **ratelimiter.go** — `RateLimiter` interface and `InMemoryRateLimiter` (token-bucket)
 - **lockout.go** — `AccountLockout` struct for tracking failed login attempts and temporary account lockouts

--- a/core/authorization_details.go
+++ b/core/authorization_details.go
@@ -1,0 +1,153 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ErrInvalidAuthorizationDetails is the OAuth error for malformed or disallowed
+// authorization_details values (RFC 9396 §5.2).
+var ErrInvalidAuthorizationDetails = fmt.Errorf("invalid_authorization_details")
+
+// commonFields lists the RFC 9396 §2 common field names. These cannot appear
+// as extension keys in AuthorizationDetail.Extra.
+var commonFields = map[string]bool{
+	"type": true, "locations": true, "actions": true,
+	"datatypes": true, "identifier": true, "privileges": true,
+}
+
+// AuthorizationDetail represents a single authorization details object per
+// RFC 9396 §2. Each object describes fine-grained authorization requirements
+// for a specific API or resource type.
+//
+// The Type field is required and identifies the authorization details type.
+// Common fields (Locations, Actions, DataTypes, Identifier, Privileges) are
+// optional and defined by the spec. API-specific extension fields are stored
+// in Extra and flattened into the top-level JSON object on marshal.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+type AuthorizationDetail struct {
+	// Type is the authorization details type identifier (required).
+	Type string `json:"type"`
+
+	// Locations is an array of URIs indicating where the requested
+	// resource can be found.
+	Locations []string `json:"locations,omitempty"`
+
+	// Actions is an array of strings describing the operations to be
+	// performed on the resource.
+	Actions []string `json:"actions,omitempty"`
+
+	// DataTypes is an array of strings describing the types of data
+	// being requested.
+	DataTypes []string `json:"datatypes,omitempty"`
+
+	// Identifier is a string identifying a specific resource at the API.
+	Identifier string `json:"identifier,omitempty"`
+
+	// Privileges is an array of strings representing privilege levels.
+	Privileges []string `json:"privileges,omitempty"`
+
+	// Extra holds API-specific extension fields. These are flattened into
+	// the top-level JSON object (not nested under an "extra" key).
+	Extra map[string]any `json:"-"`
+}
+
+// Validate checks that the AuthorizationDetail has a non-empty Type field.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func (ad *AuthorizationDetail) Validate() error {
+	if ad.Type == "" {
+		return fmt.Errorf("%w: type field is required", ErrInvalidAuthorizationDetails)
+	}
+	return nil
+}
+
+// ValidateAll validates a slice of AuthorizationDetail values.
+// Returns nil if the slice is nil or empty.
+func ValidateAll(details []AuthorizationDetail) error {
+	for i := range details {
+		if err := details[i].Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FilterByType returns the subset of details matching the given type.
+// Returns nil if no matches are found.
+func FilterByType(details []AuthorizationDetail, typ string) []AuthorizationDetail {
+	var result []AuthorizationDetail
+	for _, d := range details {
+		if d.Type == typ {
+			result = append(result, d)
+		}
+	}
+	return result
+}
+
+// MarshalJSON flattens Extra fields into the top-level JSON object alongside
+// the common RFC 9396 fields. This produces the flat structure required by the
+// spec (e.g., {"type":"payment","amount":"45"}) rather than nesting extensions.
+func (ad AuthorizationDetail) MarshalJSON() ([]byte, error) {
+	// Build a map with common fields
+	m := make(map[string]any)
+	m["type"] = ad.Type
+	if len(ad.Locations) > 0 {
+		m["locations"] = ad.Locations
+	}
+	if len(ad.Actions) > 0 {
+		m["actions"] = ad.Actions
+	}
+	if len(ad.DataTypes) > 0 {
+		m["datatypes"] = ad.DataTypes
+	}
+	if ad.Identifier != "" {
+		m["identifier"] = ad.Identifier
+	}
+	if len(ad.Privileges) > 0 {
+		m["privileges"] = ad.Privileges
+	}
+	// Flatten extensions
+	for k, v := range ad.Extra {
+		if !commonFields[k] {
+			m[k] = v
+		}
+	}
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON parses a flat JSON object into the common fields and Extra.
+// Extension keys that collide with common field names are rejected.
+func (ad *AuthorizationDetail) UnmarshalJSON(data []byte) error {
+	// First pass: decode common fields via a type alias (avoids recursion)
+	type Alias AuthorizationDetail
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*ad = AuthorizationDetail(alias)
+
+	// Second pass: decode all keys to find extensions
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Collect extension fields
+	ad.Extra = nil
+	for k, v := range raw {
+		if commonFields[k] {
+			continue
+		}
+		if ad.Extra == nil {
+			ad.Extra = make(map[string]any)
+		}
+		var val any
+		if err := json.Unmarshal(v, &val); err != nil {
+			return fmt.Errorf("failed to unmarshal extension field %q: %w", k, err)
+		}
+		ad.Extra[k] = val
+	}
+	return nil
+}

--- a/core/authorization_details_test.go
+++ b/core/authorization_details_test.go
@@ -1,0 +1,235 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAuthorizationDetail_MarshalJSON verifies that common fields and extension
+// fields are flattened into a single top-level JSON object, as required by
+// RFC 9396 §2.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestAuthorizationDetail_MarshalJSON(t *testing.T) {
+	ad := AuthorizationDetail{
+		Type:      "payment_initiation",
+		Locations: []string{"https://bank.example.com/payments"},
+		Actions:   []string{"initiate"},
+		Extra: map[string]any{
+			"instructedAmount": map[string]any{
+				"currency": "EUR",
+				"amount":   "45.00",
+			},
+			"creditorName": "Merchant A",
+		},
+	}
+
+	data, err := json.Marshal(ad)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+
+	// Parse back as raw map to verify flat structure
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal raw map failed: %v", err)
+	}
+
+	if m["type"] != "payment_initiation" {
+		t.Errorf("type = %v, want payment_initiation", m["type"])
+	}
+	if m["creditorName"] != "Merchant A" {
+		t.Errorf("creditorName = %v, want Merchant A", m["creditorName"])
+	}
+	// instructedAmount should be at top level, not nested under "extra"
+	if _, ok := m["extra"]; ok {
+		t.Error("extensions should be flattened, not nested under 'extra'")
+	}
+	if _, ok := m["instructedAmount"]; !ok {
+		t.Error("instructedAmount extension missing from top level")
+	}
+}
+
+// TestAuthorizationDetail_UnmarshalJSON verifies round-trip marshal/unmarshal
+// preserves both common and extension fields.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestAuthorizationDetail_UnmarshalJSON(t *testing.T) {
+	input := `{
+		"type": "account_information",
+		"actions": ["list_accounts", "read_balances"],
+		"locations": ["https://bank.example.com/api"],
+		"datatypes": ["balances", "transactions"],
+		"identifier": "acct-123",
+		"privileges": ["admin"],
+		"currency": "USD",
+		"maxAmount": 1000
+	}`
+
+	var ad AuthorizationDetail
+	if err := json.Unmarshal([]byte(input), &ad); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+
+	if ad.Type != "account_information" {
+		t.Errorf("Type = %q, want account_information", ad.Type)
+	}
+	if len(ad.Actions) != 2 {
+		t.Errorf("Actions length = %d, want 2", len(ad.Actions))
+	}
+	if len(ad.Locations) != 1 {
+		t.Errorf("Locations length = %d, want 1", len(ad.Locations))
+	}
+	if len(ad.DataTypes) != 2 {
+		t.Errorf("DataTypes length = %d, want 2", len(ad.DataTypes))
+	}
+	if ad.Identifier != "acct-123" {
+		t.Errorf("Identifier = %q, want acct-123", ad.Identifier)
+	}
+	if len(ad.Privileges) != 1 || ad.Privileges[0] != "admin" {
+		t.Errorf("Privileges = %v, want [admin]", ad.Privileges)
+	}
+	// Extensions
+	if ad.Extra["currency"] != "USD" {
+		t.Errorf("Extra[currency] = %v, want USD", ad.Extra["currency"])
+	}
+	if ad.Extra["maxAmount"] != float64(1000) {
+		t.Errorf("Extra[maxAmount] = %v, want 1000", ad.Extra["maxAmount"])
+	}
+
+	// Round-trip
+	data, err := json.Marshal(ad)
+	if err != nil {
+		t.Fatalf("MarshalJSON round-trip failed: %v", err)
+	}
+	var ad2 AuthorizationDetail
+	if err := json.Unmarshal(data, &ad2); err != nil {
+		t.Fatalf("UnmarshalJSON round-trip failed: %v", err)
+	}
+	if ad2.Type != ad.Type {
+		t.Errorf("Round-trip Type mismatch: %q != %q", ad2.Type, ad.Type)
+	}
+	if ad2.Extra["currency"] != ad.Extra["currency"] {
+		t.Errorf("Round-trip currency mismatch")
+	}
+}
+
+// TestAuthorizationDetail_Validate_MissingType verifies that an empty type
+// field produces the invalid_authorization_details error.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestAuthorizationDetail_Validate_MissingType(t *testing.T) {
+	ad := AuthorizationDetail{
+		Actions: []string{"read"},
+	}
+	err := ad.Validate()
+	if err == nil {
+		t.Fatal("Validate should fail for empty type")
+	}
+	if err.Error() != "invalid_authorization_details: type field is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestAuthorizationDetail_Validate_Valid verifies that a properly formed
+// AuthorizationDetail passes validation.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestAuthorizationDetail_Validate_Valid(t *testing.T) {
+	ad := AuthorizationDetail{
+		Type:    "payment_initiation",
+		Actions: []string{"initiate"},
+	}
+	if err := ad.Validate(); err != nil {
+		t.Errorf("Validate should pass: %v", err)
+	}
+}
+
+// TestValidateAll verifies batch validation of authorization details slices.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestValidateAll(t *testing.T) {
+	// nil slice is valid
+	if err := ValidateAll(nil); err != nil {
+		t.Errorf("ValidateAll(nil) should pass: %v", err)
+	}
+
+	// empty slice is valid
+	if err := ValidateAll([]AuthorizationDetail{}); err != nil {
+		t.Errorf("ValidateAll([]) should pass: %v", err)
+	}
+
+	// all valid
+	details := []AuthorizationDetail{
+		{Type: "a"},
+		{Type: "b"},
+	}
+	if err := ValidateAll(details); err != nil {
+		t.Errorf("ValidateAll with valid details should pass: %v", err)
+	}
+
+	// one invalid
+	details = append(details, AuthorizationDetail{Actions: []string{"read"}})
+	if err := ValidateAll(details); err == nil {
+		t.Error("ValidateAll should fail when one detail has no type")
+	}
+}
+
+// TestFilterByType verifies filtering authorization details by type name.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestFilterByType(t *testing.T) {
+	details := []AuthorizationDetail{
+		{Type: "payment_initiation", Actions: []string{"initiate"}},
+		{Type: "account_information", Actions: []string{"read"}},
+		{Type: "payment_initiation", Actions: []string{"cancel"}},
+	}
+
+	payments := FilterByType(details, "payment_initiation")
+	if len(payments) != 2 {
+		t.Errorf("FilterByType(payment_initiation) = %d results, want 2", len(payments))
+	}
+
+	accounts := FilterByType(details, "account_information")
+	if len(accounts) != 1 {
+		t.Errorf("FilterByType(account_information) = %d results, want 1", len(accounts))
+	}
+
+	unknown := FilterByType(details, "unknown")
+	if unknown != nil {
+		t.Errorf("FilterByType(unknown) = %v, want nil", unknown)
+	}
+
+	// nil input
+	if FilterByType(nil, "payment") != nil {
+		t.Error("FilterByType(nil) should return nil")
+	}
+}
+
+// TestAuthorizationDetail_NoExtensions verifies marshal/unmarshal with only
+// common fields (no extensions).
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestAuthorizationDetail_NoExtensions(t *testing.T) {
+	ad := AuthorizationDetail{
+		Type:    "openid_credential",
+		Actions: []string{"issue"},
+	}
+
+	data, err := json.Marshal(ad)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+
+	var ad2 AuthorizationDetail
+	if err := json.Unmarshal(data, &ad2); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+
+	if ad2.Type != "openid_credential" {
+		t.Errorf("Type = %q, want openid_credential", ad2.Type)
+	}
+	if ad2.Extra != nil {
+		t.Errorf("Extra should be nil for no-extension object, got %v", ad2.Extra)
+	}
+}

--- a/core/tokens.go
+++ b/core/tokens.go
@@ -81,8 +81,9 @@ type RefreshToken struct {
 	DeviceInfo map[string]any `json:"device_info"` // User agent, IP, etc.
 	Family     string         `json:"family"`      // Token family for rotation tracking
 	Generation int            `json:"generation"`  // Increments on rotation
-	Scopes     []string       `json:"scopes"`      // Granted scopes
-	CreatedAt  time.Time      `json:"created_at"`
+	Scopes               []string              `json:"scopes"`                          // Granted scopes
+	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
+	CreatedAt            time.Time             `json:"created_at"`
 	ExpiresAt  time.Time      `json:"expires_at"`
 	LastUsedAt time.Time      `json:"last_used_at"`
 	RevokedAt  *time.Time     `json:"revoked_at,omitempty"`
@@ -128,22 +129,24 @@ func (k *APIKey) IsValid() bool {
 
 // TokenPair represents the response from a successful authentication
 type TokenPair struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`     // "Bearer"
-	ExpiresIn    int64  `json:"expires_in"`     // Seconds until access token expires
-	RefreshToken string `json:"refresh_token,omitempty"`
-	Scope        string `json:"scope,omitempty"`
+	AccessToken          string                `json:"access_token"`
+	TokenType            string                `json:"token_type"`                        // "Bearer"
+	ExpiresIn            int64                 `json:"expires_in"`                        // Seconds until access token expires
+	RefreshToken         string                `json:"refresh_token,omitempty"`
+	Scope                string                `json:"scope,omitempty"`
+	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
 }
 
 // TokenRequest represents a request to the token endpoint
 type TokenRequest struct {
-	GrantType    string `json:"grant_type"`              // "password", "refresh_token", "client_credentials"
-	Username     string `json:"username,omitempty"`      // For password grant
-	Password     string `json:"password,omitempty"`      // For password grant
-	RefreshToken string `json:"refresh_token,omitempty"` // For refresh_token grant
-	Scope        string `json:"scope,omitempty"`         // Requested scopes
-	ClientID     string `json:"client_id,omitempty"`     // Client identifier (for client_credentials, optional for others)
-	ClientSecret string `json:"client_secret,omitempty"` // Client secret (for client_credentials via client_secret_post)
+	GrantType            string                `json:"grant_type"`                                  // "password", "refresh_token", "client_credentials"
+	Username             string                `json:"username,omitempty"`                          // For password grant
+	Password             string                `json:"password,omitempty"`                          // For password grant
+	RefreshToken         string                `json:"refresh_token,omitempty"`                     // For refresh_token grant
+	Scope                string                `json:"scope,omitempty"`                             // Requested scopes
+	ClientID             string                `json:"client_id,omitempty"`                         // Client identifier (for client_credentials, optional for others)
+	ClientSecret         string                `json:"client_secret,omitempty"`                     // Client secret (for client_credentials via client_secret_post)
+	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"`             // RFC 9396
 }
 
 // TokenError represents an OAuth 2.0 compliant error response

--- a/examples/01-client-credentials/Makefile
+++ b/examples/01-client-credentials/Makefile
@@ -1,0 +1,19 @@
+# 01 — Client Credentials Flow
+#
+# Infrastructure: None (in-memory, self-contained)
+
+EXAMPLE_DIR := 01-client-credentials
+
+# Run interactively — pause between steps
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+# Run non-interactively — full output, no pauses
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+# Regenerate README.md from the code (single source of truth)
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+.PHONY: run demo readme

--- a/examples/01-client-credentials/README.md
+++ b/examples/01-client-credentials/README.md
@@ -114,11 +114,11 @@ multi-app architecture.
 
 ## References
 
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
 - [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
 - [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
 - [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
-- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 
 ## Run it
 

--- a/examples/01-client-credentials/README.md
+++ b/examples/01-client-credentials/README.md
@@ -58,11 +58,16 @@ We spin up two in-process HTTP servers: one for the AS (issues tokens) and one f
 ### How client registration works
 
 Before a client can get tokens, it needs to register with the auth server
-and receive a `client_id` + `client_secret` pair. This is the OneAuth
-equivalent of creating an OAuth application in a provider's dashboard.
+and receive a `client_id` + `client_secret` pair. This is the equivalent
+of going to GitHub Developer Settings → OAuth Apps → "New OAuth App".
 
-In this example we use the `/apps/register` endpoint with open auth.
-In production, you'd protect this with an admin API key.
+In this example, registration is **open** (`NewNoAuth()`) for simplicity.
+In production, gate registration with authentication — see
+[How does an App get registered?](../README.md#how-does-an-app-get-registered)
+for the full spectrum from web dashboards to automated DCR.
+
+**The `client_secret` is a backend credential.** It lives in your server,
+not in a browser or mobile app. Never expose it in frontend code.
 
 ### Step 2: Register a client
 
@@ -109,11 +114,11 @@ multi-app architecture.
 
 ## References
 
-- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
-- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
 - [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
 - [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 
 ## Run it
 

--- a/examples/01-client-credentials/README.md
+++ b/examples/01-client-credentials/README.md
@@ -1,0 +1,128 @@
+# 01: Client Credentials Flow
+
+Non-UI | No infrastructure needed | RFC 6749 §4.4
+
+## What you'll learn
+
+- **Start auth server and resource server** — We spin up two in-process HTTP servers: one for the AS (issues tokens) and one for the RS (validates them). Both share the same KeyStore.
+- **Register a client** — The client receives credentials it will use to authenticate in the next step.
+- **Request an access token** — The AS verifies the client credentials and returns a signed JWT. The token carries sub=client_id (no user context in this flow).
+- **Access a protected resource** — The resource server validates the JWT signature and extracts claims from it. No network call to the auth server.
+- **Access without a token (expect rejection)** — Without a valid Bearer token, the resource server rejects the request.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over App,RS: Step 1: Start auth server and resource server
+
+    Note over App,RS: Step 2: Register a client
+    App->>AS: POST /apps/register {domain, signing_alg}
+    AS-->>App: {client_id, client_secret}
+
+    Note over App,RS: Step 3: Request an access token
+    App->>AS: POST /api/token {grant_type: client_credentials}
+    AS-->>App: {access_token, token_type, expires_in}
+
+    Note over App,RS: Step 4: Access a protected resource
+    App->>RS: GET /resource (Authorization: Bearer token)
+    RS->>RS: Validate JWT signature + claims
+    RS-->>App: 200 {data}
+
+    Note over App,RS: Step 5: Access without a token (expect rejection)
+    App->>RS: GET /resource (no Authorization header)
+    RS-->>App: 401 Unauthorized
+```
+
+## Steps
+
+### About this example
+
+**Actors:** App (a bot), Auth Server (AS), Resource Server (RS).
+Think: a GitHub bot posting to Slack's API. [What are these?](../README.md#cast-of-characters)
+
+The `client_credentials` grant is the standard OAuth 2.0 machine-to-machine
+flow. No user is involved — the bot authenticates directly with its own
+credentials and receives an access token.
+
+Common use cases: service-to-service calls, background jobs, CLI tools.
+
+### Step 1: Start auth server and resource server
+
+We spin up two in-process HTTP servers: one for the AS (issues tokens) and one for the RS (validates them). Both share the same KeyStore.
+
+### How client registration works
+
+Before a client can get tokens, it needs to register with the auth server
+and receive a `client_id` + `client_secret` pair. This is the OneAuth
+equivalent of creating an OAuth application in a provider's dashboard.
+
+In this example we use the `/apps/register` endpoint with open auth.
+In production, you'd protect this with an admin API key.
+
+### Step 2: Register a client
+
+> **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+
+The client receives credentials it will use to authenticate in the next step.
+
+### Step 3: Request an access token
+
+> **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4), [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+The AS verifies the client credentials and returns a signed JWT. The token carries sub=client_id (no user context in this flow).
+
+### What's in the JWT?
+
+The access token is a signed JWT containing:
+- `sub`: the client_id (who this token represents)
+- `scopes`: the granted scopes
+- `iss`: the issuer URL
+- `exp`/`iat`: expiry and issued-at timestamps
+- `jti`: unique token ID (for revocation)
+
+The resource server can validate this token locally by checking the
+signature — no callback to the auth server needed.
+
+### Step 4: Access a protected resource
+
+> **References:** [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750), [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+The resource server validates the JWT signature and extracts claims from it. No network call to the auth server.
+
+### Step 5: Access without a token (expect rejection)
+
+> **References:** [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
+
+Without a valid Bearer token, the resource server rejects the request.
+
+### What's next?
+
+In [02 — Resource Token (HS256)](../02-resource-token-hs256/), you'll see
+how a registered app can mint tokens *for individual users*, not just for
+itself. This is the federated authentication pattern used by OneAuth's
+multi-app architecture.
+
+## References
+
+- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+- [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
+- [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+## Run it
+
+```bash
+go run ./examples/01-client-credentials/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/01-client-credentials/ --non-interactive
+```

--- a/examples/01-client-credentials/main.go
+++ b/examples/01-client-credentials/main.go
@@ -1,0 +1,212 @@
+// Example 01: OAuth 2.0 Client Credentials Flow
+//
+// The simplest way to get a token from OneAuth. A client authenticates with
+// its client_id and client_secret, and receives a JWT access token.
+//
+// Run:   go run ./examples/01-client-credentials/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+func main() {
+	// Shared state across steps
+	var authServer, resourceServer *httptest.Server
+	var ks keys.KeyStorage
+	var clientID, clientSecret, accessToken string
+
+	demo := demokit.New("01: Client Credentials Flow").
+		Dir("01-client-credentials").
+		Description("Non-UI | No infrastructure needed | RFC 6749 §4.4").
+		Actors(
+			demokit.Actor("App", "Client App"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** App (a bot), Auth Server (AS), Resource Server (RS).",
+		"Think: a GitHub bot posting to Slack's API. [What are these?](../README.md#cast-of-characters)",
+		"",
+		"The `client_credentials` grant is the standard OAuth 2.0 machine-to-machine",
+		"flow. No user is involved — the bot authenticates directly with its own",
+		"credentials and receives an access token.",
+		"",
+		"Common use cases: service-to-service calls, background jobs, CLI tools.",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server and resource server").
+		Note("We spin up two in-process HTTP servers: one for the AS (issues tokens) and one for the RS (validates them). Both share the same KeyStore.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+			apiAuth := &apiauth.APIAuth{
+				JWTSecretKey:   "example-jwt-secret-at-least-32ch",
+				JWTIssuer:      "example-issuer",
+				ClientKeyStore: ks,
+			}
+
+			authMux := http.NewServeMux()
+			authMux.Handle("/apps/", registrar.Handler())
+			authMux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+			authServer = httptest.NewServer(authMux)
+
+			middleware := &apiauth.APIMiddleware{
+				JWTSecretKey: "example-jwt-secret-at-least-32ch",
+				JWTIssuer:    "example-issuer",
+			}
+			resMux := http.NewServeMux()
+			resMux.Handle("GET /resource", middleware.ValidateToken(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"message": "hello from protected resource",
+						"sub":     apiauth.GetUserIDFromAPIContext(r.Context()),
+						"scopes":  apiauth.GetScopesFromAPIContext(r.Context()),
+					})
+				}),
+			))
+			resourceServer = httptest.NewServer(resMux)
+
+			fmt.Printf("    Auth server:     %s\n", authServer.URL)
+			fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+		})
+
+	demo.Section("How client registration works",
+		"Before a client can get tokens, it needs to register with the auth server",
+		"and receive a `client_id` + `client_secret` pair. This is the OneAuth",
+		"equivalent of creating an OAuth application in a provider's dashboard.",
+		"",
+		"In this example we use the `/apps/register` endpoint with open auth.",
+		"In production, you'd protect this with an admin API key.",
+	)
+
+	// --- Step 1: Register ---
+	demo.Step("Register a client").
+		Ref(demokit.RFC7591).
+		Arrow("App", "AS", "POST /apps/register {domain, signing_alg}").
+		DashedArrow("AS", "App", "{client_id, client_secret}").
+		Note("The client receives credentials it will use to authenticate in the next step.").
+		Run(func() {
+			body, _ := json.Marshal(map[string]any{
+				"client_domain": "my-service.example.com",
+				"signing_alg":   "HS256",
+			})
+			resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+				strings.NewReader(string(body)))
+			var reg map[string]any
+			json.NewDecoder(resp.Body).Decode(&reg)
+			resp.Body.Close()
+
+			clientID = reg["client_id"].(string)
+			clientSecret = reg["client_secret"].(string)
+			fmt.Printf("    client_id:     %s\n", clientID)
+			fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
+		})
+
+	// --- Step 2: Token ---
+	demo.Step("Request an access token").
+		Ref(demokit.RFC6749_ClientCredentials).
+		Ref(demokit.RFC7519).
+		Arrow("App", "AS", "POST /api/token {grant_type: client_credentials}").
+		DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
+		Note("The AS verifies the client credentials and returns a signed JWT. The token carries sub=client_id (no user context in this flow).").
+		Run(func() {
+			resp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {clientID},
+				"client_secret": {clientSecret},
+				"scope":         {"read write"},
+			})
+			var tokenData map[string]any
+			json.NewDecoder(resp.Body).Decode(&tokenData)
+			resp.Body.Close()
+
+			accessToken = tokenData["access_token"].(string)
+			fmt.Printf("    token_type:   %s\n", tokenData["token_type"])
+			fmt.Printf("    scope:        %s\n", tokenData["scope"])
+			fmt.Printf("    expires_in:   %.0fs\n", tokenData["expires_in"])
+			fmt.Printf("    access_token: %s...\n", accessToken[:40])
+		})
+
+	demo.Section("What's in the JWT?",
+		"The access token is a signed JWT containing:",
+		"- `sub`: the client_id (who this token represents)",
+		"- `scopes`: the granted scopes",
+		"- `iss`: the issuer URL",
+		"- `exp`/`iat`: expiry and issued-at timestamps",
+		"- `jti`: unique token ID (for revocation)",
+		"",
+		"The resource server can validate this token locally by checking the",
+		"signature — no callback to the auth server needed.",
+	)
+
+	// --- Step 3: Use token ---
+	demo.Step("Access a protected resource").
+		Ref(demokit.RFC6750).
+		Ref(demokit.RFC7515).
+		Arrow("App", "RS", "GET /resource (Authorization: Bearer token)").
+		Arrow("RS", "RS", "Validate JWT signature + claims").
+		DashedArrow("RS", "App", "200 {data}").
+		Note("The resource server validates the JWT signature and extracts claims from it. No network call to the auth server.").
+		Run(func() {
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d\n", res.StatusCode)
+			var resource map[string]any
+			json.Unmarshal(body, &resource)
+			pretty, _ := json.MarshalIndent(resource, "    ", "  ")
+			fmt.Printf("    response: %s\n", string(pretty))
+		})
+
+	// --- Step 4: No token ---
+	demo.Step("Access without a token (expect rejection)").
+		Ref(demokit.RFC6750).
+		Arrow("App", "RS", "GET /resource (no Authorization header)").
+		DashedArrow("RS", "App", "401 Unauthorized").
+		Note("Without a valid Bearer token, the resource server rejects the request.").
+		Run(func() {
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			res, _ := http.DefaultClient.Do(req)
+			res.Body.Close()
+			fmt.Printf("    status: %d (correctly rejected)\n", res.StatusCode)
+		})
+
+	demo.Section("What's next?",
+		"In [02 — Resource Token (HS256)](../02-resource-token-hs256/), you'll see",
+		"how a registered app can mint tokens *for individual users*, not just for",
+		"itself. This is the federated authentication pattern used by OneAuth's",
+		"multi-app architecture.",
+	)
+
+	demo.Execute()
+
+	// Cleanup
+	if authServer != nil {
+		authServer.Close()
+	}
+	if resourceServer != nil {
+		resourceServer.Close()
+	}
+}

--- a/examples/01-client-credentials/main.go
+++ b/examples/01-client-credentials/main.go
@@ -91,11 +91,16 @@ func main() {
 
 	demo.Section("How client registration works",
 		"Before a client can get tokens, it needs to register with the auth server",
-		"and receive a `client_id` + `client_secret` pair. This is the OneAuth",
-		"equivalent of creating an OAuth application in a provider's dashboard.",
+		"and receive a `client_id` + `client_secret` pair. This is the equivalent",
+		"of going to GitHub Developer Settings → OAuth Apps → \"New OAuth App\".",
 		"",
-		"In this example we use the `/apps/register` endpoint with open auth.",
-		"In production, you'd protect this with an admin API key.",
+		"In this example, registration is **open** (`NewNoAuth()`) for simplicity.",
+		"In production, gate registration with authentication — see",
+		"[How does an App get registered?](../README.md#how-does-an-app-get-registered)",
+		"for the full spectrum from web dashboards to automated DCR.",
+		"",
+		"**The `client_secret` is a backend credential.** It lives in your server,",
+		"not in a browser or mobile app. Never expose it in frontend code.",
 	)
 
 	// --- Step 1: Register ---

--- a/examples/02-resource-token-hs256/Makefile
+++ b/examples/02-resource-token-hs256/Makefile
@@ -1,0 +1,16 @@
+# 02 — Resource Token with HS256 (Federated Auth)
+#
+# Infrastructure: None (in-memory, self-contained)
+
+EXAMPLE_DIR := 02-resource-token-hs256
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+.PHONY: run demo readme

--- a/examples/02-resource-token-hs256/README.md
+++ b/examples/02-resource-token-hs256/README.md
@@ -129,10 +129,10 @@ secrets — the resource server never sees the private key.
 
 ## References
 
+- [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
 - [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
 - [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
 - [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
-- [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
 
 ## Run it
 

--- a/examples/02-resource-token-hs256/README.md
+++ b/examples/02-resource-token-hs256/README.md
@@ -1,0 +1,147 @@
+# 02: Resource Token with HS256 (Federated Auth)
+
+Non-UI | No infrastructure needed | Builds on Example 01
+
+## What you'll learn
+
+- **Start auth server and resource server** — Same as Example 01, but now the resource server also extracts the `client_id` claim to know which app minted the token.
+- **Register an app with HS256 signing** — The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app and resource server can use it for signing/verification.
+- **Mint a resource token for user Alice** — The app creates a JWT with sub=alice, signed with its HS256 secret. The token includes quota claims (max_rooms) for resource-level enforcement.
+- **Mint a resource token for user Bob (different scopes)** — Same app, different user, different permissions. Bob gets read-only access with a lower room quota.
+- **Resource server validates Alice's token** — The resource server validates the JWT using the app's key from the shared KeyStore. It extracts the user ID, scopes, and quota claims.
+- **Resource server validates Bob's token** — Same resource server, different user — Bob's token has fewer scopes and a lower quota.
+- **Token signed with wrong secret is rejected** — A token signed with the wrong secret fails signature verification — the resource server rejects it immediately.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over App,RS: Step 1: Start auth server and resource server
+
+    Note over App,RS: Step 2: Register an app with HS256 signing
+    App->>AS: POST /apps/register {domain: myapp.example.com, signing_alg: HS256}
+    AS-->>App: {client_id, client_secret}
+
+    Note over App,RS: Step 3: Mint a resource token for user Alice
+    App->>App: MintResourceToken(alice, scopes=[read,write], max_rooms=10)
+
+    Note over App,RS: Step 4: Mint a resource token for user Bob (different scopes)
+    App->>App: MintResourceToken(bob, scopes=[read], max_rooms=3)
+
+    Note over App,RS: Step 5: Resource server validates Alice's token
+    App->>RS: GET /resource (Bearer: alice's token)
+    RS->>RS: Validate HS256 signature via KeyStore
+    RS-->>App: 200 {user: alice, scopes: [read,write], max_rooms: 10}
+
+    Note over App,RS: Step 6: Resource server validates Bob's token
+    App->>RS: GET /resource (Bearer: bob's token)
+    RS-->>App: 200 {user: bob, scopes: [read], max_rooms: 3}
+
+    Note over App,RS: Step 7: Token signed with wrong secret is rejected
+    App->>App: MintResourceToken(eve, secret=wrong-secret)
+    App->>RS: GET /resource (Bearer: bad token)
+    RS-->>App: 401 Unauthorized
+```
+
+## Steps
+
+### How this differs from Example 01
+
+**Actors:** App, Auth Server (AS), Resource Server (RS).
+Think: the GitHub bot now posts to Slack *as Alice*, not as itself.
+[What are these?](../README.md#cast-of-characters)
+
+In [01 — Client Credentials](../01-client-credentials/), the bot got a token
+representing *itself* (sub=client_id). That's machine-to-machine auth.
+
+Here, the app registers with the auth server and gets a shared secret (HS256).
+Then it uses `admin.MintResourceToken()` to create JWTs *for individual users*.
+Each token carries:
+- `sub` = the user's ID (not the app's)
+- `client_id` = the app that minted it
+- `scopes` = what this user can do
+- Quota claims (max_rooms, max_msg_rate) for resource-level limits
+
+The resource server validates these tokens using the same KeyStore — it trusts
+the app's signing key without calling back to the auth server.
+
+### Step 1: Start auth server and resource server
+
+Same as Example 01, but now the resource server also extracts the `client_id` claim to know which app minted the token.
+
+### Step 2: Register an app with HS256 signing
+
+> **References:** [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app and resource server can use it for signing/verification.
+
+### MintResourceToken vs client_credentials
+
+`MintResourceToken` is a library call, not an HTTP endpoint. The app calls it
+directly in its own process to create a JWT signed with the shared secret.
+
+This is different from the `client_credentials` grant in Example 01, where the
+app POSTs to the auth server's token endpoint. Here the app is trusted to mint
+tokens itself — the auth server just manages key registration.
+
+Think of it like this:
+- **client_credentials**: "Auth server, give ME a token"
+- **MintResourceToken**: "I'll make a token FOR this user, signed with my key"
+
+### Step 3: Mint a resource token for user Alice
+
+> **References:** [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519), [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515), [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+
+The app creates a JWT with sub=alice, signed with its HS256 secret. The token includes quota claims (max_rooms) for resource-level enforcement.
+
+### Step 4: Mint a resource token for user Bob (different scopes)
+
+> **References:** [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+Same app, different user, different permissions. Bob gets read-only access with a lower room quota.
+
+### Step 5: Resource server validates Alice's token
+
+> **References:** [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750), [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+The resource server validates the JWT using the app's key from the shared KeyStore. It extracts the user ID, scopes, and quota claims.
+
+### Step 6: Resource server validates Bob's token
+
+Same resource server, different user — Bob's token has fewer scopes and a lower quota.
+
+### Step 7: Token signed with wrong secret is rejected
+
+> **References:** [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+A token signed with the wrong secret fails signature verification — the resource server rejects it immediately.
+
+### What's next?
+
+In [03 — Resource Token (RS256 + JWKS)](../03-resource-token-rs256-jwks/),
+you'll see the asymmetric version: the app registers a public key, serves it
+via JWKS, and the resource server discovers it automatically. No shared
+secrets — the resource server never sees the private key.
+
+## References
+
+- [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
+- [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+- [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+
+## Run it
+
+```bash
+go run ./examples/02-resource-token-hs256/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/02-resource-token-hs256/ --non-interactive
+```

--- a/examples/02-resource-token-hs256/main.go
+++ b/examples/02-resource-token-hs256/main.go
@@ -1,0 +1,248 @@
+// Example 02: Resource Token with HS256 (Federated Auth)
+//
+// Building on Example 01, this shows how a registered app can mint
+// resource-scoped tokens for individual users — not just for itself.
+// This is OneAuth's federated authentication pattern.
+//
+// In Example 01: client_credentials → token with sub=client_id (machine identity)
+// In this example: app registers → mints per-user tokens → resource server validates
+//
+// Run:   go run ./examples/02-resource-token-hs256/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7519 (JWT)
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+func main() {
+	var authServer, resourceServer *httptest.Server
+	var ks keys.KeyStorage
+	var clientID, clientSecret string
+	var aliceToken, bobToken string
+
+	demo := demokit.New("02: Resource Token with HS256 (Federated Auth)").
+		Dir("02-resource-token-hs256").
+		Description("Non-UI | No infrastructure needed | Builds on Example 01").
+		Actors(
+			demokit.Actor("App", "Your App"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("How this differs from Example 01",
+		"**Actors:** App, Auth Server (AS), Resource Server (RS).",
+		"Think: the GitHub bot now posts to Slack *as Alice*, not as itself.",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"In [01 — Client Credentials](../01-client-credentials/), the bot got a token",
+		"representing *itself* (sub=client_id). That's machine-to-machine auth.",
+		"",
+		"Here, the app registers with the auth server and gets a shared secret (HS256).",
+		"Then it uses `admin.MintResourceToken()` to create JWTs *for individual users*.",
+		"Each token carries:",
+		"- `sub` = the user's ID (not the app's)",
+		"- `client_id` = the app that minted it",
+		"- `scopes` = what this user can do",
+		"- Quota claims (max_rooms, max_msg_rate) for resource-level limits",
+		"",
+		"The resource server validates these tokens using the same KeyStore — it trusts",
+		"the app's signing key without calling back to the auth server.",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server and resource server").
+		Note("Same as Example 01, but now the resource server also extracts the `client_id` claim to know which app minted the token.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+			authMux := http.NewServeMux()
+			authMux.Handle("/apps/", registrar.Handler())
+			authServer = httptest.NewServer(authMux)
+
+			middleware := &apiauth.APIMiddleware{KeyStore: ks}
+			resMux := http.NewServeMux()
+			resMux.Handle("GET /resource", middleware.ValidateToken(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					ctx := r.Context()
+					custom := apiauth.GetCustomClaimsFromContext(ctx)
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"user":      apiauth.GetUserIDFromAPIContext(ctx),
+						"scopes":    apiauth.GetScopesFromAPIContext(ctx),
+						"client_id": custom["client_id"],
+						"max_rooms": custom["max_rooms"],
+					})
+				}),
+			))
+			resourceServer = httptest.NewServer(resMux)
+
+			fmt.Printf("    Auth server:     %s\n", authServer.URL)
+			fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+		})
+
+	// --- Register ---
+	demo.Step("Register an app with HS256 signing").
+		Ref(demokit.RFC7515).
+		Arrow("App", "AS", "POST /apps/register {domain: myapp.example.com, signing_alg: HS256}").
+		DashedArrow("AS", "App", "{client_id, client_secret}").
+		Note("The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app and resource server can use it for signing/verification.").
+		Run(func() {
+			body, _ := json.Marshal(map[string]any{
+				"client_domain": "myapp.example.com",
+				"signing_alg":   "HS256",
+			})
+			resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+				bytes.NewReader(body))
+			var reg map[string]any
+			json.NewDecoder(resp.Body).Decode(&reg)
+			resp.Body.Close()
+
+			clientID = reg["client_id"].(string)
+			clientSecret = reg["client_secret"].(string)
+			fmt.Printf("    client_id:     %s\n", clientID)
+			fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
+		})
+
+	demo.Section("MintResourceToken vs client_credentials",
+		"`MintResourceToken` is a library call, not an HTTP endpoint. The app calls it",
+		"directly in its own process to create a JWT signed with the shared secret.",
+		"",
+		"This is different from the `client_credentials` grant in Example 01, where the",
+		"app POSTs to the auth server's token endpoint. Here the app is trusted to mint",
+		"tokens itself — the auth server just manages key registration.",
+		"",
+		"Think of it like this:",
+		"- **client_credentials**: \"Auth server, give ME a token\"",
+		"- **MintResourceToken**: \"I'll make a token FOR this user, signed with my key\"",
+	)
+
+	// --- Mint for Alice ---
+	demo.Step("Mint a resource token for user Alice").
+		Ref(demokit.RFC7519).
+		Ref(demokit.RFC7515).
+		Ref(demokit.RFC7638).
+		Arrow("App", "App", "MintResourceToken(alice, scopes=[read,write], max_rooms=10)").
+		Note("The app creates a JWT with sub=alice, signed with its HS256 secret. The token includes quota claims (max_rooms) for resource-level enforcement.").
+		Run(func() {
+			var err error
+			aliceToken, err = admin.MintResourceToken(
+				"alice", clientID, clientSecret,
+				admin.AppQuota{MaxRooms: 10, MaxMsgRate: 30.0},
+				[]string{"read", "write"}, nil,
+			)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+			fmt.Printf("    token for alice: %s...\n", aliceToken[:40])
+		})
+
+	// --- Mint for Bob ---
+	demo.Step("Mint a resource token for user Bob (different scopes)").
+		Ref(demokit.RFC7519).
+		Arrow("App", "App", "MintResourceToken(bob, scopes=[read], max_rooms=3)").
+		Note("Same app, different user, different permissions. Bob gets read-only access with a lower room quota.").
+		Run(func() {
+			var err error
+			bobToken, err = admin.MintResourceToken(
+				"bob", clientID, clientSecret,
+				admin.AppQuota{MaxRooms: 3},
+				[]string{"read"}, nil,
+			)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+			fmt.Printf("    token for bob: %s...\n", bobToken[:40])
+		})
+
+	// --- Validate Alice ---
+	demo.Step("Resource server validates Alice's token").
+		Ref(demokit.RFC6750).
+		Ref(demokit.RFC7515).
+		Arrow("App", "RS", "GET /resource (Bearer: alice's token)").
+		Arrow("RS", "RS", "Validate HS256 signature via KeyStore").
+		DashedArrow("RS", "App", "200 {user: alice, scopes: [read,write], max_rooms: 10}").
+		Note("The resource server validates the JWT using the app's key from the shared KeyStore. It extracts the user ID, scopes, and quota claims.").
+		Run(func() {
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+aliceToken)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d\n", res.StatusCode)
+			var data map[string]any
+			json.Unmarshal(body, &data)
+			pretty, _ := json.MarshalIndent(data, "    ", "  ")
+			fmt.Printf("    response: %s\n", string(pretty))
+		})
+
+	// --- Validate Bob ---
+	demo.Step("Resource server validates Bob's token").
+		Arrow("App", "RS", "GET /resource (Bearer: bob's token)").
+		DashedArrow("RS", "App", "200 {user: bob, scopes: [read], max_rooms: 3}").
+		Note("Same resource server, different user — Bob's token has fewer scopes and a lower quota.").
+		Run(func() {
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+bobToken)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d\n", res.StatusCode)
+			var data map[string]any
+			json.Unmarshal(body, &data)
+			pretty, _ := json.MarshalIndent(data, "    ", "  ")
+			fmt.Printf("    response: %s\n", string(pretty))
+		})
+
+	// --- Wrong secret ---
+	demo.Step("Token signed with wrong secret is rejected").
+		Ref(demokit.RFC7515).
+		Arrow("App", "App", "MintResourceToken(eve, secret=wrong-secret)").
+		Arrow("App", "RS", "GET /resource (Bearer: bad token)").
+		DashedArrow("RS", "App", "401 Unauthorized").
+		Note("A token signed with the wrong secret fails signature verification — the resource server rejects it immediately.").
+		Run(func() {
+			badToken, _ := admin.MintResourceToken(
+				"eve", clientID, "wrong-secret",
+				admin.AppQuota{}, []string{"admin"}, nil,
+			)
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+badToken)
+			res, _ := http.DefaultClient.Do(req)
+			res.Body.Close()
+			fmt.Printf("    status: %d (correctly rejected — wrong signing key)\n", res.StatusCode)
+		})
+
+	demo.Section("What's next?",
+		"In [03 — Resource Token (RS256 + JWKS)](../03-resource-token-rs256-jwks/),",
+		"you'll see the asymmetric version: the app registers a public key, serves it",
+		"via JWKS, and the resource server discovers it automatically. No shared",
+		"secrets — the resource server never sees the private key.",
+	)
+
+	demo.Execute()
+
+	if authServer != nil {
+		authServer.Close()
+	}
+	if resourceServer != nil {
+		resourceServer.Close()
+	}
+}

--- a/examples/03-resource-token-rs256-jwks/Makefile
+++ b/examples/03-resource-token-rs256-jwks/Makefile
@@ -1,0 +1,16 @@
+# 03 — Resource Token with RS256 + JWKS Discovery
+#
+# Infrastructure: None (in-memory, self-contained)
+
+EXAMPLE_DIR := 03-resource-token-rs256-jwks
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+.PHONY: run demo readme

--- a/examples/03-resource-token-rs256-jwks/README.md
+++ b/examples/03-resource-token-rs256-jwks/README.md
@@ -1,0 +1,161 @@
+# 03: Resource Token with RS256 + JWKS Discovery
+
+Non-UI | No infrastructure needed | Builds on Example 02
+
+## What you'll learn
+
+- **Start auth server with JWKS endpoint** — The auth server now serves two endpoints: /apps/ for registration and /.well-known/jwks.json for public key discovery.
+- **App generates an RSA key pair** — The app generates a 2048-bit RSA key pair. The private key stays with the app. The public key will be registered with the auth server.
+- **Register app with RS256 public key** — Unlike HS256 registration, no secret is returned. The auth server stores the public key and serves it via JWKS.
+- **Verify the public key appears in JWKS** — The JWKS endpoint serves only public keys — HS256 secrets are never exposed. Each key includes a kid (Key ID) computed from the key thumbprint (RFC 7638).
+- **Start resource server with JWKS-based key discovery** — The resource server points its JWKSKeyStore at the auth server's JWKS URL. It automatically fetches and caches the public keys.
+- **Mint a token with the private key and validate via JWKS** — The token's kid header tells the resource server which key to use. The signature is verified with the public key — the private key was never shared.
+- **Token signed with a different private key is rejected** — Even though the token is a valid JWT, its kid doesn't match any key in JWKS, or the signature doesn't verify with the registered public key.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over App,RS: Step 1: Start auth server with JWKS endpoint
+
+    Note over App,RS: Step 2: App generates an RSA key pair
+
+    Note over App,RS: Step 3: Register app with RS256 public key
+    App->>AS: POST /apps/register {domain, signing_alg: RS256, public_key}
+    AS-->>App: {client_id} (no client_secret — asymmetric!)
+
+    Note over App,RS: Step 4: Verify the public key appears in JWKS
+    App->>AS: GET /.well-known/jwks.json
+    AS-->>App: {keys: [{kty: RSA, alg: RS256, kid: ..., n: ..., e: ...}]}
+
+    Note over App,RS: Step 5: Start resource server with JWKS-based key discovery
+
+    Note over App,RS: Step 6: Mint a token with the private key and validate via JWKS
+    App->>App: MintResourceTokenWithKey(alice, privKey)
+    App->>RS: GET /resource (Bearer: RS256 token)
+    RS->>AS: GET /.well-known/jwks.json (cached)
+    RS->>RS: Verify RS256 signature with public key from JWKS
+    RS-->>App: 200 {user: alice}
+
+    Note over App,RS: Step 7: Token signed with a different private key is rejected
+    App->>App: MintResourceTokenWithKey(eve, differentPrivKey)
+    App->>RS: GET /resource (Bearer: bad token)
+    RS-->>App: 401 Unauthorized
+```
+
+## Steps
+
+### Why asymmetric signing?
+
+**Actors:** App, Auth Server (AS), Resource Server (RS).
+Think: the GitHub bot gets its own key pair — Slack's API never sees the private key.
+[What are these?](../README.md#cast-of-characters)
+
+In [02 — HS256](../02-resource-token-hs256/), both the app and resource server
+share the same secret. That works, but it means:
+- The resource server *could* forge tokens (it has the signing key)
+- Compromising the resource server compromises the signing key
+- Rotating keys requires coordinating both sides
+
+With RS256 (asymmetric):
+- The app keeps the private key — only it can sign tokens
+- The resource server only has the public key — it can verify but never forge
+- The public key is served via JWKS — resource servers discover it automatically
+- Key rotation is seamless: publish a new key to JWKS, resource servers pick it up
+
+### Step 1: Start auth server with JWKS endpoint
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+The auth server now serves two endpoints: /apps/ for registration and /.well-known/jwks.json for public key discovery.
+
+### Step 2: App generates an RSA key pair
+
+> **References:** [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+The app generates a 2048-bit RSA key pair. The private key stays with the app. The public key will be registered with the auth server.
+
+### Step 3: Register app with RS256 public key
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+Unlike HS256 registration, no secret is returned. The auth server stores the public key and serves it via JWKS.
+
+### Step 4: Verify the public key appears in JWKS
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517), [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+
+The JWKS endpoint serves only public keys — HS256 secrets are never exposed. Each key includes a kid (Key ID) computed from the key thumbprint (RFC 7638).
+
+### How JWKS discovery works
+
+The resource server doesn't need the auth server's key ahead of time.
+It uses `JWKSKeyStore` which:
+1. Fetches `/.well-known/jwks.json` from the auth server
+2. Caches the keys locally
+3. When a token arrives with a `kid` header, looks up the matching key
+4. Periodically refreshes to pick up new/rotated keys
+
+This is the same mechanism Keycloak, Auth0, and other IdPs use.
+
+### Step 5: Start resource server with JWKS-based key discovery
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+The resource server points its JWKSKeyStore at the auth server's JWKS URL. It automatically fetches and caches the public keys.
+
+### Step 6: Mint a token with the private key and validate via JWKS
+
+> **References:** [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519), [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515), [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+
+The token's kid header tells the resource server which key to use. The signature is verified with the public key — the private key was never shared.
+
+### Step 7: Token signed with a different private key is rejected
+
+> **References:** [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+Even though the token is a valid JWT, its kid doesn't match any key in JWKS, or the signature doesn't verify with the registered public key.
+
+### HS256 vs RS256 — when to use which
+
+| | HS256 (Example 02) | RS256 (this example) |
+|---|---|---|
+| **Key type** | Shared secret | Public/private key pair |
+| **Who can sign** | Anyone with the secret | Only the private key holder |
+| **Who can verify** | Anyone with the secret | Anyone with the public key |
+| **Key distribution** | Must be kept secret on both sides | Public key is... public |
+| **JWKS** | Secrets excluded from JWKS | Public keys served via JWKS |
+| **Best for** | Simple setups, trusted environments | Multi-service, zero-trust |
+
+**Rule of thumb:** Use RS256 when the resource server is a separate service.
+Use HS256 when the app and resource server are the same process or fully trusted.
+
+### What's next?
+
+In [04 — Discovery](../04-discovery/), you'll see how clients can
+auto-discover the auth server's endpoints (token, JWKS, introspection)
+without hardcoding URLs. This is the foundation for interoperability
+with external IdPs like Keycloak and Auth0.
+
+## References
+
+- [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+- [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+- [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+## Run it
+
+```bash
+go run ./examples/03-resource-token-rs256-jwks/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/03-resource-token-rs256-jwks/ --non-interactive
+```

--- a/examples/03-resource-token-rs256-jwks/README.md
+++ b/examples/03-resource-token-rs256-jwks/README.md
@@ -143,10 +143,10 @@ with external IdPs like Keycloak and Auth0.
 
 ## References
 
-- [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
-- [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
 - [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
 - [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+- [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+- [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
 
 ## Run it
 

--- a/examples/03-resource-token-rs256-jwks/main.go
+++ b/examples/03-resource-token-rs256-jwks/main.go
@@ -1,0 +1,284 @@
+// Example 03: Resource Token with RS256 + JWKS Discovery
+//
+// Building on Example 02 (HS256 shared secret), this shows the asymmetric
+// alternative: the app generates an RSA key pair, registers only the PUBLIC
+// key, and the resource server discovers it via JWKS. The private key never
+// leaves the app.
+//
+// In Example 02: shared secret (HS256) — both sides know the key
+// In this example: public/private key pair (RS256) — only the app has the private key
+//
+// Run:   go run ./examples/03-resource-token-rs256-jwks/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7517 (JWK)
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"crypto/rsa"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+func main() {
+	var authServer, resourceServer *httptest.Server
+	var ks keys.KeyStorage
+	var clientID string
+	var privKey *rsa.PrivateKey
+	var aliceToken string
+
+	demo := demokit.New("03: Resource Token with RS256 + JWKS Discovery").
+		Dir("03-resource-token-rs256-jwks").
+		Description("Non-UI | No infrastructure needed | Builds on Example 02").
+		Actors(
+			demokit.Actor("App", "Your App"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("Why asymmetric signing?",
+		"**Actors:** App, Auth Server (AS), Resource Server (RS).",
+		"Think: the GitHub bot gets its own key pair — Slack's API never sees the private key.",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"In [02 — HS256](../02-resource-token-hs256/), both the app and resource server",
+		"share the same secret. That works, but it means:",
+		"- The resource server *could* forge tokens (it has the signing key)",
+		"- Compromising the resource server compromises the signing key",
+		"- Rotating keys requires coordinating both sides",
+		"",
+		"With RS256 (asymmetric):",
+		"- The app keeps the private key — only it can sign tokens",
+		"- The resource server only has the public key — it can verify but never forge",
+		"- The public key is served via JWKS — resource servers discover it automatically",
+		"- Key rotation is seamless: publish a new key to JWKS, resource servers pick it up",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server with JWKS endpoint").
+		Ref(demokit.RFC7517).
+		Note("The auth server now serves two endpoints: /apps/ for registration and /.well-known/jwks.json for public key discovery.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+			jwksHandler := &keys.JWKSHandler{KeyStore: ks}
+
+			authMux := http.NewServeMux()
+			authMux.Handle("/apps/", registrar.Handler())
+			authMux.Handle("GET /.well-known/jwks.json", jwksHandler)
+			authServer = httptest.NewServer(authMux)
+
+			fmt.Printf("    Auth server: %s\n", authServer.URL)
+			fmt.Printf("    JWKS:        %s/.well-known/jwks.json\n", authServer.URL)
+		})
+
+	// --- Generate key pair ---
+	demo.Step("App generates an RSA key pair").
+		Ref(demokit.RFC7515).
+		Note("The app generates a 2048-bit RSA key pair. The private key stays with the app. The public key will be registered with the auth server.").
+		Run(func() {
+			privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+			parsed, _ := utils.ParsePrivateKeyPEM(privPEM)
+			privKey = parsed.(*rsa.PrivateKey)
+
+			fmt.Printf("    Private key: %d bytes (stays with app)\n", len(privPEM))
+			fmt.Printf("    Public key:  %d bytes (will be registered)\n", len(pubPEM))
+		})
+
+	// --- Register with public key ---
+	demo.Step("Register app with RS256 public key").
+		Ref(demokit.RFC7517).
+		Arrow("App", "AS", "POST /apps/register {domain, signing_alg: RS256, public_key}").
+		DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
+		Note("Unlike HS256 registration, no secret is returned. The auth server stores the public key and serves it via JWKS.").
+		Run(func() {
+			pubPEM, _ := utils.EncodePublicKeyPEM(&privKey.PublicKey)
+			body, _ := json.Marshal(map[string]any{
+				"client_domain": "myapp.example.com",
+				"signing_alg":   "RS256",
+				"public_key":    string(pubPEM),
+			})
+			resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+				bytes.NewReader(body))
+			var reg map[string]any
+			json.NewDecoder(resp.Body).Decode(&reg)
+			resp.Body.Close()
+
+			clientID = reg["client_id"].(string)
+			fmt.Printf("    client_id:     %s\n", clientID)
+			fmt.Printf("    client_secret: (none — RS256 uses key pair)\n")
+		})
+
+	// --- Verify JWKS ---
+	demo.Step("Verify the public key appears in JWKS").
+		Ref(demokit.RFC7517).
+		Ref(demokit.RFC7638).
+		Arrow("App", "AS", "GET /.well-known/jwks.json").
+		DashedArrow("AS", "App", "{keys: [{kty: RSA, alg: RS256, kid: ..., n: ..., e: ...}]}").
+		Note("The JWKS endpoint serves only public keys — HS256 secrets are never exposed. Each key includes a kid (Key ID) computed from the key thumbprint (RFC 7638).").
+		Run(func() {
+			resp, _ := http.Get(authServer.URL + "/.well-known/jwks.json")
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			var jwkSet map[string]any
+			json.Unmarshal(body, &jwkSet)
+			jwksKeys := jwkSet["keys"].([]any)
+			fmt.Printf("    JWKS key count: %d\n", len(jwksKeys))
+
+			if len(jwksKeys) > 0 {
+				key := jwksKeys[0].(map[string]any)
+				fmt.Printf("    kty: %s\n", key["kty"])
+				fmt.Printf("    alg: %s\n", key["alg"])
+				fmt.Printf("    kid: %s\n", key["kid"])
+				fmt.Printf("    key_ops: %v\n", key["key_ops"])
+
+				// Verify no private key fields
+				for _, field := range []string{"d", "p", "q", "dp", "dq", "qi"} {
+					if key[field] != nil {
+						fmt.Printf("    WARNING: private field %q leaked!\n", field)
+					}
+				}
+				fmt.Printf("    private fields: (absent — only public components served)\n")
+			}
+		})
+
+	demo.Section("How JWKS discovery works",
+		"The resource server doesn't need the auth server's key ahead of time.",
+		"It uses `JWKSKeyStore` which:",
+		"1. Fetches `/.well-known/jwks.json` from the auth server",
+		"2. Caches the keys locally",
+		"3. When a token arrives with a `kid` header, looks up the matching key",
+		"4. Periodically refreshes to pick up new/rotated keys",
+		"",
+		"This is the same mechanism Keycloak, Auth0, and other IdPs use.",
+	)
+
+	// --- Start resource server with JWKS discovery ---
+	demo.Step("Start resource server with JWKS-based key discovery").
+		Ref(demokit.RFC7517).
+		Note("The resource server points its JWKSKeyStore at the auth server's JWKS URL. It automatically fetches and caches the public keys.").
+		Run(func() {
+			jwksKS := keys.NewJWKSKeyStore(
+				authServer.URL+"/.well-known/jwks.json",
+				keys.WithMinRefreshGap(0),
+			)
+			jwksKS.Start()
+
+			middleware := &apiauth.APIMiddleware{KeyStore: jwksKS}
+			resMux := http.NewServeMux()
+			resMux.Handle("GET /resource", middleware.ValidateToken(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					ctx := r.Context()
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"user":   apiauth.GetUserIDFromAPIContext(ctx),
+						"scopes": apiauth.GetScopesFromAPIContext(ctx),
+					})
+				}),
+			))
+			resourceServer = httptest.NewServer(resMux)
+
+			fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+			fmt.Printf("    JWKS source:     %s/.well-known/jwks.json\n", authServer.URL)
+		})
+
+	// --- Mint and validate ---
+	demo.Step("Mint a token with the private key and validate via JWKS").
+		Ref(demokit.RFC7519).
+		Ref(demokit.RFC7515).
+		Ref(demokit.RFC7638).
+		Arrow("App", "App", "MintResourceTokenWithKey(alice, privKey)").
+		Arrow("App", "RS", "GET /resource (Bearer: RS256 token)").
+		Arrow("RS", "AS", "GET /.well-known/jwks.json (cached)").
+		Arrow("RS", "RS", "Verify RS256 signature with public key from JWKS").
+		DashedArrow("RS", "App", "200 {user: alice}").
+		Note("The token's kid header tells the resource server which key to use. The signature is verified with the public key — the private key was never shared.").
+		Run(func() {
+			aliceToken, _ = admin.MintResourceTokenWithKey(
+				"alice", clientID, privKey,
+				admin.AppQuota{}, []string{"read", "write"}, nil,
+			)
+			fmt.Printf("    token: %s...\n", aliceToken[:40])
+
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+aliceToken)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d\n", res.StatusCode)
+			var data map[string]any
+			json.Unmarshal(body, &data)
+			pretty, _ := json.MarshalIndent(data, "    ", "  ")
+			fmt.Printf("    response: %s\n", string(pretty))
+		})
+
+	// --- Wrong key ---
+	demo.Step("Token signed with a different private key is rejected").
+		Ref(demokit.RFC7515).
+		Arrow("App", "App", "MintResourceTokenWithKey(eve, differentPrivKey)").
+		Arrow("App", "RS", "GET /resource (Bearer: bad token)").
+		DashedArrow("RS", "App", "401 Unauthorized").
+		Note("Even though the token is a valid JWT, its kid doesn't match any key in JWKS, or the signature doesn't verify with the registered public key.").
+		Run(func() {
+			// Generate a completely different key pair
+			otherPrivPEM, _, _ := utils.GenerateRSAKeyPair(2048)
+			otherPrivKey, _ := utils.ParsePrivateKeyPEM(otherPrivPEM)
+
+			badToken, _ := admin.MintResourceTokenWithKey(
+				"eve", clientID, otherPrivKey,
+				admin.AppQuota{}, []string{"admin"}, nil,
+			)
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+badToken)
+			res, _ := http.DefaultClient.Do(req)
+			res.Body.Close()
+			fmt.Printf("    status: %d (correctly rejected — wrong private key)\n", res.StatusCode)
+		})
+
+	demo.Section("HS256 vs RS256 — when to use which",
+		"| | HS256 (Example 02) | RS256 (this example) |",
+		"|---|---|---|",
+		"| **Key type** | Shared secret | Public/private key pair |",
+		"| **Who can sign** | Anyone with the secret | Only the private key holder |",
+		"| **Who can verify** | Anyone with the secret | Anyone with the public key |",
+		"| **Key distribution** | Must be kept secret on both sides | Public key is... public |",
+		"| **JWKS** | Secrets excluded from JWKS | Public keys served via JWKS |",
+		"| **Best for** | Simple setups, trusted environments | Multi-service, zero-trust |",
+		"",
+		"**Rule of thumb:** Use RS256 when the resource server is a separate service.",
+		"Use HS256 when the app and resource server are the same process or fully trusted.",
+	)
+
+	demo.Section("What's next?",
+		"In [04 — Discovery](../04-discovery/), you'll see how clients can",
+		"auto-discover the auth server's endpoints (token, JWKS, introspection)",
+		"without hardcoding URLs. This is the foundation for interoperability",
+		"with external IdPs like Keycloak and Auth0.",
+	)
+
+	demo.Execute()
+
+	if authServer != nil {
+		authServer.Close()
+	}
+	if resourceServer != nil {
+		resourceServer.Close()
+	}
+}

--- a/examples/04-discovery/Makefile
+++ b/examples/04-discovery/Makefile
@@ -1,0 +1,27 @@
+# 04 — AS Metadata Discovery (RFC 8414)
+#
+# Infrastructure: None (Keycloak optional for cross-server discovery demo)
+#
+# To see the Keycloak comparison step:
+#   make upkcl    # start Keycloak for examples (port 8280)
+#   make run      # the KC step auto-detects and runs
+
+EXAMPLE_DIR := 04-discovery
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+# Start/stop Keycloak for this example (delegates to top-level examples Makefile)
+upkcl:
+	$(MAKE) -C .. upkcl
+
+downkcl:
+	$(MAKE) -C .. downkcl
+
+.PHONY: run demo readme upkcl downkcl

--- a/examples/04-discovery/README.md
+++ b/examples/04-discovery/README.md
@@ -148,9 +148,9 @@ for opaque tokens.
 
 ## References
 
-- [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
 - [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
+- [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
 
 ## Run it
 

--- a/examples/04-discovery/README.md
+++ b/examples/04-discovery/README.md
@@ -1,0 +1,165 @@
+# 04: AS Metadata Discovery
+
+Non-UI | No infrastructure needed | Builds on Examples 01-03
+
+## What you'll learn
+
+- **Start auth server with discovery, token, JWKS, and introspection endpoints** — This is the most complete auth server we've built so far — it serves discovery, tokens, JWKS, introspection, and registration.
+- **Fetch the discovery document (raw HTTP)** — The discovery document is a JSON object listing every endpoint the server supports. This is the same format Keycloak, Auth0, and Google use.
+- **Discover using the client SDK (client.DiscoverAS)** — client.DiscoverAS() fetches and parses the metadata into a typed Go struct. Production code should use this — no manual JSON parsing needed.
+- **Register a client (using discovered URL)** — Instead of hardcoding /apps/register, we use the registration_endpoint from discovery. The same code works against OneAuth, Keycloak, or any RFC 8414-compliant server.
+- **Get a token (using discovered token endpoint)** — We use discoveredMeta.TokenEndpoint instead of hardcoding /api/token. This is the key benefit — the same client code works against any compliant AS.
+- **Use the token on a resource server** — The resource server validates the token as in previous examples. Discovery doesn't change how tokens work — it only changes how the client finds the endpoints.
+- **Discover Keycloak endpoints (optional)** — Same DiscoverAS() call, completely different server. If Keycloak isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over App,RS: Step 1: Start auth server with discovery, token, JWKS, and introspection endpoints
+
+    Note over App,RS: Step 2: Fetch the discovery document (raw HTTP)
+    App->>AS: GET /.well-known/openid-configuration
+    AS-->>App: JSON {issuer, token_endpoint, jwks_uri, ...}
+
+    Note over App,RS: Step 3: Discover using the client SDK (client.DiscoverAS)
+    App->>AS: client.DiscoverAS(serverURL)
+    AS-->>App: typed ASMetadata struct
+
+    Note over App,RS: Step 4: Register a client (using discovered URL)
+    App->>AS: POST {discovered_registration_endpoint}
+    AS-->>App: {client_id, client_secret}
+
+    Note over App,RS: Step 5: Get a token (using discovered token endpoint)
+    App->>AS: POST {discovered_token_endpoint}
+    AS-->>App: {access_token, token_type, expires_in}
+
+    Note over App,RS: Step 6: Use the token on a resource server
+    App->>RS: GET /resource (Bearer token)
+    RS-->>App: 200 {data}
+
+    Note over App,RS: Step 7: Discover Keycloak endpoints (optional)
+    App->>AS: client.DiscoverAS(keycloakRealmURL)
+    AS-->>App: {issuer, token_endpoint, jwks_uri, ...}
+```
+
+## Steps
+
+### About this example
+
+**Actors:** App (a bot), Auth Server (AS), Resource Server (RS).
+Think: the GitHub bot doesn't know Slack's token URL — it discovers it.
+[What are these?](../README.md#cast-of-characters)
+
+In Examples 01-03, we hardcoded the auth server's URLs:
+```go
+http.PostForm(authServer.URL + "/api/token", ...)  // hardcoded path
+```
+
+In production, you don't know the paths ahead of time. Different auth servers
+use different URL structures (Keycloak: `/realms/{name}/protocol/openid-connect/token`,
+Auth0: `/oauth/token`, OneAuth: `/api/token`).
+
+RFC 8414 solves this: every auth server publishes a JSON document at
+`/.well-known/openid-configuration` listing all its endpoints.
+Clients fetch this once and use the discovered URLs for everything.
+
+### Step 1: Start auth server with discovery, token, JWKS, and introspection endpoints
+
+> **References:** [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+This is the most complete auth server we've built so far — it serves discovery, tokens, JWKS, introspection, and registration.
+
+### Step 2: Fetch the discovery document (raw HTTP)
+
+> **References:** [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+The discovery document is a JSON object listing every endpoint the server supports. This is the same format Keycloak, Auth0, and Google use.
+
+### What's in the metadata?
+
+| Field | What it tells the client |
+|-------|------------------------|
+| `issuer` | The AS's canonical URL — must match the `iss` claim in tokens |
+| `token_endpoint` | Where to POST for tokens (client_credentials, auth code) |
+| `jwks_uri` | Where to GET public keys for token verification |
+| `introspection_endpoint` | Where to POST for token introspection (RFC 7662) |
+| `registration_endpoint` | Where to POST for dynamic client registration (RFC 7591) |
+| `scopes_supported` | What scopes the AS recognizes |
+| `grant_types_supported` | What OAuth grant types are available |
+| `token_endpoint_auth_methods_supported` | How clients can authenticate (basic, post) |
+| `code_challenge_methods_supported` | PKCE methods (S256) |
+
+A client only needs to know the server's base URL. Everything else is discovered.
+
+### Step 3: Discover using the client SDK (client.DiscoverAS)
+
+> **References:** [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+client.DiscoverAS() fetches and parses the metadata into a typed Go struct. Production code should use this — no manual JSON parsing needed.
+
+### Step 4: Register a client (using discovered URL)
+
+Instead of hardcoding /apps/register, we use the registration_endpoint from discovery. The same code works against OneAuth, Keycloak, or any RFC 8414-compliant server.
+
+### Step 5: Get a token (using discovered token endpoint)
+
+> **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+
+We use discoveredMeta.TokenEndpoint instead of hardcoding /api/token. This is the key benefit — the same client code works against any compliant AS.
+
+### Step 6: Use the token on a resource server
+
+> **References:** [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
+
+The resource server validates the token as in previous examples. Discovery doesn't change how tokens work — it only changes how the client finds the endpoints.
+
+### Step 7: Discover Keycloak endpoints (optional)
+
+> **References:** [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+Same DiscoverAS() call, completely different server. If Keycloak isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.
+
+### Why discovery matters
+
+Without discovery, switching auth providers means updating every URL in your code.
+With discovery, you change one base URL and everything else adapts:
+
+```go
+// Works against OneAuth, Keycloak, Auth0 — same code
+meta, _ := client.DiscoverAS("https://auth.example.com")
+http.PostForm(meta.TokenEndpoint, ...)       // discovered
+jwksKS := keys.NewJWKSKeyStore(meta.JWKSURI) // discovered
+```
+
+This is especially important for the [Keycloak interop tests](../../tests/keycloak/)
+where the same test code validates against both Keycloak and OneAuth.
+
+### What's next?
+
+In [05 — Introspection](../05-introspection/), you'll see how resource
+servers can validate tokens remotely by asking the auth server "is this
+token valid?" — an alternative to local JWT verification that works even
+for opaque tokens.
+
+## References
+
+- [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+- [RFC 6750 — Bearer Token Usage](https://www.rfc-editor.org/rfc/rfc6750)
+
+## Run it
+
+```bash
+go run ./examples/04-discovery/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/04-discovery/ --non-interactive
+```

--- a/examples/04-discovery/main.go
+++ b/examples/04-discovery/main.go
@@ -1,0 +1,325 @@
+// Example 04: AS Metadata Discovery (RFC 8414)
+//
+// In Examples 01-03, we hardcoded URLs like authServer.URL+"/api/token".
+// In production, clients discover endpoints automatically from a single
+// well-known URL. This is how Keycloak, Auth0, and OneAuth all work.
+//
+// Run:   go run ./examples/04-discovery/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc8414
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+
+func main() {
+	var authServer, resourceServer *httptest.Server
+	var ks keys.KeyStorage
+	var discoveredMeta *client.ASMetadata
+	var clientID, clientSecret, accessToken string
+
+	demo := demokit.New("04: AS Metadata Discovery").
+		Dir("04-discovery").
+		Description("Non-UI | No infrastructure needed | Builds on Examples 01-03").
+		Actors(
+			demokit.Actor("App", "Client App"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** App (a bot), Auth Server (AS), Resource Server (RS).",
+		"Think: the GitHub bot doesn't know Slack's token URL — it discovers it.",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"In Examples 01-03, we hardcoded the auth server's URLs:",
+		"```go",
+		"http.PostForm(authServer.URL + \"/api/token\", ...)  // hardcoded path",
+		"```",
+		"",
+		"In production, you don't know the paths ahead of time. Different auth servers",
+		"use different URL structures (Keycloak: `/realms/{name}/protocol/openid-connect/token`,",
+		"Auth0: `/oauth/token`, OneAuth: `/api/token`).",
+		"",
+		"RFC 8414 solves this: every auth server publishes a JSON document at",
+		"`/.well-known/openid-configuration` listing all its endpoints.",
+		"Clients fetch this once and use the discovered URLs for everything.",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server with discovery, token, JWKS, and introspection endpoints").
+		Ref(demokit.RFC8414).
+		Note("This is the most complete auth server we've built so far — it serves discovery, tokens, JWKS, introspection, and registration.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+			jwksHandler := &keys.JWKSHandler{KeyStore: ks}
+
+			apiAuth := &apiauth.APIAuth{
+				JWTSecretKey:   "discovery-example-secret-32chars!",
+				ClientKeyStore: ks,
+			}
+
+			introspection := &apiauth.IntrospectionHandler{
+				Auth:           apiAuth,
+				ClientKeyStore: ks,
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/apps/", registrar.Handler())
+			mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+			mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+			mux.Handle("POST /oauth/introspect", introspection)
+			authServer = httptest.NewServer(mux)
+
+			// Set issuer to actual URL (must match tokens)
+			apiAuth.JWTIssuer = authServer.URL
+
+			// Register discovery endpoint with all the server's capabilities
+			mux.Handle("GET /.well-known/openid-configuration",
+				apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+					Issuer:                        authServer.URL,
+					TokenEndpoint:                 authServer.URL + "/api/token",
+					JWKSURI:                       authServer.URL + "/.well-known/jwks.json",
+					IntrospectionEndpoint:         authServer.URL + "/oauth/introspect",
+					RegistrationEndpoint:          authServer.URL + "/apps/register",
+					ScopesSupported:               []string{"read", "write", "admin"},
+					GrantTypesSupported:           []string{"client_credentials"},
+					ResponseTypesSupported:        []string{"token"},
+					TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
+					CodeChallengeMethodsSupported: []string{"S256"},
+				}))
+
+			// Resource server
+			middleware := &apiauth.APIMiddleware{
+				JWTSecretKey: "discovery-example-secret-32chars!",
+				JWTIssuer:    authServer.URL,
+			}
+			resMux := http.NewServeMux()
+			resMux.Handle("GET /resource", middleware.ValidateToken(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+						"scopes": apiauth.GetScopesFromAPIContext(r.Context()),
+					})
+				}),
+			))
+			resourceServer = httptest.NewServer(resMux)
+
+			fmt.Printf("    Auth server:     %s\n", authServer.URL)
+			fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+		})
+
+	// --- Fetch raw metadata ---
+	demo.Step("Fetch the discovery document (raw HTTP)").
+		Ref(demokit.RFC8414).
+		Arrow("App", "AS", "GET /.well-known/openid-configuration").
+		DashedArrow("AS", "App", "JSON {issuer, token_endpoint, jwks_uri, ...}").
+		Note("The discovery document is a JSON object listing every endpoint the server supports. This is the same format Keycloak, Auth0, and Google use.").
+		Run(func() {
+			resp, _ := http.Get(authServer.URL + "/.well-known/openid-configuration")
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			var meta map[string]any
+			json.Unmarshal(body, &meta)
+			pretty, _ := json.MarshalIndent(meta, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+		})
+
+	demo.Section("What's in the metadata?",
+		"| Field | What it tells the client |",
+		"|-------|------------------------|",
+		"| `issuer` | The AS's canonical URL — must match the `iss` claim in tokens |",
+		"| `token_endpoint` | Where to POST for tokens (client_credentials, auth code) |",
+		"| `jwks_uri` | Where to GET public keys for token verification |",
+		"| `introspection_endpoint` | Where to POST for token introspection (RFC 7662) |",
+		"| `registration_endpoint` | Where to POST for dynamic client registration (RFC 7591) |",
+		"| `scopes_supported` | What scopes the AS recognizes |",
+		"| `grant_types_supported` | What OAuth grant types are available |",
+		"| `token_endpoint_auth_methods_supported` | How clients can authenticate (basic, post) |",
+		"| `code_challenge_methods_supported` | PKCE methods (S256) |",
+		"",
+		"A client only needs to know the server's base URL. Everything else is discovered.",
+	)
+
+	// --- Use client.DiscoverAS ---
+	demo.Step("Discover using the client SDK (client.DiscoverAS)").
+		Ref(demokit.RFC8414).
+		Arrow("App", "AS", "client.DiscoverAS(serverURL)").
+		DashedArrow("AS", "App", "typed ASMetadata struct").
+		Note("client.DiscoverAS() fetches and parses the metadata into a typed Go struct. Production code should use this — no manual JSON parsing needed.").
+		Run(func() {
+			var err error
+			discoveredMeta, err = client.DiscoverAS(authServer.URL)
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+
+			fmt.Printf("    issuer:                  %s\n", discoveredMeta.Issuer)
+			fmt.Printf("    token_endpoint:          %s\n", discoveredMeta.TokenEndpoint)
+			fmt.Printf("    jwks_uri:                %s\n", discoveredMeta.JWKSURI)
+			fmt.Printf("    introspection_endpoint:  %s\n", discoveredMeta.IntrospectionEndpoint)
+			fmt.Printf("    scopes_supported:        %v\n", discoveredMeta.ScopesSupported)
+			fmt.Printf("    grant_types_supported:   %v\n", discoveredMeta.GrantTypesSupported)
+			fmt.Printf("    auth_methods:            %v\n", discoveredMeta.TokenEndpointAuthMethods)
+		})
+
+	// --- Register using discovered endpoint ---
+	demo.Step("Register a client (using discovered URL)").
+		Arrow("App", "AS", "POST {discovered_registration_endpoint}").
+		DashedArrow("AS", "App", "{client_id, client_secret}").
+		Note("Instead of hardcoding /apps/register, we use the registration_endpoint from discovery. The same code works against OneAuth, Keycloak, or any RFC 8414-compliant server.").
+		Run(func() {
+			body, _ := json.Marshal(map[string]any{
+				"client_domain": "discovery-demo.example.com",
+				"signing_alg":   "HS256",
+			})
+			resp, _ := http.Post(authServer.URL+"/apps/register",
+				"application/json", strings.NewReader(string(body)))
+			var reg map[string]any
+			json.NewDecoder(resp.Body).Decode(&reg)
+			resp.Body.Close()
+
+			clientID = reg["client_id"].(string)
+			clientSecret = reg["client_secret"].(string)
+			fmt.Printf("    client_id:     %s\n", clientID)
+			fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
+		})
+
+	// --- Get token using discovered endpoint ---
+	demo.Step("Get a token (using discovered token endpoint)").
+		Ref(demokit.RFC6749_ClientCredentials).
+		Arrow("App", "AS", "POST {discovered_token_endpoint}").
+		DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
+		Note("We use discoveredMeta.TokenEndpoint instead of hardcoding /api/token. This is the key benefit — the same client code works against any compliant AS.").
+		Run(func() {
+			resp, _ := http.PostForm(discoveredMeta.TokenEndpoint, url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {clientID},
+				"client_secret": {clientSecret},
+				"scope":         {"read write"},
+			})
+			var tokenData map[string]any
+			json.NewDecoder(resp.Body).Decode(&tokenData)
+			resp.Body.Close()
+
+			accessToken = tokenData["access_token"].(string)
+			fmt.Printf("    token_endpoint used: %s\n", discoveredMeta.TokenEndpoint)
+			fmt.Printf("    token_type:          %s\n", tokenData["token_type"])
+			fmt.Printf("    scope:               %s\n", tokenData["scope"])
+			fmt.Printf("    access_token:        %s...\n", accessToken[:40])
+		})
+
+	// --- Use the token ---
+	demo.Step("Use the token on a resource server").
+		Ref(demokit.RFC6750).
+		Arrow("App", "RS", "GET /resource (Bearer token)").
+		DashedArrow("RS", "App", "200 {data}").
+		Note("The resource server validates the token as in previous examples. Discovery doesn't change how tokens work — it only changes how the client finds the endpoints.").
+		Run(func() {
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d\n", res.StatusCode)
+			var data map[string]any
+			json.Unmarshal(body, &data)
+			pretty, _ := json.MarshalIndent(data, "    ", "  ")
+			fmt.Printf("    response: %s\n", string(pretty))
+		})
+
+	// --- Optional: Keycloak comparison ---
+	demo.Step("Discover Keycloak endpoints (optional)").
+		Ref(demokit.RFC8414).
+		Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
+		DashedArrow("AS", "App", "{issuer, token_endpoint, jwks_uri, ...}").
+		Note("Same DiscoverAS() call, completely different server. If Keycloak isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
+		Run(func() {
+			// Check if KC is reachable
+			kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			resp, err := httpClient.Get(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+				fmt.Printf("    To enable: cd examples && make upkcl\n")
+				return
+			}
+			resp.Body.Close()
+
+			kcMeta, err := client.DiscoverAS(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
+				return
+			}
+
+			fmt.Printf("    Keycloak discovered at %s:\n", kcRealmURL)
+			fmt.Printf("      issuer:           %s\n", kcMeta.Issuer)
+			fmt.Printf("      token_endpoint:   %s\n", kcMeta.TokenEndpoint)
+			fmt.Printf("      jwks_uri:         %s\n", kcMeta.JWKSURI)
+			fmt.Printf("      introspection:    %s\n", kcMeta.IntrospectionEndpoint)
+
+			fmt.Printf("\n    Side by side — same code, different servers:\n")
+			fmt.Printf("      %-25s %-45s %s\n", "Field", "OneAuth", "Keycloak")
+			fmt.Printf("      %-25s %-45s %s\n", "-----", "-------", "--------")
+			fmt.Printf("      %-25s %-45s %s\n", "token_endpoint",
+				discoveredMeta.TokenEndpoint, kcMeta.TokenEndpoint)
+			fmt.Printf("      %-25s %-45s %s\n", "jwks_uri",
+				discoveredMeta.JWKSURI, kcMeta.JWKSURI)
+			fmt.Printf("      %-25s %-45s %s\n", "introspection_endpoint",
+				discoveredMeta.IntrospectionEndpoint, kcMeta.IntrospectionEndpoint)
+		})
+
+	demo.Section("Why discovery matters",
+		"Without discovery, switching auth providers means updating every URL in your code.",
+		"With discovery, you change one base URL and everything else adapts:",
+		"",
+		"```go",
+		"// Works against OneAuth, Keycloak, Auth0 — same code",
+		"meta, _ := client.DiscoverAS(\"https://auth.example.com\")",
+		"http.PostForm(meta.TokenEndpoint, ...)       // discovered",
+		"jwksKS := keys.NewJWKSKeyStore(meta.JWKSURI) // discovered",
+		"```",
+		"",
+		"This is especially important for the [Keycloak interop tests](../../tests/keycloak/)",
+		"where the same test code validates against both Keycloak and OneAuth.",
+	)
+
+	demo.Section("What's next?",
+		"In [05 — Introspection](../05-introspection/), you'll see how resource",
+		"servers can validate tokens remotely by asking the auth server \"is this",
+		"token valid?\" — an alternative to local JWT verification that works even",
+		"for opaque tokens.",
+	)
+
+	demo.Execute()
+
+	if authServer != nil {
+		authServer.Close()
+	}
+	if resourceServer != nil {
+		resourceServer.Close()
+	}
+}

--- a/examples/05-introspection/Makefile
+++ b/examples/05-introspection/Makefile
@@ -1,0 +1,26 @@
+# 05 — Token Introspection (RFC 7662)
+#
+# Infrastructure: None (Keycloak optional for cross-server introspection demo)
+#
+# To see the Keycloak step:
+#   make upkcl    # start Keycloak for examples (port 8280)
+#   make run      # the KC step auto-detects and runs
+
+EXAMPLE_DIR := 05-introspection
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+upkcl:
+	$(MAKE) -C .. upkcl
+
+downkcl:
+	$(MAKE) -C .. downkcl
+
+.PHONY: run demo readme upkcl downkcl

--- a/examples/05-introspection/README.md
+++ b/examples/05-introspection/README.md
@@ -158,9 +158,9 @@ no admin dashboard needed. This is how third-party integrations onboard.
 
 ## References
 
+- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
 - [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
 - [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
-- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
 
 ## Run it
 

--- a/examples/05-introspection/README.md
+++ b/examples/05-introspection/README.md
@@ -1,0 +1,175 @@
+# 05: Token Introspection
+
+Non-UI | No infrastructure needed | Builds on Example 04
+
+## What you'll learn
+
+- **Start auth server with token endpoint, introspection, and blacklist** — The auth server now has a blacklist for token revocation. The introspection endpoint checks it before responding.
+- **Register a client and get an access token** — Same as Example 01 — register, then client_credentials grant. The token includes a jti (JWT ID) claim used for revocation.
+- **Introspect a valid token** — The RS authenticates with its own credentials (same client in this example). The response includes the token's claims — the RS doesn't need to decode the JWT itself.
+- **Introspect a garbage token** — Invalid tokens always return {active: false} — the AS never reveals why. This is a security requirement of RFC 7662.
+- **Revoke the token, then introspect again** — After revocation, the same token that was valid in step 3 now returns active=false. This is the key advantage over local JWT validation — revocation takes effect immediately.
+- **Introspect without authentication (rejected)** — The introspection endpoint requires the caller to authenticate. An unauthenticated request is rejected — you can't fish for valid tokens.
+- **Introspect via Keycloak (optional)** — Same introspection flow against Keycloak. If KC isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over App,RS: Step 1: Start auth server with token endpoint, introspection, and blacklist
+
+    Note over App,RS: Step 2: Register a client and get an access token
+    App->>AS: POST /apps/register → POST /api/token
+    AS-->>App: {client_id, client_secret, access_token}
+
+    Note over App,RS: Step 3: Introspect a valid token
+    RS->>AS: POST /oauth/introspect {token} (Basic auth)
+    AS-->>RS: {active: true, sub, scope, exp, iss, jti}
+
+    Note over App,RS: Step 4: Introspect a garbage token
+    RS->>AS: POST /oauth/introspect {token: not-a-real-token}
+    AS-->>RS: {active: false}
+
+    Note over App,RS: Step 5: Revoke the token, then introspect again
+    Admin->>AS: blacklist.Revoke(jti)
+    RS->>AS: POST /oauth/introspect {same token as step 3}
+    AS-->>RS: {active: false}
+
+    Note over App,RS: Step 6: Introspect without authentication (rejected)
+    Attacker->>AS: POST /oauth/introspect {token} (no Basic auth)
+    AS-->>Attacker: 401 Unauthorized
+
+    Note over App,RS: Step 7: Introspect via Keycloak (optional)
+    App->>AS: POST {KC token_endpoint} → get KC token
+    RS->>AS: POST {KC introspection_endpoint} {token}
+    AS-->>RS: {active: true, sub, scope, ...}
+```
+
+## Steps
+
+### About this example
+
+**Actors:** App, Auth Server (AS), Resource Server (RS).
+Think: Slack's API asks Slack's identity service "is this bot's token still valid?"
+[What are these?](../README.md#cast-of-characters)
+
+In Examples 01-04, the resource server validated JWTs locally — fast, but
+it can't detect revoked tokens until they expire.
+
+Token introspection (RFC 7662) is the alternative: the RS sends the token
+to the AS's introspection endpoint and gets back `{active: true/false}` plus
+the token's claims. The AS checks its blacklist before responding.
+
+**When to use which:**
+| Method | Speed | Revocation | Use when |
+|--------|-------|-----------|----------|
+| Local JWT validation | Fast (no network) | Not immediate | Most requests, short-lived tokens |
+| Introspection | Slower (HTTP call) | Immediate | Sensitive ops, long-lived tokens, revocation needed |
+| Both (hybrid) | Best of both | Immediate | Validate locally, introspect on failure or for critical ops |
+
+### Step 1: Start auth server with token endpoint, introspection, and blacklist
+
+> **References:** [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+The auth server now has a blacklist for token revocation. The introspection endpoint checks it before responding.
+
+### Step 2: Register a client and get an access token
+
+> **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4), [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+Same as Example 01 — register, then client_credentials grant. The token includes a jti (JWT ID) claim used for revocation.
+
+### How introspection works
+
+The resource server POSTs the token to `/oauth/introspect` and authenticates
+itself with HTTP Basic auth (its own client_id + secret). The AS:
+
+1. Authenticates the caller (is this a registered resource server?)
+2. Validates the token (signature, expiry)
+3. Checks the blacklist (has this token been revoked?)
+4. Returns `{active: true, sub, scope, exp, ...}` or `{active: false}`
+
+**Security:** The introspection endpoint never reveals *why* a token is invalid.
+Expired, revoked, malformed — all return `{active: false}`. This prevents
+information leakage to potentially malicious callers.
+
+### Step 3: Introspect a valid token
+
+> **References:** [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+The RS authenticates with its own credentials (same client in this example). The response includes the token's claims — the RS doesn't need to decode the JWT itself.
+
+### Step 4: Introspect a garbage token
+
+> **References:** [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+Invalid tokens always return {active: false} — the AS never reveals why. This is a security requirement of RFC 7662.
+
+### Step 5: Revoke the token, then introspect again
+
+> **References:** [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+After revocation, the same token that was valid in step 3 now returns active=false. This is the key advantage over local JWT validation — revocation takes effect immediately.
+
+### Step 6: Introspect without authentication (rejected)
+
+> **References:** [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+The introspection endpoint requires the caller to authenticate. An unauthenticated request is rejected — you can't fish for valid tokens.
+
+### Step 7: Introspect via Keycloak (optional)
+
+> **References:** [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+Same introspection flow against Keycloak. If KC isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.
+
+### Introspection vs local validation — the tradeoff
+
+```
+Local JWT validation:     RS checks signature locally
+  + No network call        ← fast
+  + Works offline          ← resilient
+  - Can't detect revocation until token expires
+
+Introspection:            RS asks AS on every request
+  + Revocation is immediate
+  + Works with opaque (non-JWT) tokens
+  - Adds latency (HTTP round-trip)
+  - AS becomes a dependency
+
+Hybrid (production pattern):
+  1. Validate JWT locally first (fast path)
+  2. If local validation fails, fall back to introspection
+  3. For critical operations, always introspect
+```
+
+OneAuth's `APIMiddleware` supports the hybrid model via the `Introspection`
+field — set it to enable automatic fallback to introspection.
+
+### What's next?
+
+In [06 — Dynamic Client Registration](../06-dynamic-client-registration/),
+you'll see how apps can register themselves programmatically via RFC 7591 —
+no admin dashboard needed. This is how third-party integrations onboard.
+
+## References
+
+- [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+## Run it
+
+```bash
+go run ./examples/05-introspection/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/05-introspection/ --non-interactive
+```

--- a/examples/05-introspection/main.go
+++ b/examples/05-introspection/main.go
@@ -1,0 +1,350 @@
+// Example 05: Token Introspection (RFC 7662)
+//
+// In Examples 01-04, the resource server validated tokens locally by checking
+// the JWT signature. That's fast but has a gap: if a token is revoked, the RS
+// won't know until the token expires.
+//
+// Introspection is the alternative: the RS asks the auth server "is this token
+// still valid?" on every request (or with caching). The AS checks its blacklist
+// and returns the token's claims.
+//
+// Run:   go run ./examples/05-introspection/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7662
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+const kcExampleClientID = "example-app"
+const kcExampleClientSecret = "example-app-secret"
+
+func main() {
+	var authServer *httptest.Server
+	var ks keys.KeyStorage
+	var blacklist *core.InMemoryBlacklist
+	var clientID, clientSecret, accessToken string
+	var tokenJTI string
+
+	demo := demokit.New("05: Token Introspection").
+		Dir("05-introspection").
+		Description("Non-UI | No infrastructure needed | Builds on Example 04").
+		Actors(
+			demokit.Actor("App", "Client App"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** App, Auth Server (AS), Resource Server (RS).",
+		"Think: Slack's API asks Slack's identity service \"is this bot's token still valid?\"",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"In Examples 01-04, the resource server validated JWTs locally — fast, but",
+		"it can't detect revoked tokens until they expire.",
+		"",
+		"Token introspection (RFC 7662) is the alternative: the RS sends the token",
+		"to the AS's introspection endpoint and gets back `{active: true/false}` plus",
+		"the token's claims. The AS checks its blacklist before responding.",
+		"",
+		"**When to use which:**",
+		"| Method | Speed | Revocation | Use when |",
+		"|--------|-------|-----------|----------|",
+		"| Local JWT validation | Fast (no network) | Not immediate | Most requests, short-lived tokens |",
+		"| Introspection | Slower (HTTP call) | Immediate | Sensitive ops, long-lived tokens, revocation needed |",
+		"| Both (hybrid) | Best of both | Immediate | Validate locally, introspect on failure or for critical ops |",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server with token endpoint, introspection, and blacklist").
+		Ref(demokit.RFC7662).
+		Note("The auth server now has a blacklist for token revocation. The introspection endpoint checks it before responding.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			blacklist = core.NewInMemoryBlacklist()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+			apiAuth := &apiauth.APIAuth{
+				JWTSecretKey:   "introspection-example-secret-32c!",
+				JWTIssuer:      "will-be-set-after-start",
+				ClientKeyStore: ks,
+				Blacklist:      blacklist,
+			}
+
+			introspectionHandler := &apiauth.IntrospectionHandler{
+				Auth:           apiAuth,
+				ClientKeyStore: ks,
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/apps/", registrar.Handler())
+			mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+			mux.Handle("POST /oauth/introspect", introspectionHandler)
+			authServer = httptest.NewServer(mux)
+			apiAuth.JWTIssuer = authServer.URL
+
+			fmt.Printf("    Auth server:            %s\n", authServer.URL)
+			fmt.Printf("    Token endpoint:         %s/api/token\n", authServer.URL)
+			fmt.Printf("    Introspection endpoint: %s/oauth/introspect\n", authServer.URL)
+		})
+
+	// --- Register + get token ---
+	demo.Step("Register a client and get an access token").
+		Ref(demokit.RFC6749_ClientCredentials).
+		Ref(demokit.RFC7519).
+		Arrow("App", "AS", "POST /apps/register → POST /api/token").
+		DashedArrow("AS", "App", "{client_id, client_secret, access_token}").
+		Note("Same as Example 01 — register, then client_credentials grant. The token includes a jti (JWT ID) claim used for revocation.").
+		Run(func() {
+			// Register
+			body, _ := json.Marshal(map[string]any{
+				"client_domain": "introspect-demo.example.com",
+				"signing_alg":   "HS256",
+			})
+			regResp, _ := http.Post(authServer.URL+"/apps/register",
+				"application/json", strings.NewReader(string(body)))
+			var reg map[string]any
+			json.NewDecoder(regResp.Body).Decode(&reg)
+			regResp.Body.Close()
+			clientID = reg["client_id"].(string)
+			clientSecret = reg["client_secret"].(string)
+
+			// Get token
+			tokenResp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {clientID},
+				"client_secret": {clientSecret},
+				"scope":         {"read write"},
+			})
+			var tokenData map[string]any
+			json.NewDecoder(tokenResp.Body).Decode(&tokenData)
+			tokenResp.Body.Close()
+			accessToken = tokenData["access_token"].(string)
+
+			// Parse jti from the token for later revocation
+			claims := parseJWTClaims(accessToken)
+			tokenJTI = claims["jti"].(string)
+
+			fmt.Printf("    client_id:    %s\n", clientID)
+			fmt.Printf("    access_token: %s...\n", accessToken[:40])
+			fmt.Printf("    jti:          %s...\n", tokenJTI[:16])
+		})
+
+	demo.Section("How introspection works",
+		"The resource server POSTs the token to `/oauth/introspect` and authenticates",
+		"itself with HTTP Basic auth (its own client_id + secret). The AS:",
+		"",
+		"1. Authenticates the caller (is this a registered resource server?)",
+		"2. Validates the token (signature, expiry)",
+		"3. Checks the blacklist (has this token been revoked?)",
+		"4. Returns `{active: true, sub, scope, exp, ...}` or `{active: false}`",
+		"",
+		"**Security:** The introspection endpoint never reveals *why* a token is invalid.",
+		"Expired, revoked, malformed — all return `{active: false}`. This prevents",
+		"information leakage to potentially malicious callers.",
+	)
+
+	// --- Introspect valid token ---
+	demo.Step("Introspect a valid token").
+		Ref(demokit.RFC7662).
+		Arrow("RS", "AS", "POST /oauth/introspect {token} (Basic auth)").
+		DashedArrow("AS", "RS", "{active: true, sub, scope, exp, iss, jti}").
+		Note("The RS authenticates with its own credentials (same client in this example). The response includes the token's claims — the RS doesn't need to decode the JWT itself.").
+		Run(func() {
+			result := introspect(authServer.URL+"/oauth/introspect", accessToken, clientID, clientSecret)
+			pretty, _ := json.MarshalIndent(result, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+		})
+
+	// --- Introspect garbage ---
+	demo.Step("Introspect a garbage token").
+		Ref(demokit.RFC7662).
+		Arrow("RS", "AS", "POST /oauth/introspect {token: not-a-real-token}").
+		DashedArrow("AS", "RS", "{active: false}").
+		Note("Invalid tokens always return {active: false} — the AS never reveals why. This is a security requirement of RFC 7662.").
+		Run(func() {
+			result := introspect(authServer.URL+"/oauth/introspect", "not-a-real-token", clientID, clientSecret)
+			pretty, _ := json.MarshalIndent(result, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+		})
+
+	// --- Revoke and re-introspect ---
+	demo.Step("Revoke the token, then introspect again").
+		Ref(demokit.RFC7662).
+		Arrow("Admin", "AS", "blacklist.Revoke(jti)").
+		Arrow("RS", "AS", "POST /oauth/introspect {same token as step 3}").
+		DashedArrow("AS", "RS", "{active: false}").
+		Note("After revocation, the same token that was valid in step 3 now returns active=false. This is the key advantage over local JWT validation — revocation takes effect immediately.").
+		Run(func() {
+			// Revoke via blacklist
+			claims := parseJWTClaims(accessToken)
+			expFloat := claims["exp"].(float64)
+			blacklist.Revoke(tokenJTI, time.Unix(int64(expFloat), 0))
+			fmt.Printf("    Revoked jti=%s...\n\n", tokenJTI[:16])
+
+			// Introspect again
+			result := introspect(authServer.URL+"/oauth/introspect", accessToken, clientID, clientSecret)
+			pretty, _ := json.MarshalIndent(result, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+		})
+
+	// --- Unauthenticated caller ---
+	demo.Step("Introspect without authentication (rejected)").
+		Ref(demokit.RFC7662).
+		Arrow("Attacker", "AS", "POST /oauth/introspect {token} (no Basic auth)").
+		DashedArrow("AS", "Attacker", "401 Unauthorized").
+		Note("The introspection endpoint requires the caller to authenticate. An unauthenticated request is rejected — you can't fish for valid tokens.").
+		Run(func() {
+			form := url.Values{"token": {accessToken}}
+			req, _ := http.NewRequest("POST", authServer.URL+"/oauth/introspect",
+				strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			// No Basic auth!
+			resp, _ := http.DefaultClient.Do(req)
+			resp.Body.Close()
+			fmt.Printf("    status: %d (correctly rejected — no authentication)\n", resp.StatusCode)
+		})
+
+	// --- Optional: Keycloak introspection ---
+	demo.Step("Introspect via Keycloak (optional)").
+		Ref(demokit.RFC7662).
+		Arrow("App", "AS", "POST {KC token_endpoint} → get KC token").
+		Arrow("RS", "AS", "POST {KC introspection_endpoint} {token}").
+		DashedArrow("AS", "RS", "{active: true, sub, scope, ...}").
+		Note("Same introspection flow against Keycloak. If KC isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
+		Run(func() {
+			// Check if KC is reachable
+			kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			resp, err := httpClient.Get(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+				fmt.Printf("    To enable: cd examples && make upkcl\n")
+				return
+			}
+			resp.Body.Close()
+
+			// Discover KC endpoints
+			kcMeta, err := client.DiscoverAS(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
+				return
+			}
+			fmt.Printf("    Keycloak introspection endpoint: %s\n\n", kcMeta.IntrospectionEndpoint)
+
+			// Get a token from KC
+			kcTokenResp, _ := http.PostForm(kcMeta.TokenEndpoint, url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {kcExampleClientID},
+				"client_secret": {kcExampleClientSecret},
+				"scope":         {"openid"},
+			})
+			var kcToken map[string]any
+			json.NewDecoder(kcTokenResp.Body).Decode(&kcToken)
+			kcTokenResp.Body.Close()
+
+			if kcToken["error"] != nil {
+				fmt.Printf("    ERROR getting KC token: %v\n", kcToken["error_description"])
+				return
+			}
+
+			kcAccessToken := kcToken["access_token"].(string)
+			fmt.Printf("    KC access_token: %s...\n\n", kcAccessToken[:40])
+
+			// Introspect via KC
+			kcResult := introspect(kcMeta.IntrospectionEndpoint,
+				kcAccessToken, kcExampleClientID, kcExampleClientSecret)
+			pretty, _ := json.MarshalIndent(kcResult, "    ", "  ")
+			fmt.Printf("    KC introspection response:\n    %s\n", string(pretty))
+		})
+
+	demo.Section("Introspection vs local validation — the tradeoff",
+		"```",
+		"Local JWT validation:     RS checks signature locally",
+		"  + No network call        ← fast",
+		"  + Works offline          ← resilient",
+		"  - Can't detect revocation until token expires",
+		"",
+		"Introspection:            RS asks AS on every request",
+		"  + Revocation is immediate",
+		"  + Works with opaque (non-JWT) tokens",
+		"  - Adds latency (HTTP round-trip)",
+		"  - AS becomes a dependency",
+		"",
+		"Hybrid (production pattern):",
+		"  1. Validate JWT locally first (fast path)",
+		"  2. If local validation fails, fall back to introspection",
+		"  3. For critical operations, always introspect",
+		"```",
+		"",
+		"OneAuth's `APIMiddleware` supports the hybrid model via the `Introspection`",
+		"field — set it to enable automatic fallback to introspection.",
+	)
+
+	demo.Section("What's next?",
+		"In [06 — Dynamic Client Registration](../06-dynamic-client-registration/),",
+		"you'll see how apps can register themselves programmatically via RFC 7591 —",
+		"no admin dashboard needed. This is how third-party integrations onboard.",
+	)
+
+	demo.Execute()
+
+	if authServer != nil {
+		authServer.Close()
+	}
+}
+
+// --- Helpers ---
+
+// introspect calls an introspection endpoint and returns the parsed response.
+// endpointURL is the full introspection URL (e.g., "http://localhost:8080/oauth/introspect").
+func introspect(endpointURL, token, callerID, callerSecret string) map[string]any {
+	form := url.Values{"token": {token}}
+	req, _ := http.NewRequest("POST", endpointURL,
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(callerID, callerSecret)
+
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var result map[string]any
+	json.Unmarshal(body, &result)
+	return result
+}
+
+// parseJWTClaims decodes JWT payload without verification (for display only).
+func parseJWTClaims(tokenStr string) map[string]any {
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	// JWT uses base64url (no padding)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	var claims map[string]any
+	json.Unmarshal(payload, &claims)
+	return claims
+}

--- a/examples/06-dynamic-client-registration/Makefile
+++ b/examples/06-dynamic-client-registration/Makefile
@@ -1,0 +1,26 @@
+# 06 — Dynamic Client Registration (RFC 7591)
+#
+# Infrastructure: None (Keycloak optional for cross-server DCR demo)
+#
+# To see the Keycloak step:
+#   make upkcl    # start Keycloak for examples (port 8280)
+#   make run      # the KC step auto-detects and runs
+
+EXAMPLE_DIR := 06-dynamic-client-registration
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+upkcl:
+	$(MAKE) -C .. upkcl
+
+downkcl:
+	$(MAKE) -C .. downkcl
+
+.PHONY: run demo readme upkcl downkcl

--- a/examples/06-dynamic-client-registration/README.md
+++ b/examples/06-dynamic-client-registration/README.md
@@ -1,0 +1,145 @@
+# 06: Dynamic Client Registration
+
+Non-UI | No infrastructure needed | Builds on Example 04
+
+## What you'll learn
+
+- **Start auth server with DCR endpoint** — The auth server serves /apps/dcr (RFC 7591) alongside the proprietary /apps/register. Both create clients in the same KeyStore.
+- **Register a symmetric client (client_secret_post)** — The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.
+- **Get a token with the DCR-registered client** — The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.
+- **Register an asymmetric client (private_key_jwt with JWKS)** — For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.
+- **Register via Keycloak DCR (optional)** — Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as New App
+    participant AS as Auth Server
+
+    Note over App,AS: Step 1: Start auth server with DCR endpoint
+
+    Note over App,AS: Step 2: Register a symmetric client (client_secret_post)
+    App->>AS: POST /apps/dcr {client_name, grant_types, auth_method}
+    AS-->>App: {client_id, client_secret, client_id_issued_at}
+
+    Note over App,AS: Step 3: Get a token with the DCR-registered client
+    App->>AS: POST /api/token {client_id, client_secret from DCR}
+    AS-->>App: {access_token}
+
+    Note over App,AS: Step 4: Register an asymmetric client (private_key_jwt with JWKS)
+    App->>AS: POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}
+    AS-->>App: {client_id} (no client_secret — asymmetric!)
+
+    Note over App,AS: Step 5: Register via Keycloak DCR (optional)
+    App->>AS: POST {KC registration_endpoint} {client_name, grant_types}
+    AS-->>App: {client_id, client_secret, registration_access_token}
+```
+
+## Steps
+
+### About this example
+
+**Actors:** App (a new third-party integration), Auth Server (AS).
+Think: a developer builds a new Slack bot and registers it via API — no admin dashboard needed.
+[What are these?](../README.md#cast-of-characters)
+
+In Examples 01-05, we registered via `/apps/register` — OneAuth's proprietary
+endpoint. RFC 7591 defines a standard registration API that works across providers:
+
+| Endpoint | Standard | Works with |
+|----------|----------|-----------|
+| `/apps/register` | OneAuth proprietary | OneAuth only |
+| `/apps/dcr` | RFC 7591 | OneAuth, Keycloak, Auth0, any compliant AS |
+
+DCR lets apps self-register by posting their metadata (name, redirect URIs,
+grant types, auth method). The AS creates the client and returns credentials.
+
+### Step 1: Start auth server with DCR endpoint
+
+> **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591), [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+The auth server serves /apps/dcr (RFC 7591) alongside the proprietary /apps/register. Both create clients in the same KeyStore.
+
+### DCR request format (RFC 7591 §2)
+
+A DCR request is a JSON object with client metadata:
+```json
+{
+  "client_name": "My Bot",
+  "client_uri": "https://mybot.example.com",
+  "grant_types": ["client_credentials"],
+  "token_endpoint_auth_method": "client_secret_post",
+  "scope": "read write"
+}
+```
+
+The AS responds with the registered client metadata plus generated credentials:
+```json
+{
+  "client_id": "app_abc123...",
+  "client_secret": "7f3e8a...",
+  "client_id_issued_at": 1700000000,
+  "client_name": "My Bot",
+  "token_endpoint_auth_method": "client_secret_post"
+}
+```
+
+### Step 2: Register a symmetric client (client_secret_post)
+
+> **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+
+The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.
+
+### Step 3: Get a token with the DCR-registered client
+
+> **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+
+The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.
+
+### Step 4: Register an asymmetric client (private_key_jwt with JWKS)
+
+> **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591), [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.
+
+### Symmetric vs asymmetric DCR
+
+| | client_secret_post / basic | private_key_jwt |
+|---|---|---|
+| **DCR sends** | Just metadata | Metadata + JWKS (public key) |
+| **AS returns** | client_id + client_secret | client_id only (no secret) |
+| **Token auth** | Send secret in request | Sign a JWT with private key |
+| **Key in JWKS** | Not in JWKS (secret) | Public key served in JWKS |
+| **Best for** | Simple integrations | High-security, multi-service |
+
+### Step 5: Register via Keycloak DCR (optional)
+
+> **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+
+Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.
+
+### What's next?
+
+In [07 — Client SDK](../07-client-sdk/), you'll see production patterns:
+automatic token caching, background refresh, scope step-up, and discovery-driven
+configuration — all wrapped in a simple `TokenSource` interface.
+
+## References
+
+- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+- [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+- [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+## Run it
+
+```bash
+go run ./examples/06-dynamic-client-registration/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/06-dynamic-client-registration/ --non-interactive
+```

--- a/examples/06-dynamic-client-registration/main.go
+++ b/examples/06-dynamic-client-registration/main.go
@@ -1,0 +1,290 @@
+// Example 06: Dynamic Client Registration (RFC 7591)
+//
+// In Examples 01-05, we registered apps via OneAuth's proprietary /apps/register
+// endpoint. That works but is OneAuth-specific. RFC 7591 defines a standard way
+// for clients to register themselves — the same API works across OneAuth,
+// Keycloak, Auth0, and any compliant provider.
+//
+// Run:   go run ./examples/06-dynamic-client-registration/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7591
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+
+func main() {
+	var authServer *httptest.Server
+	var ks keys.KeyStorage
+	var symClientID, symClientSecret string
+	var asymClientID string
+
+	demo := demokit.New("06: Dynamic Client Registration").
+		Dir("06-dynamic-client-registration").
+		Description("Non-UI | No infrastructure needed | Builds on Example 04").
+		Actors(
+			demokit.Actor("App", "New App"),
+			demokit.Actor("AS", "Auth Server"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** App (a new third-party integration), Auth Server (AS).",
+		"Think: a developer builds a new Slack bot and registers it via API — no admin dashboard needed.",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"In Examples 01-05, we registered via `/apps/register` — OneAuth's proprietary",
+		"endpoint. RFC 7591 defines a standard registration API that works across providers:",
+		"",
+		"| Endpoint | Standard | Works with |",
+		"|----------|----------|-----------|",
+		"| `/apps/register` | OneAuth proprietary | OneAuth only |",
+		"| `/apps/dcr` | RFC 7591 | OneAuth, Keycloak, Auth0, any compliant AS |",
+		"",
+		"DCR lets apps self-register by posting their metadata (name, redirect URIs,",
+		"grant types, auth method). The AS creates the client and returns credentials.",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server with DCR endpoint").
+		Ref(demokit.RFC7591).
+		Ref(demokit.RFC8414).
+		Note("The auth server serves /apps/dcr (RFC 7591) alongside the proprietary /apps/register. Both create clients in the same KeyStore.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+			jwksHandler := &keys.JWKSHandler{KeyStore: ks}
+
+			apiAuth := &apiauth.APIAuth{
+				JWTSecretKey:   "dcr-example-secret-at-least-32ch!",
+				ClientKeyStore: ks,
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/apps/", registrar.Handler()) // includes /apps/dcr
+			mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+			mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+			authServer = httptest.NewServer(mux)
+			apiAuth.JWTIssuer = authServer.URL
+
+			mux.Handle("GET /.well-known/openid-configuration",
+				apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+					Issuer:                   authServer.URL,
+					TokenEndpoint:            authServer.URL + "/api/token",
+					JWKSURI:                  authServer.URL + "/.well-known/jwks.json",
+					RegistrationEndpoint:     authServer.URL + "/apps/dcr",
+					GrantTypesSupported:      []string{"client_credentials"},
+					TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},
+				}))
+
+			fmt.Printf("    Auth server:    %s\n", authServer.URL)
+			fmt.Printf("    DCR endpoint:   %s/apps/dcr\n", authServer.URL)
+		})
+
+	demo.Section("DCR request format (RFC 7591 §2)",
+		"A DCR request is a JSON object with client metadata:",
+		"```json",
+		"{",
+		"  \"client_name\": \"My Bot\",",
+		"  \"client_uri\": \"https://mybot.example.com\",",
+		"  \"grant_types\": [\"client_credentials\"],",
+		"  \"token_endpoint_auth_method\": \"client_secret_post\",",
+		"  \"scope\": \"read write\"",
+		"}",
+		"```",
+		"",
+		"The AS responds with the registered client metadata plus generated credentials:",
+		"```json",
+		"{",
+		"  \"client_id\": \"app_abc123...\",",
+		"  \"client_secret\": \"7f3e8a...\",",
+		"  \"client_id_issued_at\": 1700000000,",
+		"  \"client_name\": \"My Bot\",",
+		"  \"token_endpoint_auth_method\": \"client_secret_post\"",
+		"}",
+		"```",
+	)
+
+	// --- Symmetric registration ---
+	demo.Step("Register a symmetric client (client_secret_post)").
+		Ref(demokit.RFC7591).
+		Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, auth_method}").
+		DashedArrow("AS", "App", "{client_id, client_secret, client_id_issued_at}").
+		Note("The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.").
+		Run(func() {
+			dcrReq := map[string]any{
+				"client_name":                "My Example Bot",
+				"client_uri":                 "https://bot.example.com",
+				"grant_types":                []string{"client_credentials"},
+				"token_endpoint_auth_method": "client_secret_post",
+				"scope":                      "read write",
+			}
+			body, _ := json.Marshal(dcrReq)
+
+			resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+				bytes.NewReader(body))
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			fmt.Printf("    HTTP status: %d\n\n", resp.StatusCode)
+
+			var dcrResp map[string]any
+			json.Unmarshal(respBody, &dcrResp)
+			pretty, _ := json.MarshalIndent(dcrResp, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+
+			symClientID = dcrResp["client_id"].(string)
+			symClientSecret = dcrResp["client_secret"].(string)
+		})
+
+	// --- Use the registered client ---
+	demo.Step("Get a token with the DCR-registered client").
+		Ref(demokit.RFC6749_ClientCredentials).
+		Arrow("App", "AS", "POST /api/token {client_id, client_secret from DCR}").
+		DashedArrow("AS", "App", "{access_token}").
+		Note("The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.").
+		Run(func() {
+			tokenResp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {symClientID},
+				"client_secret": {symClientSecret},
+				"scope":         {"read"},
+			})
+			var tokenData map[string]any
+			json.NewDecoder(tokenResp.Body).Decode(&tokenData)
+			tokenResp.Body.Close()
+
+			fmt.Printf("    token_type:    %s\n", tokenData["token_type"])
+			fmt.Printf("    scope:         %s\n", tokenData["scope"])
+			fmt.Printf("    access_token:  %s...\n", tokenData["access_token"].(string)[:40])
+		})
+
+	// --- Asymmetric registration ---
+	demo.Step("Register an asymmetric client (private_key_jwt with JWKS)").
+		Ref(demokit.RFC7591).
+		Ref(demokit.RFC7517).
+		Arrow("App", "AS", "POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}").
+		DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
+		Note("For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.").
+		Run(func() {
+			_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
+			pubKey, _ := utils.ParsePublicKeyPEM(pubPEM)
+			kid, _ := utils.ComputeKid(pubKey, "RS256")
+			jwk, _ := utils.PublicKeyToJWK(kid, "RS256", pubKey)
+
+			dcrReq := map[string]any{
+				"client_name":                "My Secure Service",
+				"grant_types":                []string{"client_credentials"},
+				"token_endpoint_auth_method": "private_key_jwt",
+				"jwks":                       map[string]any{"keys": []any{jwk}},
+			}
+			body, _ := json.Marshal(dcrReq)
+
+			resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+				bytes.NewReader(body))
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			fmt.Printf("    HTTP status: %d\n\n", resp.StatusCode)
+
+			var dcrResp map[string]any
+			json.Unmarshal(respBody, &dcrResp)
+			pretty, _ := json.MarshalIndent(dcrResp, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+
+			asymClientID = dcrResp["client_id"].(string)
+			hasSecret := dcrResp["client_secret"] != nil && dcrResp["client_secret"] != ""
+			fmt.Printf("\n    client_id:     %s\n", asymClientID)
+			fmt.Printf("    client_secret: %v (asymmetric — no secret needed)\n", hasSecret)
+		})
+
+	demo.Section("Symmetric vs asymmetric DCR",
+		"| | client_secret_post / basic | private_key_jwt |",
+		"|---|---|---|",
+		"| **DCR sends** | Just metadata | Metadata + JWKS (public key) |",
+		"| **AS returns** | client_id + client_secret | client_id only (no secret) |",
+		"| **Token auth** | Send secret in request | Sign a JWT with private key |",
+		"| **Key in JWKS** | Not in JWKS (secret) | Public key served in JWKS |",
+		"| **Best for** | Simple integrations | High-security, multi-service |",
+	)
+
+	// --- Optional: Keycloak DCR ---
+	demo.Step("Register via Keycloak DCR (optional)").
+		Ref(demokit.RFC7591).
+		Arrow("App", "AS", "POST {KC registration_endpoint} {client_name, grant_types}").
+		DashedArrow("AS", "App", "{client_id, client_secret, registration_access_token}").
+		Note("Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.").
+		Run(func() {
+			kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			resp, err := httpClient.Get(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+				fmt.Printf("    To enable: cd examples && make upkcl\n")
+				return
+			}
+			resp.Body.Close()
+
+			// Discover KC registration endpoint
+			kcMeta, err := client.DiscoverAS(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
+				return
+			}
+
+			if kcMeta.RegistrationEndpoint == "" {
+				fmt.Printf("    SKIPPED: Keycloak does not advertise a registration_endpoint\n")
+				fmt.Printf("    (KC may need 'registrationAllowed' enabled on the realm)\n")
+				return
+			}
+
+			fmt.Printf("    KC registration endpoint: %s\n\n", kcMeta.RegistrationEndpoint)
+
+			dcrReq := map[string]any{
+				"client_name": "Example Bot (from OneAuth demo)",
+				"grant_types": []string{"client_credentials"},
+			}
+			body, _ := json.Marshal(dcrReq)
+
+			dcrResp, _ := http.Post(kcMeta.RegistrationEndpoint, "application/json",
+				bytes.NewReader(body))
+			dcrBody, _ := io.ReadAll(dcrResp.Body)
+			dcrResp.Body.Close()
+
+			fmt.Printf("    HTTP status: %d\n", dcrResp.StatusCode)
+			var kcDCR map[string]any
+			json.Unmarshal(dcrBody, &kcDCR)
+			pretty, _ := json.MarshalIndent(kcDCR, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+		})
+
+	demo.Section("What's next?",
+		"In [07 — Client SDK](../07-client-sdk/), you'll see production patterns:",
+		"automatic token caching, background refresh, scope step-up, and discovery-driven",
+		"configuration — all wrapped in a simple `TokenSource` interface.",
+	)
+
+	demo.Execute()
+
+	if authServer != nil {
+		authServer.Close()
+	}
+}

--- a/examples/07-client-sdk/Makefile
+++ b/examples/07-client-sdk/Makefile
@@ -1,0 +1,22 @@
+# 07 — Client SDK: Production Patterns
+#
+# Infrastructure: None (Keycloak optional for cross-server demo)
+
+EXAMPLE_DIR := 07-client-sdk
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+upkcl:
+	$(MAKE) -C .. upkcl
+
+downkcl:
+	$(MAKE) -C .. downkcl
+
+.PHONY: run demo readme upkcl downkcl

--- a/examples/07-client-sdk/README.md
+++ b/examples/07-client-sdk/README.md
@@ -1,0 +1,143 @@
+# 07: Client SDK — Production Patterns
+
+Non-UI | No infrastructure needed | Builds on Examples 01-06
+
+## What you'll learn
+
+- **Start auth server and resource server** — Same auth server as previous examples. We also pre-register a client since the SDK focuses on token acquisition, not registration.
+- **One-shot token with AuthClient** — AuthClient is the low-level SDK: discover endpoints, then make a single token request. Good for one-off calls. Uses discovery to find the token endpoint automatically.
+- **Cached token with ClientCredentialsSource** — ClientCredentialsSource implements TokenSource: Token() returns a cached token if still valid, or fetches a new one. Multiple goroutines can safely call Token() concurrently.
+- **Scope step-up with TokenForScopes** — When your app needs additional permissions, TokenForScopes merges the new scopes with existing ones, invalidates the cache, and fetches a fresh token.
+- **Use the SDK against Keycloak (optional)** — Same SDK code, pointed at Keycloak. DiscoverAS finds the KC token endpoint automatically. If KC isn't running, this step is skipped.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Client App (SDK)
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over App,RS: Step 1: Start auth server and resource server
+
+    Note over App,RS: Step 2: One-shot token with AuthClient
+    App->>AS: client.DiscoverAS(serverURL)
+    App->>AS: authClient.ClientCredentialsToken(id, secret, scopes)
+    AS-->>App: ServerCredential{AccessToken, ExpiresAt, Scope}
+
+    Note over App,RS: Step 3: Cached token with ClientCredentialsSource
+    App->>App: tokenSource.Token() → cached or fetched
+    App->>RS: GET /resource (Bearer: cached token)
+    RS-->>App: 200 {data}
+
+    Note over App,RS: Step 4: Scope step-up with TokenForScopes
+    App->>App: tokenSource.TokenForScopes(["write"])
+    App->>AS: POST /api/token {scope: read write} (merged)
+    AS-->>App: new token with expanded scopes
+
+    Note over App,RS: Step 5: Use the SDK against Keycloak (optional)
+    App->>AS: client.DiscoverAS(keycloakRealmURL)
+    App->>AS: authClient.ClientCredentialsToken(...)
+    AS-->>App: ServerCredential from Keycloak
+```
+
+## Steps
+
+### About this example
+
+**Actors:** App (using the client SDK), Auth Server (AS), Resource Server (RS).
+Think: the GitHub bot in production — not making raw HTTP calls, but using a library.
+[What are these?](../README.md#cast-of-characters)
+
+In Examples 01-06, we made raw `http.Post` calls to the token endpoint.
+That works for learning, but production code needs:
+- **Discovery** — don't hardcode URLs (Example 04)
+- **Token caching** — don't fetch a new token on every request
+- **Auto-refresh** — renew tokens before they expire
+- **Scope step-up** — request additional scopes when needed
+
+OneAuth's client SDK wraps all of this in a `TokenSource` interface:
+```go
+token, err := tokenSource.Token()  // cached, auto-refreshed
+```
+
+### Step 1: Start auth server and resource server
+
+Same auth server as previous examples. We also pre-register a client since the SDK focuses on token acquisition, not registration.
+
+### Step 2: One-shot token with AuthClient
+
+> **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4), [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+AuthClient is the low-level SDK: discover endpoints, then make a single token request. Good for one-off calls. Uses discovery to find the token endpoint automatically.
+
+### AuthClient vs ClientCredentialsSource
+
+| | AuthClient | ClientCredentialsSource |
+|---|---|---|
+| **Use case** | One-shot token requests | Long-running services |
+| **Caching** | None — new request every time | Automatic — reuses valid tokens |
+| **Refresh** | Manual | Automatic (on next Token() call) |
+| **Interface** | `ClientCredentialsToken()` | `Token() string` (TokenSource) |
+| **Scope step-up** | Manual | `TokenForScopes()` |
+
+### Step 3: Cached token with ClientCredentialsSource
+
+> **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+
+ClientCredentialsSource implements TokenSource: Token() returns a cached token if still valid, or fetches a new one. Multiple goroutines can safely call Token() concurrently.
+
+### Step 4: Scope step-up with TokenForScopes
+
+When your app needs additional permissions, TokenForScopes merges the new scopes with existing ones, invalidates the cache, and fetches a fresh token.
+
+### TokenSource in practice
+
+The `TokenSource` interface (`Token() (string, error)`) is designed to
+plug into HTTP clients, gRPC interceptors, or any code that needs a token:
+
+```go
+// Create once, reuse everywhere
+ts := &client.ClientCredentialsSource{
+    TokenEndpoint: meta.TokenEndpoint,
+    ClientID:      "my-app",
+    ClientSecret:  "my-secret",
+    Scopes:        []string{"read"},
+}
+
+// In your HTTP client middleware
+token, _ := ts.Token()  // fast: returns cached token
+req.Header.Set("Authorization", "Bearer " + token)
+```
+
+The interface matches `mcpkit/core.TokenSource` by structural typing —
+no cross-module import needed.
+
+### Step 5: Use the SDK against Keycloak (optional)
+
+> **References:** [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414), [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+
+Same SDK code, pointed at Keycloak. DiscoverAS finds the KC token endpoint automatically. If KC isn't running, this step is skipped.
+
+### What's next?
+
+In [08 — Rich Authorization Requests](../08-rich-authorization-requests/),
+you'll see how to go beyond flat scopes: request fine-grained permissions
+like "transfer 45 EUR to Merchant A" using RFC 9396.
+
+## References
+
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+- [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+## Run it
+
+```bash
+go run ./examples/07-client-sdk/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/07-client-sdk/ --non-interactive
+```

--- a/examples/07-client-sdk/main.go
+++ b/examples/07-client-sdk/main.go
@@ -1,0 +1,308 @@
+// Example 07: Client SDK — Production Patterns
+//
+// Examples 01-06 showed the server side and raw HTTP calls. This example shows
+// how production client code works: discovery-driven configuration, automatic
+// token caching/refresh, and scope step-up — all via OneAuth's client SDK.
+//
+// Run:   go run ./examples/07-client-sdk/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+const kcExampleClientID = "example-app"
+const kcExampleClientSecret = "example-app-secret"
+
+func main() {
+	var authServer, resourceServer *httptest.Server
+	var registeredClientID, registeredSecret string
+	var tokenSource *client.ClientCredentialsSource
+
+	demo := demokit.New("07: Client SDK — Production Patterns").
+		Dir("07-client-sdk").
+		Description("Non-UI | No infrastructure needed | Builds on Examples 01-06").
+		Actors(
+			demokit.Actor("App", "Client App (SDK)"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** App (using the client SDK), Auth Server (AS), Resource Server (RS).",
+		"Think: the GitHub bot in production — not making raw HTTP calls, but using a library.",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"In Examples 01-06, we made raw `http.Post` calls to the token endpoint.",
+		"That works for learning, but production code needs:",
+		"- **Discovery** — don't hardcode URLs (Example 04)",
+		"- **Token caching** — don't fetch a new token on every request",
+		"- **Auto-refresh** — renew tokens before they expire",
+		"- **Scope step-up** — request additional scopes when needed",
+		"",
+		"OneAuth's client SDK wraps all of this in a `TokenSource` interface:",
+		"```go",
+		"token, err := tokenSource.Token()  // cached, auto-refreshed",
+		"```",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server and resource server").
+		Note("Same auth server as previous examples. We also pre-register a client since the SDK focuses on token acquisition, not registration.").
+		Run(func() {
+			ks := keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+			apiAuth := &apiauth.APIAuth{
+				JWTSecretKey:   "sdk-example-secret-at-least-32ch!",
+				ClientKeyStore: ks,
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/apps/", registrar.Handler())
+			mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+			authServer = httptest.NewServer(mux)
+			apiAuth.JWTIssuer = authServer.URL
+
+			mux.Handle("GET /.well-known/openid-configuration",
+				apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+					Issuer:                   authServer.URL,
+					TokenEndpoint:            authServer.URL + "/api/token",
+					GrantTypesSupported:      []string{"client_credentials"},
+					TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic"},
+				}))
+
+			// Resource server
+			middleware := &apiauth.APIMiddleware{
+				JWTSecretKey: "sdk-example-secret-at-least-32ch!",
+				JWTIssuer:    authServer.URL,
+			}
+			resMux := http.NewServeMux()
+			resMux.Handle("GET /resource", middleware.ValidateToken(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+						"scopes": apiauth.GetScopesFromAPIContext(r.Context()),
+					})
+				}),
+			))
+			resourceServer = httptest.NewServer(resMux)
+
+			// Pre-register a client
+			resp := postJSON(authServer.URL+"/apps/register", map[string]any{
+				"client_domain": "sdk-demo.example.com",
+				"signing_alg":   "HS256",
+			})
+			registeredClientID = resp["client_id"].(string)
+			registeredSecret = resp["client_secret"].(string)
+
+			fmt.Printf("    Auth server:     %s\n", authServer.URL)
+			fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+			fmt.Printf("    Client ID:       %s\n", registeredClientID)
+		})
+
+	// --- One-shot token ---
+	demo.Step("One-shot token with AuthClient").
+		Ref(demokit.RFC6749_ClientCredentials).
+		Ref(demokit.RFC8414).
+		Arrow("App", "AS", "client.DiscoverAS(serverURL)").
+		Arrow("App", "AS", "authClient.ClientCredentialsToken(id, secret, scopes)").
+		DashedArrow("AS", "App", "ServerCredential{AccessToken, ExpiresAt, Scope}").
+		Note("AuthClient is the low-level SDK: discover endpoints, then make a single token request. Good for one-off calls. Uses discovery to find the token endpoint automatically.").
+		Run(func() {
+			// Discover + create client
+			meta, _ := client.DiscoverAS(authServer.URL)
+			authClient := client.NewAuthClient(authServer.URL, nil,
+				client.WithASMetadata(meta))
+
+			cred, err := authClient.ClientCredentialsToken(
+				registeredClientID, registeredSecret, []string{"read"})
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+
+			fmt.Printf("    access_token: %s...\n", cred.AccessToken[:40])
+			fmt.Printf("    scope:        %s\n", cred.Scope)
+			fmt.Printf("    expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))
+		})
+
+	demo.Section("AuthClient vs ClientCredentialsSource",
+		"| | AuthClient | ClientCredentialsSource |",
+		"|---|---|---|",
+		"| **Use case** | One-shot token requests | Long-running services |",
+		"| **Caching** | None — new request every time | Automatic — reuses valid tokens |",
+		"| **Refresh** | Manual | Automatic (on next Token() call) |",
+		"| **Interface** | `ClientCredentialsToken()` | `Token() string` (TokenSource) |",
+		"| **Scope step-up** | Manual | `TokenForScopes()` |",
+	)
+
+	// --- TokenSource with caching ---
+	demo.Step("Cached token with ClientCredentialsSource").
+		Ref(demokit.RFC6749_ClientCredentials).
+		Arrow("App", "App", "tokenSource.Token() → cached or fetched").
+		Arrow("App", "RS", "GET /resource (Bearer: cached token)").
+		DashedArrow("RS", "App", "200 {data}").
+		Note("ClientCredentialsSource implements TokenSource: Token() returns a cached token if still valid, or fetches a new one. Multiple goroutines can safely call Token() concurrently.").
+		Run(func() {
+			tokenSource = &client.ClientCredentialsSource{
+				TokenEndpoint: authServer.URL + "/api/token",
+				ClientID:      registeredClientID,
+				ClientSecret:  registeredSecret,
+				Scopes:        []string{"read"},
+			}
+
+			// First call: fetches a new token
+			token1, err := tokenSource.Token()
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+			fmt.Printf("    First call:  %s... (fetched)\n", token1[:40])
+
+			// Second call: returns cached token (no HTTP call)
+			token2, _ := tokenSource.Token()
+			fmt.Printf("    Second call: %s... (cached)\n", token2[:40])
+			fmt.Printf("    Same token:  %v\n", token1 == token2)
+
+			// Use the token on a resource server
+			req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+			req.Header.Set("Authorization", "Bearer "+token1)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    Resource:    %d %s\n", res.StatusCode, string(body))
+		})
+
+	// --- Scope step-up ---
+	demo.Step("Scope step-up with TokenForScopes").
+		Arrow("App", "App", "tokenSource.TokenForScopes([\"write\"])").
+		Arrow("App", "AS", "POST /api/token {scope: read write} (merged)").
+		DashedArrow("AS", "App", "new token with expanded scopes").
+		Note("When your app needs additional permissions, TokenForScopes merges the new scopes with existing ones, invalidates the cache, and fetches a fresh token.").
+		Run(func() {
+			// Original token has "read" only
+			oldToken, _ := tokenSource.Token()
+			fmt.Printf("    Before step-up: %s...\n", oldToken[:40])
+
+			// Step up to include "write"
+			newToken, err := tokenSource.TokenForScopes([]string{"write"})
+			if err != nil {
+				fmt.Printf("    ERROR: %v\n", err)
+				return
+			}
+			fmt.Printf("    After step-up:  %s...\n", newToken[:40])
+			fmt.Printf("    Different token: %v (cache was invalidated)\n", oldToken != newToken)
+		})
+
+	demo.Section("TokenSource in practice",
+		"The `TokenSource` interface (`Token() (string, error)`) is designed to",
+		"plug into HTTP clients, gRPC interceptors, or any code that needs a token:",
+		"",
+		"```go",
+		"// Create once, reuse everywhere",
+		"ts := &client.ClientCredentialsSource{",
+		"    TokenEndpoint: meta.TokenEndpoint,",
+		"    ClientID:      \"my-app\",",
+		"    ClientSecret:  \"my-secret\",",
+		"    Scopes:        []string{\"read\"},",
+		"}",
+		"",
+		"// In your HTTP client middleware",
+		"token, _ := ts.Token()  // fast: returns cached token",
+		"req.Header.Set(\"Authorization\", \"Bearer \" + token)",
+		"```",
+		"",
+		"The interface matches `mcpkit/core.TokenSource` by structural typing —",
+		"no cross-module import needed.",
+	)
+
+	// --- Optional: Keycloak ---
+	demo.Step("Use the SDK against Keycloak (optional)").
+		Ref(demokit.RFC8414).
+		Ref(demokit.RFC6749_ClientCredentials).
+		Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
+		Arrow("App", "AS", "authClient.ClientCredentialsToken(...)").
+		DashedArrow("AS", "App", "ServerCredential from Keycloak").
+		Note("Same SDK code, pointed at Keycloak. DiscoverAS finds the KC token endpoint automatically. If KC isn't running, this step is skipped.").
+		Run(func() {
+			kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			resp, err := httpClient.Get(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+				fmt.Printf("    To enable: cd examples && make upkcl\n")
+				return
+			}
+			resp.Body.Close()
+
+			// Discover KC
+			kcMeta, err := client.DiscoverAS(kcRealmURL)
+			if err != nil {
+				fmt.Printf("    ERROR discovering KC: %v\n", err)
+				return
+			}
+
+			// Use AuthClient against KC
+			kcClient := client.NewAuthClient(kcRealmURL, nil,
+				client.WithASMetadata(kcMeta))
+			cred, err := kcClient.ClientCredentialsToken(
+				kcExampleClientID, kcExampleClientSecret, []string{"openid"})
+			if err != nil {
+				fmt.Printf("    ERROR getting KC token: %v\n", err)
+				return
+			}
+
+			fmt.Printf("    KC access_token: %s...\n", cred.AccessToken[:40])
+			fmt.Printf("    KC scope:        %s\n", cred.Scope)
+			fmt.Printf("    KC expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))
+			fmt.Printf("\n    Same SDK code — different server. That's the point.\n")
+		})
+
+	demo.Section("What's next?",
+		"In [08 — Rich Authorization Requests](../08-rich-authorization-requests/),",
+		"you'll see how to go beyond flat scopes: request fine-grained permissions",
+		"like \"transfer 45 EUR to Merchant A\" using RFC 9396.",
+	)
+
+	demo.Execute()
+
+	if tokenSource != nil {
+		tokenSource.Close()
+	}
+	if authServer != nil {
+		authServer.Close()
+	}
+	if resourceServer != nil {
+		resourceServer.Close()
+	}
+}
+
+// postJSON is a helper that POSTs JSON and returns the decoded response.
+func postJSON(url string, body any) map[string]any {
+	data, _ := json.Marshal(body)
+	resp, _ := http.Post(url, "application/json", bytes.NewReader(data))
+	defer resp.Body.Close()
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+	return result
+}

--- a/examples/08-rich-authorization-requests/Makefile
+++ b/examples/08-rich-authorization-requests/Makefile
@@ -1,0 +1,19 @@
+# 08 — Rich Authorization Requests (RFC 9396)
+#
+# Infrastructure: None (RAR test issuer optional for cross-server demo)
+#
+# To see the cross-server step:
+#   make uprar (from repo root) — starts RAR test issuer on port 8181
+
+EXAMPLE_DIR := 08-rich-authorization-requests
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+.PHONY: run demo readme

--- a/examples/08-rich-authorization-requests/README.md
+++ b/examples/08-rich-authorization-requests/README.md
@@ -183,11 +183,11 @@ transition, then fail after the grace window closes.
 
 ## References
 
+- [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
 - [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
 - [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
 - [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
-- [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
 
 ## Run it
 

--- a/examples/08-rich-authorization-requests/README.md
+++ b/examples/08-rich-authorization-requests/README.md
@@ -1,0 +1,202 @@
+# 08: Rich Authorization Requests (RFC 9396)
+
+Non-UI | No infrastructure needed | Builds on all previous examples
+
+## What you'll learn
+
+- **Start auth server with RAR support + two resource servers** — The auth server advertises authorization_details_types_supported in its discovery document. Two resource servers enforce different authorization types.
+- **Discover supported authorization_details types** — RFC 9396 §10: the AS advertises which authorization_details types it supports. Clients check this before requesting.
+- **Register a banking app via DCR (RFC 7591)** — Using standards-compliant DCR (Example 06) instead of the proprietary endpoint. A banking app should be fully standards-based.
+- **Request a token with payment authorization_details** — The token request includes structured authorization_details — not just 'scope=payments' but the exact payment to initiate. The AS validates, embeds in the JWT, and echoes in the response.
+- **Access the Payments API (authorized)** — The Payments API uses RequireAuthorizationDetails middleware — it checks that the token has a payment_initiation authorization_details entry. The details are available in the request context.
+- **Access the Accounts API with a payment token (rejected)** — The payment token has type=payment_initiation but the Accounts API requires type=account_information. Fine-grained enforcement: a payment token can't read account data.
+- **Introspect the payment token** — Introspection returns the authorization_details alongside the standard claims. Resource servers that use introspection (instead of local JWT validation) get the same fine-grained information.
+- **RAR coexists with scopes** — Scopes and authorization_details are independent — you can use both in the same request. Scopes for coarse-grained access, RAR for fine-grained.
+- **Cross-server RAR validation (optional — RAR test issuer)** — No open-source IdP supports RFC 9396 on standard OAuth flows yet. We built a RAR test issuer (cmd/rar-test-issuer) for interop testing. Run 'make uprar' to start it. When Keycloak adds RAR support, this step will migrate to KC.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Banking App
+    participant AS as Auth Server
+    participant Pay as Payments API
+    participant Acct as Accounts API
+
+    Note over App,Acct: Step 1: Start auth server with RAR support + two resource servers
+
+    Note over App,Acct: Step 2: Discover supported authorization_details types
+    App->>AS: GET /.well-known/openid-configuration
+    AS-->>App: {..., authorization_details_types_supported: [...]}
+
+    Note over App,Acct: Step 3: Register a banking app via DCR (RFC 7591)
+    App->>AS: POST /apps/dcr {client_name, grant_types, scope}
+    AS-->>App: {client_id, client_secret}
+
+    Note over App,Acct: Step 4: Request a token with payment authorization_details
+    App->>AS: POST /api/token {authorization_details: [{type: payment_initiation, ...}]}
+    AS-->>App: {access_token, authorization_details: [{type: payment_initiation, ...}]}
+
+    Note over App,Acct: Step 5: Access the Payments API (authorized)
+    App->>Pay: POST /payments (Bearer: payment token)
+    Pay->>Pay: RequireAuthorizationDetails("payment_initiation") ✓
+    Pay-->>App: 200 {status: payment_accepted, details: [...]}
+
+    Note over App,Acct: Step 6: Access the Accounts API with a payment token (rejected)
+    App->>Acct: GET /accounts (Bearer: payment token)
+    Acct->>Acct: RequireAuthorizationDetails("account_information") ✗
+    Acct-->>App: 401 Unauthorized
+
+    Note over App,Acct: Step 7: Introspect the payment token
+    RS->>AS: POST /oauth/introspect {token}
+    AS-->>RS: {active: true, authorization_details: [...]}
+
+    Note over App,Acct: Step 8: RAR coexists with scopes
+    App->>AS: POST /api/token {scope: read, authorization_details: [...]}
+    AS-->>App: {scope: read, authorization_details: [...]}
+
+    Note over App,Acct: Step 9: Cross-server RAR validation (optional — RAR test issuer)
+    App->>AS: POST {RAR issuer}/api/token {authorization_details}
+    App->>RS: Bearer token → validate via JWKS from RAR issuer
+```
+
+## Steps
+
+### About this example
+
+**Actors:** Banking App, Auth Server (AS), Payments API (RS), Accounts API (RS).
+Think: a fintech app that needs to initiate a specific payment — not just "access payments".
+[What are these?](../README.md#cast-of-characters)
+
+**The problem with scopes:**
+```
+scope=payments              ← "can do anything with payments" (too broad)
+scope=payments:initiate     ← better, but can't express amount/recipient
+scope=payments:initiate:45EUR:merchant-a  ← this is getting silly
+```
+
+**RFC 9396 solution — authorization_details:**
+```json
+{
+  "type": "payment_initiation",
+  "actions": ["initiate"],
+  "instructedAmount": {"currency": "EUR", "amount": "45.00"},
+  "creditorName": "Merchant A"
+}
+```
+
+Structured, typed, with API-specific extension fields. This is what banks,
+fintechs, and any regulated industry needs.
+
+### Step 1: Start auth server with RAR support + two resource servers
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396), [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+The auth server advertises authorization_details_types_supported in its discovery document. Two resource servers enforce different authorization types.
+
+### Step 2: Discover supported authorization_details types
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396), [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+
+RFC 9396 §10: the AS advertises which authorization_details types it supports. Clients check this before requesting.
+
+### Step 3: Register a banking app via DCR (RFC 7591)
+
+> **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+
+Using standards-compliant DCR (Example 06) instead of the proprietary endpoint. A banking app should be fully standards-based.
+
+### Step 4: Request a token with payment authorization_details
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396), [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+
+The token request includes structured authorization_details — not just 'scope=payments' but the exact payment to initiate. The AS validates, embeds in the JWT, and echoes in the response.
+
+### What's in the JWT?
+
+The access token now carries `authorization_details` as a JWT claim:
+```json
+{
+  "sub": "app_abc123",
+  "scopes": [...],
+  "authorization_details": [
+    {
+      "type": "payment_initiation",
+      "actions": ["initiate"],
+      "instructedAmount": {"currency": "EUR", "amount": "45.00"},
+      "creditorName": "Merchant A"
+    }
+  ]
+}
+```
+The resource server reads this claim to enforce fine-grained access.
+
+### Step 5: Access the Payments API (authorized)
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+
+The Payments API uses RequireAuthorizationDetails middleware — it checks that the token has a payment_initiation authorization_details entry. The details are available in the request context.
+
+### Step 6: Access the Accounts API with a payment token (rejected)
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+
+The payment token has type=payment_initiation but the Accounts API requires type=account_information. Fine-grained enforcement: a payment token can't read account data.
+
+### Step 7: Introspect the payment token
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396), [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+
+Introspection returns the authorization_details alongside the standard claims. Resource servers that use introspection (instead of local JWT validation) get the same fine-grained information.
+
+### Step 8: RAR coexists with scopes
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+
+Scopes and authorization_details are independent — you can use both in the same request. Scopes for coarse-grained access, RAR for fine-grained.
+
+### Step 9: Cross-server RAR validation (optional — RAR test issuer)
+
+> **References:** [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+
+No open-source IdP supports RFC 9396 on standard OAuth flows yet. We built a RAR test issuer (cmd/rar-test-issuer) for interop testing. Run 'make uprar' to start it. When Keycloak adds RAR support, this step will migrate to KC.
+
+### RFC 9396 in OneAuth — what we built
+
+| Layer | What | RFC section |
+|-------|------|------------|
+| Data model | `core.AuthorizationDetail` with JSON flattening | §2 |
+| Token endpoint | Parse, validate, embed in JWT, return in response | §5 |
+| Form-encoded | `authorization_details` as JSON string in form params | §6.1 |
+| Introspection | Include in introspection response | §9.1 |
+| AS metadata | `authorization_details_types_supported` | §10 |
+| DCR | `authorization_details_types` on client registration | §10 |
+| Middleware | `RequireAuthorizationDetails()` enforcement | §2 |
+| Client SDK | `AuthorizationDetails` on token requests/responses | §5 |
+| Error handling | `invalid_authorization_details` error code | §5.2 |
+
+### What's next?
+
+In [09 — Key Rotation](../09-key-rotation/), you'll see how to rotate
+signing keys with a grace period — old tokens keep working during the
+transition, then fail after the grace window closes.
+
+## References
+
+- [RFC 8414 — AS Metadata Discovery](https://www.rfc-editor.org/rfc/rfc8414)
+- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
+- [RFC 7662 — Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+- [RFC 9396 — Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+
+## Run it
+
+```bash
+go run ./examples/08-rich-authorization-requests/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/08-rich-authorization-requests/ --non-interactive
+```

--- a/examples/08-rich-authorization-requests/main.go
+++ b/examples/08-rich-authorization-requests/main.go
@@ -1,0 +1,419 @@
+// Example 08: Rich Authorization Requests (RFC 9396)
+//
+// This is the culmination of Examples 01-07. Flat scopes like "read" and "write"
+// can't express "transfer 45 EUR to Merchant A". RFC 9396 adds structured
+// authorization_details to OAuth — fine-grained, typed, with API-specific fields.
+//
+// This is the feature that motivated this entire PR — driven by a banking client
+// evaluating OneAuth for transaction-level authorization.
+//
+// Run:   go run ./examples/08-rich-authorization-requests/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+const rarIssuerURL = "http://localhost:8181"
+
+func main() {
+	var authServer, paymentsRS, accountsRS *httptest.Server
+	var ks keys.KeyStorage
+	var clientID, clientSecret string
+	var paymentToken string
+
+	demo := demokit.New("08: Rich Authorization Requests (RFC 9396)").
+		Dir("08-rich-authorization-requests").
+		Description("Non-UI | No infrastructure needed | Builds on all previous examples").
+		Actors(
+			demokit.Actor("App", "Banking App"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("Pay", "Payments API"),
+			demokit.Actor("Acct", "Accounts API"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** Banking App, Auth Server (AS), Payments API (RS), Accounts API (RS).",
+		"Think: a fintech app that needs to initiate a specific payment — not just \"access payments\".",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"**The problem with scopes:**",
+		"```",
+		"scope=payments              ← \"can do anything with payments\" (too broad)",
+		"scope=payments:initiate     ← better, but can't express amount/recipient",
+		"scope=payments:initiate:45EUR:merchant-a  ← this is getting silly",
+		"```",
+		"",
+		"**RFC 9396 solution — authorization_details:**",
+		"```json",
+		"{",
+		"  \"type\": \"payment_initiation\",",
+		"  \"actions\": [\"initiate\"],",
+		"  \"instructedAmount\": {\"currency\": \"EUR\", \"amount\": \"45.00\"},",
+		"  \"creditorName\": \"Merchant A\"",
+		"}",
+		"```",
+		"",
+		"Structured, typed, with API-specific extension fields. This is what banks,",
+		"fintechs, and any regulated industry needs.",
+	)
+
+	// --- Setup ---
+	demo.Step("Start auth server with RAR support + two resource servers").
+		Ref(demokit.RFC9396).
+		Ref(demokit.RFC8414).
+		Note("The auth server advertises authorization_details_types_supported in its discovery document. Two resource servers enforce different authorization types.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+			apiAuth := &apiauth.APIAuth{
+				JWTSecretKey:   "rar-example-secret-at-least-32ch!",
+				ClientKeyStore: ks,
+			}
+
+			introspection := &apiauth.IntrospectionHandler{
+				Auth:           apiAuth,
+				ClientKeyStore: ks,
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/apps/", registrar.Handler())
+			mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+			mux.Handle("POST /oauth/introspect", introspection)
+			authServer = httptest.NewServer(mux)
+			apiAuth.JWTIssuer = authServer.URL
+
+			mux.Handle("GET /.well-known/openid-configuration",
+				apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+					Issuer:                             authServer.URL,
+					TokenEndpoint:                      authServer.URL + "/api/token",
+					IntrospectionEndpoint:              authServer.URL + "/oauth/introspect",
+					GrantTypesSupported:                []string{"client_credentials"},
+					TokenEndpointAuthMethods:           []string{"client_secret_post", "client_secret_basic"},
+					AuthorizationDetailsTypesSupported: []string{"payment_initiation", "account_information"},
+				}))
+
+			// Payments resource server — requires payment_initiation type
+			payMW := &apiauth.APIMiddleware{
+				JWTSecretKey: "rar-example-secret-at-least-32ch!",
+				JWTIssuer:    authServer.URL,
+			}
+			payMux := http.NewServeMux()
+			payMux.Handle("POST /payments", payMW.RequireAuthorizationDetails("payment_initiation")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"status":  "payment_accepted",
+						"details": details,
+					})
+				}),
+			))
+			paymentsRS = httptest.NewServer(payMux)
+
+			// Accounts resource server — requires account_information type
+			acctMW := &apiauth.APIMiddleware{
+				JWTSecretKey: "rar-example-secret-at-least-32ch!",
+				JWTIssuer:    authServer.URL,
+			}
+			acctMux := http.NewServeMux()
+			acctMux.Handle("GET /accounts", acctMW.RequireAuthorizationDetails("account_information")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"status":  "accounts_listed",
+						"details": details,
+					})
+				}),
+			))
+			accountsRS = httptest.NewServer(acctMux)
+
+			fmt.Printf("    Auth server:   %s\n", authServer.URL)
+			fmt.Printf("    Payments API:  %s\n", paymentsRS.URL)
+			fmt.Printf("    Accounts API:  %s\n", accountsRS.URL)
+		})
+
+	// --- Discovery ---
+	demo.Step("Discover supported authorization_details types").
+		Ref(demokit.RFC9396).
+		Ref(demokit.RFC8414).
+		Arrow("App", "AS", "GET /.well-known/openid-configuration").
+		DashedArrow("AS", "App", "{..., authorization_details_types_supported: [...]}").
+		Note("RFC 9396 §10: the AS advertises which authorization_details types it supports. Clients check this before requesting.").
+		Run(func() {
+			meta, _ := client.DiscoverAS(authServer.URL)
+			resp, _ := http.Get(authServer.URL + "/.well-known/openid-configuration")
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			var raw map[string]any
+			json.Unmarshal(body, &raw)
+
+			types := raw["authorization_details_types_supported"]
+			fmt.Printf("    authorization_details_types_supported: %v\n", types)
+			fmt.Printf("    token_endpoint: %s\n", meta.TokenEndpoint)
+		})
+
+	// --- Register via DCR ---
+	demo.Step("Register a banking app via DCR (RFC 7591)").
+		Ref(demokit.RFC7591).
+		Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, scope}").
+		DashedArrow("AS", "App", "{client_id, client_secret}").
+		Note("Using standards-compliant DCR (Example 06) instead of the proprietary endpoint. A banking app should be fully standards-based.").
+		Run(func() {
+			body, _ := json.Marshal(map[string]any{
+				"client_name":                "Fintech Payment App",
+				"grant_types":                []string{"client_credentials"},
+				"token_endpoint_auth_method": "client_secret_post",
+				"scope":                      "payments accounts",
+			})
+			resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+				bytes.NewReader(body))
+			var reg map[string]any
+			json.NewDecoder(resp.Body).Decode(&reg)
+			resp.Body.Close()
+			clientID = reg["client_id"].(string)
+			clientSecret = reg["client_secret"].(string)
+			fmt.Printf("    client_id:   %s\n", clientID)
+			fmt.Printf("    client_name: %s\n", reg["client_name"])
+		})
+
+	// --- Payment token ---
+	demo.Step("Request a token with payment authorization_details").
+		Ref(demokit.RFC9396).
+		Ref(demokit.RFC6749_ClientCredentials).
+		Arrow("App", "AS", "POST /api/token {authorization_details: [{type: payment_initiation, ...}]}").
+		DashedArrow("AS", "App", "{access_token, authorization_details: [{type: payment_initiation, ...}]}").
+		Note("The token request includes structured authorization_details — not just 'scope=payments' but the exact payment to initiate. The AS validates, embeds in the JWT, and echoes in the response.").
+		Run(func() {
+			reqBody := map[string]any{
+				"grant_type":    "client_credentials",
+				"client_id":     clientID,
+				"client_secret": clientSecret,
+				"authorization_details": []map[string]any{
+					{
+						"type":      "payment_initiation",
+						"actions":   []string{"initiate"},
+						"locations": []string{paymentsRS.URL + "/payments"},
+						"instructedAmount": map[string]any{
+							"currency": "EUR",
+							"amount":   "45.00",
+						},
+						"creditorName": "Merchant A",
+					},
+				},
+			}
+			body, _ := json.Marshal(reqBody)
+
+			resp, _ := http.Post(authServer.URL+"/api/token", "application/json",
+				bytes.NewReader(body))
+			var tokenData map[string]any
+			json.NewDecoder(resp.Body).Decode(&tokenData)
+			resp.Body.Close()
+
+			paymentToken = tokenData["access_token"].(string)
+
+			// Show the authorization_details in the response
+			ad := tokenData["authorization_details"].([]any)
+			adPretty, _ := json.MarshalIndent(ad, "    ", "  ")
+			fmt.Printf("    authorization_details in response:\n    %s\n\n", string(adPretty))
+			fmt.Printf("    access_token: %s...\n", paymentToken[:40])
+		})
+
+	demo.Section("What's in the JWT?",
+		"The access token now carries `authorization_details` as a JWT claim:",
+		"```json",
+		"{",
+		"  \"sub\": \"app_abc123\",",
+		"  \"scopes\": [...],",
+		"  \"authorization_details\": [",
+		"    {",
+		"      \"type\": \"payment_initiation\",",
+		"      \"actions\": [\"initiate\"],",
+		"      \"instructedAmount\": {\"currency\": \"EUR\", \"amount\": \"45.00\"},",
+		"      \"creditorName\": \"Merchant A\"",
+		"    }",
+		"  ]",
+		"}",
+		"```",
+		"The resource server reads this claim to enforce fine-grained access.",
+	)
+
+	// --- Use on payments RS ---
+	demo.Step("Access the Payments API (authorized)").
+		Ref(demokit.RFC9396).
+		Arrow("App", "Pay", "POST /payments (Bearer: payment token)").
+		Arrow("Pay", "Pay", "RequireAuthorizationDetails(\"payment_initiation\") ✓").
+		DashedArrow("Pay", "App", "200 {status: payment_accepted, details: [...]}").
+		Note("The Payments API uses RequireAuthorizationDetails middleware — it checks that the token has a payment_initiation authorization_details entry. The details are available in the request context.").
+		Run(func() {
+			req, _ := http.NewRequest("POST", paymentsRS.URL+"/payments", nil)
+			req.Header.Set("Authorization", "Bearer "+paymentToken)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d\n", res.StatusCode)
+			var data map[string]any
+			json.Unmarshal(body, &data)
+			pretty, _ := json.MarshalIndent(data, "    ", "  ")
+			fmt.Printf("    response: %s\n", string(pretty))
+		})
+
+	// --- Use on accounts RS (should fail) ---
+	demo.Step("Access the Accounts API with a payment token (rejected)").
+		Ref(demokit.RFC9396).
+		Arrow("App", "Acct", "GET /accounts (Bearer: payment token)").
+		Arrow("Acct", "Acct", "RequireAuthorizationDetails(\"account_information\") ✗").
+		DashedArrow("Acct", "App", "401 Unauthorized").
+		Note("The payment token has type=payment_initiation but the Accounts API requires type=account_information. Fine-grained enforcement: a payment token can't read account data.").
+		Run(func() {
+			req, _ := http.NewRequest("GET", accountsRS.URL+"/accounts", nil)
+			req.Header.Set("Authorization", "Bearer "+paymentToken)
+			res, _ := http.DefaultClient.Do(req)
+			res.Body.Close()
+
+			fmt.Printf("    status: %d (correctly rejected — wrong authorization type)\n", res.StatusCode)
+		})
+
+	// --- Introspect ---
+	demo.Step("Introspect the payment token").
+		Ref(demokit.RFC9396).
+		Ref(demokit.RFC7662).
+		Arrow("RS", "AS", "POST /oauth/introspect {token}").
+		DashedArrow("AS", "RS", "{active: true, authorization_details: [...]}").
+		Note("Introspection returns the authorization_details alongside the standard claims. Resource servers that use introspection (instead of local JWT validation) get the same fine-grained information.").
+		Run(func() {
+			form := url.Values{"token": {paymentToken}}
+			req, _ := http.NewRequest("POST", authServer.URL+"/oauth/introspect",
+				strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.SetBasicAuth(clientID, clientSecret)
+			res, _ := http.DefaultClient.Do(req)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+
+			var result map[string]any
+			json.Unmarshal(body, &result)
+			pretty, _ := json.MarshalIndent(result, "    ", "  ")
+			fmt.Printf("    %s\n", string(pretty))
+		})
+
+	// --- Scope coexistence ---
+	demo.Step("RAR coexists with scopes").
+		Ref(demokit.RFC9396).
+		Arrow("App", "AS", "POST /api/token {scope: read, authorization_details: [...]}").
+		DashedArrow("AS", "App", "{scope: read, authorization_details: [...]}").
+		Note("Scopes and authorization_details are independent — you can use both in the same request. Scopes for coarse-grained access, RAR for fine-grained.").
+		Run(func() {
+			reqBody := map[string]any{
+				"grant_type":    "client_credentials",
+				"client_id":     clientID,
+				"client_secret": clientSecret,
+				"scope":         "read write",
+				"authorization_details": []map[string]any{
+					{"type": "account_information", "actions": []string{"list_accounts"}},
+				},
+			}
+			body, _ := json.Marshal(reqBody)
+			resp, _ := http.Post(authServer.URL+"/api/token", "application/json",
+				bytes.NewReader(body))
+			var tokenData map[string]any
+			json.NewDecoder(resp.Body).Decode(&tokenData)
+			resp.Body.Close()
+
+			fmt.Printf("    scope: %s\n", tokenData["scope"])
+			ad := tokenData["authorization_details"].([]any)
+			fmt.Printf("    authorization_details: %d entries\n", len(ad))
+			fmt.Printf("    Both present — independent, composable.\n")
+		})
+
+	// --- Optional: RAR test issuer ---
+	demo.Step("Cross-server RAR validation (optional — RAR test issuer)").
+		Ref(demokit.RFC9396).
+		Arrow("App", "AS", "POST {RAR issuer}/api/token {authorization_details}").
+		Arrow("App", "RS", "Bearer token → validate via JWKS from RAR issuer").
+		Note("No open-source IdP supports RFC 9396 on standard OAuth flows yet. We built a RAR test issuer (cmd/rar-test-issuer) for interop testing. Run 'make uprar' to start it. When Keycloak adds RAR support, this step will migrate to KC.").
+		Run(func() {
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			resp, err := httpClient.Get(rarIssuerURL + "/_ah/health")
+			if err != nil {
+				fmt.Printf("    SKIPPED: RAR test issuer not running at %s\n", rarIssuerURL)
+				fmt.Printf("    To enable: make uprar (from repo root)\n")
+				return
+			}
+			resp.Body.Close()
+
+			// Get a RAR token from the external issuer
+			reqBody := map[string]any{
+				"grant_type":    "client_credentials",
+				"client_id":     "rar-test-client",
+				"client_secret": "rar-test-secret",
+				"authorization_details": []map[string]any{
+					{"type": "payment_initiation", "actions": []string{"initiate"}},
+				},
+			}
+			body, _ := json.Marshal(reqBody)
+			tokenResp, _ := http.Post(rarIssuerURL+"/api/token", "application/json",
+				bytes.NewReader(body))
+			var tokenData map[string]any
+			json.NewDecoder(tokenResp.Body).Decode(&tokenData)
+			tokenResp.Body.Close()
+
+			fmt.Printf("    Token from RAR test issuer: %s...\n", tokenData["access_token"].(string)[:40])
+
+			ad := tokenData["authorization_details"].([]any)
+			fmt.Printf("    authorization_details: %v\n", ad[0].(map[string]any)["type"])
+			fmt.Printf("\n    Same RFC 9396 format — issued by a different server.\n")
+		})
+
+	demo.Section("RFC 9396 in OneAuth — what we built",
+		"| Layer | What | RFC section |",
+		"|-------|------|------------|",
+		"| Data model | `core.AuthorizationDetail` with JSON flattening | §2 |",
+		"| Token endpoint | Parse, validate, embed in JWT, return in response | §5 |",
+		"| Form-encoded | `authorization_details` as JSON string in form params | §6.1 |",
+		"| Introspection | Include in introspection response | §9.1 |",
+		"| AS metadata | `authorization_details_types_supported` | §10 |",
+		"| DCR | `authorization_details_types` on client registration | §10 |",
+		"| Middleware | `RequireAuthorizationDetails()` enforcement | §2 |",
+		"| Client SDK | `AuthorizationDetails` on token requests/responses | §5 |",
+		"| Error handling | `invalid_authorization_details` error code | §5.2 |",
+	)
+
+	demo.Section("What's next?",
+		"In [09 — Key Rotation](../09-key-rotation/), you'll see how to rotate",
+		"signing keys with a grace period — old tokens keep working during the",
+		"transition, then fail after the grace window closes.",
+	)
+
+	demo.Execute()
+
+	if authServer != nil {
+		authServer.Close()
+	}
+	if paymentsRS != nil {
+		paymentsRS.Close()
+	}
+	if accountsRS != nil {
+		accountsRS.Close()
+	}
+}

--- a/examples/09-key-rotation/Makefile
+++ b/examples/09-key-rotation/Makefile
@@ -1,0 +1,14 @@
+# 09-key-rotation
+
+EXAMPLE_DIR := 09-key-rotation
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+.PHONY: run demo readme

--- a/examples/09-key-rotation/README.md
+++ b/examples/09-key-rotation/README.md
@@ -1,0 +1,133 @@
+# 09: Key Rotation with Grace Periods
+
+Non-UI | No infrastructure needed | Builds on Example 02
+
+## What you'll learn
+
+- **Set up auth server with key rotation support** — The auth server uses a KidStore alongside the main KeyStore. On rotation, the old key moves to KidStore with a grace period TTL. The CompositeKeyLookup checks both.
+- **Register an app and mint a token with the original key** — The app gets a client_secret (HS256). We mint a token for Alice — this token's kid header is derived from the old key.
+- **Rotate the key** — Rotation replaces the key in the main KeyStore and moves the old key to KidStore with a grace period TTL. Both keys are now valid.
+- **During grace period — both tokens work** — The CompositeKeyLookup checks the main KeyStore first, then falls back to KidStore. Old tokens find their key in the grace store; new tokens find theirs in the main store.
+- **After grace period — old token rejected** — After the grace period expires (100ms in this demo), the old key is removed from KidStore. Tokens signed with it are now rejected.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Admin
+    participant AS as Auth Server
+    participant RS as Resource Server
+
+    Note over Admin,RS: Step 1: Set up auth server with key rotation support
+
+    Note over Admin,RS: Step 2: Register an app and mint a token with the original key
+    Admin->>AS: POST /apps/register
+    AS-->>Admin: {client_id, client_secret}
+    Admin->>Admin: MintResourceToken(alice, oldSecret)
+
+    Note over Admin,RS: Step 3: Rotate the key
+    Admin->>AS: POST /apps/{id}/rotate
+    AS-->>Admin: {client_secret: newSecret}
+
+    Note over Admin,RS: Step 4: During grace period — both tokens work
+    RS->>RS: Validate old token → kid found in KidStore (grace) ✓
+    RS->>RS: Validate new token → kid found in KeyStore (current) ✓
+
+    Note over Admin,RS: Step 5: After grace period — old token rejected
+    RS->>RS: Validate old token → kid not found anywhere ✗
+    RS->>RS: Validate new token → kid found in KeyStore ✓
+```
+
+## Steps
+
+### About this example
+
+**Actors:** Admin, Auth Server (AS), Resource Server (RS).
+Think: Slack rotates its signing keys — existing bot tokens must keep working during the transition.
+[What are these?](../README.md#cast-of-characters)
+
+**The problem:** You rotate an app's signing key. Tokens signed with the old
+key are still in flight — users have them cached, they haven't expired yet.
+If the resource server only knows the new key, those tokens break.
+
+**The solution:** A grace period. After rotation, the old key stays valid for
+a configurable window. Both old and new tokens work. After the grace period,
+old tokens are rejected.
+
+```
+Time: ──────────────────────────────────────────────────►
+       ┌─── old key valid ───┐
+       │                     │ ← grace period
+       ├─── rotation ────────┤
+       │                     ├─── new key valid ──────►
+       │  both keys work     │  only new key works
+```
+
+### Step 1: Set up auth server with key rotation support
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517), [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+
+The auth server uses a KidStore alongside the main KeyStore. On rotation, the old key moves to KidStore with a grace period TTL. The CompositeKeyLookup checks both.
+
+### Step 2: Register an app and mint a token with the original key
+
+> **References:** [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+The app gets a client_secret (HS256). We mint a token for Alice — this token's kid header is derived from the old key.
+
+### Step 3: Rotate the key
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+Rotation replaces the key in the main KeyStore and moves the old key to KidStore with a grace period TTL. Both keys are now valid.
+
+### Step 4: During grace period — both tokens work
+
+> **References:** [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+
+The CompositeKeyLookup checks the main KeyStore first, then falls back to KidStore. Old tokens find their key in the grace store; new tokens find theirs in the main store.
+
+### Step 5: After grace period — old token rejected
+
+After the grace period expires (100ms in this demo), the old key is removed from KidStore. Tokens signed with it are now rejected.
+
+### How it works under the hood
+
+```
+CompositeKeyLookup
+  ├── KeyStore (current keys)     ← new key lives here
+  └── KidStore (grace period)     ← old key lives here temporarily
+
+Token arrives with kid header:
+  1. Check KeyStore by kid → found? validate with that key
+  2. Not found → check KidStore by kid → found and not expired? validate
+  3. Not found anywhere → reject
+```
+
+The kid (Key ID) in the JWT header is a RFC 7638 thumbprint of the signing
+key. Each key has a unique kid, so the lookup is deterministic — there's no
+ambiguity about which key to use for verification.
+
+### What's next?
+
+In [10 — Security](../10-security/), you'll see attack prevention:
+algorithm confusion (CVE-2015-9235), cross-app token forgery, and
+JWKS security properties.
+
+## References
+
+- [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+- [RFC 7638 — JWK Thumbprint (kid)](https://www.rfc-editor.org/rfc/rfc7638)
+- [RFC 7519 — JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519)
+
+## Run it
+
+```bash
+go run ./examples/09-key-rotation/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/09-key-rotation/ --non-interactive
+```

--- a/examples/09-key-rotation/main.go
+++ b/examples/09-key-rotation/main.go
@@ -1,0 +1,223 @@
+// Example 09: Key Rotation with Grace Periods
+//
+// In production, signing keys need to be rotated periodically. But you can't
+// just swap keys — existing tokens signed with the old key would break. OneAuth
+// solves this with a grace period: old keys stay valid for a window after
+// rotation, then expire.
+//
+// Run:   go run ./examples/09-key-rotation/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7517 (JWK)
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+)
+
+func main() {
+	var regHandler http.Handler
+	var ks keys.KeyStorage
+	var kidStore *keys.KidStore
+	var middleware *apiauth.APIMiddleware
+	var clientID, oldSecret, newSecret string
+	var oldToken, newToken string
+
+	demo := demokit.New("09: Key Rotation with Grace Periods").
+		Dir("09-key-rotation").
+		Description("Non-UI | No infrastructure needed | Builds on Example 02").
+		Actors(
+			demokit.Actor("Admin", "Admin"),
+			demokit.Actor("AS", "Auth Server"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("About this example",
+		"**Actors:** Admin, Auth Server (AS), Resource Server (RS).",
+		"Think: Slack rotates its signing keys — existing bot tokens must keep working during the transition.",
+		"[What are these?](../README.md#cast-of-characters)",
+		"",
+		"**The problem:** You rotate an app's signing key. Tokens signed with the old",
+		"key are still in flight — users have them cached, they haven't expired yet.",
+		"If the resource server only knows the new key, those tokens break.",
+		"",
+		"**The solution:** A grace period. After rotation, the old key stays valid for",
+		"a configurable window. Both old and new tokens work. After the grace period,",
+		"old tokens are rejected.",
+		"",
+		"```",
+		"Time: ──────────────────────────────────────────────────►",
+		"       ┌─── old key valid ───┐",
+		"       │                     │ ← grace period",
+		"       ├─── rotation ────────┤",
+		"       │                     ├─── new key valid ──────►",
+		"       │  both keys work     │  only new key works",
+		"```",
+	)
+
+	// --- Setup ---
+	demo.Step("Set up auth server with key rotation support").
+		Ref(demokit.RFC7517).
+		Ref(demokit.RFC7638).
+		Note("The auth server uses a KidStore alongside the main KeyStore. On rotation, the old key moves to KidStore with a grace period TTL. The CompositeKeyLookup checks both.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+			kidStore = keys.NewKidStore()
+
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+			registrar.KidStore = kidStore
+			registrar.DefaultGracePeriod = 100 * time.Millisecond // short for demo
+			regHandler = registrar.Handler()
+
+			// CompositeKeyLookup: check current keys first, then grace period keys
+			composite := &keys.CompositeKeyLookup{
+				Lookups: []keys.KeyLookup{ks, kidStore},
+			}
+			middleware = &apiauth.APIMiddleware{KeyStore: composite}
+
+			fmt.Printf("    KeyStore:     in-memory (current keys)\n")
+			fmt.Printf("    KidStore:     in-memory (grace period keys)\n")
+			fmt.Printf("    Grace period: 100ms (short for demo)\n")
+		})
+
+	// --- Register and mint ---
+	demo.Step("Register an app and mint a token with the original key").
+		Ref(demokit.RFC7519).
+		Arrow("Admin", "AS", "POST /apps/register").
+		DashedArrow("AS", "Admin", "{client_id, client_secret}").
+		Arrow("Admin", "Admin", "MintResourceToken(alice, oldSecret)").
+		Note("The app gets a client_secret (HS256). We mint a token for Alice — this token's kid header is derived from the old key.").
+		Run(func() {
+			body, _ := json.Marshal(map[string]any{"client_domain": "rotate.example.com"})
+			req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			regHandler.ServeHTTP(rr, req)
+
+			var reg map[string]any
+			json.NewDecoder(rr.Body).Decode(&reg)
+			clientID = reg["client_id"].(string)
+			oldSecret = reg["client_secret"].(string)
+
+			oldToken, _ = admin.MintResourceToken(
+				"alice", clientID, oldSecret,
+				admin.AppQuota{}, []string{"read"}, nil)
+
+			// Show the kid
+			parser := jwt.NewParser()
+			parsed, _, _ := parser.ParseUnverified(oldToken, jwt.MapClaims{})
+			fmt.Printf("    client_id:   %s\n", clientID)
+			fmt.Printf("    old secret:  %s...\n", oldSecret[:16])
+			fmt.Printf("    old token kid: %s\n", parsed.Header["kid"])
+		})
+
+	// --- Rotate ---
+	demo.Step("Rotate the key").
+		Ref(demokit.RFC7517).
+		Arrow("Admin", "AS", "POST /apps/{id}/rotate").
+		DashedArrow("AS", "Admin", "{client_secret: newSecret}").
+		Note("Rotation replaces the key in the main KeyStore and moves the old key to KidStore with a grace period TTL. Both keys are now valid.").
+		Run(func() {
+			req := httptest.NewRequest("POST", "/apps/"+clientID+"/rotate", nil)
+			rr := httptest.NewRecorder()
+			regHandler.ServeHTTP(rr, req)
+
+			var rot map[string]any
+			json.NewDecoder(rr.Body).Decode(&rot)
+			newSecret = rot["client_secret"].(string)
+
+			newToken, _ = admin.MintResourceToken(
+				"alice", clientID, newSecret,
+				admin.AppQuota{}, []string{"read"}, nil)
+
+			fmt.Printf("    new secret:  %s...\n", newSecret[:16])
+			fmt.Printf("    different:   %v\n", oldSecret != newSecret)
+
+			parser := jwt.NewParser()
+			parsed, _, _ := parser.ParseUnverified(newToken, jwt.MapClaims{})
+			fmt.Printf("    new token kid: %s\n", parsed.Header["kid"])
+		})
+
+	// --- During grace period ---
+	demo.Step("During grace period — both tokens work").
+		Ref(demokit.RFC7638).
+		Arrow("RS", "RS", "Validate old token → kid found in KidStore (grace) ✓").
+		Arrow("RS", "RS", "Validate new token → kid found in KeyStore (current) ✓").
+		Note("The CompositeKeyLookup checks the main KeyStore first, then falls back to KidStore. Old tokens find their key in the grace store; new tokens find theirs in the main store.").
+		Run(func() {
+			handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			oldResult := validateToken(handler, oldToken)
+			newResult := validateToken(handler, newToken)
+
+			fmt.Printf("    old token (during grace): %d ✓\n", oldResult)
+			fmt.Printf("    new token:                %d ✓\n", newResult)
+		})
+
+	// --- After grace period ---
+	demo.Step("After grace period — old token rejected").
+		Arrow("RS", "RS", "Validate old token → kid not found anywhere ✗").
+		Arrow("RS", "RS", "Validate new token → kid found in KeyStore ✓").
+		Note("After the grace period expires (100ms in this demo), the old key is removed from KidStore. Tokens signed with it are now rejected.").
+		Run(func() {
+			// Wait for grace period to expire
+			time.Sleep(120 * time.Millisecond)
+
+			handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			oldResult := validateToken(handler, oldToken)
+			newResult := validateToken(handler, newToken)
+
+			fmt.Printf("    old token (after grace):  %d ✗ (correctly rejected)\n", oldResult)
+			fmt.Printf("    new token:                %d ✓\n", newResult)
+		})
+
+	demo.Section("How it works under the hood",
+		"```",
+		"CompositeKeyLookup",
+		"  ├── KeyStore (current keys)     ← new key lives here",
+		"  └── KidStore (grace period)     ← old key lives here temporarily",
+		"",
+		"Token arrives with kid header:",
+		"  1. Check KeyStore by kid → found? validate with that key",
+		"  2. Not found → check KidStore by kid → found and not expired? validate",
+		"  3. Not found anywhere → reject",
+		"```",
+		"",
+		"The kid (Key ID) in the JWT header is a RFC 7638 thumbprint of the signing",
+		"key. Each key has a unique kid, so the lookup is deterministic — there's no",
+		"ambiguity about which key to use for verification.",
+	)
+
+	demo.Section("What's next?",
+		"In [10 — Security](../10-security/), you'll see attack prevention:",
+		"algorithm confusion (CVE-2015-9235), cross-app token forgery, and",
+		"JWKS security properties.",
+	)
+
+	demo.Execute()
+}
+
+// validateToken runs a token through the middleware and returns the HTTP status.
+func validateToken(handler http.Handler, token string) int {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(rr, req)
+	return rr.Code
+}

--- a/examples/10-security/Makefile
+++ b/examples/10-security/Makefile
@@ -1,0 +1,14 @@
+# 10-security
+
+EXAMPLE_DIR := 10-security
+
+run:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/
+
+demo:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
+
+readme:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --readme > examples/$(EXAMPLE_DIR)/README.md
+
+.PHONY: run demo readme

--- a/examples/10-security/README.md
+++ b/examples/10-security/README.md
@@ -1,0 +1,143 @@
+# 10: Security — Attack Prevention
+
+Non-UI | No infrastructure needed | Standalone
+
+## What you'll learn
+
+- **Set up KeyStore with an RS256 app and an HS256 app** — Two apps coexist: one with an RSA key pair (RS256), one with a shared secret (HS256). The resource server validates tokens from both.
+- **Attack 1: Algorithm confusion (CVE-2015-9235)** — The attack: The attacker knows the RSA public key (it's public, served via JWKS). They craft a JWT with alg:HS256 and sign it using the public key bytes as the HMAC secret. A naive server reads alg:HS256, grabs the stored key bytes, and verifies — which passes because the attacker used those same bytes.
+
+OneAuth's defense: The middleware checks that the token's alg header matches the KeyRecord.Algorithm. Store says RS256, token says HS256 → mismatch → rejected before any signature check.
+- **Attack 2: alg:none — no signature at all** — The attack: The attacker sends a JWT with alg:none — no signature at all. Some JWT libraries accept this as valid.
+
+OneAuth uses golang-jwt/v5 which rejects alg:none by default unless explicitly opted in with UnsafeAllowNoneSignatureType.
+- **Attack 3: Cross-app token forgery** — The attack: App A's key is compromised. The attacker signs a token claiming to be App B (client_id=app-B) using App A's key. If the resource server only checks the signature and not which app owns the key, the token validates.
+
+OneAuth's defense: The middleware checks that the kid's owning client matches the client_id claim. App A's key → kid owned by app-A → client_id claim says app-B → mismatch → rejected.
+- **JWKS security: only public keys, never secrets** — JWKS serves only asymmetric public keys. HS256 secrets are excluded entirely. RSA keys include only public components (n, e) — private fields (d, p, q) are structurally absent from the JWK type.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Legit as Legitimate App
+    participant Attacker
+    participant RS as Resource Server
+
+    Note over Legit,RS: Step 1: Set up KeyStore with an RS256 app and an HS256 app
+
+    Note over Legit,RS: Step 2: Attack 1: Algorithm confusion (CVE-2015-9235)
+    Attacker->>Attacker: Craft JWT: alg=HS256, sign with RSA public key
+    Attacker->>RS: Bearer: confused token
+    RS-->>Attacker: 401 Unauthorized (blocked)
+
+    Note over Legit,RS: Step 3: Attack 2: alg:none — no signature at all
+    Attacker->>Attacker: Craft JWT: alg=none, no signature
+    Attacker->>RS: Bearer: unsigned token
+    RS-->>Attacker: 401 Unauthorized (blocked)
+
+    Note over Legit,RS: Step 4: Attack 3: Cross-app token forgery
+    Attacker->>Attacker: Sign JWT with app-A's key but claim client_id=app-B
+    Attacker->>RS: Bearer: cross-app token
+    RS-->>Attacker: 401 Unauthorized (blocked)
+
+    Note over Legit,RS: Step 5: JWKS security: only public keys, never secrets
+    Anyone->>AS: GET /.well-known/jwks.json
+    AS-->>Anyone: {keys: [RSA public key only]}
+```
+
+## Steps
+
+### About this example
+
+This example demonstrates real JWT attacks and OneAuth's defenses.
+Each attack is executed live — you'll see both the attack and the defense in action.
+
+**Attacks covered:**
+1. Algorithm confusion (CVE-2015-9235) — the most famous JWT vulnerability
+2. Cross-app token forgery — using one app's key with another app's client_id
+3. `alg: none` — disabling signature verification entirely
+4. JWKS private key leakage — checking that secrets stay secret
+
+### Step 1: Set up KeyStore with an RS256 app and an HS256 app
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+Two apps coexist: one with an RSA key pair (RS256), one with a shared secret (HS256). The resource server validates tokens from both.
+
+### Step 2: Attack 1: Algorithm confusion (CVE-2015-9235)
+
+> **References:** [CVE-2015-9235 — JWT Algorithm Confusion](https://nvd.nist.gov/vuln/detail/CVE-2015-9235), [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+
+The attack: The attacker knows the RSA public key (it's public, served via JWKS). They craft a JWT with alg:HS256 and sign it using the public key bytes as the HMAC secret. A naive server reads alg:HS256, grabs the stored key bytes, and verifies — which passes because the attacker used those same bytes.
+
+OneAuth's defense: The middleware checks that the token's alg header matches the KeyRecord.Algorithm. Store says RS256, token says HS256 → mismatch → rejected before any signature check.
+
+### Step 3: Attack 2: alg:none — no signature at all
+
+> **References:** [CVE-2015-9235 — JWT Algorithm Confusion](https://nvd.nist.gov/vuln/detail/CVE-2015-9235)
+
+The attack: The attacker sends a JWT with alg:none — no signature at all. Some JWT libraries accept this as valid.
+
+OneAuth uses golang-jwt/v5 which rejects alg:none by default unless explicitly opted in with UnsafeAllowNoneSignatureType.
+
+### Step 4: Attack 3: Cross-app token forgery
+
+The attack: App A's key is compromised. The attacker signs a token claiming to be App B (client_id=app-B) using App A's key. If the resource server only checks the signature and not which app owns the key, the token validates.
+
+OneAuth's defense: The middleware checks that the kid's owning client matches the client_id claim. App A's key → kid owned by app-A → client_id claim says app-B → mismatch → rejected.
+
+### Step 5: JWKS security: only public keys, never secrets
+
+> **References:** [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+JWKS serves only asymmetric public keys. HS256 secrets are excluded entirely. RSA keys include only public components (n, e) — private fields (d, p, q) are structurally absent from the JWK type.
+
+### Summary of defenses
+
+| Attack | How it works | OneAuth's defense |
+|--------|-------------|------------------|
+| Algorithm confusion (CVE-2015-9235) | Sign HS256 with RSA public key | alg must match KeyRecord.Algorithm |
+| alg:none | No signature at all | golang-jwt/v5 rejects by default |
+| Cross-app forgery | Sign with app A's key, claim app B | kid owner must match client_id claim |
+| JWKS private key leak | Serve private key fields | JWK struct cannot carry private fields |
+| HS256 secret in JWKS | Expose shared secret via JWKS | HS256 keys excluded from JWKS output |
+
+These defenses are built into the middleware and key management layers —
+they're always active, not opt-in. You get them by using `APIMiddleware`
+and `JWKSHandler`.
+
+### End of the journey
+
+You've completed all 10 examples! Here's what you've learned:
+
+| # | Concept | RFC |
+|---|---------|-----|
+| 01 | Client credentials — get a token | RFC 6749 §4.4 |
+| 02 | Resource tokens — per-user JWTs | RFC 7519 |
+| 03 | Asymmetric signing + JWKS discovery | RFC 7517, 7515 |
+| 04 | AS metadata discovery | RFC 8414 |
+| 05 | Token introspection + revocation | RFC 7662 |
+| 06 | Dynamic client registration | RFC 7591 |
+| 07 | Client SDK production patterns | — |
+| 08 | Rich Authorization Requests | RFC 9396 |
+| 09 | Key rotation with grace periods | RFC 7638 |
+| 10 | Security — attack prevention | CVE-2015-9235 |
+
+## References
+
+- [CVE-2015-9235 — JWT Algorithm Confusion](https://nvd.nist.gov/vuln/detail/CVE-2015-9235)
+- [RFC 7515 — JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515)
+- [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+
+## Run it
+
+```bash
+go run ./examples/10-security/
+```
+
+Pass `--non-interactive` to skip pauses:
+
+```bash
+go run ./examples/10-security/ --non-interactive
+```

--- a/examples/10-security/main.go
+++ b/examples/10-security/main.go
@@ -1,0 +1,256 @@
+// Example 10: Security — Attack Prevention
+//
+// This example demonstrates real attacks against JWT-based auth systems and
+// how OneAuth prevents them. Each step shows the attack, why it works against
+// naive implementations, and how OneAuth's defenses block it.
+//
+// Run:   go run ./examples/10-security/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://nvd.nist.gov/vuln/detail/CVE-2015-9235 (algorithm confusion)
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/examples/demokit"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+func main() {
+	var ks *keys.InMemoryKeyStore
+	var middleware *apiauth.APIMiddleware
+	var rsaPrivKey *rsa.PrivateKey
+	var pubPEM []byte
+
+	demo := demokit.New("10: Security — Attack Prevention").
+		Dir("10-security").
+		Description("Non-UI | No infrastructure needed | Standalone").
+		Actors(
+			demokit.Actor("Legit", "Legitimate App"),
+			demokit.Actor("Attacker", "Attacker"),
+			demokit.Actor("RS", "Resource Server"),
+		)
+
+	demo.Section("About this example",
+		"This example demonstrates real JWT attacks and OneAuth's defenses.",
+		"Each attack is executed live — you'll see both the attack and the defense in action.",
+		"",
+		"**Attacks covered:**",
+		"1. Algorithm confusion (CVE-2015-9235) — the most famous JWT vulnerability",
+		"2. Cross-app token forgery — using one app's key with another app's client_id",
+		"3. `alg: none` — disabling signature verification entirely",
+		"4. JWKS private key leakage — checking that secrets stay secret",
+	)
+
+	// --- Setup ---
+	demo.Step("Set up KeyStore with an RS256 app and an HS256 app").
+		Ref(demokit.RFC7517).
+		Note("Two apps coexist: one with an RSA key pair (RS256), one with a shared secret (HS256). The resource server validates tokens from both.").
+		Run(func() {
+			ks = keys.NewInMemoryKeyStore()
+
+			// RS256 app
+			rsaPrivKey, _ = rsa.GenerateKey(rand.Reader, 2048)
+			pubPEM, _ = utils.EncodePublicKeyPEM(&rsaPrivKey.PublicKey)
+			ks.RegisterKey("app-rsa", pubPEM, "RS256")
+
+			// HS256 app
+			ks.RegisterKey("app-hmac", []byte("shared-secret-for-hs256-app"), "HS256")
+
+			middleware = &apiauth.APIMiddleware{KeyStore: ks}
+
+			fmt.Printf("    app-rsa:  RS256 (public key registered)\n")
+			fmt.Printf("    app-hmac: HS256 (shared secret registered)\n")
+		})
+
+	// --- Attack 1: Algorithm confusion ---
+	demo.Step("Attack 1: Algorithm confusion (CVE-2015-9235)").
+		Ref(demokit.CVE_2015_9235).
+		Ref(demokit.RFC7515).
+		Arrow("Attacker", "Attacker", "Craft JWT: alg=HS256, sign with RSA public key").
+		Arrow("Attacker", "RS", "Bearer: confused token").
+		DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
+		Note("The attack: The attacker knows the RSA public key (it's public, served via JWKS). They craft a JWT with alg:HS256 and sign it using the public key bytes as the HMAC secret. A naive server reads alg:HS256, grabs the stored key bytes, and verifies — which passes because the attacker used those same bytes.\n\nOneAuth's defense: The middleware checks that the token's alg header matches the KeyRecord.Algorithm. Store says RS256, token says HS256 → mismatch → rejected before any signature check.").
+		Run(func() {
+			handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			// Legitimate RS256 token
+			legit := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+				"sub": "alice", "client_id": "app-rsa", "type": "access",
+				"scopes": []string{"read"}, "exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			})
+			if kid, err := utils.ComputeKid(&rsaPrivKey.PublicKey, "RS256"); err == nil {
+				legit.Header["kid"] = kid
+			}
+			legitToken, _ := legit.SignedString(rsaPrivKey)
+			fmt.Printf("    Legitimate RS256 token: %d\n", validateToken(handler, legitToken))
+
+			// Algorithm confusion: sign with public key as HMAC secret
+			attack := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"sub": "attacker", "client_id": "app-rsa", "type": "access",
+				"scopes": []string{"admin"}, "exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			})
+			attackToken, _ := attack.SignedString(pubPEM) // public key as HMAC secret!
+			fmt.Printf("    Algorithm confusion:    %d (blocked — alg mismatch)\n", validateToken(handler, attackToken))
+		})
+
+	// --- Attack 2: alg:none ---
+	demo.Step("Attack 2: alg:none — no signature at all").
+		Ref(demokit.CVE_2015_9235).
+		Arrow("Attacker", "Attacker", "Craft JWT: alg=none, no signature").
+		Arrow("Attacker", "RS", "Bearer: unsigned token").
+		DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
+		Note("The attack: The attacker sends a JWT with alg:none — no signature at all. Some JWT libraries accept this as valid.\n\nOneAuth uses golang-jwt/v5 which rejects alg:none by default unless explicitly opted in with UnsafeAllowNoneSignatureType.").
+		Run(func() {
+			handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			none := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+				"sub": "attacker", "client_id": "app-rsa", "type": "access",
+				"scopes": []string{"admin"}, "exp": time.Now().Add(time.Hour).Unix(),
+				"iat": time.Now().Unix(),
+			})
+			noneToken, _ := none.SignedString(jwt.UnsafeAllowNoneSignatureType)
+			fmt.Printf("    alg:none token: %d (blocked)\n", validateToken(handler, noneToken))
+		})
+
+	// --- Attack 3: Cross-app forgery ---
+	demo.Step("Attack 3: Cross-app token forgery").
+		Arrow("Attacker", "Attacker", "Sign JWT with app-A's key but claim client_id=app-B").
+		Arrow("Attacker", "RS", "Bearer: cross-app token").
+		DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
+		Note("The attack: App A's key is compromised. The attacker signs a token claiming to be App B (client_id=app-B) using App A's key. If the resource server only checks the signature and not which app owns the key, the token validates.\n\nOneAuth's defense: The middleware checks that the kid's owning client matches the client_id claim. App A's key → kid owned by app-A → client_id claim says app-B → mismatch → rejected.").
+		Run(func() {
+			// Register two apps
+			registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+			regHandler := registrar.Handler()
+
+			var clientIDs [2]string
+			var secrets [2]string
+			for i, domain := range []string{"app-a.com", "app-b.com"} {
+				body, _ := json.Marshal(map[string]any{"client_domain": domain})
+				req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				rr := httptest.NewRecorder()
+				regHandler.ServeHTTP(rr, req)
+				var resp map[string]any
+				json.NewDecoder(rr.Body).Decode(&resp)
+				clientIDs[i] = resp["client_id"].(string)
+				secrets[i] = resp["client_secret"].(string)
+			}
+
+			handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			// Cross-app: sign with app A's secret, claim app B's client_id
+			crossToken, _ := admin.MintResourceToken(
+				"eve", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
+			fmt.Printf("    Cross-app token (A's key, B's id): %d (blocked — kid/client_id mismatch)\n",
+				validateToken(handler, crossToken))
+
+			// Correct: app A's secret with app A's client_id
+			correctToken, _ := admin.MintResourceToken(
+				"alice", clientIDs[0], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
+			fmt.Printf("    Correct token (A's key, A's id):   %d ✓\n",
+				validateToken(handler, correctToken))
+		})
+
+	// --- JWKS security ---
+	demo.Step("JWKS security: only public keys, never secrets").
+		Ref(demokit.RFC7517).
+		Arrow("Anyone", "AS", "GET /.well-known/jwks.json").
+		DashedArrow("AS", "Anyone", "{keys: [RSA public key only]}").
+		Note("JWKS serves only asymmetric public keys. HS256 secrets are excluded entirely. RSA keys include only public components (n, e) — private fields (d, p, q) are structurally absent from the JWK type.").
+		Run(func() {
+			jwksHandler := &keys.JWKSHandler{KeyStore: ks}
+			srv := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))
+			defer srv.Close()
+
+			resp, _ := http.Get(srv.URL)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			var raw map[string]any
+			json.Unmarshal(body, &raw)
+			jwksKeys := raw["keys"].([]any)
+
+			fmt.Printf("    Total apps in KeyStore: 2 (RSA + HMAC)\n")
+			fmt.Printf("    Keys in JWKS:           %d (only RSA — HMAC secret excluded)\n", len(jwksKeys))
+
+			if len(jwksKeys) > 0 {
+				key := jwksKeys[0].(map[string]any)
+				fmt.Printf("    kty: %s, alg: %s, key_ops: %v\n", key["kty"], key["alg"], key["key_ops"])
+
+				leaked := false
+				for _, field := range []string{"d", "p", "q", "dp", "dq", "qi"} {
+					if key[field] != nil {
+						fmt.Printf("    LEAK: private field %q found!\n", field)
+						leaked = true
+					}
+				}
+				if !leaked {
+					fmt.Printf("    Private fields (d, p, q, dp, dq, qi): absent ✓\n")
+				}
+			}
+		})
+
+	demo.Section("Summary of defenses",
+		"| Attack | How it works | OneAuth's defense |",
+		"|--------|-------------|------------------|",
+		"| Algorithm confusion (CVE-2015-9235) | Sign HS256 with RSA public key | alg must match KeyRecord.Algorithm |",
+		"| alg:none | No signature at all | golang-jwt/v5 rejects by default |",
+		"| Cross-app forgery | Sign with app A's key, claim app B | kid owner must match client_id claim |",
+		"| JWKS private key leak | Serve private key fields | JWK struct cannot carry private fields |",
+		"| HS256 secret in JWKS | Expose shared secret via JWKS | HS256 keys excluded from JWKS output |",
+		"",
+		"These defenses are built into the middleware and key management layers —",
+		"they're always active, not opt-in. You get them by using `APIMiddleware`",
+		"and `JWKSHandler`.",
+	)
+
+	demo.Section("End of the journey",
+		"You've completed all 10 examples! Here's what you've learned:",
+		"",
+		"| # | Concept | RFC |",
+		"|---|---------|-----|",
+		"| 01 | Client credentials — get a token | RFC 6749 §4.4 |",
+		"| 02 | Resource tokens — per-user JWTs | RFC 7519 |",
+		"| 03 | Asymmetric signing + JWKS discovery | RFC 7517, 7515 |",
+		"| 04 | AS metadata discovery | RFC 8414 |",
+		"| 05 | Token introspection + revocation | RFC 7662 |",
+		"| 06 | Dynamic client registration | RFC 7591 |",
+		"| 07 | Client SDK production patterns | — |",
+		"| 08 | Rich Authorization Requests | RFC 9396 |",
+		"| 09 | Key rotation with grace periods | RFC 7638 |",
+		"| 10 | Security — attack prevention | CVE-2015-9235 |",
+	)
+
+	demo.Execute()
+}
+
+func validateToken(handler http.Handler, token string) int {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(rr, req)
+	return rr.Code
+}

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -24,4 +24,33 @@ list:
 		echo "  $$dir"; \
 	done
 
-.PHONY: readmes list
+# =============================================================================
+# Keycloak for examples (separate from test KC on port 8180)
+# =============================================================================
+KC_EXAMPLES_PORT := 8280
+KC_EXAMPLES_CONTAINER := oneauth-examples-keycloak
+KC_EXAMPLES_IMAGE := quay.io/keycloak/keycloak:26.6
+KC_EXAMPLES_REALM := $(PWD)/keycloak-realm.json
+
+upkcl:
+	@if docker ps --format '{{.Names}}' | grep -q '^$(KC_EXAMPLES_CONTAINER)$$'; then \
+		echo "Examples Keycloak already running on port $(KC_EXAMPLES_PORT)"; \
+	else \
+		echo "Starting Keycloak for examples on port $(KC_EXAMPLES_PORT)..."; \
+		docker run --rm -d \
+			--name $(KC_EXAMPLES_CONTAINER) \
+			-p $(KC_EXAMPLES_PORT):8080 \
+			-v $(KC_EXAMPLES_REALM):/opt/keycloak/data/import/oneauth-examples-realm.json \
+			-e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+			-e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+			$(KC_EXAMPLES_IMAGE) start-dev --import-realm; \
+		echo "Waiting for Keycloak..."; \
+		until curl -sf http://localhost:$(KC_EXAMPLES_PORT)/realms/oneauth-examples > /dev/null 2>&1; do sleep 2; done; \
+		echo "Keycloak ready at http://localhost:$(KC_EXAMPLES_PORT)"; \
+		echo "  Realm: http://localhost:$(KC_EXAMPLES_PORT)/realms/oneauth-examples"; \
+	fi
+
+downkcl:
+	@docker stop $(KC_EXAMPLES_CONTAINER) 2>/dev/null || echo "Not running"
+
+.PHONY: readmes list upkcl downkcl

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,27 @@
+# Examples top-level Makefile
+#
+# Batch operations across all examples. Per-example commands
+# (run, demo, readme) live in each example's own Makefile.
+
+EXAMPLES := $(sort $(wildcard [0-9][0-9]-*/))
+
+# Generate README.md for every example that has Go files.
+readmes:
+	@count=0; for dir in $(EXAMPLES); do \
+		if ls $$dir/*.go >/dev/null 2>&1; then \
+			echo "[readme] $$dir"; \
+			$(MAKE) -C $$dir readme; \
+			count=$$((count + 1)); \
+		else \
+			echo "[skip]   $$dir (no Go files yet)"; \
+		fi; \
+	done; \
+	echo "Done. Generated $$count READMEs."
+
+# List all examples.
+list:
+	@for dir in $(EXAMPLES); do \
+		echo "  $$dir"; \
+	done
+
+.PHONY: readmes list

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,84 @@
+# OneAuth Examples
+
+Progressive examples demonstrating OneAuth's authentication and authorization capabilities. Start at 01 and work your way up — each builds on concepts from the previous.
+
+## Cast of Characters
+
+Every example involves the same cast. To make them concrete, imagine you're building **Slack** — a messaging app with channels, bots, and third-party integrations.
+
+### The players
+
+| Term                     | In Slack                                                                            | What it does                                                                                                                          | In the examples                                             |
+|--------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| **Auth Server (AS)**     | Slack's identity service                                                            | Manages user accounts, registers apps, issues tokens, serves public keys (JWKS). The source of truth for "who is allowed to do what." | `authServer` — token endpoint, JWKS, introspection          |
+| **Resource Server (RS)** | Slack's API (channels, messages, files)                                             | Protects resources behind token validation. Checks every request: "does this token grant access to this channel?"                     | `resourceServer` — validates Bearer tokens, enforces scopes |
+| **App (Client)**         | A Slack bot or third-party integration (e.g., the GitHub bot that posts PR updates) | Registers with the AS, gets credentials, then requests tokens to act on its own behalf or on behalf of users.                         | The code making HTTP calls                                  |
+| **User**                 | A person using Slack (sending messages, joining channels)                           | The human the token represents. Some flows have no user (bot-to-bot); others carry a specific user's identity.                        | `alice`, `bob` — subjects in tokens                         |
+| **Developer**            | You, building the GitHub bot                                                        | Writes the App code, registers it with the AS, decides what scopes to request.                                                        | You, running these examples                                 |
+| **Admin**                | Slack workspace admin                                                               | Configures the AS: which apps are allowed, what scopes exist, key rotation policies.                                                  | Sets up `AppRegistrar`, `APIKeyAuth`                        |
+
+### How they connect
+
+```
+Developer builds the App (GitHub bot)
+         │
+         ▼
+   ┌──────────┐     registers      ┌───────────┐
+   │   App    │ ──────────────────▶│  Auth     │
+   │ (GitHub  │     gets tokens    │  Server   │
+   │   bot)   │ ◀──────────────────│  (AS)     │
+   └────┬─────┘                    └──────┬────┘
+        │                                 │
+        │  Bearer token                   │  serves JWKS
+        ▼                                 ▼
+   ┌──────────┐    validates token  ┌──────────┐
+   │ Resource │  ◀─ ─ ─ ─ ─ ─ ─ ─   │  JWKS    │
+   │  Server  │    (using pub key)  │ endpoint │
+   │ (Slack   │                     └──────────┘
+   │   API)   │
+   └──────────┘
+```
+
+### When is a user involved?
+
+| Flow | Slack equivalent | User involved? | Who authenticates? |
+|------|-----------------|---------------|-------------------|
+| Client Credentials (Example 01) | Bot posts to #general using its own identity | No — the bot acts as itself | The app (bot) authenticates with client_id + secret |
+| Resource Token (Example 02-03) | Bot posts to #general *as Alice* (on her behalf) | Yes — token carries Alice's user ID | The app mints a token for Alice |
+| Auth Code + PKCE (future) | Alice clicks "Sign in with Slack" on a third-party site | Yes — Alice logs in via browser | The user authenticates directly |
+
+## Examples
+
+| # | Example | Type | Infra | What you'll learn |
+|---|---------|------|-------|-------------------|
+| [01](01-client-credentials/) | Client Credentials | Non-UI | None | Get your first token via the HTTP token endpoint |
+| [02](02-resource-token-hs256/) | Resource Token (HS256) | Non-UI | None | Federated auth: app registers, mints tokens, resource server validates |
+| [03](03-resource-token-rs256-jwks/) | Resource Token (RS256 + JWKS) | Non-UI | None | Asymmetric signing with automatic JWKS key discovery |
+| [04](04-discovery/) | AS Metadata Discovery | Non-UI | None | Auto-discover endpoints — no hardcoded URLs |
+| [05](05-introspection/) | Token Introspection | Non-UI | None | Remote token validation via RFC 7662 |
+| [06](06-dynamic-client-registration/) | Dynamic Client Registration | Non-UI | None | Self-service client onboarding via RFC 7591 |
+| [07](07-client-sdk/) | Client SDK | Non-UI | None | Production patterns: caching, auto-refresh, scope step-up |
+| [08](08-rich-authorization-requests/) | Rich Authorization Requests | Non-UI | None | Fine-grained authorization beyond scopes (RFC 9396) |
+| [09](09-key-rotation/) | Key Rotation | Non-UI | None | Rotate secrets with grace periods — zero downtime |
+| [10](10-security/) | Security | Non-UI | None | Attack prevention: algorithm confusion, cross-app forgery |
+
+## Run examples
+
+```bash
+# Interactive step-through
+cd examples/01-client-credentials && make run
+
+# Non-interactive (full output)
+cd examples/01-client-credentials && make demo
+
+# Regenerate all READMEs from code
+cd examples && make readmes
+```
+
+## How the examples work
+
+Every example is a standalone `main.go` you run with `go run`. No external services needed — they spin up in-memory stores and `httptest` servers, make real HTTP calls, and print step-by-step output.
+
+In interactive mode (`make run`), the example pauses between steps so you can follow along with the README's sequence diagram. In non-interactive mode (`make demo`), it runs straight through.
+
+READMEs are generated from the code (`make readme` in each directory). The sequence diagrams, step descriptions, and reference links are all defined in the Go source — single source of truth.

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,21 @@ Developer builds the App (GitHub bot)
    └──────────┘
 ```
 
+### How does an App get registered?
+
+Before an App can get tokens, it must register with the Auth Server and receive credentials (`client_id` + `client_secret`). But who is allowed to register?
+
+| Method | Real-world example | Who acts | Automated? |
+|--------|-------------------|----------|-----------|
+| **Web dashboard** | GitHub Developer Settings, Google Cloud Console | Developer logs in, fills a form | No — human reviews |
+| **Admin API** | Internal tooling with `X-Admin-Key` | Admin provisions via script | Yes, gated by admin key |
+| **DCR + access token** | RFC 7591 §3 | Developer's code self-registers | Yes, gated by one-time token |
+| **Open DCR** | Examples in this repo (`NewNoAuth()`) | Anyone | Yes, **ungated — not for production** |
+
+**In these examples**, registration is open (`NewNoAuth()`) for simplicity. In production, always gate registration with authentication — see `admin.NewAPIKeyAuth()` or protect the endpoint at the network level.
+
+**Important:** The `client_secret` is a backend credential. It lives in your server, not in a browser or mobile app. Frontend apps use PKCE (public clients) instead of secrets.
+
 ### When is a user involved?
 
 | Flow | Slack equivalent | User involved? | Who authenticates? |

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,18 +49,20 @@ Developer builds the App (GitHub bot)
 
 ## Examples
 
-| # | Example | Type | Infra | What you'll learn |
-|---|---------|------|-------|-------------------|
-| [01](01-client-credentials/) | Client Credentials | Non-UI | None | Get your first token via the HTTP token endpoint |
-| [02](02-resource-token-hs256/) | Resource Token (HS256) | Non-UI | None | Federated auth: app registers, mints tokens, resource server validates |
-| [03](03-resource-token-rs256-jwks/) | Resource Token (RS256 + JWKS) | Non-UI | None | Asymmetric signing with automatic JWKS key discovery |
-| [04](04-discovery/) | AS Metadata Discovery | Non-UI | None | Auto-discover endpoints — no hardcoded URLs |
-| [05](05-introspection/) | Token Introspection | Non-UI | None | Remote token validation via RFC 7662 |
-| [06](06-dynamic-client-registration/) | Dynamic Client Registration | Non-UI | None | Self-service client onboarding via RFC 7591 |
-| [07](07-client-sdk/) | Client SDK | Non-UI | None | Production patterns: caching, auto-refresh, scope step-up |
-| [08](08-rich-authorization-requests/) | Rich Authorization Requests | Non-UI | None | Fine-grained authorization beyond scopes (RFC 9396) |
-| [09](09-key-rotation/) | Key Rotation | Non-UI | None | Rotate secrets with grace periods — zero downtime |
-| [10](10-security/) | Security | Non-UI | None | Attack prevention: algorithm confusion, cross-app forgery |
+| #                                     | Example                       | Type   | Infra               | Keycloak | What you'll learn                                                      |
+|---------------------------------------|-------------------------------|--------|---------------------|----------|------------------------------------------------------------------------|
+| [01](01-client-credentials/README.md)          | Client Credentials            | Non-UI | None                | —        | Get your first token via the HTTP token endpoint                       |
+| [02](02-resource-token-hs256/README.md)        | Resource Token (HS256)        | Non-UI | None                | —        | Federated auth: app registers, mints tokens, resource server validates |
+| [03](03-resource-token-rs256-jwks/README.md)   | Resource Token (RS256 + JWKS) | Non-UI | None                | —        | Asymmetric signing with automatic JWKS key discovery                   |
+| [04](04-discovery/README.md)          | AS Metadata Discovery         | Non-UI | KC optional         | Optional | Auto-discover endpoints — no hardcoded URLs                            |
+| [05](05-introspection/README.md)               | Token Introspection           | Non-UI | KC optional         | Optional | Remote token validation via RFC 7662                                   |
+| [06](06-dynamic-client-registration/README.md) | Dynamic Client Registration   | Non-UI | KC optional         | Optional | Self-service client onboarding via RFC 7591                            |
+| [07](07-client-sdk/README.md)                  | Client SDK                    | Non-UI | KC optional         | Optional | Production patterns: caching, auto-refresh, scope step-up              |
+| [08](08-rich-authorization-requests/README.md) | Rich Authorization Requests   | Non-UI | RAR issuer optional | —        | Fine-grained authorization beyond scopes (RFC 9396)                    |
+| [09](09-key-rotation/README.md)                | Key Rotation                  | Non-UI | None                | —        | Rotate secrets with grace periods — zero downtime                      |
+| [10](10-security/README.md)                    | Security                      | Non-UI | None                | —        | Attack prevention: algorithm confusion, cross-app forgery              |
+
+**Keycloak column:** Examples marked "Optional" have an extra step that runs against Keycloak if it's available, showing the same code working against a real-world IdP. Start KC with `cd examples && make upkcl`. All examples work without KC — the KC steps skip gracefully.
 
 ## Run examples
 

--- a/examples/demokit/demokit.go
+++ b/examples/demokit/demokit.go
@@ -1,0 +1,370 @@
+// Package demokit provides an interactive step-through framework for OneAuth
+// examples. Each example defines a sequence of steps (with mermaid diagram
+// arrows) and optional sections (explanatory text). The same definitions
+// drive both the interactive CLI and the generated README.
+//
+// Single source of truth: step titles, arrows, and notes are defined in Go
+// code. The README's mermaid diagram and step documentation are generated
+// from these definitions — never maintained by hand.
+//
+// Usage:
+//
+//	demo := demokit.New("01: Client Credentials Flow").
+//	    Description("Non-UI | No infrastructure needed").
+//	    Actors(
+//	        demokit.Actor("App", "Client App"),
+//	        demokit.Actor("AS", "Auth Server"),
+//	    )
+//	demo.Step("Register a client").
+//	    Arrow("App", "AS", "POST /apps/register").
+//	    Arrow("AS", "App", "{client_id, client_secret}").
+//	    Note("The client gets credentials for later use.").
+//	    Run(func() { fmt.Println("registered!") })
+//	demo.Execute()
+package demokit
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ActorDef defines a participant in the sequence diagram.
+type ActorDef struct {
+	ID    string // Short identifier used in arrows (e.g., "AS")
+	Label string // Display label (e.g., "Auth Server")
+}
+
+// Actor creates an ActorDef.
+func Actor(id, label string) ActorDef {
+	return ActorDef{ID: id, Label: label}
+}
+
+// item is a union type for the ordered sequence of steps and sections.
+type item interface {
+	isItem()
+}
+
+// Ref is a named reference (RFC, CVE, blog post, spec section, etc.).
+type Ref struct {
+	Name string // e.g., "RFC 7519 (JWT)" or "CVE-2015-9235"
+	URL  string // e.g., "https://www.rfc-editor.org/rfc/rfc7519"
+}
+
+// StepDef defines one executable step in the demo.
+type StepDef struct {
+	title  string
+	arrows []arrowDef
+	refs   []Ref
+	note   string
+	runFn  func()
+}
+
+type arrowDef struct {
+	from, to, label string
+	dashed          bool // -->> vs ->>
+}
+
+func (s *StepDef) isItem() {}
+
+// Arrow adds a solid arrow (request) to the step's sequence diagram.
+func (s *StepDef) Arrow(from, to, label string) *StepDef {
+	s.arrows = append(s.arrows, arrowDef{from: from, to: to, label: label})
+	return s
+}
+
+// DashedArrow adds a dashed arrow (response) to the step's sequence diagram.
+func (s *StepDef) DashedArrow(from, to, label string) *StepDef {
+	s.arrows = append(s.arrows, arrowDef{from: from, to: to, label: label, dashed: true})
+	return s
+}
+
+// Ref adds a reference (RFC, CVE, spec section, blog post, etc.) to this step.
+// Use pre-defined constants from refs.go: demokit.RFC7519, demokit.CVE_2015_9235, etc.
+func (s *StepDef) Ref(ref Ref) *StepDef {
+	s.refs = append(s.refs, ref)
+	return s
+}
+
+// Note adds explanatory text shown in both CLI and README.
+func (s *StepDef) Note(text string) *StepDef {
+	s.note = text
+	return s
+}
+
+// Run sets the function to execute for this step.
+func (s *StepDef) Run(fn func()) *StepDef {
+	s.runFn = fn
+	return s
+}
+
+// SectionDef is a non-executable block of explanatory content.
+type SectionDef struct {
+	title string
+	body  string
+}
+
+func (s *SectionDef) isItem() {}
+
+// Demo is the top-level container for an interactive example.
+type Demo struct {
+	title       string
+	description string
+	dir         string // directory name for run commands in generated README
+	actors      []ActorDef
+	items       []item
+	stepCount   int
+}
+
+// New creates a new Demo with the given title.
+func New(title string) *Demo {
+	return &Demo{title: title}
+}
+
+// Description sets the one-line description shown in the CLI header.
+func (d *Demo) Description(desc string) *Demo {
+	d.description = desc
+	return d
+}
+
+// Dir sets the directory name used in generated README run commands.
+// e.g., Dir("01-client-credentials") produces "go run ./examples/01-client-credentials/"
+func (d *Demo) Dir(name string) *Demo {
+	d.dir = name
+	return d
+}
+
+// Actors sets the sequence diagram participants.
+func (d *Demo) Actors(actors ...ActorDef) *Demo {
+	d.actors = actors
+	return d
+}
+
+// Step adds an executable step to the demo. Returns the StepDef for chaining.
+func (d *Demo) Step(title string) *StepDef {
+	s := &StepDef{title: title}
+	d.items = append(d.items, s)
+	d.stepCount++
+	return s
+}
+
+// Section adds a non-executable explanatory block. Lines are joined with
+// newlines, so you can write multi-paragraph markdown naturally:
+//
+//	demo.Section("How it works",
+//	    "The auth server signs tokens with HS256.",
+//	    "",
+//	    "**Key insight:** Both servers share the same KeyStore.",
+//	)
+func (d *Demo) Section(title string, lines ...string) *Demo {
+	d.items = append(d.items, &SectionDef{title: title, body: strings.Join(lines, "\n")})
+	return d
+}
+
+// Execute runs the demo interactively — pausing between steps for Enter.
+// If --non-interactive is passed (or stdin is not a terminal), runs without pausing.
+func (d *Demo) Execute() {
+	interactive := isTerminal()
+	for _, arg := range os.Args[1:] {
+		if arg == "--non-interactive" {
+			interactive = false
+		}
+		if arg == "--readme" {
+			fmt.Print(d.Markdown())
+			return
+		}
+	}
+
+	// Header
+	fmt.Printf("=== %s ===\n", d.title)
+	if d.description != "" {
+		fmt.Printf("    %s\n", d.description)
+	}
+	fmt.Printf("    %d steps\n", d.stepCount)
+	fmt.Println()
+
+	reader := bufio.NewReader(os.Stdin)
+	stepNum := 0
+
+	for _, it := range d.items {
+		switch v := it.(type) {
+		case *StepDef:
+			stepNum++
+			// Step header
+			fmt.Printf("  Step %d/%d: %s", stepNum, d.stepCount, v.title)
+			fmt.Printf("  [README → Step %d]\n", stepNum)
+
+			// References
+			if len(v.refs) > 0 {
+				fmt.Print("    Refs: ")
+				for i, ref := range v.refs {
+					if i > 0 {
+						fmt.Print(", ")
+					}
+					fmt.Print(ref.Name)
+				}
+				fmt.Println()
+			}
+
+			// Diagram arrows
+			for _, a := range v.arrows {
+				arrow := "->>"
+				if a.dashed {
+					arrow = "-->>"
+				}
+				fmt.Printf("    %s %s %s: %s\n", a.from, arrow, a.to, a.label)
+			}
+
+			// Note
+			if v.note != "" {
+				fmt.Printf("\n    %s\n", v.note)
+			}
+
+			// Pause
+			if interactive {
+				fmt.Print("\n    Press Enter to run this step...")
+				reader.ReadString('\n')
+			}
+			fmt.Println()
+
+			// Execute
+			if v.runFn != nil {
+				v.runFn()
+			}
+			fmt.Println()
+
+		case *SectionDef:
+			fmt.Printf("  --- %s ---\n", v.title)
+			for _, line := range strings.Split(v.body, "\n") {
+				fmt.Printf("    %s\n", line)
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Println("=== Done ===")
+}
+
+// Markdown generates the full README content from the demo definition.
+// This is the single source of truth — run with --readme to regenerate.
+func (d *Demo) Markdown() string {
+	var b strings.Builder
+
+	// Title and description
+	fmt.Fprintf(&b, "# %s\n\n", d.title)
+	if d.description != "" {
+		fmt.Fprintf(&b, "%s\n\n", d.description)
+	}
+
+	// Collect steps for the summary
+	var steps []*StepDef
+	for _, it := range d.items {
+		if s, ok := it.(*StepDef); ok {
+			steps = append(steps, s)
+		}
+	}
+
+	// What you'll learn (from step notes)
+	hasNotes := false
+	for _, s := range steps {
+		if s.note != "" {
+			hasNotes = true
+			break
+		}
+	}
+	if hasNotes {
+		b.WriteString("## What you'll learn\n\n")
+		for _, s := range steps {
+			if s.note != "" {
+				fmt.Fprintf(&b, "- **%s** — %s\n", s.title, s.note)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	// Sequence diagram
+	b.WriteString("## Flow\n\n```mermaid\nsequenceDiagram\n")
+	for _, a := range d.actors {
+		if a.ID != a.Label {
+			fmt.Fprintf(&b, "    participant %s as %s\n", a.ID, a.Label)
+		} else {
+			fmt.Fprintf(&b, "    participant %s\n", a.ID)
+		}
+	}
+	stepNum := 0
+	for _, it := range d.items {
+		switch v := it.(type) {
+		case *StepDef:
+			stepNum++
+			fmt.Fprintf(&b, "\n    Note over %s,%s: Step %d: %s\n",
+				d.actors[0].ID, d.actors[len(d.actors)-1].ID, stepNum, v.title)
+			for _, a := range v.arrows {
+				if a.dashed {
+					fmt.Fprintf(&b, "    %s-->>%s: %s\n", a.from, a.to, a.label)
+				} else {
+					fmt.Fprintf(&b, "    %s->>%s: %s\n", a.from, a.to, a.label)
+				}
+			}
+		}
+	}
+	b.WriteString("```\n\n")
+
+	// Steps detail
+	b.WriteString("## Steps\n\n")
+	stepNum = 0
+	allRefs := make(map[string]Ref) // dedup by URL
+	for _, it := range d.items {
+		switch v := it.(type) {
+		case *StepDef:
+			stepNum++
+			fmt.Fprintf(&b, "### Step %d: %s\n\n", stepNum, v.title)
+			if len(v.refs) > 0 {
+				b.WriteString("> **References:** ")
+				for i, ref := range v.refs {
+					if i > 0 {
+						b.WriteString(", ")
+					}
+					fmt.Fprintf(&b, "[%s](%s)", ref.Name, ref.URL)
+					allRefs[ref.URL] = ref
+				}
+				b.WriteString("\n\n")
+			}
+			if v.note != "" {
+				fmt.Fprintf(&b, "%s\n\n", v.note)
+			}
+		case *SectionDef:
+			fmt.Fprintf(&b, "### %s\n\n%s\n\n", v.title, v.body)
+		}
+	}
+
+	// Collected references (deduped)
+	if len(allRefs) > 0 {
+		b.WriteString("## References\n\n")
+		for _, ref := range allRefs {
+			fmt.Fprintf(&b, "- [%s](%s)\n", ref.Name, ref.URL)
+		}
+		b.WriteString("\n")
+	}
+
+	// Run command
+	dir := d.dir
+	if dir == "" {
+		dir = "<this-directory>"
+	}
+	b.WriteString("## Run it\n\n")
+	fmt.Fprintf(&b, "```bash\ngo run ./examples/%s/\n```\n\n", dir)
+	b.WriteString("Pass `--non-interactive` to skip pauses:\n\n")
+	fmt.Fprintf(&b, "```bash\ngo run ./examples/%s/ --non-interactive\n```\n", dir)
+
+	return b.String()
+}
+
+// isTerminal returns true if stdin appears to be an interactive terminal.
+func isTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/examples/demokit/refs.go
+++ b/examples/demokit/refs.go
@@ -1,0 +1,47 @@
+package demokit
+
+// Pre-defined references for common standards. Use these in Step.Ref() calls
+// to avoid typing URLs repeatedly and to ensure consistent naming.
+//
+// Usage:
+//
+//	demo.Step("Get a token").
+//	    Ref(demokit.RFC6749_ClientCredentials).
+//	    Ref(demokit.RFC7519).
+//	    Run(func() { ... })
+
+// OAuth 2.0
+var (
+	RFC6749                    = Ref{"RFC 6749 — OAuth 2.0", "https://www.rfc-editor.org/rfc/rfc6749"}
+	RFC6749_ClientCredentials  = Ref{"RFC 6749 §4.4 — Client Credentials Grant", "https://www.rfc-editor.org/rfc/rfc6749#section-4.4"}
+	RFC6749_AuthorizationCode  = Ref{"RFC 6749 §4.1 — Authorization Code Grant", "https://www.rfc-editor.org/rfc/rfc6749#section-4.1"}
+	RFC6750                    = Ref{"RFC 6750 — Bearer Token Usage", "https://www.rfc-editor.org/rfc/rfc6750"}
+)
+
+// JWT / JWS / JWK
+var (
+	RFC7515 = Ref{"RFC 7515 — JSON Web Signature (JWS)", "https://www.rfc-editor.org/rfc/rfc7515"}
+	RFC7517 = Ref{"RFC 7517 — JSON Web Key (JWK)", "https://www.rfc-editor.org/rfc/rfc7517"}
+	RFC7519 = Ref{"RFC 7519 — JSON Web Token (JWT)", "https://www.rfc-editor.org/rfc/rfc7519"}
+	RFC7638 = Ref{"RFC 7638 — JWK Thumbprint (kid)", "https://www.rfc-editor.org/rfc/rfc7638"}
+)
+
+// Token management
+var (
+	RFC7591 = Ref{"RFC 7591 — Dynamic Client Registration", "https://www.rfc-editor.org/rfc/rfc7591"}
+	RFC7636 = Ref{"RFC 7636 — PKCE", "https://www.rfc-editor.org/rfc/rfc7636"}
+	RFC7662 = Ref{"RFC 7662 — Token Introspection", "https://www.rfc-editor.org/rfc/rfc7662"}
+	RFC8414 = Ref{"RFC 8414 — AS Metadata Discovery", "https://www.rfc-editor.org/rfc/rfc8414"}
+)
+
+// Rich Authorization Requests
+var (
+	RFC9396 = Ref{"RFC 9396 — Rich Authorization Requests", "https://www.rfc-editor.org/rfc/rfc9396"}
+)
+
+// Security
+var (
+	RFC9728 = Ref{"RFC 9728 — Protected Resource Metadata", "https://www.rfc-editor.org/rfc/rfc9728"}
+
+	CVE_2015_9235 = Ref{"CVE-2015-9235 — JWT Algorithm Confusion", "https://nvd.nist.gov/vuln/detail/CVE-2015-9235"}
+)

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -47,7 +47,7 @@ func ExampleAppRegistrar_hs256FederatedFlow() {
 
 	// App mints a resource token for user "alice"
 	token, err := admin.MintResourceToken("alice", clientID, clientSecret,
-		admin.AppQuota{MaxRooms: 10}, []string{"read", "write"})
+		admin.AppQuota{MaxRooms: 10}, []string{"read", "write"}, nil)
 	fmt.Println("token_minted:", err == nil && token != "")
 
 	// Resource server validates tokens using the same KeyStore
@@ -128,7 +128,7 @@ func ExampleAppRegistrar_rs256WithJWKS() {
 	defer resSrv.Close()
 
 	// App mints token with its private key
-	token, _ := admin.MintResourceTokenWithKey("bob", clientID, privKey, admin.AppQuota{}, []string{"read"})
+	token, _ := admin.MintResourceTokenWithKey("bob", clientID, privKey, admin.AppQuota{}, []string{"read"}, nil)
 
 	req, _ := http.NewRequest("GET", resSrv.URL+"/data", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -161,8 +161,8 @@ func ExampleAPIMiddleware_kidBasedLookup() {
 	ks.RegisterKey("app-rs256", pubPEM, "RS256")
 
 	// Mint tokens — both get kid headers automatically
-	hsToken, _ := admin.MintResourceToken("alice", "app-hs256", "my-secret", admin.AppQuota{}, []string{"read"})
-	rsToken, _ := admin.MintResourceTokenWithKey("bob", "app-rs256", privKey, admin.AppQuota{}, []string{"read"})
+	hsToken, _ := admin.MintResourceToken("alice", "app-hs256", "my-secret", admin.AppQuota{}, []string{"read"}, nil)
+	rsToken, _ := admin.MintResourceTokenWithKey("bob", "app-rs256", privKey, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Verify kid headers are present
 	parser := jwt.NewParser()
@@ -225,7 +225,7 @@ func ExampleCompositeKeyLookup_keyRotationGracePeriod() {
 	oldSecret := regResp["client_secret"].(string)
 
 	// Mint token with old secret
-	oldToken, _ := admin.MintResourceToken("alice", clientID, oldSecret, admin.AppQuota{}, []string{"read"})
+	oldToken, _ := admin.MintResourceToken("alice", clientID, oldSecret, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Rotate key (uses DefaultGracePeriod of 50ms)
 	req = httptest.NewRequest("POST", "/apps/"+clientID+"/rotate", nil)
@@ -235,7 +235,7 @@ func ExampleCompositeKeyLookup_keyRotationGracePeriod() {
 	var rotResp map[string]any
 	json.NewDecoder(rr.Body).Decode(&rotResp)
 	newSecret := rotResp["client_secret"].(string)
-	newToken, _ := admin.MintResourceToken("alice", clientID, newSecret, admin.AppQuota{}, []string{"read"})
+	newToken, _ := admin.MintResourceToken("alice", clientID, newSecret, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Build composite: current keys + grace period keys
 	composite := &keys.CompositeKeyLookup{Lookups: []keys.KeyLookup{ks, kidStore}}
@@ -306,11 +306,11 @@ func ExampleAPIMiddleware_crossAppIsolation() {
 
 	// Cross-app forgery: mint with app A's secret but claim app B's client_id.
 	// The kid is derived from app A's secret, so kid owner != client_id claim.
-	crossToken, _ := admin.MintResourceToken("eve", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"})
+	crossToken, _ := admin.MintResourceToken("eve", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
 	fmt.Println("cross_app_token:", checkToken(crossToken))
 
 	// Correct token: app A's secret with app A's client_id
-	correctToken, _ := admin.MintResourceToken("alice", clientIDs[0], secrets[0], admin.AppQuota{}, []string{"read"})
+	correctToken, _ := admin.MintResourceToken("alice", clientIDs[0], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
 	fmt.Println("correct_token:", checkToken(correctToken))
 
 	// Output:
@@ -419,7 +419,7 @@ func ExampleJWKSHandler_multiAlgorithm() {
 	defer resSrv.Close()
 
 	// RS256 token validates via JWKS
-	rsToken, _ := admin.MintResourceTokenWithKey("alice", "app-rsa", privKey, admin.AppQuota{}, []string{"read"})
+	rsToken, _ := admin.MintResourceTokenWithKey("alice", "app-rsa", privKey, admin.AppQuota{}, []string{"read"}, nil)
 	req, _ := http.NewRequest("GET", resSrv.URL, nil)
 	req.Header.Set("Authorization", "Bearer "+rsToken)
 	res, _ := http.DefaultClient.Do(req)
@@ -427,7 +427,7 @@ func ExampleJWKSHandler_multiAlgorithm() {
 	fmt.Println("rs256_via_jwks:", res.StatusCode)
 
 	// HS256 token fails via JWKS (secrets are never exposed)
-	hsToken, _ := admin.MintResourceToken("bob", "app-hmac", "shared-secret", admin.AppQuota{}, []string{"read"})
+	hsToken, _ := admin.MintResourceToken("bob", "app-hmac", "shared-secret", admin.AppQuota{}, []string{"read"}, nil)
 	req, _ = http.NewRequest("GET", resSrv.URL, nil)
 	req.Header.Set("Authorization", "Bearer "+hsToken)
 	res, _ = http.DefaultClient.Do(req)

--- a/examples/keycloak-realm.json
+++ b/examples/keycloak-realm.json
@@ -1,0 +1,34 @@
+{
+  "realm": "oneauth-examples",
+  "enabled": true,
+  "sslRequired": "none",
+  "defaultSignatureAlgorithm": "RS256",
+  "accessTokenLifespan": 300,
+  "clients": [
+    {
+      "clientId": "example-app",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "example-app-secret",
+      "serviceAccountsEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "standardFlowEnabled": false,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "defaultClientScopes": ["openid"],
+      "optionalClientScopes": ["read", "write"]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "read",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true" }
+    },
+    {
+      "name": "write",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true" }
+    }
+  ]
+}

--- a/go.work
+++ b/go.work
@@ -1,14 +1,15 @@
-go 1.26.1
+go 1.26.2
 
 use (
 	.
-	./stores/gorm
-	./stores/gae
-	./saml
-	./grpc
-	./oauth2
-	./cmd/oneauth-server
 	./cmd/demo-hostapp
 	./cmd/demo-resource-server
+	./cmd/oneauth-server
+	./cmd/rar-test-issuer
+	./grpc
+	./oauth2
+	./saml
+	./stores/gae
+	./stores/gorm
 	./tests/keycloak
 )

--- a/keys/jwks_e2e_test.go
+++ b/keys/jwks_e2e_test.go
@@ -54,7 +54,7 @@ func TestFederated_EndToEnd_HS256(t *testing.T) {
 	tokenStr, err := admin.MintResourceToken(
 		"user-alice", clientID, clientSecret,
 		admin.AppQuota{MaxRooms: 10, MaxMsgRate: 30},
-		[]string{"collab", "read"},
+		[]string{"collab", "read"}, nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +104,7 @@ func TestFederated_EndToEnd_HS256_WrongSecret(t *testing.T) {
 	clientID := regResp["client_id"].(string)
 
 	// Mint with wrong secret
-	tokenStr, _ := admin.MintResourceToken("user-eve", clientID, "totally-wrong-secret", admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceToken("user-eve", clientID, "totally-wrong-secret", admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -144,7 +144,7 @@ func TestFederated_EndToEnd_HS256_CrossAppRejection(t *testing.T) {
 	}
 
 	// Mint token with app A's secret but claim app B's client_id
-	tokenStr, _ := admin.MintResourceToken("user-1", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceToken("user-1", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -180,7 +180,7 @@ func TestFederated_EndToEnd_HS256_SecretRotation(t *testing.T) {
 	oldSecret := regResp["client_secret"].(string)
 
 	// Mint with old secret
-	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"})
+	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Rotate
 	req = httptest.NewRequest(http.MethodPost, "/apps/"+clientID+"/rotate", nil)
@@ -205,7 +205,7 @@ func TestFederated_EndToEnd_HS256_SecretRotation(t *testing.T) {
 	}
 
 	// New token should succeed
-	newToken, _ := admin.MintResourceToken("user-1", clientID, newSecret, admin.AppQuota{}, []string{"read"})
+	newToken, _ := admin.MintResourceToken("user-1", clientID, newSecret, admin.AppQuota{}, []string{"read"}, nil)
 	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
 	req.Header.Set("Authorization", "Bearer "+newToken)
 	rr = httptest.NewRecorder()
@@ -244,7 +244,7 @@ func TestFederated_EndToEnd_RS256_ViaRegistrar(t *testing.T) {
 	clientID := regResp["client_id"].(string)
 
 	// Mint with private key
-	tokenStr, _ := admin.MintResourceTokenWithKey("alice", clientID, privKey, admin.AppQuota{MaxRooms: 5}, []string{"read"})
+	tokenStr, _ := admin.MintResourceTokenWithKey("alice", clientID, privKey, admin.AppQuota{MaxRooms: 5}, []string{"read"}, nil)
 
 	// Validate via middleware
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
@@ -306,7 +306,7 @@ func TestJWKS_EndToEnd_RS256(t *testing.T) {
 	tokenStr, err := admin.MintResourceTokenWithKey(
 		"alice", "app_rsa_e2e", privKey,
 		admin.AppQuota{MaxRooms: 10, MaxMsgRate: 50},
-		[]string{"collab", "read"},
+		[]string{"collab", "read"}, nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -359,7 +359,7 @@ func TestJWKS_EndToEnd_ES256(t *testing.T) {
 	tokenStr, err := admin.MintResourceTokenWithKey(
 		"bob", "app_ec_e2e", privKey,
 		admin.AppQuota{MaxRooms: 5},
-		[]string{"write"},
+		[]string{"write"}, nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -409,7 +409,7 @@ func TestJWKS_EndToEnd_HS256Excluded(t *testing.T) {
 	resourceKeyStore.Start()
 	defer resourceKeyStore.Stop()
 
-	tokenStr, _ := admin.MintResourceToken("user1", "app_hmac", "supersecret", admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceToken("user1", "app_hmac", "supersecret", admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: resourceKeyStore}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -445,7 +445,7 @@ func TestJWKS_EndToEnd_WrongPrivateKey(t *testing.T) {
 	resourceKeyStore.Start()
 	defer resourceKeyStore.Stop()
 
-	tokenStr, _ := admin.MintResourceTokenWithKey("eve", "app_rsa", otherPrivKey, admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceTokenWithKey("eve", "app_rsa", otherPrivKey, admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: resourceKeyStore}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -503,7 +503,7 @@ func TestJWKS_EndToEnd_MixedAlgorithms(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokenStr, _ := admin.MintResourceTokenWithKey(tt.userID, tt.clientID, tt.key, admin.AppQuota{}, []string{"read"})
+			tokenStr, _ := admin.MintResourceTokenWithKey(tt.userID, tt.clientID, tt.key, admin.AppQuota{}, []string{"read"}, nil)
 			req := httptest.NewRequest(http.MethodGet, "/resource", nil)
 			req.Header.Set("Authorization", "Bearer "+tokenStr)
 			rr := httptest.NewRecorder()

--- a/keys/kid_test.go
+++ b/keys/kid_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestMintResourceToken_HasKid(t *testing.T) {
 	secret := "test-secret-for-kid"
-	tokenStr, err := admin.MintResourceToken("user-1", "app-1", secret, admin.AppQuota{}, []string{"read"})
+	tokenStr, err := admin.MintResourceToken("user-1", "app-1", secret, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestMintResourceTokenWithKey_RSA_HasKid(t *testing.T) {
 	}
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 
-	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"})
+	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestValidateJWT_WithKid(t *testing.T) {
 	ks.RegisterKey("app-1", secret, "HS256")
 
 	// Mint token (now includes kid header)
-	tokenStr, _ := admin.MintResourceToken("user-1", "app-1", string(secret), admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceToken("user-1", "app-1", string(secret), admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	var gotUserID string
@@ -382,7 +382,7 @@ func TestValidateJWT_CrossAppRejectedViaKid(t *testing.T) {
 
 	// Mint with app-a's secret but claim client_id=app-b
 	// The kid will be derived from secret-a, so cross-check should fail
-	tokenStr, _ := admin.MintResourceToken("user-1", "app-b", "secret-a", admin.AppQuota{}, []string{"read"})
+	tokenStr, _ := admin.MintResourceToken("user-1", "app-b", "secret-a", admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -426,7 +426,7 @@ func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 	oldSecret := regResp["client_secret"].(string)
 
 	// Mint token with old secret
-	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"})
+	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Rotate with grace period
 	rotBody, _ := json.Marshal(map[string]any{"grace_period": "1h"})
@@ -464,7 +464,7 @@ func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 	}
 
 	// New token should work
-	newToken, _ := admin.MintResourceToken("user-1", clientID, newSecret, admin.AppQuota{}, []string{"read"})
+	newToken, _ := admin.MintResourceToken("user-1", clientID, newSecret, admin.AppQuota{}, []string{"read"}, nil)
 	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
 	req.Header.Set("Authorization", "Bearer "+newToken)
 	rr = httptest.NewRecorder()
@@ -494,7 +494,7 @@ func TestAppRegistrar_RotateExpiredGrace(t *testing.T) {
 	clientID := regResp["client_id"].(string)
 	oldSecret := regResp["client_secret"].(string)
 
-	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"})
+	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"}, nil)
 
 	// Rotate (uses default tiny grace period)
 	req = httptest.NewRequest(http.MethodPost, "/apps/"+clientID+"/rotate", nil)

--- a/keys/kid_test.go
+++ b/keys/kid_test.go
@@ -82,7 +82,7 @@ func TestCreateAccessToken_HasKid(t *testing.T) {
 	auth := &apiauth.APIAuth{
 		JWTSecretKey: "my-secret",
 	}
-	tokenStr, _, err := auth.CreateAccessToken("user-1", []string{"read"})
+	tokenStr, _, err := auth.CreateAccessToken("user-1", []string{"read"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/fs/fsrefreshtoken_store.go
+++ b/stores/fs/fsrefreshtoken_store.go
@@ -158,18 +158,19 @@ func (s *FSRefreshTokenStore) RotateRefreshToken(oldToken string) (*core.Refresh
 	}
 
 	refreshToken := &core.RefreshToken{
-		Token:      newToken,
-		TokenHash:  s.hashToken(newToken),
-		UserID:     old.UserID,
-		ClientID:   old.ClientID,
-		DeviceInfo: old.DeviceInfo,
-		Family:     old.Family,
-		Generation: old.Generation + 1,
-		Scopes:     old.Scopes,
-		CreatedAt:  now,
-		ExpiresAt:  now.Add(core.TokenExpiryRefreshToken),
-		LastUsedAt: now,
-		Revoked:    false,
+		Token:                newToken,
+		TokenHash:            s.hashToken(newToken),
+		UserID:               old.UserID,
+		ClientID:             old.ClientID,
+		DeviceInfo:           old.DeviceInfo,
+		Family:               old.Family,
+		Generation:           old.Generation + 1,
+		Scopes:               old.Scopes,
+		AuthorizationDetails: old.AuthorizationDetails,
+		CreatedAt:            now,
+		ExpiresAt:            now.Add(core.TokenExpiryRefreshToken),
+		LastUsedAt:           now,
+		Revoked:              false,
 	}
 
 	if err := s.saveToken(refreshToken); err != nil {

--- a/stores/gae/models.go
+++ b/stores/gae/models.go
@@ -106,18 +106,19 @@ func AuthTokenToEntity(t *core.AuthToken, key *datastore.Key) *AuthTokenEntity {
 
 // RefreshTokenEntity is the Datastore entity for refresh tokens
 type RefreshTokenEntity struct {
-	Key        *datastore.Key `datastore:"__key__"` // Key is the token hash
-	UserID     string         `datastore:"user_id"`
-	ClientID   string         `datastore:"client_id,omitempty"`
-	DeviceInfo []byte         `datastore:"device_info,noindex"` // JSON encoded
-	Family     string         `datastore:"family"`
-	Generation int            `datastore:"generation"`
-	Scopes     []byte         `datastore:"scopes,noindex"` // JSON encoded
-	CreatedAt  time.Time      `datastore:"created_at"`
-	ExpiresAt  time.Time      `datastore:"expires_at"`
-	LastUsedAt time.Time      `datastore:"last_used_at"`
-	RevokedAt  time.Time      `datastore:"revoked_at,omitempty"`
-	Revoked    bool           `datastore:"revoked"`
+	Key                  *datastore.Key `datastore:"__key__"` // Key is the token hash
+	UserID               string         `datastore:"user_id"`
+	ClientID             string         `datastore:"client_id,omitempty"`
+	DeviceInfo           []byte         `datastore:"device_info,noindex"`            // JSON encoded
+	Family               string         `datastore:"family"`
+	Generation           int            `datastore:"generation"`
+	Scopes               []byte         `datastore:"scopes,noindex"`                // JSON encoded
+	AuthorizationDetails []byte         `datastore:"authorization_details,noindex"` // JSON encoded, RFC 9396
+	CreatedAt            time.Time      `datastore:"created_at"`
+	ExpiresAt            time.Time      `datastore:"expires_at"`
+	LastUsedAt           time.Time      `datastore:"last_used_at"`
+	RevokedAt            time.Time      `datastore:"revoked_at,omitempty"`
+	Revoked              bool           `datastore:"revoked"`
 }
 
 // APIKeyEntity is the Datastore entity for API keys

--- a/stores/gae/stores.go
+++ b/stores/gae/stores.go
@@ -692,19 +692,24 @@ func (s *RefreshTokenStore) entityToToken(entity *RefreshTokenEntity) *core.Refr
 	if entity.Scopes != nil {
 		json.Unmarshal(entity.Scopes, &scopes)
 	}
+	var authzDetails []core.AuthorizationDetail
+	if entity.AuthorizationDetails != nil {
+		json.Unmarshal(entity.AuthorizationDetails, &authzDetails)
+	}
 
 	rt := &core.RefreshToken{
-		TokenHash:  entity.Key.Name,
-		UserID:     entity.UserID,
-		ClientID:   entity.ClientID,
-		DeviceInfo: deviceInfo,
-		Family:     entity.Family,
-		Generation: entity.Generation,
-		Scopes:     scopes,
-		CreatedAt:  entity.CreatedAt,
-		ExpiresAt:  entity.ExpiresAt,
-		LastUsedAt: entity.LastUsedAt,
-		Revoked:    entity.Revoked,
+		TokenHash:            entity.Key.Name,
+		UserID:               entity.UserID,
+		ClientID:             entity.ClientID,
+		DeviceInfo:           deviceInfo,
+		Family:               entity.Family,
+		Generation:           entity.Generation,
+		Scopes:               scopes,
+		AuthorizationDetails: authzDetails,
+		CreatedAt:            entity.CreatedAt,
+		ExpiresAt:            entity.ExpiresAt,
+		LastUsedAt:           entity.LastUsedAt,
+		Revoked:              entity.Revoked,
 	}
 	if !entity.RevokedAt.IsZero() {
 		rt.RevokedAt = &entity.RevokedAt
@@ -774,26 +779,30 @@ func (s *RefreshTokenStore) RotateRefreshToken(oldToken string) (*core.RefreshTo
 		newHash := s.hashToken(newTokenStr)
 		newKey := s.namespacedKey(KindRefreshToken, newHash)
 
-		var deviceBytes, scopeBytes []byte
+		var deviceBytes, scopeBytes, authzDetailsBytes []byte
 		if oldRT.DeviceInfo != nil {
 			deviceBytes, _ = json.Marshal(oldRT.DeviceInfo)
 		}
 		if oldRT.Scopes != nil {
 			scopeBytes, _ = json.Marshal(oldRT.Scopes)
 		}
+		if oldRT.AuthorizationDetails != nil {
+			authzDetailsBytes, _ = json.Marshal(oldRT.AuthorizationDetails)
+		}
 
 		newEntity := &RefreshTokenEntity{
-			Key:        newKey,
-			UserID:     oldRT.UserID,
-			ClientID:   oldRT.ClientID,
-			DeviceInfo: deviceBytes,
-			Family:     oldRT.Family,
-			Generation: oldRT.Generation + 1,
-			Scopes:     scopeBytes,
-			CreatedAt:  now,
-			ExpiresAt:  now.Add(core.TokenExpiryRefreshToken),
-			LastUsedAt: now,
-			Revoked:    false,
+			Key:                  newKey,
+			UserID:               oldRT.UserID,
+			ClientID:             oldRT.ClientID,
+			DeviceInfo:           deviceBytes,
+			Family:               oldRT.Family,
+			Generation:           oldRT.Generation + 1,
+			Scopes:               scopeBytes,
+			AuthorizationDetails: authzDetailsBytes,
+			CreatedAt:            now,
+			ExpiresAt:            now.Add(core.TokenExpiryRefreshToken),
+			LastUsedAt:           now,
+			Revoked:              false,
 		}
 
 		if _, err := tx.Put(newKey, newEntity); err != nil {
@@ -801,17 +810,18 @@ func (s *RefreshTokenStore) RotateRefreshToken(oldToken string) (*core.RefreshTo
 		}
 
 		newRefreshToken = &core.RefreshToken{
-			Token:      newTokenStr,
-			TokenHash:  newHash,
-			UserID:     oldRT.UserID,
-			ClientID:   oldRT.ClientID,
-			DeviceInfo: oldRT.DeviceInfo,
-			Family:     oldRT.Family,
-			Generation: oldRT.Generation + 1,
-			Scopes:     oldRT.Scopes,
-			CreatedAt:  now,
-			ExpiresAt:  now.Add(core.TokenExpiryRefreshToken),
-			LastUsedAt: now,
+			Token:                newTokenStr,
+			TokenHash:            newHash,
+			UserID:               oldRT.UserID,
+			ClientID:             oldRT.ClientID,
+			DeviceInfo:           oldRT.DeviceInfo,
+			Family:               oldRT.Family,
+			Generation:           oldRT.Generation + 1,
+			Scopes:               oldRT.Scopes,
+			AuthorizationDetails: oldRT.AuthorizationDetails,
+			CreatedAt:            now,
+			ExpiresAt:            now.Add(core.TokenExpiryRefreshToken),
+			LastUsedAt:           now,
 			Revoked:    false,
 		}
 

--- a/stores/gorm/models.go
+++ b/stores/gorm/models.go
@@ -55,6 +55,28 @@ func (s *StringSlice) Scan(value any) error {
 	return json.Unmarshal(bytes, s)
 }
 
+// AuthorizationDetailsJSON is a helper type for storing []core.AuthorizationDetail in GORM as JSONB
+type AuthorizationDetailsJSON []core.AuthorizationDetail
+
+func (a AuthorizationDetailsJSON) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+	return json.Marshal(a)
+}
+
+func (a *AuthorizationDetailsJSON) Scan(value any) error {
+	if value == nil {
+		*a = nil
+		return nil
+	}
+	bytes, ok := value.([]byte)
+	if !ok {
+		return nil
+	}
+	return json.Unmarshal(bytes, a)
+}
+
 // UserModel is the GORM model for users
 type UserModel struct {
 	ID        string    `gorm:"primaryKey;size:64"`
@@ -194,13 +216,14 @@ type RefreshTokenModel struct {
 	ClientID   string      `gorm:"size:64"`
 	DeviceInfo JSONMap     `gorm:"type:jsonb"`
 	Family     string      `gorm:"size:32;index"`
-	Generation int         `gorm:"default:1"`
-	Scopes     StringSlice `gorm:"type:jsonb"`
-	CreatedAt  time.Time   `gorm:"autoCreateTime"`
-	ExpiresAt  time.Time   `gorm:"index"`
-	LastUsedAt time.Time
-	RevokedAt  *time.Time
-	Revoked    bool `gorm:"default:false;index"`
+	Generation           int                      `gorm:"default:1"`
+	Scopes               StringSlice              `gorm:"type:jsonb"`
+	AuthorizationDetails AuthorizationDetailsJSON `gorm:"type:jsonb"` // RFC 9396
+	CreatedAt            time.Time                `gorm:"autoCreateTime"`
+	ExpiresAt            time.Time                `gorm:"index"`
+	LastUsedAt           time.Time
+	RevokedAt            *time.Time
+	Revoked              bool `gorm:"default:false;index"`
 }
 
 func (RefreshTokenModel) TableName() string {
@@ -209,34 +232,36 @@ func (RefreshTokenModel) TableName() string {
 
 func (m *RefreshTokenModel) ToRefreshToken() *core.RefreshToken {
 	return &core.RefreshToken{
-		Token:      m.Token,
-		TokenHash:  m.TokenHash,
-		UserID:     m.UserID,
-		ClientID:   m.ClientID,
-		DeviceInfo: m.DeviceInfo,
-		Family:     m.Family,
-		Generation: m.Generation,
-		Scopes:     m.Scopes,
-		CreatedAt:  m.CreatedAt,
-		ExpiresAt:  m.ExpiresAt,
-		LastUsedAt: m.LastUsedAt,
-		RevokedAt:  m.RevokedAt,
-		Revoked:    m.Revoked,
+		Token:                m.Token,
+		TokenHash:            m.TokenHash,
+		UserID:               m.UserID,
+		ClientID:             m.ClientID,
+		DeviceInfo:           m.DeviceInfo,
+		Family:               m.Family,
+		Generation:           m.Generation,
+		Scopes:               m.Scopes,
+		AuthorizationDetails: m.AuthorizationDetails,
+		CreatedAt:            m.CreatedAt,
+		ExpiresAt:            m.ExpiresAt,
+		LastUsedAt:           m.LastUsedAt,
+		RevokedAt:            m.RevokedAt,
+		Revoked:              m.Revoked,
 	}
 }
 
 func RefreshTokenToModel(t *core.RefreshToken) *RefreshTokenModel {
 	return &RefreshTokenModel{
-		Token:      t.Token,
-		TokenHash:  t.TokenHash,
-		UserID:     t.UserID,
-		ClientID:   t.ClientID,
-		DeviceInfo: JSONMap(t.DeviceInfo),
-		Family:     t.Family,
-		Generation: t.Generation,
-		Scopes:     StringSlice(t.Scopes),
-		CreatedAt:  t.CreatedAt,
-		ExpiresAt:  t.ExpiresAt,
+		Token:                t.Token,
+		TokenHash:            t.TokenHash,
+		UserID:               t.UserID,
+		ClientID:             t.ClientID,
+		DeviceInfo:           JSONMap(t.DeviceInfo),
+		Family:               t.Family,
+		Generation:           t.Generation,
+		Scopes:               StringSlice(t.Scopes),
+		AuthorizationDetails: AuthorizationDetailsJSON(t.AuthorizationDetails),
+		CreatedAt:            t.CreatedAt,
+		ExpiresAt:            t.ExpiresAt,
 		LastUsedAt: t.LastUsedAt,
 		RevokedAt:  t.RevokedAt,
 		Revoked:    t.Revoked,

--- a/stores/gorm/stores.go
+++ b/stores/gorm/stores.go
@@ -376,16 +376,17 @@ func (s *RefreshTokenStore) RotateRefreshToken(oldToken string) (*core.RefreshTo
 		newTokenValue = newToken
 
 		newModel := &RefreshTokenModel{
-			TokenHash:  s.hashToken(newToken),
-			UserID:     oldModel.UserID,
-			ClientID:   oldModel.ClientID,
-			DeviceInfo: oldModel.DeviceInfo,
-			Family:     oldModel.Family,
-			Generation: oldModel.Generation + 1,
-			Scopes:     oldModel.Scopes,
-			ExpiresAt:  now.Add(core.TokenExpiryRefreshToken),
-			LastUsedAt: now,
-			Revoked:    false,
+			TokenHash:            s.hashToken(newToken),
+			UserID:               oldModel.UserID,
+			ClientID:             oldModel.ClientID,
+			DeviceInfo:           oldModel.DeviceInfo,
+			Family:               oldModel.Family,
+			Generation:           oldModel.Generation + 1,
+			Scopes:               oldModel.Scopes,
+			AuthorizationDetails: oldModel.AuthorizationDetails,
+			ExpiresAt:            now.Add(core.TokenExpiryRefreshToken),
+			LastUsedAt:           now,
+			Revoked:              false,
 		}
 
 		if err := tx.Create(newModel).Error; err != nil {

--- a/test-reports/coverage.html
+++ b/test-reports/coverage.html
@@ -59,7 +59,7 @@
 				
 				<option value="file1">github.com/panyam/oneauth/admin/dcr.go (75.7%)</option>
 				
-				<option value="file2">github.com/panyam/oneauth/admin/mint.go (78.9%)</option>
+				<option value="file2">github.com/panyam/oneauth/admin/mint.go (76.2%)</option>
 				
 				<option value="file3">github.com/panyam/oneauth/admin/registrar.go (74.1%)</option>
 				
@@ -67,9 +67,9 @@
 				
 				<option value="file5">github.com/panyam/oneauth/apiauth/as_metadata_proxy.go (91.9%)</option>
 				
-				<option value="file6">github.com/panyam/oneauth/apiauth/auth.go (70.4%)</option>
+				<option value="file6">github.com/panyam/oneauth/apiauth/auth.go (64.6%)</option>
 				
-				<option value="file7">github.com/panyam/oneauth/apiauth/introspection.go (85.7%)</option>
+				<option value="file7">github.com/panyam/oneauth/apiauth/introspection.go (86.2%)</option>
 				
 				<option value="file8">github.com/panyam/oneauth/apiauth/introspection_client.go (85.7%)</option>
 				
@@ -81,7 +81,7 @@
 				
 				<option value="file12">github.com/panyam/oneauth/client/browser_login.go (82.5%)</option>
 				
-				<option value="file13">github.com/panyam/oneauth/client/client.go (78.5%)</option>
+				<option value="file13">github.com/panyam/oneauth/client/client.go (76.2%)</option>
 				
 				<option value="file14">github.com/panyam/oneauth/client/client_credentials_source.go (90.9%)</option>
 				
@@ -97,81 +97,105 @@
 				
 				<option value="file20">github.com/panyam/oneauth/client/validation.go (100.0%)</option>
 				
-				<option value="file21">github.com/panyam/oneauth/core/blacklist.go (0.0%)</option>
+				<option value="file21">github.com/panyam/oneauth/core/authorization_details.go (93.6%)</option>
 				
-				<option value="file22">github.com/panyam/oneauth/core/context.go (0.0%)</option>
+				<option value="file22">github.com/panyam/oneauth/core/blacklist.go (0.0%)</option>
 				
-				<option value="file23">github.com/panyam/oneauth/core/credentials.go (0.0%)</option>
+				<option value="file23">github.com/panyam/oneauth/core/context.go (0.0%)</option>
 				
-				<option value="file24">github.com/panyam/oneauth/core/email.go (0.0%)</option>
+				<option value="file24">github.com/panyam/oneauth/core/credentials.go (0.0%)</option>
 				
-				<option value="file25">github.com/panyam/oneauth/core/ratelimiter.go (0.0%)</option>
+				<option value="file25">github.com/panyam/oneauth/core/email.go (0.0%)</option>
 				
-				<option value="file26">github.com/panyam/oneauth/core/scopes.go (14.5%)</option>
+				<option value="file26">github.com/panyam/oneauth/core/ratelimiter.go (0.0%)</option>
 				
-				<option value="file27">github.com/panyam/oneauth/core/tokens.go (0.0%)</option>
+				<option value="file27">github.com/panyam/oneauth/core/scopes.go (14.5%)</option>
 				
-				<option value="file28">github.com/panyam/oneauth/core/user.go (0.0%)</option>
+				<option value="file28">github.com/panyam/oneauth/core/tokens.go (0.0%)</option>
 				
-				<option value="file29">github.com/panyam/oneauth/httpauth/bodylimit.go (50.0%)</option>
+				<option value="file29">github.com/panyam/oneauth/core/user.go (0.0%)</option>
 				
-				<option value="file30">github.com/panyam/oneauth/httpauth/csrf.go (88.1%)</option>
+				<option value="file30">github.com/panyam/oneauth/examples/01-client-credentials/main.go (0.0%)</option>
 				
-				<option value="file31">github.com/panyam/oneauth/httpauth/middleware.go (0.0%)</option>
+				<option value="file31">github.com/panyam/oneauth/examples/02-resource-token-hs256/main.go (0.0%)</option>
 				
-				<option value="file32">github.com/panyam/oneauth/httpauth/mux.go (0.0%)</option>
+				<option value="file32">github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks/main.go (0.0%)</option>
 				
-				<option value="file33">github.com/panyam/oneauth/httpauth/securityheaders.go (97.1%)</option>
+				<option value="file33">github.com/panyam/oneauth/examples/04-discovery/main.go (0.0%)</option>
 				
-				<option value="file34">github.com/panyam/oneauth/keys/encrypted.go (80.8%)</option>
+				<option value="file34">github.com/panyam/oneauth/examples/05-introspection/main.go (0.0%)</option>
 				
-				<option value="file35">github.com/panyam/oneauth/keys/jwks_handler.go (52.5%)</option>
+				<option value="file35">github.com/panyam/oneauth/examples/06-dynamic-client-registration/main.go (0.0%)</option>
 				
-				<option value="file36">github.com/panyam/oneauth/keys/jwks_keystore.go (76.7%)</option>
+				<option value="file36">github.com/panyam/oneauth/examples/07-client-sdk/main.go (0.0%)</option>
 				
-				<option value="file37">github.com/panyam/oneauth/keys/keystore.go (86.4%)</option>
+				<option value="file37">github.com/panyam/oneauth/examples/08-rich-authorization-requests/main.go (0.0%)</option>
 				
-				<option value="file38">github.com/panyam/oneauth/keys/kid.go (84.8%)</option>
+				<option value="file38">github.com/panyam/oneauth/examples/09-key-rotation/main.go (0.0%)</option>
 				
-				<option value="file39">github.com/panyam/oneauth/keystoretest/keystoretest.go (0.0%)</option>
+				<option value="file39">github.com/panyam/oneauth/examples/10-security/main.go (0.0%)</option>
 				
-				<option value="file40">github.com/panyam/oneauth/localauth/helpers.go (77.0%)</option>
+				<option value="file40">github.com/panyam/oneauth/examples/demokit/demokit.go (0.0%)</option>
 				
-				<option value="file41">github.com/panyam/oneauth/localauth/local.go (56.1%)</option>
+				<option value="file41">github.com/panyam/oneauth/httpauth/bodylimit.go (50.0%)</option>
 				
-				<option value="file42">github.com/panyam/oneauth/localauth/signup.go (60.7%)</option>
+				<option value="file42">github.com/panyam/oneauth/httpauth/csrf.go (88.1%)</option>
 				
-				<option value="file43">github.com/panyam/oneauth/stores/fs/fsapikey_store.go (14.3%)</option>
+				<option value="file43">github.com/panyam/oneauth/httpauth/middleware.go (0.0%)</option>
 				
-				<option value="file44">github.com/panyam/oneauth/stores/fs/fschannel_store.go (21.7%)</option>
+				<option value="file44">github.com/panyam/oneauth/httpauth/mux.go (0.0%)</option>
 				
-				<option value="file45">github.com/panyam/oneauth/stores/fs/fsidentity_store.go (18.3%)</option>
+				<option value="file45">github.com/panyam/oneauth/httpauth/securityheaders.go (97.1%)</option>
 				
-				<option value="file46">github.com/panyam/oneauth/stores/fs/fskeystore.go (71.8%)</option>
+				<option value="file46">github.com/panyam/oneauth/keys/encrypted.go (80.8%)</option>
 				
-				<option value="file47">github.com/panyam/oneauth/stores/fs/fsrefreshtoken_store.go (8.8%)</option>
+				<option value="file47">github.com/panyam/oneauth/keys/jwks_handler.go (52.5%)</option>
 				
-				<option value="file48">github.com/panyam/oneauth/stores/fs/fstoken_store.go (16.7%)</option>
+				<option value="file48">github.com/panyam/oneauth/keys/jwks_keystore.go (76.7%)</option>
 				
-				<option value="file49">github.com/panyam/oneauth/stores/fs/fsuser_store.go (54.1%)</option>
+				<option value="file49">github.com/panyam/oneauth/keys/keystore.go (86.4%)</option>
 				
-				<option value="file50">github.com/panyam/oneauth/stores/fs/fsusername_store.go (16.5%)</option>
+				<option value="file50">github.com/panyam/oneauth/keys/kid.go (84.8%)</option>
 				
-				<option value="file51">github.com/panyam/oneauth/stores/fs/utils.go (72.7%)</option>
+				<option value="file51">github.com/panyam/oneauth/keystoretest/keystoretest.go (0.0%)</option>
 				
-				<option value="file52">github.com/panyam/oneauth/testutil/helpers.go (71.9%)</option>
+				<option value="file52">github.com/panyam/oneauth/localauth/helpers.go (77.0%)</option>
 				
-				<option value="file53">github.com/panyam/oneauth/testutil/server.go (82.5%)</option>
+				<option value="file53">github.com/panyam/oneauth/localauth/local.go (56.1%)</option>
 				
-				<option value="file54">github.com/panyam/oneauth/testutil/token.go (90.5%)</option>
+				<option value="file54">github.com/panyam/oneauth/localauth/signup.go (60.7%)</option>
 				
-				<option value="file55">github.com/panyam/oneauth/utils/crypto_helpers.go (78.9%)</option>
+				<option value="file55">github.com/panyam/oneauth/stores/fs/fsapikey_store.go (14.3%)</option>
 				
-				<option value="file56">github.com/panyam/oneauth/utils/flask.go (4.9%)</option>
+				<option value="file56">github.com/panyam/oneauth/stores/fs/fschannel_store.go (21.7%)</option>
 				
-				<option value="file57">github.com/panyam/oneauth/utils/jwk.go (83.0%)</option>
+				<option value="file57">github.com/panyam/oneauth/stores/fs/fsidentity_store.go (18.3%)</option>
 				
-				<option value="file58">github.com/panyam/oneauth/utils/jwk_thumbprint.go (83.9%)</option>
+				<option value="file58">github.com/panyam/oneauth/stores/fs/fskeystore.go (71.8%)</option>
+				
+				<option value="file59">github.com/panyam/oneauth/stores/fs/fsrefreshtoken_store.go (8.8%)</option>
+				
+				<option value="file60">github.com/panyam/oneauth/stores/fs/fstoken_store.go (16.7%)</option>
+				
+				<option value="file61">github.com/panyam/oneauth/stores/fs/fsuser_store.go (54.1%)</option>
+				
+				<option value="file62">github.com/panyam/oneauth/stores/fs/fsusername_store.go (16.5%)</option>
+				
+				<option value="file63">github.com/panyam/oneauth/stores/fs/utils.go (72.7%)</option>
+				
+				<option value="file64">github.com/panyam/oneauth/testutil/helpers.go (71.9%)</option>
+				
+				<option value="file65">github.com/panyam/oneauth/testutil/server.go (82.5%)</option>
+				
+				<option value="file66">github.com/panyam/oneauth/testutil/token.go (90.5%)</option>
+				
+				<option value="file67">github.com/panyam/oneauth/utils/crypto_helpers.go (78.9%)</option>
+				
+				<option value="file68">github.com/panyam/oneauth/utils/flask.go (4.9%)</option>
+				
+				<option value="file69">github.com/panyam/oneauth/utils/jwk.go (83.0%)</option>
+				
+				<option value="file70">github.com/panyam/oneauth/utils/jwk_thumbprint.go (83.9%)</option>
 				
 				</select>
 			</div>
@@ -287,6 +311,9 @@ type DCRRequest struct {
         // Authentication method
         TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
 
+        // RFC 9396 — authorization details types this client intends to use
+        AuthorizationDetailsTypes []string `json:"authorization_details_types,omitempty"`
+
         // Keys — for asymmetric auth methods (private_key_jwt)
         JWKS *utils.JWKSet `json:"jwks,omitempty"`
 }
@@ -301,9 +328,10 @@ type DCRResponse struct {
         ClientName              string   `json:"client_name,omitempty"`
         ClientURI               string   `json:"client_uri,omitempty"`
         RedirectURIs            []string `json:"redirect_uris,omitempty"`
-        GrantTypes              []string `json:"grant_types,omitempty"`
-        TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
-        Scope                   string   `json:"scope,omitempty"`
+        GrantTypes                []string `json:"grant_types,omitempty"`
+        TokenEndpointAuthMethod   string   `json:"token_endpoint_auth_method,omitempty"`
+        Scope                     string   `json:"scope,omitempty"`
+        AuthorizationDetailsTypes []string `json:"authorization_details_types,omitempty"` // RFC 9396
 }
 
 // ServeHTTP handles POST /register per RFC 7591.
@@ -352,15 +380,16 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span cla
         }</span>
 
         <span class="cov8" title="1">resp := DCRResponse{
-                ClientID:                clientID,
-                ClientIDIssuedAt:        time.Now().Unix(),
-                ClientSecretExpiresAt:   0, // never expires
-                ClientName:              req.ClientName,
-                ClientURI:               req.ClientURI,
-                RedirectURIs:            req.RedirectURIs,
-                GrantTypes:              req.GrantTypes,
-                TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
-                Scope:                   req.Scope,
+                ClientID:                  clientID,
+                ClientIDIssuedAt:          time.Now().Unix(),
+                ClientSecretExpiresAt:     0, // never expires
+                ClientName:                req.ClientName,
+                ClientURI:                 req.ClientURI,
+                RedirectURIs:              req.RedirectURIs,
+                GrantTypes:                req.GrantTypes,
+                TokenEndpointAuthMethod:   req.TokenEndpointAuthMethod,
+                Scope:                     req.Scope,
+                AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
         }
 
         if utils.IsAsymmetricAlg(signingAlg) </span><span class="cov8" title="1">{
@@ -404,10 +433,11 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span cla
                         domain = req.ClientName
                 }</span>
                 <span class="cov8" title="1">reg := &amp;AppRegistration{
-                        ClientID:     clientID,
-                        ClientDomain: domain,
-                        SigningAlg:   signingAlg,
-                        CreatedAt:    time.Now(),
+                        ClientID:                  clientID,
+                        ClientDomain:              domain,
+                        SigningAlg:                signingAlg,
+                        AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
+                        CreatedAt:                 time.Now(),
                 }
                 h.Registrar.mu.Lock()
                 h.Registrar.apps[clientID] = reg
@@ -454,6 +484,7 @@ import (
         "time"
 
         "github.com/golang-jwt/jwt/v5"
+        "github.com/panyam/oneauth/core"
         "github.com/panyam/oneauth/utils"
 )
 
@@ -465,8 +496,8 @@ type AppQuota struct {
 
 // MintResourceToken creates a resource-scoped JWT for a user on behalf of a registered App,
 // signed with the app's shared secret (HS256). This is the backwards-compatible API.
-func MintResourceToken(userID, appClientID, appSecret string, quota AppQuota, scopes []string) (string, error) <span class="cov8" title="1">{
-        return MintResourceTokenWithKey(userID, appClientID, []byte(appSecret), quota, scopes)
+func MintResourceToken(userID, appClientID, appSecret string, quota AppQuota, scopes []string, authzDetails []core.AuthorizationDetail) (string, error) <span class="cov8" title="1">{
+        return MintResourceTokenWithKey(userID, appClientID, []byte(appSecret), quota, scopes, authzDetails)
 }</span>
 
 // MintResourceTokenWithKey creates a resource-scoped JWT signed with the provided key.
@@ -474,7 +505,7 @@ func MintResourceToken(userID, appClientID, appSecret string, quota AppQuota, sc
 //   - []byte → HS256
 //   - *rsa.PrivateKey → RS256
 //   - *ecdsa.PrivateKey → ES256
-func MintResourceTokenWithKey(userID, appClientID string, signingKey any, quota AppQuota, scopes []string) (string, error) <span class="cov8" title="1">{
+func MintResourceTokenWithKey(userID, appClientID string, signingKey any, quota AppQuota, scopes []string, authzDetails []core.AuthorizationDetail) (string, error) <span class="cov8" title="1">{
         method, err := signingMethodFromKey(signingKey)
         if err != nil </span><span class="cov0" title="0">{
                 return "", err
@@ -490,7 +521,11 @@ func MintResourceTokenWithKey(userID, appClientID string, signingKey any, quota 
                 "exp":       now.Add(15 * time.Minute).Unix(),
         }
 
-        if quota.MaxRooms &gt; 0 </span><span class="cov8" title="1">{
+        if len(authzDetails) &gt; 0 </span><span class="cov0" title="0">{
+                claims["authorization_details"] = authzDetails
+        }</span>
+
+        <span class="cov8" title="1">if quota.MaxRooms &gt; 0 </span><span class="cov8" title="1">{
                 claims["max_rooms"] = quota.MaxRooms
         }</span>
         <span class="cov8" title="1">if quota.MaxMsgRate &gt; 0 </span><span class="cov8" title="1">{
@@ -537,13 +572,14 @@ import (
 
 // AppRegistration holds metadata about a registered App.
 type AppRegistration struct {
-        ClientID     string    `json:"client_id"`
-        ClientDomain string    `json:"client_domain"`
-        SigningAlg   string    `json:"signing_alg"`
-        MaxRooms     int       `json:"max_rooms,omitempty"`
-        MaxMsgRate   float64   `json:"max_msg_rate,omitempty"`
-        CreatedAt    time.Time `json:"created_at"`
-        Revoked      bool      `json:"revoked"`
+        ClientID                  string    `json:"client_id"`
+        ClientDomain              string    `json:"client_domain"`
+        SigningAlg                string    `json:"signing_alg"`
+        MaxRooms                  int       `json:"max_rooms,omitempty"`
+        MaxMsgRate                float64   `json:"max_msg_rate,omitempty"`
+        AuthorizationDetailsTypes []string  `json:"authorization_details_types,omitempty"` // RFC 9396
+        CreatedAt                 time.Time `json:"created_at"`
+        Revoked                   bool      `json:"revoked"`
 }
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.
@@ -939,7 +975,8 @@ type ASServerMetadata struct {
         UserinfoEndpoint      string `json:"userinfo_endpoint,omitempty"`
 
         // Supported features
-        ScopesSupported               []string `json:"scopes_supported,omitempty"`
+        AuthorizationDetailsTypesSupported []string `json:"authorization_details_types_supported,omitempty"` // RFC 9396
+        ScopesSupported                    []string `json:"scopes_supported,omitempty"`
         ResponseTypesSupported        []string `json:"response_types_supported,omitempty"`
         GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
         TokenEndpointAuthMethods      []string `json:"token_endpoint_auth_methods_supported,omitempty"`
@@ -1257,12 +1294,12 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class=
         // Parse request body — support both form-encoded (RFC 6749) and JSON
         <span class="cov8" title="1">var req core.TokenRequest
         ct := r.Header.Get("Content-Type")
-        if strings.HasPrefix(ct, "application/x-www-form-urlencoded") </span><span class="cov0" title="0">{
+        if strings.HasPrefix(ct, "application/x-www-form-urlencoded") </span><span class="cov8" title="1">{
                 if err := r.ParseForm(); err != nil </span><span class="cov0" title="0">{
                         a.errorResponse(w, "invalid_request", "Invalid form body", http.StatusBadRequest)
                         return
                 }</span>
-                <span class="cov0" title="0">req = core.TokenRequest{
+                <span class="cov8" title="1">req = core.TokenRequest{
                         GrantType:    r.FormValue("grant_type"),
                         Username:     r.FormValue("username"),
                         Password:     r.FormValue("password"),
@@ -1270,7 +1307,14 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class=
                         Scope:        r.FormValue("scope"),
                         ClientID:     r.FormValue("client_id"),
                         ClientSecret: r.FormValue("client_secret"),
-                }</span>
+                }
+                // RFC 9396 §6.1: authorization_details is a JSON-encoded string in form params
+                if adStr := r.FormValue("authorization_details"); adStr != "" </span><span class="cov8" title="1">{
+                        if err := json.Unmarshal([]byte(adStr), &amp;req.AuthorizationDetails); err != nil </span><span class="cov8" title="1">{
+                                a.errorResponse(w, "invalid_authorization_details", "Invalid authorization_details JSON", http.StatusBadRequest)
+                                return
+                        }</span>
+                }
         } else<span class="cov8" title="1"> {
                 if err := json.NewDecoder(r.Body).Decode(&amp;req); err != nil </span><span class="cov0" title="0">{
                         a.errorResponse(w, "invalid_request", "Invalid request body", http.StatusBadRequest)
@@ -1354,8 +1398,14 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
                 return
         }</span>
 
+        // Validate authorization_details if present (RFC 9396)
+        <span class="cov8" title="1">if err := core.ValidateAll(req.AuthorizationDetails); err != nil </span><span class="cov0" title="0">{
+                a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+                return
+        }</span>
+
         // Create access token (JWT)
-        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes)
+        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
         if err != nil </span><span class="cov0" title="0">{
                 log.Printf("Error creating access token: %v", err)
                 a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -1368,7 +1418,7 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
         }</span>
 
         // Return token pair
-        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, refreshToken.Token, grantedScopes)</span>
+        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, refreshToken.Token, grantedScopes, req.AuthorizationDetails)</span>
 }
 
 // handleRefreshTokenGrant handles the refresh_token grant type
@@ -1419,8 +1469,8 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
                 return</span>
         }
 
-        // Create new access token
-        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.UserID, refreshToken.Scopes)
+        // Create new access token (carry forward authorization_details from original grant)
+        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.UserID, refreshToken.Scopes, refreshToken.AuthorizationDetails)
         if err != nil </span><span class="cov0" title="0">{
                 log.Printf("Error creating access token: %v", err)
                 a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -1428,7 +1478,7 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
         }</span>
 
         // Return new token pair
-        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, newRefreshToken.Token, refreshToken.Scopes)</span>
+        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, newRefreshToken.Token, refreshToken.Scopes, refreshToken.AuthorizationDetails)</span>
 }
 
 // handleClientCredentialsGrant handles the client_credentials grant type (RFC 6749 §4.4).
@@ -1485,8 +1535,14 @@ func (a *APIAuth) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Re
                 scopes = strings.Split(req.Scope, " ")
         }</span>
 
+        // Validate authorization_details if present (RFC 9396)
+        <span class="cov8" title="1">if err := core.ValidateAll(req.AuthorizationDetails); err != nil </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+                return
+        }</span>
+
         // Create access token with sub=client_id (no user context)
-        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(clientID, scopes)
+        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(clientID, scopes, req.AuthorizationDetails)
         if err != nil </span><span class="cov0" title="0">{
                 log.Printf("Error creating client_credentials token: %v", err)
                 a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -1494,7 +1550,7 @@ func (a *APIAuth) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Re
         }</span>
 
         // Return access token only — no refresh token for client_credentials
-        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, "", scopes)</span>
+        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, "", scopes, req.AuthorizationDetails)</span>
 }
 
 // constantTimeEqual performs a constant-time string comparison to prevent
@@ -1615,11 +1671,13 @@ func (a *APIAuth) HandleListSessions(w http.ResponseWriter, r *http.Request) <sp
 var standardClaims = map[string]bool{
         "sub": true, "iss": true, "aud": true, "exp": true,
         "iat": true, "type": true, "scopes": true, "jti": true,
+        "authorization_details": true, // RFC 9396
 }
 
 // CreateAccessToken creates a signed JWT access token. If CustomClaimsFunc is set,
 // its returned claims are merged into the token (standard claims cannot be overridden).
-func (a *APIAuth) CreateAccessToken(userID string, scopes []string) (string, int64, error) <span class="cov8" title="1">{
+// authzDetails is an optional RFC 9396 authorization_details array embedded in the JWT.
+func (a *APIAuth) CreateAccessToken(userID string, scopes []string, authzDetails []core.AuthorizationDetail) (string, int64, error) <span class="cov8" title="1">{
         expiry := a.AccessTokenExpiry
         if expiry == 0 </span><span class="cov8" title="1">{
                 expiry = core.TokenExpiryAccessToken
@@ -1643,7 +1701,11 @@ func (a *APIAuth) CreateAccessToken(userID string, scopes []string) (string, int
                 "exp":    expiresAt.Unix(),
         }
 
-        if a.JWTIssuer != "" </span><span class="cov8" title="1">{
+        if len(authzDetails) &gt; 0 </span><span class="cov8" title="1">{
+                claims["authorization_details"] = authzDetails
+        }</span>
+
+        <span class="cov8" title="1">if a.JWTIssuer != "" </span><span class="cov8" title="1">{
                 claims["iss"] = a.JWTIssuer
         }</span>
         <span class="cov8" title="1">if a.JWTAudience != "" </span><span class="cov0" title="0">{
@@ -1877,13 +1939,14 @@ func (a *APIAuth) jwtKeyFunc(token *jwt.Token) (any, error) <span class="cov8" t
 }
 
 // tokenResponse sends a successful token response
-func (a *APIAuth) tokenResponse(w http.ResponseWriter, accessToken string, expiresIn int64, refreshToken string, scopes []string) <span class="cov8" title="1">{
+func (a *APIAuth) tokenResponse(w http.ResponseWriter, accessToken string, expiresIn int64, refreshToken string, scopes []string, authzDetails []core.AuthorizationDetail) <span class="cov8" title="1">{
         resp := core.TokenPair{
-                AccessToken:  accessToken,
-                TokenType:    "Bearer",
-                ExpiresIn:    expiresIn,
-                RefreshToken: refreshToken,
-                Scope:        core.JoinScopes(scopes),
+                AccessToken:          accessToken,
+                TokenType:            "Bearer",
+                ExpiresIn:            expiresIn,
+                RefreshToken:         refreshToken,
+                Scope:                core.JoinScopes(scopes),
+                AuthorizationDetails: authzDetails,
         }
 
         w.Header().Set("Content-Type", "application/json")
@@ -2104,10 +2167,11 @@ func (a *APIAuth) HandleRevokeAPIKey(w http.ResponseWriter, r *http.Request) <sp
 type apiContextKey string
 
 const (
-        contextKeyUserID   apiContextKey = "api_user_id"
-        contextKeyScopes   apiContextKey = "api_scopes"
-        contextKeyAuthType    apiContextKey = "api_auth_type" // "jwt" or "api_key"
-        contextKeyCustomClaims apiContextKey = "api_custom_claims"
+        contextKeyUserID               apiContextKey = "api_user_id"
+        contextKeyScopes               apiContextKey = "api_scopes"
+        contextKeyAuthType             apiContextKey = "api_auth_type" // "jwt" or "api_key"
+        contextKeyCustomClaims         apiContextKey = "api_custom_claims"
+        contextKeyAuthorizationDetails apiContextKey = "api_authorization_details" // RFC 9396
 )
 
 // APIMiddleware provides middleware for validating API tokens
@@ -2192,6 +2256,17 @@ func GetCustomClaimsFromContext(ctx context.Context) map[string]any <span class=
         <span class="cov8" title="1">return nil</span>
 }
 
+// GetAuthorizationDetailsFromContext retrieves the RFC 9396 authorization_details from context.
+// Returns nil if no authorization details are present (e.g., API key auth or token without RAR).
+func GetAuthorizationDetailsFromContext(ctx context.Context) []core.AuthorizationDetail <span class="cov0" title="0">{
+        if v := ctx.Value(contextKeyAuthorizationDetails); v != nil </span><span class="cov0" title="0">{
+                if details, ok := v.([]core.AuthorizationDetail); ok </span><span class="cov0" title="0">{
+                        return details
+                }</span>
+        }
+        <span class="cov0" title="0">return nil</span>
+}
+
 // ValidateToken middleware validates Bearer tokens (JWT or API key) and sets user info in context
 func (m *APIMiddleware) ValidateToken(next http.Handler) http.Handler <span class="cov8" title="1">{
         return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov8" title="1">{
@@ -2201,15 +2276,7 @@ func (m *APIMiddleware) ValidateToken(next http.Handler) http.Handler <span clas
                         return
                 }</span>
 
-                <span class="cov8" title="1">ctx := r.Context()
-                ctx = context.WithValue(ctx, contextKeyUserID, userID)
-                ctx = context.WithValue(ctx, contextKeyScopes, scopes)
-                ctx = context.WithValue(ctx, contextKeyAuthType, authType)
-                if customClaims != nil </span><span class="cov8" title="1">{
-                        ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
-                }</span>
-                <span class="cov8" title="1">ctx = core.SetUserIDInContext(ctx, userID)
-
+                <span class="cov8" title="1">ctx := setAuthContext(r.Context(), userID, scopes, authType, customClaims)
                 next.ServeHTTP(w, r.WithContext(ctx))</span>
         })
 }
@@ -2229,15 +2296,7 @@ func (m *APIMiddleware) RequireScopes(requiredScopes ...string) func(http.Handle
                                 return
                         }</span>
 
-                        <span class="cov8" title="1">ctx := r.Context()
-                        ctx = context.WithValue(ctx, contextKeyUserID, userID)
-                        ctx = context.WithValue(ctx, contextKeyScopes, grantedScopes)
-                        ctx = context.WithValue(ctx, contextKeyAuthType, authType)
-                        if customClaims != nil </span><span class="cov8" title="1">{
-                                ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
-                        }</span>
-                        <span class="cov8" title="1">ctx = core.SetUserIDInContext(ctx, userID)
-
+                        <span class="cov8" title="1">ctx := setAuthContext(r.Context(), userID, grantedScopes, authType, customClaims)
                         next.ServeHTTP(w, r.WithContext(ctx))</span>
                 })
         }
@@ -2248,16 +2307,9 @@ func (m *APIMiddleware) Optional(next http.Handler) http.Handler <span class="co
         return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov8" title="1">{
                 userID, scopes, authType, customClaims, err := m.validateRequest(r)
                 if err == nil &amp;&amp; userID != "" </span><span class="cov8" title="1">{
-                        ctx := r.Context()
-                        ctx = context.WithValue(ctx, contextKeyUserID, userID)
-                        ctx = context.WithValue(ctx, contextKeyScopes, scopes)
-                        ctx = context.WithValue(ctx, contextKeyAuthType, authType)
-                        if customClaims != nil </span><span class="cov8" title="1">{
-                                ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
-                        }</span>
-                        <span class="cov8" title="1">ctx = core.SetUserIDInContext(ctx, userID)
-                        r = r.WithContext(ctx)</span>
-                }
+                        ctx := setAuthContext(r.Context(), userID, scopes, authType, customClaims)
+                        r = r.WithContext(ctx)
+                }</span>
                 <span class="cov8" title="1">next.ServeHTTP(w, r)</span>
         })
 }
@@ -2427,6 +2479,15 @@ func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes [
                 }</span>
         }
 
+        // Extract authorization_details (RFC 9396) from JWT claims.
+        // Stored under a private key in customClaims so context-setting code can extract it.
+        <span class="cov8" title="1">if adRaw, ok := claims["authorization_details"].([]any); ok </span><span class="cov0" title="0">{
+                authzDetails := parseAuthorizationDetailsFromClaims(adRaw)
+                if len(authzDetails) &gt; 0 </span><span class="cov0" title="0">{
+                        customClaims["__authz_details"] = authzDetails
+                }</span>
+        }
+
         // Check blacklist if configured
         <span class="cov8" title="1">if m.Blacklist != nil </span><span class="cov8" title="1">{
                 if jti, ok := claims["jti"].(string); ok &amp;&amp; jti != "" </span><span class="cov8" title="1">{
@@ -2494,6 +2555,125 @@ func getClientIP(r *http.Request) string <span class="cov8" title="1">{
                 ip = ip[:colonIdx]
         }</span>
         <span class="cov8" title="1">return ip</span>
+}
+
+// =============================================================================
+// RFC 9396 helpers
+// =============================================================================
+
+// standardADFields are the RFC 9396 §2 common field names used when parsing
+// authorization_details from JWT claims to separate known fields from extensions.
+var standardADFields = map[string]bool{
+        "type": true, "locations": true, "actions": true,
+        "datatypes": true, "identifier": true, "privileges": true,
+}
+
+// parseAuthorizationDetailsFromClaims converts raw JWT claim data ([]any of
+// map[string]any) into typed AuthorizationDetail structs.
+func parseAuthorizationDetailsFromClaims(raw []any) []core.AuthorizationDetail <span class="cov0" title="0">{
+        var result []core.AuthorizationDetail
+        for _, item := range raw </span><span class="cov0" title="0">{
+                adMap, ok := item.(map[string]any)
+                if !ok </span><span class="cov0" title="0">{
+                        continue</span>
+                }
+                <span class="cov0" title="0">ad := core.AuthorizationDetail{
+                        Type:       stringFromMap(adMap, "type"),
+                        Identifier: stringFromMap(adMap, "identifier"),
+                        Locations:  toStringSlice(anySliceFromMap(adMap, "locations")),
+                        Actions:    toStringSlice(anySliceFromMap(adMap, "actions")),
+                        DataTypes:  toStringSlice(anySliceFromMap(adMap, "datatypes")),
+                        Privileges: toStringSlice(anySliceFromMap(adMap, "privileges")),
+                }
+                for k, v := range adMap </span><span class="cov0" title="0">{
+                        if !standardADFields[k] </span><span class="cov0" title="0">{
+                                if ad.Extra == nil </span><span class="cov0" title="0">{
+                                        ad.Extra = make(map[string]any)
+                                }</span>
+                                <span class="cov0" title="0">ad.Extra[k] = v</span>
+                        }
+                }
+                <span class="cov0" title="0">result = append(result, ad)</span>
+        }
+        <span class="cov0" title="0">return result</span>
+}
+
+func stringFromMap(m map[string]any, key string) string <span class="cov0" title="0">{
+        if v, ok := m[key].(string); ok </span><span class="cov0" title="0">{
+                return v
+        }</span>
+        <span class="cov0" title="0">return ""</span>
+}
+
+func anySliceFromMap(m map[string]any, key string) []any <span class="cov0" title="0">{
+        if v, ok := m[key].([]any); ok </span><span class="cov0" title="0">{
+                return v
+        }</span>
+        <span class="cov0" title="0">return nil</span>
+}
+
+func toStringSlice(raw []any) []string <span class="cov0" title="0">{
+        if len(raw) == 0 </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        <span class="cov0" title="0">result := make([]string, 0, len(raw))
+        for _, v := range raw </span><span class="cov0" title="0">{
+                if s, ok := v.(string); ok </span><span class="cov0" title="0">{
+                        result = append(result, s)
+                }</span>
+        }
+        <span class="cov0" title="0">return result</span>
+}
+
+// setAuthContext sets all standard auth context values on the request context.
+func setAuthContext(ctx context.Context, userID string, scopes []string, authType string, customClaims map[string]any) context.Context <span class="cov8" title="1">{
+        ctx = context.WithValue(ctx, contextKeyUserID, userID)
+        ctx = context.WithValue(ctx, contextKeyScopes, scopes)
+        ctx = context.WithValue(ctx, contextKeyAuthType, authType)
+        if customClaims != nil </span><span class="cov8" title="1">{
+                // Extract authorization_details from the private key and set in dedicated context
+                if authzDetails, ok := customClaims["__authz_details"].([]core.AuthorizationDetail); ok </span><span class="cov0" title="0">{
+                        ctx = context.WithValue(ctx, contextKeyAuthorizationDetails, authzDetails)
+                        delete(customClaims, "__authz_details")
+                }</span>
+                <span class="cov8" title="1">ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)</span>
+        }
+        <span class="cov8" title="1">ctx = core.SetUserIDInContext(ctx, userID)
+        return ctx</span>
+}
+
+// RequireAuthorizationDetails middleware ensures the token contains
+// authorization_details matching all required types. For each required type,
+// there must be at least one authorization_details entry with that type.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+func (m *APIMiddleware) RequireAuthorizationDetails(requiredTypes ...string) func(http.Handler) http.Handler <span class="cov0" title="0">{
+        return func(next http.Handler) http.Handler </span><span class="cov0" title="0">{
+                return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        userID, scopes, authType, customClaims, err := m.validateRequest(r)
+                        if err != nil </span><span class="cov0" title="0">{
+                                m.handleAuthError(w, r, err)
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">ctx := setAuthContext(r.Context(), userID, scopes, authType, customClaims)
+                        granted := GetAuthorizationDetailsFromContext(ctx)
+
+                        // Check that all required types are present
+                        grantedTypes := make(map[string]bool)
+                        for _, ad := range granted </span><span class="cov0" title="0">{
+                                grantedTypes[ad.Type] = true
+                        }</span>
+                        <span class="cov0" title="0">for _, reqType := range requiredTypes </span><span class="cov0" title="0">{
+                                if !grantedTypes[reqType] </span><span class="cov0" title="0">{
+                                        m.handleAuthError(w, r, fmt.Errorf("missing required authorization_details type: %s", reqType))
+                                        return
+                                }</span>
+                        }
+
+                        <span class="cov0" title="0">next.ServeHTTP(w, r.WithContext(ctx))</span>
+                })
+        }
 }
 </pre>
 		
@@ -2593,6 +2773,11 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
                         resp[claim] = v
                 }</span>
         }
+
+        // Include authorization_details if present (RFC 9396 §9.1)
+        <span class="cov8" title="1">if ad, ok := rawClaims["authorization_details"]; ok </span><span class="cov8" title="1">{
+                resp["authorization_details"] = ad
+        }</span>
 
         <span class="cov8" title="1">h.jsonResponse(w, http.StatusOK, resp)</span>
 }
@@ -3650,6 +3835,8 @@ import (
         "strings"
         "sync"
         "time"
+
+        "github.com/panyam/oneauth/core"
 )
 
 // RefreshThreshold is how long before expiry to proactively refresh
@@ -3703,13 +3890,14 @@ type OAuth2TokenRequest struct {
 
 // OAuth2TokenResponse is the response from token endpoint
 type OAuth2TokenResponse struct {
-        AccessToken  string `json:"access_token"`
-        TokenType    string `json:"token_type"`
-        ExpiresIn    int64  `json:"expires_in"`
-        RefreshToken string `json:"refresh_token,omitempty"`
-        Scope        string `json:"scope,omitempty"`
-        Error        string `json:"error,omitempty"`
-        ErrorDesc    string `json:"error_description,omitempty"`
+        AccessToken          string `json:"access_token"`
+        TokenType            string `json:"token_type"`
+        ExpiresIn            int64  `json:"expires_in"`
+        RefreshToken         string `json:"refresh_token,omitempty"`
+        Scope                string `json:"scope,omitempty"`
+        AuthorizationDetails []any  `json:"authorization_details,omitempty"` // RFC 9396 (raw JSON)
+        Error                string `json:"error,omitempty"`
+        ErrorDesc            string `json:"error_description,omitempty"`
 }
 
 // ClientOption configures an AuthClient
@@ -4054,14 +4242,16 @@ func (c *AuthClient) requestTokenForm(tokenEndpoint string, data url.Values, aut
 
         <span class="cov8" title="1">expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
-        return &amp;ServerCredential{
+        cred := &amp;ServerCredential{
                 AccessToken:  tokenResp.AccessToken,
                 RefreshToken: tokenResp.RefreshToken,
                 TokenType:    tokenResp.TokenType,
                 Scope:        tokenResp.Scope,
                 ExpiresAt:    expiresAt,
                 CreatedAt:    time.Now(),
-        }, nil</span>
+        }
+        cred.AuthorizationDetails = parseAuthzDetailsFromRaw(tokenResp.AuthorizationDetails)
+        return cred, nil</span>
 }
 
 // requestToken makes a token request to the server using JSON encoding.
@@ -4105,14 +4295,16 @@ func (c *AuthClient) requestToken(req OAuth2TokenRequest) (*ServerCredential, er
 
         <span class="cov8" title="1">expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
-        return &amp;ServerCredential{
+        cred := &amp;ServerCredential{
                 AccessToken:  tokenResp.AccessToken,
                 RefreshToken: tokenResp.RefreshToken,
                 TokenType:    tokenResp.TokenType,
                 Scope:        tokenResp.Scope,
                 ExpiresAt:    expiresAt,
                 CreatedAt:    time.Now(),
-        }, nil</span>
+        }
+        cred.AuthorizationDetails = parseAuthzDetailsFromRaw(tokenResp.AuthorizationDetails)
+        return cred, nil</span>
 }
 
 // refreshTransport is an http.RoundTripper that adds auth and handles refresh
@@ -4168,6 +4360,23 @@ func (t *refreshTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
         <span class="cov8" title="1">return resp, nil</span>
 }
+
+// parseAuthzDetailsFromRaw converts raw JSON authorization_details ([]any from
+// token response) into typed AuthorizationDetail structs via JSON re-marshal.
+func parseAuthzDetailsFromRaw(raw []any) []core.AuthorizationDetail <span class="cov8" title="1">{
+        if len(raw) == 0 </span><span class="cov8" title="1">{
+                return nil
+        }</span>
+        <span class="cov0" title="0">data, err := json.Marshal(raw)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        <span class="cov0" title="0">var details []core.AuthorizationDetail
+        if err := json.Unmarshal(data, &amp;details); err != nil </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        <span class="cov0" title="0">return details</span>
+}
 </pre>
 		
 		<pre class="file" id="file14" style="display: none">package client
@@ -4220,6 +4429,9 @@ type ClientCredentialsSource struct {
 
         // Scopes to request.
         Scopes []string
+
+        // AuthorizationDetails to request (RFC 9396). Sent alongside scopes.
+        AuthorizationDetails []core.AuthorizationDetail
 
         // Audience is the resource server's canonical URI (RFC 8707 resource indicator).
         Audience string
@@ -4432,18 +4644,21 @@ package client
 
 import (
         "time"
+
+        "github.com/panyam/oneauth/core"
 )
 
 // ServerCredential holds authentication info for a single server
 type ServerCredential struct {
-        AccessToken  string    `json:"access_token"`
-        RefreshToken string    `json:"refresh_token,omitempty"`
-        TokenType    string    `json:"token_type,omitempty"`
-        UserID       string    `json:"user_id,omitempty"`
-        UserEmail    string    `json:"user_email,omitempty"`
-        Scope        string    `json:"scope,omitempty"`
-        ExpiresAt    time.Time `json:"expires_at"`
-        CreatedAt    time.Time `json:"created_at"`
+        AccessToken          string                     `json:"access_token"`
+        RefreshToken         string                     `json:"refresh_token,omitempty"`
+        TokenType            string                     `json:"token_type,omitempty"`
+        UserID               string                     `json:"user_id,omitempty"`
+        UserEmail            string                     `json:"user_email,omitempty"`
+        Scope                string                     `json:"scope,omitempty"`
+        AuthorizationDetails []core.AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
+        ExpiresAt            time.Time                  `json:"expires_at"`
+        CreatedAt            time.Time                  `json:"created_at"`
 }
 
 // IsExpired returns true if the access token has expired
@@ -5077,6 +5292,161 @@ func ValidateCIMDURL(rawURL string) error <span class="cov8" title="1">{
 		<pre class="file" id="file21" style="display: none">package core
 
 import (
+        "encoding/json"
+        "fmt"
+)
+
+// ErrInvalidAuthorizationDetails is the OAuth error for malformed or disallowed
+// authorization_details values (RFC 9396 §5.2).
+var ErrInvalidAuthorizationDetails = fmt.Errorf("invalid_authorization_details")
+
+// commonFields lists the RFC 9396 §2 common field names. These cannot appear
+// as extension keys in AuthorizationDetail.Extra.
+var commonFields = map[string]bool{
+        "type": true, "locations": true, "actions": true,
+        "datatypes": true, "identifier": true, "privileges": true,
+}
+
+// AuthorizationDetail represents a single authorization details object per
+// RFC 9396 §2. Each object describes fine-grained authorization requirements
+// for a specific API or resource type.
+//
+// The Type field is required and identifies the authorization details type.
+// Common fields (Locations, Actions, DataTypes, Identifier, Privileges) are
+// optional and defined by the spec. API-specific extension fields are stored
+// in Extra and flattened into the top-level JSON object on marshal.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+type AuthorizationDetail struct {
+        // Type is the authorization details type identifier (required).
+        Type string `json:"type"`
+
+        // Locations is an array of URIs indicating where the requested
+        // resource can be found.
+        Locations []string `json:"locations,omitempty"`
+
+        // Actions is an array of strings describing the operations to be
+        // performed on the resource.
+        Actions []string `json:"actions,omitempty"`
+
+        // DataTypes is an array of strings describing the types of data
+        // being requested.
+        DataTypes []string `json:"datatypes,omitempty"`
+
+        // Identifier is a string identifying a specific resource at the API.
+        Identifier string `json:"identifier,omitempty"`
+
+        // Privileges is an array of strings representing privilege levels.
+        Privileges []string `json:"privileges,omitempty"`
+
+        // Extra holds API-specific extension fields. These are flattened into
+        // the top-level JSON object (not nested under an "extra" key).
+        Extra map[string]any `json:"-"`
+}
+
+// Validate checks that the AuthorizationDetail has a non-empty Type field.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func (ad *AuthorizationDetail) Validate() error <span class="cov8" title="1">{
+        if ad.Type == "" </span><span class="cov8" title="1">{
+                return fmt.Errorf("%w: type field is required", ErrInvalidAuthorizationDetails)
+        }</span>
+        <span class="cov8" title="1">return nil</span>
+}
+
+// ValidateAll validates a slice of AuthorizationDetail values.
+// Returns nil if the slice is nil or empty.
+func ValidateAll(details []AuthorizationDetail) error <span class="cov8" title="1">{
+        for i := range details </span><span class="cov8" title="1">{
+                if err := details[i].Validate(); err != nil </span><span class="cov8" title="1">{
+                        return err
+                }</span>
+        }
+        <span class="cov8" title="1">return nil</span>
+}
+
+// FilterByType returns the subset of details matching the given type.
+// Returns nil if no matches are found.
+func FilterByType(details []AuthorizationDetail, typ string) []AuthorizationDetail <span class="cov8" title="1">{
+        var result []AuthorizationDetail
+        for _, d := range details </span><span class="cov8" title="1">{
+                if d.Type == typ </span><span class="cov8" title="1">{
+                        result = append(result, d)
+                }</span>
+        }
+        <span class="cov8" title="1">return result</span>
+}
+
+// MarshalJSON flattens Extra fields into the top-level JSON object alongside
+// the common RFC 9396 fields. This produces the flat structure required by the
+// spec (e.g., {"type":"payment","amount":"45"}) rather than nesting extensions.
+func (ad AuthorizationDetail) MarshalJSON() ([]byte, error) <span class="cov8" title="1">{
+        // Build a map with common fields
+        m := make(map[string]any)
+        m["type"] = ad.Type
+        if len(ad.Locations) &gt; 0 </span><span class="cov8" title="1">{
+                m["locations"] = ad.Locations
+        }</span>
+        <span class="cov8" title="1">if len(ad.Actions) &gt; 0 </span><span class="cov8" title="1">{
+                m["actions"] = ad.Actions
+        }</span>
+        <span class="cov8" title="1">if len(ad.DataTypes) &gt; 0 </span><span class="cov8" title="1">{
+                m["datatypes"] = ad.DataTypes
+        }</span>
+        <span class="cov8" title="1">if ad.Identifier != "" </span><span class="cov8" title="1">{
+                m["identifier"] = ad.Identifier
+        }</span>
+        <span class="cov8" title="1">if len(ad.Privileges) &gt; 0 </span><span class="cov8" title="1">{
+                m["privileges"] = ad.Privileges
+        }</span>
+        // Flatten extensions
+        <span class="cov8" title="1">for k, v := range ad.Extra </span><span class="cov8" title="1">{
+                if !commonFields[k] </span><span class="cov8" title="1">{
+                        m[k] = v
+                }</span>
+        }
+        <span class="cov8" title="1">return json.Marshal(m)</span>
+}
+
+// UnmarshalJSON parses a flat JSON object into the common fields and Extra.
+// Extension keys that collide with common field names are rejected.
+func (ad *AuthorizationDetail) UnmarshalJSON(data []byte) error <span class="cov8" title="1">{
+        // First pass: decode common fields via a type alias (avoids recursion)
+        type Alias AuthorizationDetail
+        var alias Alias
+        if err := json.Unmarshal(data, &amp;alias); err != nil </span><span class="cov0" title="0">{
+                return err
+        }</span>
+        <span class="cov8" title="1">*ad = AuthorizationDetail(alias)
+
+        // Second pass: decode all keys to find extensions
+        var raw map[string]json.RawMessage
+        if err := json.Unmarshal(data, &amp;raw); err != nil </span><span class="cov0" title="0">{
+                return err
+        }</span>
+
+        // Collect extension fields
+        <span class="cov8" title="1">ad.Extra = nil
+        for k, v := range raw </span><span class="cov8" title="1">{
+                if commonFields[k] </span><span class="cov8" title="1">{
+                        continue</span>
+                }
+                <span class="cov8" title="1">if ad.Extra == nil </span><span class="cov8" title="1">{
+                        ad.Extra = make(map[string]any)
+                }</span>
+                <span class="cov8" title="1">var val any
+                if err := json.Unmarshal(v, &amp;val); err != nil </span><span class="cov0" title="0">{
+                        return fmt.Errorf("failed to unmarshal extension field %q: %w", k, err)
+                }</span>
+                <span class="cov8" title="1">ad.Extra[k] = val</span>
+        }
+        <span class="cov8" title="1">return nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file22" style="display: none">package core
+
+import (
         "sync"
         "time"
 )
@@ -5154,7 +5524,7 @@ func (b *InMemoryBlacklist) Len() int <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file22" style="display: none">package core
+		<pre class="file" id="file23" style="display: none">package core
 
 import "context"
 
@@ -5180,7 +5550,7 @@ func SetUserIDInContext(ctx context.Context, userID string) context.Context <spa
 }</span>
 </pre>
 		
-		<pre class="file" id="file23" style="display: none">package core
+		<pre class="file" id="file24" style="display: none">package core
 
 import (
         "fmt"
@@ -5398,7 +5768,7 @@ func DetectUsernameType(username string) string <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file24" style="display: none">package core
+		<pre class="file" id="file25" style="display: none">package core
 
 import "log"
 
@@ -5430,7 +5800,7 @@ func (c *ConsoleEmailSender) SendPasswordResetEmail(to string, resetLink string)
 }</span>
 </pre>
 		
-		<pre class="file" id="file25" style="display: none">package core
+		<pre class="file" id="file26" style="display: none">package core
 
 import (
         "sync"
@@ -5590,7 +5960,7 @@ func (l *AccountLockout) Reset(key string) <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file26" style="display: none">package core
+		<pre class="file" id="file27" style="display: none">package core
 
 import (
         "sort"
@@ -5754,7 +6124,7 @@ func ScopesEqual(a, b []string) bool <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file27" style="display: none">package core
+		<pre class="file" id="file28" style="display: none">package core
 
 import (
         "crypto/rand"
@@ -5837,8 +6207,9 @@ type RefreshToken struct {
         DeviceInfo map[string]any `json:"device_info"` // User agent, IP, etc.
         Family     string         `json:"family"`      // Token family for rotation tracking
         Generation int            `json:"generation"`  // Increments on rotation
-        Scopes     []string       `json:"scopes"`      // Granted scopes
-        CreatedAt  time.Time      `json:"created_at"`
+        Scopes               []string              `json:"scopes"`                          // Granted scopes
+        AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
+        CreatedAt            time.Time             `json:"created_at"`
         ExpiresAt  time.Time      `json:"expires_at"`
         LastUsedAt time.Time      `json:"last_used_at"`
         RevokedAt  *time.Time     `json:"revoked_at,omitempty"`
@@ -5884,22 +6255,24 @@ func (k *APIKey) IsValid() bool <span class="cov0" title="0">{
 
 // TokenPair represents the response from a successful authentication
 type TokenPair struct {
-        AccessToken  string `json:"access_token"`
-        TokenType    string `json:"token_type"`     // "Bearer"
-        ExpiresIn    int64  `json:"expires_in"`     // Seconds until access token expires
-        RefreshToken string `json:"refresh_token,omitempty"`
-        Scope        string `json:"scope,omitempty"`
+        AccessToken          string                `json:"access_token"`
+        TokenType            string                `json:"token_type"`                        // "Bearer"
+        ExpiresIn            int64                 `json:"expires_in"`                        // Seconds until access token expires
+        RefreshToken         string                `json:"refresh_token,omitempty"`
+        Scope                string                `json:"scope,omitempty"`
+        AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
 }
 
 // TokenRequest represents a request to the token endpoint
 type TokenRequest struct {
-        GrantType    string `json:"grant_type"`              // "password", "refresh_token", "client_credentials"
-        Username     string `json:"username,omitempty"`      // For password grant
-        Password     string `json:"password,omitempty"`      // For password grant
-        RefreshToken string `json:"refresh_token,omitempty"` // For refresh_token grant
-        Scope        string `json:"scope,omitempty"`         // Requested scopes
-        ClientID     string `json:"client_id,omitempty"`     // Client identifier (for client_credentials, optional for others)
-        ClientSecret string `json:"client_secret,omitempty"` // Client secret (for client_credentials via client_secret_post)
+        GrantType            string                `json:"grant_type"`                                  // "password", "refresh_token", "client_credentials"
+        Username             string                `json:"username,omitempty"`                          // For password grant
+        Password             string                `json:"password,omitempty"`                          // For password grant
+        RefreshToken         string                `json:"refresh_token,omitempty"`                     // For refresh_token grant
+        Scope                string                `json:"scope,omitempty"`                             // Requested scopes
+        ClientID             string                `json:"client_id,omitempty"`                         // Client identifier (for client_credentials, optional for others)
+        ClientSecret         string                `json:"client_secret,omitempty"`                     // Client secret (for client_credentials via client_secret_post)
+        AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"`             // RFC 9396
 }
 
 // TokenError represents an OAuth 2.0 compliant error response
@@ -5927,7 +6300,7 @@ func GenerateAPIKeySecret() (string, error) <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file28" style="display: none">package core
+		<pre class="file" id="file29" style="display: none">package core
 
 import (
         "net/http"
@@ -5991,7 +6364,3319 @@ func IdentityKey(identityType, identityValue string) string <span class="cov0" t
 type HandleUserFunc func(authtype string, provider string, token *oauth2.Token, userInfo map[string]any, w http.ResponseWriter, r *http.Request)
 </pre>
 		
-		<pre class="file" id="file29" style="display: none">package httpauth
+		<pre class="file" id="file30" style="display: none">// Example 01: OAuth 2.0 Client Credentials Flow
+//
+// The simplest way to get a token from OneAuth. A client authenticates with
+// its client_id and client_secret, and receives a JWT access token.
+//
+// Run:   go run ./examples/01-client-credentials/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+package main
+
+import (
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "net/url"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+func main() <span class="cov0" title="0">{
+        // Shared state across steps
+        var authServer, resourceServer *httptest.Server
+        var ks keys.KeyStorage
+        var clientID, clientSecret, accessToken string
+
+        demo := demokit.New("01: Client Credentials Flow").
+                Dir("01-client-credentials").
+                Description("Non-UI | No infrastructure needed | RFC 6749 §4.4").
+                Actors(
+                        demokit.Actor("App", "Client App"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** App (a bot), Auth Server (AS), Resource Server (RS).",
+                "Think: a GitHub bot posting to Slack's API. [What are these?](../README.md#cast-of-characters)",
+                "",
+                "The `client_credentials` grant is the standard OAuth 2.0 machine-to-machine",
+                "flow. No user is involved — the bot authenticates directly with its own",
+                "credentials and receives an access token.",
+                "",
+                "Common use cases: service-to-service calls, background jobs, CLI tools.",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server and resource server").
+                Note("We spin up two in-process HTTP servers: one for the AS (issues tokens) and one for the RS (validates them). Both share the same KeyStore.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+                        apiAuth := &amp;apiauth.APIAuth{
+                                JWTSecretKey:   "example-jwt-secret-at-least-32ch",
+                                JWTIssuer:      "example-issuer",
+                                ClientKeyStore: ks,
+                        }
+
+                        authMux := http.NewServeMux()
+                        authMux.Handle("/apps/", registrar.Handler())
+                        authMux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+                        authServer = httptest.NewServer(authMux)
+
+                        middleware := &amp;apiauth.APIMiddleware{
+                                JWTSecretKey: "example-jwt-secret-at-least-32ch",
+                                JWTIssuer:    "example-issuer",
+                        }
+                        resMux := http.NewServeMux()
+                        resMux.Handle("GET /resource", middleware.ValidateToken(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "message": "hello from protected resource",
+                                                "sub":     apiauth.GetUserIDFromAPIContext(r.Context()),
+                                                "scopes":  apiauth.GetScopesFromAPIContext(r.Context()),
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
+
+                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
+                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("How client registration works",
+                "Before a client can get tokens, it needs to register with the auth server",
+                "and receive a `client_id` + `client_secret` pair. This is the equivalent",
+                "of going to GitHub Developer Settings → OAuth Apps → \"New OAuth App\".",
+                "",
+                "In this example, registration is **open** (`NewNoAuth()`) for simplicity.",
+                "In production, gate registration with authentication — see",
+                "[How does an App get registered?](../README.md#how-does-an-app-get-registered)",
+                "for the full spectrum from web dashboards to automated DCR.",
+                "",
+                "**The `client_secret` is a backend credential.** It lives in your server,",
+                "not in a browser or mobile app. Never expose it in frontend code.",
+        )
+
+        // --- Step 1: Register ---
+        demo.Step("Register a client").
+                Ref(demokit.RFC7591).
+                Arrow("App", "AS", "POST /apps/register {domain, signing_alg}").
+                DashedArrow("AS", "App", "{client_id, client_secret}").
+                Note("The client receives credentials it will use to authenticate in the next step.").
+                Run(func() </span><span class="cov0" title="0">{
+                        body, _ := json.Marshal(map[string]any{
+                                "client_domain": "my-service.example.com",
+                                "signing_alg":   "HS256",
+                        })
+                        resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+                                strings.NewReader(string(body)))
+                        var reg map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;reg)
+                        resp.Body.Close()
+
+                        clientID = reg["client_id"].(string)
+                        clientSecret = reg["client_secret"].(string)
+                        fmt.Printf("    client_id:     %s\n", clientID)
+                        fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
+                }</span>)
+
+        // --- Step 2: Token ---
+        <span class="cov0" title="0">demo.Step("Request an access token").
+                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(demokit.RFC7519).
+                Arrow("App", "AS", "POST /api/token {grant_type: client_credentials}").
+                DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
+                Note("The AS verifies the client credentials and returns a signed JWT. The token carries sub=client_id (no user context in this flow).").
+                Run(func() </span><span class="cov0" title="0">{
+                        resp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+                                "grant_type":    {"client_credentials"},
+                                "client_id":     {clientID},
+                                "client_secret": {clientSecret},
+                                "scope":         {"read write"},
+                        })
+                        var tokenData map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;tokenData)
+                        resp.Body.Close()
+
+                        accessToken = tokenData["access_token"].(string)
+                        fmt.Printf("    token_type:   %s\n", tokenData["token_type"])
+                        fmt.Printf("    scope:        %s\n", tokenData["scope"])
+                        fmt.Printf("    expires_in:   %.0fs\n", tokenData["expires_in"])
+                        fmt.Printf("    access_token: %s...\n", accessToken[:40])
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("What's in the JWT?",
+                "The access token is a signed JWT containing:",
+                "- `sub`: the client_id (who this token represents)",
+                "- `scopes`: the granted scopes",
+                "- `iss`: the issuer URL",
+                "- `exp`/`iat`: expiry and issued-at timestamps",
+                "- `jti`: unique token ID (for revocation)",
+                "",
+                "The resource server can validate this token locally by checking the",
+                "signature — no callback to the auth server needed.",
+        )
+
+        // --- Step 3: Use token ---
+        demo.Step("Access a protected resource").
+                Ref(demokit.RFC6750).
+                Ref(demokit.RFC7515).
+                Arrow("App", "RS", "GET /resource (Authorization: Bearer token)").
+                Arrow("RS", "RS", "Validate JWT signature + claims").
+                DashedArrow("RS", "App", "200 {data}").
+                Note("The resource server validates the JWT signature and extracts claims from it. No network call to the auth server.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+accessToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d\n", res.StatusCode)
+                        var resource map[string]any
+                        json.Unmarshal(body, &amp;resource)
+                        pretty, _ := json.MarshalIndent(resource, "    ", "  ")
+                        fmt.Printf("    response: %s\n", string(pretty))
+                }</span>)
+
+        // --- Step 4: No token ---
+        <span class="cov0" title="0">demo.Step("Access without a token (expect rejection)").
+                Ref(demokit.RFC6750).
+                Arrow("App", "RS", "GET /resource (no Authorization header)").
+                DashedArrow("RS", "App", "401 Unauthorized").
+                Note("Without a valid Bearer token, the resource server rejects the request.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        res, _ := http.DefaultClient.Do(req)
+                        res.Body.Close()
+                        fmt.Printf("    status: %d (correctly rejected)\n", res.StatusCode)
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("What's next?",
+                "In [02 — Resource Token (HS256)](../02-resource-token-hs256/), you'll see",
+                "how a registered app can mint tokens *for individual users*, not just for",
+                "itself. This is the federated authentication pattern used by OneAuth's",
+                "multi-app architecture.",
+        )
+
+        demo.Execute()
+
+        // Cleanup
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
+                resourceServer.Close()
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file31" style="display: none">// Example 02: Resource Token with HS256 (Federated Auth)
+//
+// Building on Example 01, this shows how a registered app can mint
+// resource-scoped tokens for individual users — not just for itself.
+// This is OneAuth's federated authentication pattern.
+//
+// In Example 01: client_credentials → token with sub=client_id (machine identity)
+// In this example: app registers → mints per-user tokens → resource server validates
+//
+// Run:   go run ./examples/02-resource-token-hs256/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7519 (JWT)
+package main
+
+import (
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+func main() <span class="cov0" title="0">{
+        var authServer, resourceServer *httptest.Server
+        var ks keys.KeyStorage
+        var clientID, clientSecret string
+        var aliceToken, bobToken string
+
+        demo := demokit.New("02: Resource Token with HS256 (Federated Auth)").
+                Dir("02-resource-token-hs256").
+                Description("Non-UI | No infrastructure needed | Builds on Example 01").
+                Actors(
+                        demokit.Actor("App", "Your App"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("How this differs from Example 01",
+                "**Actors:** App, Auth Server (AS), Resource Server (RS).",
+                "Think: the GitHub bot now posts to Slack *as Alice*, not as itself.",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "In [01 — Client Credentials](../01-client-credentials/), the bot got a token",
+                "representing *itself* (sub=client_id). That's machine-to-machine auth.",
+                "",
+                "Here, the app registers with the auth server and gets a shared secret (HS256).",
+                "Then it uses `admin.MintResourceToken()` to create JWTs *for individual users*.",
+                "Each token carries:",
+                "- `sub` = the user's ID (not the app's)",
+                "- `client_id` = the app that minted it",
+                "- `scopes` = what this user can do",
+                "- Quota claims (max_rooms, max_msg_rate) for resource-level limits",
+                "",
+                "The resource server validates these tokens using the same KeyStore — it trusts",
+                "the app's signing key without calling back to the auth server.",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server and resource server").
+                Note("Same as Example 01, but now the resource server also extracts the `client_id` claim to know which app minted the token.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+                        authMux := http.NewServeMux()
+                        authMux.Handle("/apps/", registrar.Handler())
+                        authServer = httptest.NewServer(authMux)
+
+                        middleware := &amp;apiauth.APIMiddleware{KeyStore: ks}
+                        resMux := http.NewServeMux()
+                        resMux.Handle("GET /resource", middleware.ValidateToken(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        ctx := r.Context()
+                                        custom := apiauth.GetCustomClaimsFromContext(ctx)
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "user":      apiauth.GetUserIDFromAPIContext(ctx),
+                                                "scopes":    apiauth.GetScopesFromAPIContext(ctx),
+                                                "client_id": custom["client_id"],
+                                                "max_rooms": custom["max_rooms"],
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
+
+                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
+                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)</span>
+                })
+
+        // --- Register ---
+        <span class="cov0" title="0">demo.Step("Register an app with HS256 signing").
+                Ref(demokit.RFC7515).
+                Arrow("App", "AS", "POST /apps/register {domain: myapp.example.com, signing_alg: HS256}").
+                DashedArrow("AS", "App", "{client_id, client_secret}").
+                Note("The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app and resource server can use it for signing/verification.").
+                Run(func() </span><span class="cov0" title="0">{
+                        body, _ := json.Marshal(map[string]any{
+                                "client_domain": "myapp.example.com",
+                                "signing_alg":   "HS256",
+                        })
+                        resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+                                bytes.NewReader(body))
+                        var reg map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;reg)
+                        resp.Body.Close()
+
+                        clientID = reg["client_id"].(string)
+                        clientSecret = reg["client_secret"].(string)
+                        fmt.Printf("    client_id:     %s\n", clientID)
+                        fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("MintResourceToken vs client_credentials",
+                "`MintResourceToken` is a library call, not an HTTP endpoint. The app calls it",
+                "directly in its own process to create a JWT signed with the shared secret.",
+                "",
+                "This is different from the `client_credentials` grant in Example 01, where the",
+                "app POSTs to the auth server's token endpoint. Here the app is trusted to mint",
+                "tokens itself — the auth server just manages key registration.",
+                "",
+                "Think of it like this:",
+                "- **client_credentials**: \"Auth server, give ME a token\"",
+                "- **MintResourceToken**: \"I'll make a token FOR this user, signed with my key\"",
+        )
+
+        // --- Mint for Alice ---
+        demo.Step("Mint a resource token for user Alice").
+                Ref(demokit.RFC7519).
+                Ref(demokit.RFC7515).
+                Ref(demokit.RFC7638).
+                Arrow("App", "App", "MintResourceToken(alice, scopes=[read,write], max_rooms=10)").
+                Note("The app creates a JWT with sub=alice, signed with its HS256 secret. The token includes quota claims (max_rooms) for resource-level enforcement.").
+                Run(func() </span><span class="cov0" title="0">{
+                        var err error
+                        aliceToken, err = admin.MintResourceToken(
+                                "alice", clientID, clientSecret,
+                                admin.AppQuota{MaxRooms: 10, MaxMsgRate: 30.0},
+                                []string{"read", "write"}, nil,
+                        )
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    token for alice: %s...\n", aliceToken[:40])</span>
+                })
+
+        // --- Mint for Bob ---
+        <span class="cov0" title="0">demo.Step("Mint a resource token for user Bob (different scopes)").
+                Ref(demokit.RFC7519).
+                Arrow("App", "App", "MintResourceToken(bob, scopes=[read], max_rooms=3)").
+                Note("Same app, different user, different permissions. Bob gets read-only access with a lower room quota.").
+                Run(func() </span><span class="cov0" title="0">{
+                        var err error
+                        bobToken, err = admin.MintResourceToken(
+                                "bob", clientID, clientSecret,
+                                admin.AppQuota{MaxRooms: 3},
+                                []string{"read"}, nil,
+                        )
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    token for bob: %s...\n", bobToken[:40])</span>
+                })
+
+        // --- Validate Alice ---
+        <span class="cov0" title="0">demo.Step("Resource server validates Alice's token").
+                Ref(demokit.RFC6750).
+                Ref(demokit.RFC7515).
+                Arrow("App", "RS", "GET /resource (Bearer: alice's token)").
+                Arrow("RS", "RS", "Validate HS256 signature via KeyStore").
+                DashedArrow("RS", "App", "200 {user: alice, scopes: [read,write], max_rooms: 10}").
+                Note("The resource server validates the JWT using the app's key from the shared KeyStore. It extracts the user ID, scopes, and quota claims.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+aliceToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d\n", res.StatusCode)
+                        var data map[string]any
+                        json.Unmarshal(body, &amp;data)
+                        pretty, _ := json.MarshalIndent(data, "    ", "  ")
+                        fmt.Printf("    response: %s\n", string(pretty))
+                }</span>)
+
+        // --- Validate Bob ---
+        <span class="cov0" title="0">demo.Step("Resource server validates Bob's token").
+                Arrow("App", "RS", "GET /resource (Bearer: bob's token)").
+                DashedArrow("RS", "App", "200 {user: bob, scopes: [read], max_rooms: 3}").
+                Note("Same resource server, different user — Bob's token has fewer scopes and a lower quota.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+bobToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d\n", res.StatusCode)
+                        var data map[string]any
+                        json.Unmarshal(body, &amp;data)
+                        pretty, _ := json.MarshalIndent(data, "    ", "  ")
+                        fmt.Printf("    response: %s\n", string(pretty))
+                }</span>)
+
+        // --- Wrong secret ---
+        <span class="cov0" title="0">demo.Step("Token signed with wrong secret is rejected").
+                Ref(demokit.RFC7515).
+                Arrow("App", "App", "MintResourceToken(eve, secret=wrong-secret)").
+                Arrow("App", "RS", "GET /resource (Bearer: bad token)").
+                DashedArrow("RS", "App", "401 Unauthorized").
+                Note("A token signed with the wrong secret fails signature verification — the resource server rejects it immediately.").
+                Run(func() </span><span class="cov0" title="0">{
+                        badToken, _ := admin.MintResourceToken(
+                                "eve", clientID, "wrong-secret",
+                                admin.AppQuota{}, []string{"admin"}, nil,
+                        )
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+badToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        res.Body.Close()
+                        fmt.Printf("    status: %d (correctly rejected — wrong signing key)\n", res.StatusCode)
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("What's next?",
+                "In [03 — Resource Token (RS256 + JWKS)](../03-resource-token-rs256-jwks/),",
+                "you'll see the asymmetric version: the app registers a public key, serves it",
+                "via JWKS, and the resource server discovers it automatically. No shared",
+                "secrets — the resource server never sees the private key.",
+        )
+
+        demo.Execute()
+
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
+                resourceServer.Close()
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file32" style="display: none">// Example 03: Resource Token with RS256 + JWKS Discovery
+//
+// Building on Example 02 (HS256 shared secret), this shows the asymmetric
+// alternative: the app generates an RSA key pair, registers only the PUBLIC
+// key, and the resource server discovers it via JWKS. The private key never
+// leaves the app.
+//
+// In Example 02: shared secret (HS256) — both sides know the key
+// In this example: public/private key pair (RS256) — only the app has the private key
+//
+// Run:   go run ./examples/03-resource-token-rs256-jwks/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7517 (JWK)
+package main
+
+import (
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+
+        "crypto/rsa"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+        "github.com/panyam/oneauth/utils"
+)
+
+func main() <span class="cov0" title="0">{
+        var authServer, resourceServer *httptest.Server
+        var ks keys.KeyStorage
+        var clientID string
+        var privKey *rsa.PrivateKey
+        var aliceToken string
+
+        demo := demokit.New("03: Resource Token with RS256 + JWKS Discovery").
+                Dir("03-resource-token-rs256-jwks").
+                Description("Non-UI | No infrastructure needed | Builds on Example 02").
+                Actors(
+                        demokit.Actor("App", "Your App"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("Why asymmetric signing?",
+                "**Actors:** App, Auth Server (AS), Resource Server (RS).",
+                "Think: the GitHub bot gets its own key pair — Slack's API never sees the private key.",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "In [02 — HS256](../02-resource-token-hs256/), both the app and resource server",
+                "share the same secret. That works, but it means:",
+                "- The resource server *could* forge tokens (it has the signing key)",
+                "- Compromising the resource server compromises the signing key",
+                "- Rotating keys requires coordinating both sides",
+                "",
+                "With RS256 (asymmetric):",
+                "- The app keeps the private key — only it can sign tokens",
+                "- The resource server only has the public key — it can verify but never forge",
+                "- The public key is served via JWKS — resource servers discover it automatically",
+                "- Key rotation is seamless: publish a new key to JWKS, resource servers pick it up",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server with JWKS endpoint").
+                Ref(demokit.RFC7517).
+                Note("The auth server now serves two endpoints: /apps/ for registration and /.well-known/jwks.json for public key discovery.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+                        authMux := http.NewServeMux()
+                        authMux.Handle("/apps/", registrar.Handler())
+                        authMux.Handle("GET /.well-known/jwks.json", jwksHandler)
+                        authServer = httptest.NewServer(authMux)
+
+                        fmt.Printf("    Auth server: %s\n", authServer.URL)
+                        fmt.Printf("    JWKS:        %s/.well-known/jwks.json\n", authServer.URL)
+                }</span>)
+
+        // --- Generate key pair ---
+        <span class="cov0" title="0">demo.Step("App generates an RSA key pair").
+                Ref(demokit.RFC7515).
+                Note("The app generates a 2048-bit RSA key pair. The private key stays with the app. The public key will be registered with the auth server.").
+                Run(func() </span><span class="cov0" title="0">{
+                        privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+                        <span class="cov0" title="0">parsed, _ := utils.ParsePrivateKeyPEM(privPEM)
+                        privKey = parsed.(*rsa.PrivateKey)
+
+                        fmt.Printf("    Private key: %d bytes (stays with app)\n", len(privPEM))
+                        fmt.Printf("    Public key:  %d bytes (will be registered)\n", len(pubPEM))</span>
+                })
+
+        // --- Register with public key ---
+        <span class="cov0" title="0">demo.Step("Register app with RS256 public key").
+                Ref(demokit.RFC7517).
+                Arrow("App", "AS", "POST /apps/register {domain, signing_alg: RS256, public_key}").
+                DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
+                Note("Unlike HS256 registration, no secret is returned. The auth server stores the public key and serves it via JWKS.").
+                Run(func() </span><span class="cov0" title="0">{
+                        pubPEM, _ := utils.EncodePublicKeyPEM(&amp;privKey.PublicKey)
+                        body, _ := json.Marshal(map[string]any{
+                                "client_domain": "myapp.example.com",
+                                "signing_alg":   "RS256",
+                                "public_key":    string(pubPEM),
+                        })
+                        resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+                                bytes.NewReader(body))
+                        var reg map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;reg)
+                        resp.Body.Close()
+
+                        clientID = reg["client_id"].(string)
+                        fmt.Printf("    client_id:     %s\n", clientID)
+                        fmt.Printf("    client_secret: (none — RS256 uses key pair)\n")
+                }</span>)
+
+        // --- Verify JWKS ---
+        <span class="cov0" title="0">demo.Step("Verify the public key appears in JWKS").
+                Ref(demokit.RFC7517).
+                Ref(demokit.RFC7638).
+                Arrow("App", "AS", "GET /.well-known/jwks.json").
+                DashedArrow("AS", "App", "{keys: [{kty: RSA, alg: RS256, kid: ..., n: ..., e: ...}]}").
+                Note("The JWKS endpoint serves only public keys — HS256 secrets are never exposed. Each key includes a kid (Key ID) computed from the key thumbprint (RFC 7638).").
+                Run(func() </span><span class="cov0" title="0">{
+                        resp, _ := http.Get(authServer.URL + "/.well-known/jwks.json")
+                        body, _ := io.ReadAll(resp.Body)
+                        resp.Body.Close()
+
+                        var jwkSet map[string]any
+                        json.Unmarshal(body, &amp;jwkSet)
+                        jwksKeys := jwkSet["keys"].([]any)
+                        fmt.Printf("    JWKS key count: %d\n", len(jwksKeys))
+
+                        if len(jwksKeys) &gt; 0 </span><span class="cov0" title="0">{
+                                key := jwksKeys[0].(map[string]any)
+                                fmt.Printf("    kty: %s\n", key["kty"])
+                                fmt.Printf("    alg: %s\n", key["alg"])
+                                fmt.Printf("    kid: %s\n", key["kid"])
+                                fmt.Printf("    key_ops: %v\n", key["key_ops"])
+
+                                // Verify no private key fields
+                                for _, field := range []string{"d", "p", "q", "dp", "dq", "qi"} </span><span class="cov0" title="0">{
+                                        if key[field] != nil </span><span class="cov0" title="0">{
+                                                fmt.Printf("    WARNING: private field %q leaked!\n", field)
+                                        }</span>
+                                }
+                                <span class="cov0" title="0">fmt.Printf("    private fields: (absent — only public components served)\n")</span>
+                        }
+                })
+
+        <span class="cov0" title="0">demo.Section("How JWKS discovery works",
+                "The resource server doesn't need the auth server's key ahead of time.",
+                "It uses `JWKSKeyStore` which:",
+                "1. Fetches `/.well-known/jwks.json` from the auth server",
+                "2. Caches the keys locally",
+                "3. When a token arrives with a `kid` header, looks up the matching key",
+                "4. Periodically refreshes to pick up new/rotated keys",
+                "",
+                "This is the same mechanism Keycloak, Auth0, and other IdPs use.",
+        )
+
+        // --- Start resource server with JWKS discovery ---
+        demo.Step("Start resource server with JWKS-based key discovery").
+                Ref(demokit.RFC7517).
+                Note("The resource server points its JWKSKeyStore at the auth server's JWKS URL. It automatically fetches and caches the public keys.").
+                Run(func() </span><span class="cov0" title="0">{
+                        jwksKS := keys.NewJWKSKeyStore(
+                                authServer.URL+"/.well-known/jwks.json",
+                                keys.WithMinRefreshGap(0),
+                        )
+                        jwksKS.Start()
+
+                        middleware := &amp;apiauth.APIMiddleware{KeyStore: jwksKS}
+                        resMux := http.NewServeMux()
+                        resMux.Handle("GET /resource", middleware.ValidateToken(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        ctx := r.Context()
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "user":   apiauth.GetUserIDFromAPIContext(ctx),
+                                                "scopes": apiauth.GetScopesFromAPIContext(ctx),
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
+
+                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+                        fmt.Printf("    JWKS source:     %s/.well-known/jwks.json\n", authServer.URL)</span>
+                })
+
+        // --- Mint and validate ---
+        <span class="cov0" title="0">demo.Step("Mint a token with the private key and validate via JWKS").
+                Ref(demokit.RFC7519).
+                Ref(demokit.RFC7515).
+                Ref(demokit.RFC7638).
+                Arrow("App", "App", "MintResourceTokenWithKey(alice, privKey)").
+                Arrow("App", "RS", "GET /resource (Bearer: RS256 token)").
+                Arrow("RS", "AS", "GET /.well-known/jwks.json (cached)").
+                Arrow("RS", "RS", "Verify RS256 signature with public key from JWKS").
+                DashedArrow("RS", "App", "200 {user: alice}").
+                Note("The token's kid header tells the resource server which key to use. The signature is verified with the public key — the private key was never shared.").
+                Run(func() </span><span class="cov0" title="0">{
+                        aliceToken, _ = admin.MintResourceTokenWithKey(
+                                "alice", clientID, privKey,
+                                admin.AppQuota{}, []string{"read", "write"}, nil,
+                        )
+                        fmt.Printf("    token: %s...\n", aliceToken[:40])
+
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+aliceToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d\n", res.StatusCode)
+                        var data map[string]any
+                        json.Unmarshal(body, &amp;data)
+                        pretty, _ := json.MarshalIndent(data, "    ", "  ")
+                        fmt.Printf("    response: %s\n", string(pretty))
+                }</span>)
+
+        // --- Wrong key ---
+        <span class="cov0" title="0">demo.Step("Token signed with a different private key is rejected").
+                Ref(demokit.RFC7515).
+                Arrow("App", "App", "MintResourceTokenWithKey(eve, differentPrivKey)").
+                Arrow("App", "RS", "GET /resource (Bearer: bad token)").
+                DashedArrow("RS", "App", "401 Unauthorized").
+                Note("Even though the token is a valid JWT, its kid doesn't match any key in JWKS, or the signature doesn't verify with the registered public key.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Generate a completely different key pair
+                        otherPrivPEM, _, _ := utils.GenerateRSAKeyPair(2048)
+                        otherPrivKey, _ := utils.ParsePrivateKeyPEM(otherPrivPEM)
+
+                        badToken, _ := admin.MintResourceTokenWithKey(
+                                "eve", clientID, otherPrivKey,
+                                admin.AppQuota{}, []string{"admin"}, nil,
+                        )
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+badToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        res.Body.Close()
+                        fmt.Printf("    status: %d (correctly rejected — wrong private key)\n", res.StatusCode)
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("HS256 vs RS256 — when to use which",
+                "| | HS256 (Example 02) | RS256 (this example) |",
+                "|---|---|---|",
+                "| **Key type** | Shared secret | Public/private key pair |",
+                "| **Who can sign** | Anyone with the secret | Only the private key holder |",
+                "| **Who can verify** | Anyone with the secret | Anyone with the public key |",
+                "| **Key distribution** | Must be kept secret on both sides | Public key is... public |",
+                "| **JWKS** | Secrets excluded from JWKS | Public keys served via JWKS |",
+                "| **Best for** | Simple setups, trusted environments | Multi-service, zero-trust |",
+                "",
+                "**Rule of thumb:** Use RS256 when the resource server is a separate service.",
+                "Use HS256 when the app and resource server are the same process or fully trusted.",
+        )
+
+        demo.Section("What's next?",
+                "In [04 — Discovery](../04-discovery/), you'll see how clients can",
+                "auto-discover the auth server's endpoints (token, JWKS, introspection)",
+                "without hardcoding URLs. This is the foundation for interoperability",
+                "with external IdPs like Keycloak and Auth0.",
+        )
+
+        demo.Execute()
+
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
+                resourceServer.Close()
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file33" style="display: none">// Example 04: AS Metadata Discovery (RFC 8414)
+//
+// In Examples 01-03, we hardcoded URLs like authServer.URL+"/api/token".
+// In production, clients discover endpoints automatically from a single
+// well-known URL. This is how Keycloak, Auth0, and OneAuth all work.
+//
+// Run:   go run ./examples/04-discovery/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc8414
+package main
+
+import (
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "net/url"
+        "strings"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+
+func main() <span class="cov0" title="0">{
+        var authServer, resourceServer *httptest.Server
+        var ks keys.KeyStorage
+        var discoveredMeta *client.ASMetadata
+        var clientID, clientSecret, accessToken string
+
+        demo := demokit.New("04: AS Metadata Discovery").
+                Dir("04-discovery").
+                Description("Non-UI | No infrastructure needed | Builds on Examples 01-03").
+                Actors(
+                        demokit.Actor("App", "Client App"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** App (a bot), Auth Server (AS), Resource Server (RS).",
+                "Think: the GitHub bot doesn't know Slack's token URL — it discovers it.",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "In Examples 01-03, we hardcoded the auth server's URLs:",
+                "```go",
+                "http.PostForm(authServer.URL + \"/api/token\", ...)  // hardcoded path",
+                "```",
+                "",
+                "In production, you don't know the paths ahead of time. Different auth servers",
+                "use different URL structures (Keycloak: `/realms/{name}/protocol/openid-connect/token`,",
+                "Auth0: `/oauth/token`, OneAuth: `/api/token`).",
+                "",
+                "RFC 8414 solves this: every auth server publishes a JSON document at",
+                "`/.well-known/openid-configuration` listing all its endpoints.",
+                "Clients fetch this once and use the discovered URLs for everything.",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server with discovery, token, JWKS, and introspection endpoints").
+                Ref(demokit.RFC8414).
+                Note("This is the most complete auth server we've built so far — it serves discovery, tokens, JWKS, introspection, and registration.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+                        apiAuth := &amp;apiauth.APIAuth{
+                                JWTSecretKey:   "discovery-example-secret-32chars!",
+                                ClientKeyStore: ks,
+                        }
+
+                        introspection := &amp;apiauth.IntrospectionHandler{
+                                Auth:           apiAuth,
+                                ClientKeyStore: ks,
+                        }
+
+                        mux := http.NewServeMux()
+                        mux.Handle("/apps/", registrar.Handler())
+                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+                        mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+                        mux.Handle("POST /oauth/introspect", introspection)
+                        authServer = httptest.NewServer(mux)
+
+                        // Set issuer to actual URL (must match tokens)
+                        apiAuth.JWTIssuer = authServer.URL
+
+                        // Register discovery endpoint with all the server's capabilities
+                        mux.Handle("GET /.well-known/openid-configuration",
+                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                                        Issuer:                        authServer.URL,
+                                        TokenEndpoint:                 authServer.URL + "/api/token",
+                                        JWKSURI:                       authServer.URL + "/.well-known/jwks.json",
+                                        IntrospectionEndpoint:         authServer.URL + "/oauth/introspect",
+                                        RegistrationEndpoint:          authServer.URL + "/apps/register",
+                                        ScopesSupported:               []string{"read", "write", "admin"},
+                                        GrantTypesSupported:           []string{"client_credentials"},
+                                        ResponseTypesSupported:        []string{"token"},
+                                        TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
+                                        CodeChallengeMethodsSupported: []string{"S256"},
+                                }))
+
+                        // Resource server
+                        middleware := &amp;apiauth.APIMiddleware{
+                                JWTSecretKey: "discovery-example-secret-32chars!",
+                                JWTIssuer:    authServer.URL,
+                        }
+                        resMux := http.NewServeMux()
+                        resMux.Handle("GET /resource", middleware.ValidateToken(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+                                                "scopes": apiauth.GetScopesFromAPIContext(r.Context()),
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
+
+                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
+                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)</span>
+                })
+
+        // --- Fetch raw metadata ---
+        <span class="cov0" title="0">demo.Step("Fetch the discovery document (raw HTTP)").
+                Ref(demokit.RFC8414).
+                Arrow("App", "AS", "GET /.well-known/openid-configuration").
+                DashedArrow("AS", "App", "JSON {issuer, token_endpoint, jwks_uri, ...}").
+                Note("The discovery document is a JSON object listing every endpoint the server supports. This is the same format Keycloak, Auth0, and Google use.").
+                Run(func() </span><span class="cov0" title="0">{
+                        resp, _ := http.Get(authServer.URL + "/.well-known/openid-configuration")
+                        body, _ := io.ReadAll(resp.Body)
+                        resp.Body.Close()
+
+                        var meta map[string]any
+                        json.Unmarshal(body, &amp;meta)
+                        pretty, _ := json.MarshalIndent(meta, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("What's in the metadata?",
+                "| Field | What it tells the client |",
+                "|-------|------------------------|",
+                "| `issuer` | The AS's canonical URL — must match the `iss` claim in tokens |",
+                "| `token_endpoint` | Where to POST for tokens (client_credentials, auth code) |",
+                "| `jwks_uri` | Where to GET public keys for token verification |",
+                "| `introspection_endpoint` | Where to POST for token introspection (RFC 7662) |",
+                "| `registration_endpoint` | Where to POST for dynamic client registration (RFC 7591) |",
+                "| `scopes_supported` | What scopes the AS recognizes |",
+                "| `grant_types_supported` | What OAuth grant types are available |",
+                "| `token_endpoint_auth_methods_supported` | How clients can authenticate (basic, post) |",
+                "| `code_challenge_methods_supported` | PKCE methods (S256) |",
+                "",
+                "A client only needs to know the server's base URL. Everything else is discovered.",
+        )
+
+        // --- Use client.DiscoverAS ---
+        demo.Step("Discover using the client SDK (client.DiscoverAS)").
+                Ref(demokit.RFC8414).
+                Arrow("App", "AS", "client.DiscoverAS(serverURL)").
+                DashedArrow("AS", "App", "typed ASMetadata struct").
+                Note("client.DiscoverAS() fetches and parses the metadata into a typed Go struct. Production code should use this — no manual JSON parsing needed.").
+                Run(func() </span><span class="cov0" title="0">{
+                        var err error
+                        discoveredMeta, err = client.DiscoverAS(authServer.URL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">fmt.Printf("    issuer:                  %s\n", discoveredMeta.Issuer)
+                        fmt.Printf("    token_endpoint:          %s\n", discoveredMeta.TokenEndpoint)
+                        fmt.Printf("    jwks_uri:                %s\n", discoveredMeta.JWKSURI)
+                        fmt.Printf("    introspection_endpoint:  %s\n", discoveredMeta.IntrospectionEndpoint)
+                        fmt.Printf("    scopes_supported:        %v\n", discoveredMeta.ScopesSupported)
+                        fmt.Printf("    grant_types_supported:   %v\n", discoveredMeta.GrantTypesSupported)
+                        fmt.Printf("    auth_methods:            %v\n", discoveredMeta.TokenEndpointAuthMethods)</span>
+                })
+
+        // --- Register using discovered endpoint ---
+        <span class="cov0" title="0">demo.Step("Register a client (using discovered URL)").
+                Arrow("App", "AS", "POST {discovered_registration_endpoint}").
+                DashedArrow("AS", "App", "{client_id, client_secret}").
+                Note("Instead of hardcoding /apps/register, we use the registration_endpoint from discovery. The same code works against OneAuth, Keycloak, or any RFC 8414-compliant server.").
+                Run(func() </span><span class="cov0" title="0">{
+                        body, _ := json.Marshal(map[string]any{
+                                "client_domain": "discovery-demo.example.com",
+                                "signing_alg":   "HS256",
+                        })
+                        resp, _ := http.Post(authServer.URL+"/apps/register",
+                                "application/json", strings.NewReader(string(body)))
+                        var reg map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;reg)
+                        resp.Body.Close()
+
+                        clientID = reg["client_id"].(string)
+                        clientSecret = reg["client_secret"].(string)
+                        fmt.Printf("    client_id:     %s\n", clientID)
+                        fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
+                }</span>)
+
+        // --- Get token using discovered endpoint ---
+        <span class="cov0" title="0">demo.Step("Get a token (using discovered token endpoint)").
+                Ref(demokit.RFC6749_ClientCredentials).
+                Arrow("App", "AS", "POST {discovered_token_endpoint}").
+                DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
+                Note("We use discoveredMeta.TokenEndpoint instead of hardcoding /api/token. This is the key benefit — the same client code works against any compliant AS.").
+                Run(func() </span><span class="cov0" title="0">{
+                        resp, _ := http.PostForm(discoveredMeta.TokenEndpoint, url.Values{
+                                "grant_type":    {"client_credentials"},
+                                "client_id":     {clientID},
+                                "client_secret": {clientSecret},
+                                "scope":         {"read write"},
+                        })
+                        var tokenData map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;tokenData)
+                        resp.Body.Close()
+
+                        accessToken = tokenData["access_token"].(string)
+                        fmt.Printf("    token_endpoint used: %s\n", discoveredMeta.TokenEndpoint)
+                        fmt.Printf("    token_type:          %s\n", tokenData["token_type"])
+                        fmt.Printf("    scope:               %s\n", tokenData["scope"])
+                        fmt.Printf("    access_token:        %s...\n", accessToken[:40])
+                }</span>)
+
+        // --- Use the token ---
+        <span class="cov0" title="0">demo.Step("Use the token on a resource server").
+                Ref(demokit.RFC6750).
+                Arrow("App", "RS", "GET /resource (Bearer token)").
+                DashedArrow("RS", "App", "200 {data}").
+                Note("The resource server validates the token as in previous examples. Discovery doesn't change how tokens work — it only changes how the client finds the endpoints.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+accessToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d\n", res.StatusCode)
+                        var data map[string]any
+                        json.Unmarshal(body, &amp;data)
+                        pretty, _ := json.MarshalIndent(data, "    ", "  ")
+                        fmt.Printf("    response: %s\n", string(pretty))
+                }</span>)
+
+        // --- Optional: Keycloak comparison ---
+        <span class="cov0" title="0">demo.Step("Discover Keycloak endpoints (optional)").
+                Ref(demokit.RFC8414).
+                Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
+                DashedArrow("AS", "App", "{issuer, token_endpoint, jwks_uri, ...}").
+                Note("Same DiscoverAS() call, completely different server. If Keycloak isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Check if KC is reachable
+                        kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+                        httpClient := &amp;http.Client{Timeout: 2 * time.Second}
+                        resp, err := httpClient.Get(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+                                fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
+                                return
+                        }</span>
+                        <span class="cov0" title="0">resp.Body.Close()
+
+                        kcMeta, err := client.DiscoverAS(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">fmt.Printf("    Keycloak discovered at %s:\n", kcRealmURL)
+                        fmt.Printf("      issuer:           %s\n", kcMeta.Issuer)
+                        fmt.Printf("      token_endpoint:   %s\n", kcMeta.TokenEndpoint)
+                        fmt.Printf("      jwks_uri:         %s\n", kcMeta.JWKSURI)
+                        fmt.Printf("      introspection:    %s\n", kcMeta.IntrospectionEndpoint)
+
+                        fmt.Printf("\n    Side by side — same code, different servers:\n")
+                        fmt.Printf("      %-25s %-45s %s\n", "Field", "OneAuth", "Keycloak")
+                        fmt.Printf("      %-25s %-45s %s\n", "-----", "-------", "--------")
+                        fmt.Printf("      %-25s %-45s %s\n", "token_endpoint",
+                                discoveredMeta.TokenEndpoint, kcMeta.TokenEndpoint)
+                        fmt.Printf("      %-25s %-45s %s\n", "jwks_uri",
+                                discoveredMeta.JWKSURI, kcMeta.JWKSURI)
+                        fmt.Printf("      %-25s %-45s %s\n", "introspection_endpoint",
+                                discoveredMeta.IntrospectionEndpoint, kcMeta.IntrospectionEndpoint)</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("Why discovery matters",
+                "Without discovery, switching auth providers means updating every URL in your code.",
+                "With discovery, you change one base URL and everything else adapts:",
+                "",
+                "```go",
+                "// Works against OneAuth, Keycloak, Auth0 — same code",
+                "meta, _ := client.DiscoverAS(\"https://auth.example.com\")",
+                "http.PostForm(meta.TokenEndpoint, ...)       // discovered",
+                "jwksKS := keys.NewJWKSKeyStore(meta.JWKSURI) // discovered",
+                "```",
+                "",
+                "This is especially important for the [Keycloak interop tests](../../tests/keycloak/)",
+                "where the same test code validates against both Keycloak and OneAuth.",
+        )
+
+        demo.Section("What's next?",
+                "In [05 — Introspection](../05-introspection/), you'll see how resource",
+                "servers can validate tokens remotely by asking the auth server \"is this",
+                "token valid?\" — an alternative to local JWT verification that works even",
+                "for opaque tokens.",
+        )
+
+        demo.Execute()
+
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
+                resourceServer.Close()
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file34" style="display: none">// Example 05: Token Introspection (RFC 7662)
+//
+// In Examples 01-04, the resource server validated tokens locally by checking
+// the JWT signature. That's fast but has a gap: if a token is revoked, the RS
+// won't know until the token expires.
+//
+// Introspection is the alternative: the RS asks the auth server "is this token
+// still valid?" on every request (or with caching). The AS checks its blacklist
+// and returns the token's claims.
+//
+// Run:   go run ./examples/05-introspection/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7662
+package main
+
+import (
+        "encoding/base64"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "net/url"
+        "strings"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/core"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+const kcExampleClientID = "example-app"
+const kcExampleClientSecret = "example-app-secret"
+
+func main() <span class="cov0" title="0">{
+        var authServer *httptest.Server
+        var ks keys.KeyStorage
+        var blacklist *core.InMemoryBlacklist
+        var clientID, clientSecret, accessToken string
+        var tokenJTI string
+
+        demo := demokit.New("05: Token Introspection").
+                Dir("05-introspection").
+                Description("Non-UI | No infrastructure needed | Builds on Example 04").
+                Actors(
+                        demokit.Actor("App", "Client App"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** App, Auth Server (AS), Resource Server (RS).",
+                "Think: Slack's API asks Slack's identity service \"is this bot's token still valid?\"",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "In Examples 01-04, the resource server validated JWTs locally — fast, but",
+                "it can't detect revoked tokens until they expire.",
+                "",
+                "Token introspection (RFC 7662) is the alternative: the RS sends the token",
+                "to the AS's introspection endpoint and gets back `{active: true/false}` plus",
+                "the token's claims. The AS checks its blacklist before responding.",
+                "",
+                "**When to use which:**",
+                "| Method | Speed | Revocation | Use when |",
+                "|--------|-------|-----------|----------|",
+                "| Local JWT validation | Fast (no network) | Not immediate | Most requests, short-lived tokens |",
+                "| Introspection | Slower (HTTP call) | Immediate | Sensitive ops, long-lived tokens, revocation needed |",
+                "| Both (hybrid) | Best of both | Immediate | Validate locally, introspect on failure or for critical ops |",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server with token endpoint, introspection, and blacklist").
+                Ref(demokit.RFC7662).
+                Note("The auth server now has a blacklist for token revocation. The introspection endpoint checks it before responding.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        blacklist = core.NewInMemoryBlacklist()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+                        apiAuth := &amp;apiauth.APIAuth{
+                                JWTSecretKey:   "introspection-example-secret-32c!",
+                                JWTIssuer:      "will-be-set-after-start",
+                                ClientKeyStore: ks,
+                                Blacklist:      blacklist,
+                        }
+
+                        introspectionHandler := &amp;apiauth.IntrospectionHandler{
+                                Auth:           apiAuth,
+                                ClientKeyStore: ks,
+                        }
+
+                        mux := http.NewServeMux()
+                        mux.Handle("/apps/", registrar.Handler())
+                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+                        mux.Handle("POST /oauth/introspect", introspectionHandler)
+                        authServer = httptest.NewServer(mux)
+                        apiAuth.JWTIssuer = authServer.URL
+
+                        fmt.Printf("    Auth server:            %s\n", authServer.URL)
+                        fmt.Printf("    Token endpoint:         %s/api/token\n", authServer.URL)
+                        fmt.Printf("    Introspection endpoint: %s/oauth/introspect\n", authServer.URL)
+                }</span>)
+
+        // --- Register + get token ---
+        <span class="cov0" title="0">demo.Step("Register a client and get an access token").
+                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(demokit.RFC7519).
+                Arrow("App", "AS", "POST /apps/register → POST /api/token").
+                DashedArrow("AS", "App", "{client_id, client_secret, access_token}").
+                Note("Same as Example 01 — register, then client_credentials grant. The token includes a jti (JWT ID) claim used for revocation.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Register
+                        body, _ := json.Marshal(map[string]any{
+                                "client_domain": "introspect-demo.example.com",
+                                "signing_alg":   "HS256",
+                        })
+                        regResp, _ := http.Post(authServer.URL+"/apps/register",
+                                "application/json", strings.NewReader(string(body)))
+                        var reg map[string]any
+                        json.NewDecoder(regResp.Body).Decode(&amp;reg)
+                        regResp.Body.Close()
+                        clientID = reg["client_id"].(string)
+                        clientSecret = reg["client_secret"].(string)
+
+                        // Get token
+                        tokenResp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+                                "grant_type":    {"client_credentials"},
+                                "client_id":     {clientID},
+                                "client_secret": {clientSecret},
+                                "scope":         {"read write"},
+                        })
+                        var tokenData map[string]any
+                        json.NewDecoder(tokenResp.Body).Decode(&amp;tokenData)
+                        tokenResp.Body.Close()
+                        accessToken = tokenData["access_token"].(string)
+
+                        // Parse jti from the token for later revocation
+                        claims := parseJWTClaims(accessToken)
+                        tokenJTI = claims["jti"].(string)
+
+                        fmt.Printf("    client_id:    %s\n", clientID)
+                        fmt.Printf("    access_token: %s...\n", accessToken[:40])
+                        fmt.Printf("    jti:          %s...\n", tokenJTI[:16])
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("How introspection works",
+                "The resource server POSTs the token to `/oauth/introspect` and authenticates",
+                "itself with HTTP Basic auth (its own client_id + secret). The AS:",
+                "",
+                "1. Authenticates the caller (is this a registered resource server?)",
+                "2. Validates the token (signature, expiry)",
+                "3. Checks the blacklist (has this token been revoked?)",
+                "4. Returns `{active: true, sub, scope, exp, ...}` or `{active: false}`",
+                "",
+                "**Security:** The introspection endpoint never reveals *why* a token is invalid.",
+                "Expired, revoked, malformed — all return `{active: false}`. This prevents",
+                "information leakage to potentially malicious callers.",
+        )
+
+        // --- Introspect valid token ---
+        demo.Step("Introspect a valid token").
+                Ref(demokit.RFC7662).
+                Arrow("RS", "AS", "POST /oauth/introspect {token} (Basic auth)").
+                DashedArrow("AS", "RS", "{active: true, sub, scope, exp, iss, jti}").
+                Note("The RS authenticates with its own credentials (same client in this example). The response includes the token's claims — the RS doesn't need to decode the JWT itself.").
+                Run(func() </span><span class="cov0" title="0">{
+                        result := introspect(authServer.URL+"/oauth/introspect", accessToken, clientID, clientSecret)
+                        pretty, _ := json.MarshalIndent(result, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+                }</span>)
+
+        // --- Introspect garbage ---
+        <span class="cov0" title="0">demo.Step("Introspect a garbage token").
+                Ref(demokit.RFC7662).
+                Arrow("RS", "AS", "POST /oauth/introspect {token: not-a-real-token}").
+                DashedArrow("AS", "RS", "{active: false}").
+                Note("Invalid tokens always return {active: false} — the AS never reveals why. This is a security requirement of RFC 7662.").
+                Run(func() </span><span class="cov0" title="0">{
+                        result := introspect(authServer.URL+"/oauth/introspect", "not-a-real-token", clientID, clientSecret)
+                        pretty, _ := json.MarshalIndent(result, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+                }</span>)
+
+        // --- Revoke and re-introspect ---
+        <span class="cov0" title="0">demo.Step("Revoke the token, then introspect again").
+                Ref(demokit.RFC7662).
+                Arrow("Admin", "AS", "blacklist.Revoke(jti)").
+                Arrow("RS", "AS", "POST /oauth/introspect {same token as step 3}").
+                DashedArrow("AS", "RS", "{active: false}").
+                Note("After revocation, the same token that was valid in step 3 now returns active=false. This is the key advantage over local JWT validation — revocation takes effect immediately.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Revoke via blacklist
+                        claims := parseJWTClaims(accessToken)
+                        expFloat := claims["exp"].(float64)
+                        blacklist.Revoke(tokenJTI, time.Unix(int64(expFloat), 0))
+                        fmt.Printf("    Revoked jti=%s...\n\n", tokenJTI[:16])
+
+                        // Introspect again
+                        result := introspect(authServer.URL+"/oauth/introspect", accessToken, clientID, clientSecret)
+                        pretty, _ := json.MarshalIndent(result, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+                }</span>)
+
+        // --- Unauthenticated caller ---
+        <span class="cov0" title="0">demo.Step("Introspect without authentication (rejected)").
+                Ref(demokit.RFC7662).
+                Arrow("Attacker", "AS", "POST /oauth/introspect {token} (no Basic auth)").
+                DashedArrow("AS", "Attacker", "401 Unauthorized").
+                Note("The introspection endpoint requires the caller to authenticate. An unauthenticated request is rejected — you can't fish for valid tokens.").
+                Run(func() </span><span class="cov0" title="0">{
+                        form := url.Values{"token": {accessToken}}
+                        req, _ := http.NewRequest("POST", authServer.URL+"/oauth/introspect",
+                                strings.NewReader(form.Encode()))
+                        req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+                        // No Basic auth!
+                        resp, _ := http.DefaultClient.Do(req)
+                        resp.Body.Close()
+                        fmt.Printf("    status: %d (correctly rejected — no authentication)\n", resp.StatusCode)
+                }</span>)
+
+        // --- Optional: Keycloak introspection ---
+        <span class="cov0" title="0">demo.Step("Introspect via Keycloak (optional)").
+                Ref(demokit.RFC7662).
+                Arrow("App", "AS", "POST {KC token_endpoint} → get KC token").
+                Arrow("RS", "AS", "POST {KC introspection_endpoint} {token}").
+                DashedArrow("AS", "RS", "{active: true, sub, scope, ...}").
+                Note("Same introspection flow against Keycloak. If KC isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Check if KC is reachable
+                        kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+                        httpClient := &amp;http.Client{Timeout: 2 * time.Second}
+                        resp, err := httpClient.Get(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+                                fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
+                                return
+                        }</span>
+                        <span class="cov0" title="0">resp.Body.Close()
+
+                        // Discover KC endpoints
+                        kcMeta, err := client.DiscoverAS(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
+                                return
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    Keycloak introspection endpoint: %s\n\n", kcMeta.IntrospectionEndpoint)
+
+                        // Get a token from KC
+                        kcTokenResp, _ := http.PostForm(kcMeta.TokenEndpoint, url.Values{
+                                "grant_type":    {"client_credentials"},
+                                "client_id":     {kcExampleClientID},
+                                "client_secret": {kcExampleClientSecret},
+                                "scope":         {"openid"},
+                        })
+                        var kcToken map[string]any
+                        json.NewDecoder(kcTokenResp.Body).Decode(&amp;kcToken)
+                        kcTokenResp.Body.Close()
+
+                        if kcToken["error"] != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR getting KC token: %v\n", kcToken["error_description"])
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">kcAccessToken := kcToken["access_token"].(string)
+                        fmt.Printf("    KC access_token: %s...\n\n", kcAccessToken[:40])
+
+                        // Introspect via KC
+                        kcResult := introspect(kcMeta.IntrospectionEndpoint,
+                                kcAccessToken, kcExampleClientID, kcExampleClientSecret)
+                        pretty, _ := json.MarshalIndent(kcResult, "    ", "  ")
+                        fmt.Printf("    KC introspection response:\n    %s\n", string(pretty))</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("Introspection vs local validation — the tradeoff",
+                "```",
+                "Local JWT validation:     RS checks signature locally",
+                "  + No network call        ← fast",
+                "  + Works offline          ← resilient",
+                "  - Can't detect revocation until token expires",
+                "",
+                "Introspection:            RS asks AS on every request",
+                "  + Revocation is immediate",
+                "  + Works with opaque (non-JWT) tokens",
+                "  - Adds latency (HTTP round-trip)",
+                "  - AS becomes a dependency",
+                "",
+                "Hybrid (production pattern):",
+                "  1. Validate JWT locally first (fast path)",
+                "  2. If local validation fails, fall back to introspection",
+                "  3. For critical operations, always introspect",
+                "```",
+                "",
+                "OneAuth's `APIMiddleware` supports the hybrid model via the `Introspection`",
+                "field — set it to enable automatic fallback to introspection.",
+        )
+
+        demo.Section("What's next?",
+                "In [06 — Dynamic Client Registration](../06-dynamic-client-registration/),",
+                "you'll see how apps can register themselves programmatically via RFC 7591 —",
+                "no admin dashboard needed. This is how third-party integrations onboard.",
+        )
+
+        demo.Execute()
+
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+}
+
+// --- Helpers ---
+
+// introspect calls an introspection endpoint and returns the parsed response.
+// endpointURL is the full introspection URL (e.g., "http://localhost:8080/oauth/introspect").
+func introspect(endpointURL, token, callerID, callerSecret string) map[string]any <span class="cov0" title="0">{
+        form := url.Values{"token": {token}}
+        req, _ := http.NewRequest("POST", endpointURL,
+                strings.NewReader(form.Encode()))
+        req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+        req.SetBasicAuth(callerID, callerSecret)
+
+        resp, _ := http.DefaultClient.Do(req)
+        defer resp.Body.Close()
+        body, _ := io.ReadAll(resp.Body)
+
+        var result map[string]any
+        json.Unmarshal(body, &amp;result)
+        return result
+}</span>
+
+// parseJWTClaims decodes JWT payload without verification (for display only).
+func parseJWTClaims(tokenStr string) map[string]any <span class="cov0" title="0">{
+        parts := strings.Split(tokenStr, ".")
+        if len(parts) != 3 </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        // JWT uses base64url (no padding)
+        <span class="cov0" title="0">payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+        if err != nil </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        <span class="cov0" title="0">var claims map[string]any
+        json.Unmarshal(payload, &amp;claims)
+        return claims</span>
+}
+</pre>
+		
+		<pre class="file" id="file35" style="display: none">// Example 06: Dynamic Client Registration (RFC 7591)
+//
+// In Examples 01-05, we registered apps via OneAuth's proprietary /apps/register
+// endpoint. That works but is OneAuth-specific. RFC 7591 defines a standard way
+// for clients to register themselves — the same API works across OneAuth,
+// Keycloak, Auth0, and any compliant provider.
+//
+// Run:   go run ./examples/06-dynamic-client-registration/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7591
+package main
+
+import (
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "net/url"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+        "github.com/panyam/oneauth/utils"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+
+func main() <span class="cov0" title="0">{
+        var authServer *httptest.Server
+        var ks keys.KeyStorage
+        var symClientID, symClientSecret string
+        var asymClientID string
+
+        demo := demokit.New("06: Dynamic Client Registration").
+                Dir("06-dynamic-client-registration").
+                Description("Non-UI | No infrastructure needed | Builds on Example 04").
+                Actors(
+                        demokit.Actor("App", "New App"),
+                        demokit.Actor("AS", "Auth Server"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** App (a new third-party integration), Auth Server (AS).",
+                "Think: a developer builds a new Slack bot and registers it via API — no admin dashboard needed.",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "In Examples 01-05, we registered via `/apps/register` — OneAuth's proprietary",
+                "endpoint. RFC 7591 defines a standard registration API that works across providers:",
+                "",
+                "| Endpoint | Standard | Works with |",
+                "|----------|----------|-----------|",
+                "| `/apps/register` | OneAuth proprietary | OneAuth only |",
+                "| `/apps/dcr` | RFC 7591 | OneAuth, Keycloak, Auth0, any compliant AS |",
+                "",
+                "DCR lets apps self-register by posting their metadata (name, redirect URIs,",
+                "grant types, auth method). The AS creates the client and returns credentials.",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server with DCR endpoint").
+                Ref(demokit.RFC7591).
+                Ref(demokit.RFC8414).
+                Note("The auth server serves /apps/dcr (RFC 7591) alongside the proprietary /apps/register. Both create clients in the same KeyStore.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+                        apiAuth := &amp;apiauth.APIAuth{
+                                JWTSecretKey:   "dcr-example-secret-at-least-32ch!",
+                                ClientKeyStore: ks,
+                        }
+
+                        mux := http.NewServeMux()
+                        mux.Handle("/apps/", registrar.Handler()) // includes /apps/dcr
+                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+                        mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+                        authServer = httptest.NewServer(mux)
+                        apiAuth.JWTIssuer = authServer.URL
+
+                        mux.Handle("GET /.well-known/openid-configuration",
+                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                                        Issuer:                   authServer.URL,
+                                        TokenEndpoint:            authServer.URL + "/api/token",
+                                        JWKSURI:                  authServer.URL + "/.well-known/jwks.json",
+                                        RegistrationEndpoint:     authServer.URL + "/apps/dcr",
+                                        GrantTypesSupported:      []string{"client_credentials"},
+                                        TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},
+                                }))
+
+                        fmt.Printf("    Auth server:    %s\n", authServer.URL)
+                        fmt.Printf("    DCR endpoint:   %s/apps/dcr\n", authServer.URL)
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("DCR request format (RFC 7591 §2)",
+                "A DCR request is a JSON object with client metadata:",
+                "```json",
+                "{",
+                "  \"client_name\": \"My Bot\",",
+                "  \"client_uri\": \"https://mybot.example.com\",",
+                "  \"grant_types\": [\"client_credentials\"],",
+                "  \"token_endpoint_auth_method\": \"client_secret_post\",",
+                "  \"scope\": \"read write\"",
+                "}",
+                "```",
+                "",
+                "The AS responds with the registered client metadata plus generated credentials:",
+                "```json",
+                "{",
+                "  \"client_id\": \"app_abc123...\",",
+                "  \"client_secret\": \"7f3e8a...\",",
+                "  \"client_id_issued_at\": 1700000000,",
+                "  \"client_name\": \"My Bot\",",
+                "  \"token_endpoint_auth_method\": \"client_secret_post\"",
+                "}",
+                "```",
+        )
+
+        // --- Symmetric registration ---
+        demo.Step("Register a symmetric client (client_secret_post)").
+                Ref(demokit.RFC7591).
+                Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, auth_method}").
+                DashedArrow("AS", "App", "{client_id, client_secret, client_id_issued_at}").
+                Note("The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.").
+                Run(func() </span><span class="cov0" title="0">{
+                        dcrReq := map[string]any{
+                                "client_name":                "My Example Bot",
+                                "client_uri":                 "https://bot.example.com",
+                                "grant_types":                []string{"client_credentials"},
+                                "token_endpoint_auth_method": "client_secret_post",
+                                "scope":                      "read write",
+                        }
+                        body, _ := json.Marshal(dcrReq)
+
+                        resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+                                bytes.NewReader(body))
+                        respBody, _ := io.ReadAll(resp.Body)
+                        resp.Body.Close()
+
+                        fmt.Printf("    HTTP status: %d\n\n", resp.StatusCode)
+
+                        var dcrResp map[string]any
+                        json.Unmarshal(respBody, &amp;dcrResp)
+                        pretty, _ := json.MarshalIndent(dcrResp, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+
+                        symClientID = dcrResp["client_id"].(string)
+                        symClientSecret = dcrResp["client_secret"].(string)
+                }</span>)
+
+        // --- Use the registered client ---
+        <span class="cov0" title="0">demo.Step("Get a token with the DCR-registered client").
+                Ref(demokit.RFC6749_ClientCredentials).
+                Arrow("App", "AS", "POST /api/token {client_id, client_secret from DCR}").
+                DashedArrow("AS", "App", "{access_token}").
+                Note("The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.").
+                Run(func() </span><span class="cov0" title="0">{
+                        tokenResp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+                                "grant_type":    {"client_credentials"},
+                                "client_id":     {symClientID},
+                                "client_secret": {symClientSecret},
+                                "scope":         {"read"},
+                        })
+                        var tokenData map[string]any
+                        json.NewDecoder(tokenResp.Body).Decode(&amp;tokenData)
+                        tokenResp.Body.Close()
+
+                        fmt.Printf("    token_type:    %s\n", tokenData["token_type"])
+                        fmt.Printf("    scope:         %s\n", tokenData["scope"])
+                        fmt.Printf("    access_token:  %s...\n", tokenData["access_token"].(string)[:40])
+                }</span>)
+
+        // --- Asymmetric registration ---
+        <span class="cov0" title="0">demo.Step("Register an asymmetric client (private_key_jwt with JWKS)").
+                Ref(demokit.RFC7591).
+                Ref(demokit.RFC7517).
+                Arrow("App", "AS", "POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}").
+                DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
+                Note("For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.").
+                Run(func() </span><span class="cov0" title="0">{
+                        _, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
+                        pubKey, _ := utils.ParsePublicKeyPEM(pubPEM)
+                        kid, _ := utils.ComputeKid(pubKey, "RS256")
+                        jwk, _ := utils.PublicKeyToJWK(kid, "RS256", pubKey)
+
+                        dcrReq := map[string]any{
+                                "client_name":                "My Secure Service",
+                                "grant_types":                []string{"client_credentials"},
+                                "token_endpoint_auth_method": "private_key_jwt",
+                                "jwks":                       map[string]any{"keys": []any{jwk}},
+                        }
+                        body, _ := json.Marshal(dcrReq)
+
+                        resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+                                bytes.NewReader(body))
+                        respBody, _ := io.ReadAll(resp.Body)
+                        resp.Body.Close()
+
+                        fmt.Printf("    HTTP status: %d\n\n", resp.StatusCode)
+
+                        var dcrResp map[string]any
+                        json.Unmarshal(respBody, &amp;dcrResp)
+                        pretty, _ := json.MarshalIndent(dcrResp, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+
+                        asymClientID = dcrResp["client_id"].(string)
+                        hasSecret := dcrResp["client_secret"] != nil &amp;&amp; dcrResp["client_secret"] != ""
+                        fmt.Printf("\n    client_id:     %s\n", asymClientID)
+                        fmt.Printf("    client_secret: %v (asymmetric — no secret needed)\n", hasSecret)
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("Symmetric vs asymmetric DCR",
+                "| | client_secret_post / basic | private_key_jwt |",
+                "|---|---|---|",
+                "| **DCR sends** | Just metadata | Metadata + JWKS (public key) |",
+                "| **AS returns** | client_id + client_secret | client_id only (no secret) |",
+                "| **Token auth** | Send secret in request | Sign a JWT with private key |",
+                "| **Key in JWKS** | Not in JWKS (secret) | Public key served in JWKS |",
+                "| **Best for** | Simple integrations | High-security, multi-service |",
+        )
+
+        // --- Optional: Keycloak DCR ---
+        demo.Step("Register via Keycloak DCR (optional)").
+                Ref(demokit.RFC7591).
+                Arrow("App", "AS", "POST {KC registration_endpoint} {client_name, grant_types}").
+                DashedArrow("AS", "App", "{client_id, client_secret, registration_access_token}").
+                Note("Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.").
+                Run(func() </span><span class="cov0" title="0">{
+                        kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+                        httpClient := &amp;http.Client{Timeout: 2 * time.Second}
+                        resp, err := httpClient.Get(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+                                fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
+                                return
+                        }</span>
+                        <span class="cov0" title="0">resp.Body.Close()
+
+                        // Discover KC registration endpoint
+                        kcMeta, err := client.DiscoverAS(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">if kcMeta.RegistrationEndpoint == "" </span><span class="cov0" title="0">{
+                                fmt.Printf("    SKIPPED: Keycloak does not advertise a registration_endpoint\n")
+                                fmt.Printf("    (KC may need 'registrationAllowed' enabled on the realm)\n")
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">fmt.Printf("    KC registration endpoint: %s\n\n", kcMeta.RegistrationEndpoint)
+
+                        dcrReq := map[string]any{
+                                "client_name": "Example Bot (from OneAuth demo)",
+                                "grant_types": []string{"client_credentials"},
+                        }
+                        body, _ := json.Marshal(dcrReq)
+
+                        dcrResp, _ := http.Post(kcMeta.RegistrationEndpoint, "application/json",
+                                bytes.NewReader(body))
+                        dcrBody, _ := io.ReadAll(dcrResp.Body)
+                        dcrResp.Body.Close()
+
+                        fmt.Printf("    HTTP status: %d\n", dcrResp.StatusCode)
+                        var kcDCR map[string]any
+                        json.Unmarshal(dcrBody, &amp;kcDCR)
+                        pretty, _ := json.MarshalIndent(kcDCR, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("What's next?",
+                "In [07 — Client SDK](../07-client-sdk/), you'll see production patterns:",
+                "automatic token caching, background refresh, scope step-up, and discovery-driven",
+                "configuration — all wrapped in a simple `TokenSource` interface.",
+        )
+
+        demo.Execute()
+
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file36" style="display: none">// Example 07: Client SDK — Production Patterns
+//
+// Examples 01-06 showed the server side and raw HTTP calls. This example shows
+// how production client code works: discovery-driven configuration, automatic
+// token caching/refresh, and scope step-up — all via OneAuth's client SDK.
+//
+// Run:   go run ./examples/07-client-sdk/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+package main
+
+import (
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+const kcExamplesURL = "http://localhost:8280"
+const kcExamplesRealm = "oneauth-examples"
+const kcExampleClientID = "example-app"
+const kcExampleClientSecret = "example-app-secret"
+
+func main() <span class="cov0" title="0">{
+        var authServer, resourceServer *httptest.Server
+        var registeredClientID, registeredSecret string
+        var tokenSource *client.ClientCredentialsSource
+
+        demo := demokit.New("07: Client SDK — Production Patterns").
+                Dir("07-client-sdk").
+                Description("Non-UI | No infrastructure needed | Builds on Examples 01-06").
+                Actors(
+                        demokit.Actor("App", "Client App (SDK)"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** App (using the client SDK), Auth Server (AS), Resource Server (RS).",
+                "Think: the GitHub bot in production — not making raw HTTP calls, but using a library.",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "In Examples 01-06, we made raw `http.Post` calls to the token endpoint.",
+                "That works for learning, but production code needs:",
+                "- **Discovery** — don't hardcode URLs (Example 04)",
+                "- **Token caching** — don't fetch a new token on every request",
+                "- **Auto-refresh** — renew tokens before they expire",
+                "- **Scope step-up** — request additional scopes when needed",
+                "",
+                "OneAuth's client SDK wraps all of this in a `TokenSource` interface:",
+                "```go",
+                "token, err := tokenSource.Token()  // cached, auto-refreshed",
+                "```",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server and resource server").
+                Note("Same auth server as previous examples. We also pre-register a client since the SDK focuses on token acquisition, not registration.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks := keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+                        apiAuth := &amp;apiauth.APIAuth{
+                                JWTSecretKey:   "sdk-example-secret-at-least-32ch!",
+                                ClientKeyStore: ks,
+                        }
+
+                        mux := http.NewServeMux()
+                        mux.Handle("/apps/", registrar.Handler())
+                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+                        authServer = httptest.NewServer(mux)
+                        apiAuth.JWTIssuer = authServer.URL
+
+                        mux.Handle("GET /.well-known/openid-configuration",
+                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                                        Issuer:                   authServer.URL,
+                                        TokenEndpoint:            authServer.URL + "/api/token",
+                                        GrantTypesSupported:      []string{"client_credentials"},
+                                        TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic"},
+                                }))
+
+                        // Resource server
+                        middleware := &amp;apiauth.APIMiddleware{
+                                JWTSecretKey: "sdk-example-secret-at-least-32ch!",
+                                JWTIssuer:    authServer.URL,
+                        }
+                        resMux := http.NewServeMux()
+                        resMux.Handle("GET /resource", middleware.ValidateToken(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+                                                "scopes": apiauth.GetScopesFromAPIContext(r.Context()),
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
+
+                        // Pre-register a client
+                        resp := postJSON(authServer.URL+"/apps/register", map[string]any{
+                                "client_domain": "sdk-demo.example.com",
+                                "signing_alg":   "HS256",
+                        })
+                        registeredClientID = resp["client_id"].(string)
+                        registeredSecret = resp["client_secret"].(string)
+
+                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
+                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+                        fmt.Printf("    Client ID:       %s\n", registeredClientID)</span>
+                })
+
+        // --- One-shot token ---
+        <span class="cov0" title="0">demo.Step("One-shot token with AuthClient").
+                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(demokit.RFC8414).
+                Arrow("App", "AS", "client.DiscoverAS(serverURL)").
+                Arrow("App", "AS", "authClient.ClientCredentialsToken(id, secret, scopes)").
+                DashedArrow("AS", "App", "ServerCredential{AccessToken, ExpiresAt, Scope}").
+                Note("AuthClient is the low-level SDK: discover endpoints, then make a single token request. Good for one-off calls. Uses discovery to find the token endpoint automatically.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Discover + create client
+                        meta, _ := client.DiscoverAS(authServer.URL)
+                        authClient := client.NewAuthClient(authServer.URL, nil,
+                                client.WithASMetadata(meta))
+
+                        cred, err := authClient.ClientCredentialsToken(
+                                registeredClientID, registeredSecret, []string{"read"})
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">fmt.Printf("    access_token: %s...\n", cred.AccessToken[:40])
+                        fmt.Printf("    scope:        %s\n", cred.Scope)
+                        fmt.Printf("    expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("AuthClient vs ClientCredentialsSource",
+                "| | AuthClient | ClientCredentialsSource |",
+                "|---|---|---|",
+                "| **Use case** | One-shot token requests | Long-running services |",
+                "| **Caching** | None — new request every time | Automatic — reuses valid tokens |",
+                "| **Refresh** | Manual | Automatic (on next Token() call) |",
+                "| **Interface** | `ClientCredentialsToken()` | `Token() string` (TokenSource) |",
+                "| **Scope step-up** | Manual | `TokenForScopes()` |",
+        )
+
+        // --- TokenSource with caching ---
+        demo.Step("Cached token with ClientCredentialsSource").
+                Ref(demokit.RFC6749_ClientCredentials).
+                Arrow("App", "App", "tokenSource.Token() → cached or fetched").
+                Arrow("App", "RS", "GET /resource (Bearer: cached token)").
+                DashedArrow("RS", "App", "200 {data}").
+                Note("ClientCredentialsSource implements TokenSource: Token() returns a cached token if still valid, or fetches a new one. Multiple goroutines can safely call Token() concurrently.").
+                Run(func() </span><span class="cov0" title="0">{
+                        tokenSource = &amp;client.ClientCredentialsSource{
+                                TokenEndpoint: authServer.URL + "/api/token",
+                                ClientID:      registeredClientID,
+                                ClientSecret:  registeredSecret,
+                                Scopes:        []string{"read"},
+                        }
+
+                        // First call: fetches a new token
+                        token1, err := tokenSource.Token()
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    First call:  %s... (fetched)\n", token1[:40])
+
+                        // Second call: returns cached token (no HTTP call)
+                        token2, _ := tokenSource.Token()
+                        fmt.Printf("    Second call: %s... (cached)\n", token2[:40])
+                        fmt.Printf("    Same token:  %v\n", token1 == token2)
+
+                        // Use the token on a resource server
+                        req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
+                        req.Header.Set("Authorization", "Bearer "+token1)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    Resource:    %d %s\n", res.StatusCode, string(body))</span>
+                })
+
+        // --- Scope step-up ---
+        <span class="cov0" title="0">demo.Step("Scope step-up with TokenForScopes").
+                Arrow("App", "App", "tokenSource.TokenForScopes([\"write\"])").
+                Arrow("App", "AS", "POST /api/token {scope: read write} (merged)").
+                DashedArrow("AS", "App", "new token with expanded scopes").
+                Note("When your app needs additional permissions, TokenForScopes merges the new scopes with existing ones, invalidates the cache, and fetches a fresh token.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Original token has "read" only
+                        oldToken, _ := tokenSource.Token()
+                        fmt.Printf("    Before step-up: %s...\n", oldToken[:40])
+
+                        // Step up to include "write"
+                        newToken, err := tokenSource.TokenForScopes([]string{"write"})
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    After step-up:  %s...\n", newToken[:40])
+                        fmt.Printf("    Different token: %v (cache was invalidated)\n", oldToken != newToken)</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("TokenSource in practice",
+                "The `TokenSource` interface (`Token() (string, error)`) is designed to",
+                "plug into HTTP clients, gRPC interceptors, or any code that needs a token:",
+                "",
+                "```go",
+                "// Create once, reuse everywhere",
+                "ts := &amp;client.ClientCredentialsSource{",
+                "    TokenEndpoint: meta.TokenEndpoint,",
+                "    ClientID:      \"my-app\",",
+                "    ClientSecret:  \"my-secret\",",
+                "    Scopes:        []string{\"read\"},",
+                "}",
+                "",
+                "// In your HTTP client middleware",
+                "token, _ := ts.Token()  // fast: returns cached token",
+                "req.Header.Set(\"Authorization\", \"Bearer \" + token)",
+                "```",
+                "",
+                "The interface matches `mcpkit/core.TokenSource` by structural typing —",
+                "no cross-module import needed.",
+        )
+
+        // --- Optional: Keycloak ---
+        demo.Step("Use the SDK against Keycloak (optional)").
+                Ref(demokit.RFC8414).
+                Ref(demokit.RFC6749_ClientCredentials).
+                Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
+                Arrow("App", "AS", "authClient.ClientCredentialsToken(...)").
+                DashedArrow("AS", "App", "ServerCredential from Keycloak").
+                Note("Same SDK code, pointed at Keycloak. DiscoverAS finds the KC token endpoint automatically. If KC isn't running, this step is skipped.").
+                Run(func() </span><span class="cov0" title="0">{
+                        kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
+                        httpClient := &amp;http.Client{Timeout: 2 * time.Second}
+                        resp, err := httpClient.Get(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
+                                fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
+                                return
+                        }</span>
+                        <span class="cov0" title="0">resp.Body.Close()
+
+                        // Discover KC
+                        kcMeta, err := client.DiscoverAS(kcRealmURL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR discovering KC: %v\n", err)
+                                return
+                        }</span>
+
+                        // Use AuthClient against KC
+                        <span class="cov0" title="0">kcClient := client.NewAuthClient(kcRealmURL, nil,
+                                client.WithASMetadata(kcMeta))
+                        cred, err := kcClient.ClientCredentialsToken(
+                                kcExampleClientID, kcExampleClientSecret, []string{"openid"})
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR getting KC token: %v\n", err)
+                                return
+                        }</span>
+
+                        <span class="cov0" title="0">fmt.Printf("    KC access_token: %s...\n", cred.AccessToken[:40])
+                        fmt.Printf("    KC scope:        %s\n", cred.Scope)
+                        fmt.Printf("    KC expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))
+                        fmt.Printf("\n    Same SDK code — different server. That's the point.\n")</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("What's next?",
+                "In [08 — Rich Authorization Requests](../08-rich-authorization-requests/),",
+                "you'll see how to go beyond flat scopes: request fine-grained permissions",
+                "like \"transfer 45 EUR to Merchant A\" using RFC 9396.",
+        )
+
+        demo.Execute()
+
+        if tokenSource != nil </span><span class="cov0" title="0">{
+                tokenSource.Close()
+        }</span>
+        <span class="cov0" title="0">if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
+                resourceServer.Close()
+        }</span>
+}
+
+// postJSON is a helper that POSTs JSON and returns the decoded response.
+func postJSON(url string, body any) map[string]any <span class="cov0" title="0">{
+        data, _ := json.Marshal(body)
+        resp, _ := http.Post(url, "application/json", bytes.NewReader(data))
+        defer resp.Body.Close()
+        var result map[string]any
+        json.NewDecoder(resp.Body).Decode(&amp;result)
+        return result
+}</span>
+</pre>
+		
+		<pre class="file" id="file37" style="display: none">// Example 08: Rich Authorization Requests (RFC 9396)
+//
+// This is the culmination of Examples 01-07. Flat scopes like "read" and "write"
+// can't express "transfer 45 EUR to Merchant A". RFC 9396 adds structured
+// authorization_details to OAuth — fine-grained, typed, with API-specific fields.
+//
+// This is the feature that motivated this entire PR — driven by a banking client
+// evaluating OneAuth for transaction-level authorization.
+//
+// Run:   go run ./examples/08-rich-authorization-requests/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+package main
+
+import (
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "net/url"
+        "strings"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+const rarIssuerURL = "http://localhost:8181"
+
+func main() <span class="cov0" title="0">{
+        var authServer, paymentsRS, accountsRS *httptest.Server
+        var ks keys.KeyStorage
+        var clientID, clientSecret string
+        var paymentToken string
+
+        demo := demokit.New("08: Rich Authorization Requests (RFC 9396)").
+                Dir("08-rich-authorization-requests").
+                Description("Non-UI | No infrastructure needed | Builds on all previous examples").
+                Actors(
+                        demokit.Actor("App", "Banking App"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("Pay", "Payments API"),
+                        demokit.Actor("Acct", "Accounts API"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** Banking App, Auth Server (AS), Payments API (RS), Accounts API (RS).",
+                "Think: a fintech app that needs to initiate a specific payment — not just \"access payments\".",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "**The problem with scopes:**",
+                "```",
+                "scope=payments              ← \"can do anything with payments\" (too broad)",
+                "scope=payments:initiate     ← better, but can't express amount/recipient",
+                "scope=payments:initiate:45EUR:merchant-a  ← this is getting silly",
+                "```",
+                "",
+                "**RFC 9396 solution — authorization_details:**",
+                "```json",
+                "{",
+                "  \"type\": \"payment_initiation\",",
+                "  \"actions\": [\"initiate\"],",
+                "  \"instructedAmount\": {\"currency\": \"EUR\", \"amount\": \"45.00\"},",
+                "  \"creditorName\": \"Merchant A\"",
+                "}",
+                "```",
+                "",
+                "Structured, typed, with API-specific extension fields. This is what banks,",
+                "fintechs, and any regulated industry needs.",
+        )
+
+        // --- Setup ---
+        demo.Step("Start auth server with RAR support + two resource servers").
+                Ref(demokit.RFC9396).
+                Ref(demokit.RFC8414).
+                Note("The auth server advertises authorization_details_types_supported in its discovery document. Two resource servers enforce different authorization types.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+                        apiAuth := &amp;apiauth.APIAuth{
+                                JWTSecretKey:   "rar-example-secret-at-least-32ch!",
+                                ClientKeyStore: ks,
+                        }
+
+                        introspection := &amp;apiauth.IntrospectionHandler{
+                                Auth:           apiAuth,
+                                ClientKeyStore: ks,
+                        }
+
+                        mux := http.NewServeMux()
+                        mux.Handle("/apps/", registrar.Handler())
+                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+                        mux.Handle("POST /oauth/introspect", introspection)
+                        authServer = httptest.NewServer(mux)
+                        apiAuth.JWTIssuer = authServer.URL
+
+                        mux.Handle("GET /.well-known/openid-configuration",
+                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                                        Issuer:                             authServer.URL,
+                                        TokenEndpoint:                      authServer.URL + "/api/token",
+                                        IntrospectionEndpoint:              authServer.URL + "/oauth/introspect",
+                                        GrantTypesSupported:                []string{"client_credentials"},
+                                        TokenEndpointAuthMethods:           []string{"client_secret_post", "client_secret_basic"},
+                                        AuthorizationDetailsTypesSupported: []string{"payment_initiation", "account_information"},
+                                }))
+
+                        // Payments resource server — requires payment_initiation type
+                        payMW := &amp;apiauth.APIMiddleware{
+                                JWTSecretKey: "rar-example-secret-at-least-32ch!",
+                                JWTIssuer:    authServer.URL,
+                        }
+                        payMux := http.NewServeMux()
+                        payMux.Handle("POST /payments", payMW.RequireAuthorizationDetails("payment_initiation")(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "status":  "payment_accepted",
+                                                "details": details,
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">paymentsRS = httptest.NewServer(payMux)
+
+                        // Accounts resource server — requires account_information type
+                        acctMW := &amp;apiauth.APIMiddleware{
+                                JWTSecretKey: "rar-example-secret-at-least-32ch!",
+                                JWTIssuer:    authServer.URL,
+                        }
+                        acctMux := http.NewServeMux()
+                        acctMux.Handle("GET /accounts", acctMW.RequireAuthorizationDetails("account_information")(
+                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                        details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+                                        w.Header().Set("Content-Type", "application/json")
+                                        json.NewEncoder(w).Encode(map[string]any{
+                                                "status":  "accounts_listed",
+                                                "details": details,
+                                        })
+                                }</span>),
+                        ))
+                        <span class="cov0" title="0">accountsRS = httptest.NewServer(acctMux)
+
+                        fmt.Printf("    Auth server:   %s\n", authServer.URL)
+                        fmt.Printf("    Payments API:  %s\n", paymentsRS.URL)
+                        fmt.Printf("    Accounts API:  %s\n", accountsRS.URL)</span>
+                })
+
+        // --- Discovery ---
+        <span class="cov0" title="0">demo.Step("Discover supported authorization_details types").
+                Ref(demokit.RFC9396).
+                Ref(demokit.RFC8414).
+                Arrow("App", "AS", "GET /.well-known/openid-configuration").
+                DashedArrow("AS", "App", "{..., authorization_details_types_supported: [...]}").
+                Note("RFC 9396 §10: the AS advertises which authorization_details types it supports. Clients check this before requesting.").
+                Run(func() </span><span class="cov0" title="0">{
+                        meta, _ := client.DiscoverAS(authServer.URL)
+                        resp, _ := http.Get(authServer.URL + "/.well-known/openid-configuration")
+                        body, _ := io.ReadAll(resp.Body)
+                        resp.Body.Close()
+                        var raw map[string]any
+                        json.Unmarshal(body, &amp;raw)
+
+                        types := raw["authorization_details_types_supported"]
+                        fmt.Printf("    authorization_details_types_supported: %v\n", types)
+                        fmt.Printf("    token_endpoint: %s\n", meta.TokenEndpoint)
+                }</span>)
+
+        // --- Register via DCR ---
+        <span class="cov0" title="0">demo.Step("Register a banking app via DCR (RFC 7591)").
+                Ref(demokit.RFC7591).
+                Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, scope}").
+                DashedArrow("AS", "App", "{client_id, client_secret}").
+                Note("Using standards-compliant DCR (Example 06) instead of the proprietary endpoint. A banking app should be fully standards-based.").
+                Run(func() </span><span class="cov0" title="0">{
+                        body, _ := json.Marshal(map[string]any{
+                                "client_name":                "Fintech Payment App",
+                                "grant_types":                []string{"client_credentials"},
+                                "token_endpoint_auth_method": "client_secret_post",
+                                "scope":                      "payments accounts",
+                        })
+                        resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+                                bytes.NewReader(body))
+                        var reg map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;reg)
+                        resp.Body.Close()
+                        clientID = reg["client_id"].(string)
+                        clientSecret = reg["client_secret"].(string)
+                        fmt.Printf("    client_id:   %s\n", clientID)
+                        fmt.Printf("    client_name: %s\n", reg["client_name"])
+                }</span>)
+
+        // --- Payment token ---
+        <span class="cov0" title="0">demo.Step("Request a token with payment authorization_details").
+                Ref(demokit.RFC9396).
+                Ref(demokit.RFC6749_ClientCredentials).
+                Arrow("App", "AS", "POST /api/token {authorization_details: [{type: payment_initiation, ...}]}").
+                DashedArrow("AS", "App", "{access_token, authorization_details: [{type: payment_initiation, ...}]}").
+                Note("The token request includes structured authorization_details — not just 'scope=payments' but the exact payment to initiate. The AS validates, embeds in the JWT, and echoes in the response.").
+                Run(func() </span><span class="cov0" title="0">{
+                        reqBody := map[string]any{
+                                "grant_type":    "client_credentials",
+                                "client_id":     clientID,
+                                "client_secret": clientSecret,
+                                "authorization_details": []map[string]any{
+                                        {
+                                                "type":      "payment_initiation",
+                                                "actions":   []string{"initiate"},
+                                                "locations": []string{paymentsRS.URL + "/payments"},
+                                                "instructedAmount": map[string]any{
+                                                        "currency": "EUR",
+                                                        "amount":   "45.00",
+                                                },
+                                                "creditorName": "Merchant A",
+                                        },
+                                },
+                        }
+                        body, _ := json.Marshal(reqBody)
+
+                        resp, _ := http.Post(authServer.URL+"/api/token", "application/json",
+                                bytes.NewReader(body))
+                        var tokenData map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;tokenData)
+                        resp.Body.Close()
+
+                        paymentToken = tokenData["access_token"].(string)
+
+                        // Show the authorization_details in the response
+                        ad := tokenData["authorization_details"].([]any)
+                        adPretty, _ := json.MarshalIndent(ad, "    ", "  ")
+                        fmt.Printf("    authorization_details in response:\n    %s\n\n", string(adPretty))
+                        fmt.Printf("    access_token: %s...\n", paymentToken[:40])
+                }</span>)
+
+        <span class="cov0" title="0">demo.Section("What's in the JWT?",
+                "The access token now carries `authorization_details` as a JWT claim:",
+                "```json",
+                "{",
+                "  \"sub\": \"app_abc123\",",
+                "  \"scopes\": [...],",
+                "  \"authorization_details\": [",
+                "    {",
+                "      \"type\": \"payment_initiation\",",
+                "      \"actions\": [\"initiate\"],",
+                "      \"instructedAmount\": {\"currency\": \"EUR\", \"amount\": \"45.00\"},",
+                "      \"creditorName\": \"Merchant A\"",
+                "    }",
+                "  ]",
+                "}",
+                "```",
+                "The resource server reads this claim to enforce fine-grained access.",
+        )
+
+        // --- Use on payments RS ---
+        demo.Step("Access the Payments API (authorized)").
+                Ref(demokit.RFC9396).
+                Arrow("App", "Pay", "POST /payments (Bearer: payment token)").
+                Arrow("Pay", "Pay", "RequireAuthorizationDetails(\"payment_initiation\") ✓").
+                DashedArrow("Pay", "App", "200 {status: payment_accepted, details: [...]}").
+                Note("The Payments API uses RequireAuthorizationDetails middleware — it checks that the token has a payment_initiation authorization_details entry. The details are available in the request context.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("POST", paymentsRS.URL+"/payments", nil)
+                        req.Header.Set("Authorization", "Bearer "+paymentToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d\n", res.StatusCode)
+                        var data map[string]any
+                        json.Unmarshal(body, &amp;data)
+                        pretty, _ := json.MarshalIndent(data, "    ", "  ")
+                        fmt.Printf("    response: %s\n", string(pretty))
+                }</span>)
+
+        // --- Use on accounts RS (should fail) ---
+        <span class="cov0" title="0">demo.Step("Access the Accounts API with a payment token (rejected)").
+                Ref(demokit.RFC9396).
+                Arrow("App", "Acct", "GET /accounts (Bearer: payment token)").
+                Arrow("Acct", "Acct", "RequireAuthorizationDetails(\"account_information\") ✗").
+                DashedArrow("Acct", "App", "401 Unauthorized").
+                Note("The payment token has type=payment_initiation but the Accounts API requires type=account_information. Fine-grained enforcement: a payment token can't read account data.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("GET", accountsRS.URL+"/accounts", nil)
+                        req.Header.Set("Authorization", "Bearer "+paymentToken)
+                        res, _ := http.DefaultClient.Do(req)
+                        res.Body.Close()
+
+                        fmt.Printf("    status: %d (correctly rejected — wrong authorization type)\n", res.StatusCode)
+                }</span>)
+
+        // --- Introspect ---
+        <span class="cov0" title="0">demo.Step("Introspect the payment token").
+                Ref(demokit.RFC9396).
+                Ref(demokit.RFC7662).
+                Arrow("RS", "AS", "POST /oauth/introspect {token}").
+                DashedArrow("AS", "RS", "{active: true, authorization_details: [...]}").
+                Note("Introspection returns the authorization_details alongside the standard claims. Resource servers that use introspection (instead of local JWT validation) get the same fine-grained information.").
+                Run(func() </span><span class="cov0" title="0">{
+                        form := url.Values{"token": {paymentToken}}
+                        req, _ := http.NewRequest("POST", authServer.URL+"/oauth/introspect",
+                                strings.NewReader(form.Encode()))
+                        req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+                        req.SetBasicAuth(clientID, clientSecret)
+                        res, _ := http.DefaultClient.Do(req)
+                        body, _ := io.ReadAll(res.Body)
+                        res.Body.Close()
+
+                        var result map[string]any
+                        json.Unmarshal(body, &amp;result)
+                        pretty, _ := json.MarshalIndent(result, "    ", "  ")
+                        fmt.Printf("    %s\n", string(pretty))
+                }</span>)
+
+        // --- Scope coexistence ---
+        <span class="cov0" title="0">demo.Step("RAR coexists with scopes").
+                Ref(demokit.RFC9396).
+                Arrow("App", "AS", "POST /api/token {scope: read, authorization_details: [...]}").
+                DashedArrow("AS", "App", "{scope: read, authorization_details: [...]}").
+                Note("Scopes and authorization_details are independent — you can use both in the same request. Scopes for coarse-grained access, RAR for fine-grained.").
+                Run(func() </span><span class="cov0" title="0">{
+                        reqBody := map[string]any{
+                                "grant_type":    "client_credentials",
+                                "client_id":     clientID,
+                                "client_secret": clientSecret,
+                                "scope":         "read write",
+                                "authorization_details": []map[string]any{
+                                        {"type": "account_information", "actions": []string{"list_accounts"}},
+                                },
+                        }
+                        body, _ := json.Marshal(reqBody)
+                        resp, _ := http.Post(authServer.URL+"/api/token", "application/json",
+                                bytes.NewReader(body))
+                        var tokenData map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;tokenData)
+                        resp.Body.Close()
+
+                        fmt.Printf("    scope: %s\n", tokenData["scope"])
+                        ad := tokenData["authorization_details"].([]any)
+                        fmt.Printf("    authorization_details: %d entries\n", len(ad))
+                        fmt.Printf("    Both present — independent, composable.\n")
+                }</span>)
+
+        // --- Optional: RAR test issuer ---
+        <span class="cov0" title="0">demo.Step("Cross-server RAR validation (optional — RAR test issuer)").
+                Ref(demokit.RFC9396).
+                Arrow("App", "AS", "POST {RAR issuer}/api/token {authorization_details}").
+                Arrow("App", "RS", "Bearer token → validate via JWKS from RAR issuer").
+                Note("No open-source IdP supports RFC 9396 on standard OAuth flows yet. We built a RAR test issuer (cmd/rar-test-issuer) for interop testing. Run 'make uprar' to start it. When Keycloak adds RAR support, this step will migrate to KC.").
+                Run(func() </span><span class="cov0" title="0">{
+                        httpClient := &amp;http.Client{Timeout: 2 * time.Second}
+                        resp, err := httpClient.Get(rarIssuerURL + "/_ah/health")
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    SKIPPED: RAR test issuer not running at %s\n", rarIssuerURL)
+                                fmt.Printf("    To enable: make uprar (from repo root)\n")
+                                return
+                        }</span>
+                        <span class="cov0" title="0">resp.Body.Close()
+
+                        // Get a RAR token from the external issuer
+                        reqBody := map[string]any{
+                                "grant_type":    "client_credentials",
+                                "client_id":     "rar-test-client",
+                                "client_secret": "rar-test-secret",
+                                "authorization_details": []map[string]any{
+                                        {"type": "payment_initiation", "actions": []string{"initiate"}},
+                                },
+                        }
+                        body, _ := json.Marshal(reqBody)
+                        tokenResp, _ := http.Post(rarIssuerURL+"/api/token", "application/json",
+                                bytes.NewReader(body))
+                        var tokenData map[string]any
+                        json.NewDecoder(tokenResp.Body).Decode(&amp;tokenData)
+                        tokenResp.Body.Close()
+
+                        fmt.Printf("    Token from RAR test issuer: %s...\n", tokenData["access_token"].(string)[:40])
+
+                        ad := tokenData["authorization_details"].([]any)
+                        fmt.Printf("    authorization_details: %v\n", ad[0].(map[string]any)["type"])
+                        fmt.Printf("\n    Same RFC 9396 format — issued by a different server.\n")</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("RFC 9396 in OneAuth — what we built",
+                "| Layer | What | RFC section |",
+                "|-------|------|------------|",
+                "| Data model | `core.AuthorizationDetail` with JSON flattening | §2 |",
+                "| Token endpoint | Parse, validate, embed in JWT, return in response | §5 |",
+                "| Form-encoded | `authorization_details` as JSON string in form params | §6.1 |",
+                "| Introspection | Include in introspection response | §9.1 |",
+                "| AS metadata | `authorization_details_types_supported` | §10 |",
+                "| DCR | `authorization_details_types` on client registration | §10 |",
+                "| Middleware | `RequireAuthorizationDetails()` enforcement | §2 |",
+                "| Client SDK | `AuthorizationDetails` on token requests/responses | §5 |",
+                "| Error handling | `invalid_authorization_details` error code | §5.2 |",
+        )
+
+        demo.Section("What's next?",
+                "In [09 — Key Rotation](../09-key-rotation/), you'll see how to rotate",
+                "signing keys with a grace period — old tokens keep working during the",
+                "transition, then fail after the grace window closes.",
+        )
+
+        demo.Execute()
+
+        if authServer != nil </span><span class="cov0" title="0">{
+                authServer.Close()
+        }</span>
+        <span class="cov0" title="0">if paymentsRS != nil </span><span class="cov0" title="0">{
+                paymentsRS.Close()
+        }</span>
+        <span class="cov0" title="0">if accountsRS != nil </span><span class="cov0" title="0">{
+                accountsRS.Close()
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file38" style="display: none">// Example 09: Key Rotation with Grace Periods
+//
+// In production, signing keys need to be rotated periodically. But you can't
+// just swap keys — existing tokens signed with the old key would break. OneAuth
+// solves this with a grace period: old keys stay valid for a window after
+// rotation, then expire.
+//
+// Run:   go run ./examples/09-key-rotation/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://www.rfc-editor.org/rfc/rfc7517 (JWK)
+package main
+
+import (
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "net/http"
+        "net/http/httptest"
+        "time"
+
+        "github.com/golang-jwt/jwt/v5"
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+)
+
+func main() <span class="cov0" title="0">{
+        var regHandler http.Handler
+        var ks keys.KeyStorage
+        var kidStore *keys.KidStore
+        var middleware *apiauth.APIMiddleware
+        var clientID, oldSecret, newSecret string
+        var oldToken, newToken string
+
+        demo := demokit.New("09: Key Rotation with Grace Periods").
+                Dir("09-key-rotation").
+                Description("Non-UI | No infrastructure needed | Builds on Example 02").
+                Actors(
+                        demokit.Actor("Admin", "Admin"),
+                        demokit.Actor("AS", "Auth Server"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("About this example",
+                "**Actors:** Admin, Auth Server (AS), Resource Server (RS).",
+                "Think: Slack rotates its signing keys — existing bot tokens must keep working during the transition.",
+                "[What are these?](../README.md#cast-of-characters)",
+                "",
+                "**The problem:** You rotate an app's signing key. Tokens signed with the old",
+                "key are still in flight — users have them cached, they haven't expired yet.",
+                "If the resource server only knows the new key, those tokens break.",
+                "",
+                "**The solution:** A grace period. After rotation, the old key stays valid for",
+                "a configurable window. Both old and new tokens work. After the grace period,",
+                "old tokens are rejected.",
+                "",
+                "```",
+                "Time: ──────────────────────────────────────────────────►",
+                "       ┌─── old key valid ───┐",
+                "       │                     │ ← grace period",
+                "       ├─── rotation ────────┤",
+                "       │                     ├─── new key valid ──────►",
+                "       │  both keys work     │  only new key works",
+                "```",
+        )
+
+        // --- Setup ---
+        demo.Step("Set up auth server with key rotation support").
+                Ref(demokit.RFC7517).
+                Ref(demokit.RFC7638).
+                Note("The auth server uses a KidStore alongside the main KeyStore. On rotation, the old key moves to KidStore with a grace period TTL. The CompositeKeyLookup checks both.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+                        kidStore = keys.NewKidStore()
+
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+                        registrar.KidStore = kidStore
+                        registrar.DefaultGracePeriod = 100 * time.Millisecond // short for demo
+                        regHandler = registrar.Handler()
+
+                        // CompositeKeyLookup: check current keys first, then grace period keys
+                        composite := &amp;keys.CompositeKeyLookup{
+                                Lookups: []keys.KeyLookup{ks, kidStore},
+                        }
+                        middleware = &amp;apiauth.APIMiddleware{KeyStore: composite}
+
+                        fmt.Printf("    KeyStore:     in-memory (current keys)\n")
+                        fmt.Printf("    KidStore:     in-memory (grace period keys)\n")
+                        fmt.Printf("    Grace period: 100ms (short for demo)\n")
+                }</span>)
+
+        // --- Register and mint ---
+        <span class="cov0" title="0">demo.Step("Register an app and mint a token with the original key").
+                Ref(demokit.RFC7519).
+                Arrow("Admin", "AS", "POST /apps/register").
+                DashedArrow("AS", "Admin", "{client_id, client_secret}").
+                Arrow("Admin", "Admin", "MintResourceToken(alice, oldSecret)").
+                Note("The app gets a client_secret (HS256). We mint a token for Alice — this token's kid header is derived from the old key.").
+                Run(func() </span><span class="cov0" title="0">{
+                        body, _ := json.Marshal(map[string]any{"client_domain": "rotate.example.com"})
+                        req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
+                        req.Header.Set("Content-Type", "application/json")
+                        rr := httptest.NewRecorder()
+                        regHandler.ServeHTTP(rr, req)
+
+                        var reg map[string]any
+                        json.NewDecoder(rr.Body).Decode(&amp;reg)
+                        clientID = reg["client_id"].(string)
+                        oldSecret = reg["client_secret"].(string)
+
+                        oldToken, _ = admin.MintResourceToken(
+                                "alice", clientID, oldSecret,
+                                admin.AppQuota{}, []string{"read"}, nil)
+
+                        // Show the kid
+                        parser := jwt.NewParser()
+                        parsed, _, _ := parser.ParseUnverified(oldToken, jwt.MapClaims{})
+                        fmt.Printf("    client_id:   %s\n", clientID)
+                        fmt.Printf("    old secret:  %s...\n", oldSecret[:16])
+                        fmt.Printf("    old token kid: %s\n", parsed.Header["kid"])
+                }</span>)
+
+        // --- Rotate ---
+        <span class="cov0" title="0">demo.Step("Rotate the key").
+                Ref(demokit.RFC7517).
+                Arrow("Admin", "AS", "POST /apps/{id}/rotate").
+                DashedArrow("AS", "Admin", "{client_secret: newSecret}").
+                Note("Rotation replaces the key in the main KeyStore and moves the old key to KidStore with a grace period TTL. Both keys are now valid.").
+                Run(func() </span><span class="cov0" title="0">{
+                        req := httptest.NewRequest("POST", "/apps/"+clientID+"/rotate", nil)
+                        rr := httptest.NewRecorder()
+                        regHandler.ServeHTTP(rr, req)
+
+                        var rot map[string]any
+                        json.NewDecoder(rr.Body).Decode(&amp;rot)
+                        newSecret = rot["client_secret"].(string)
+
+                        newToken, _ = admin.MintResourceToken(
+                                "alice", clientID, newSecret,
+                                admin.AppQuota{}, []string{"read"}, nil)
+
+                        fmt.Printf("    new secret:  %s...\n", newSecret[:16])
+                        fmt.Printf("    different:   %v\n", oldSecret != newSecret)
+
+                        parser := jwt.NewParser()
+                        parsed, _, _ := parser.ParseUnverified(newToken, jwt.MapClaims{})
+                        fmt.Printf("    new token kid: %s\n", parsed.Header["kid"])
+                }</span>)
+
+        // --- During grace period ---
+        <span class="cov0" title="0">demo.Step("During grace period — both tokens work").
+                Ref(demokit.RFC7638).
+                Arrow("RS", "RS", "Validate old token → kid found in KidStore (grace) ✓").
+                Arrow("RS", "RS", "Validate new token → kid found in KeyStore (current) ✓").
+                Note("The CompositeKeyLookup checks the main KeyStore first, then falls back to KidStore. Old tokens find their key in the grace store; new tokens find theirs in the main store.").
+                Run(func() </span><span class="cov0" title="0">{
+                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                w.WriteHeader(http.StatusOK)
+                        }</span>))
+
+                        <span class="cov0" title="0">oldResult := validateToken(handler, oldToken)
+                        newResult := validateToken(handler, newToken)
+
+                        fmt.Printf("    old token (during grace): %d ✓\n", oldResult)
+                        fmt.Printf("    new token:                %d ✓\n", newResult)</span>
+                })
+
+        // --- After grace period ---
+        <span class="cov0" title="0">demo.Step("After grace period — old token rejected").
+                Arrow("RS", "RS", "Validate old token → kid not found anywhere ✗").
+                Arrow("RS", "RS", "Validate new token → kid found in KeyStore ✓").
+                Note("After the grace period expires (100ms in this demo), the old key is removed from KidStore. Tokens signed with it are now rejected.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Wait for grace period to expire
+                        time.Sleep(120 * time.Millisecond)
+
+                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                w.WriteHeader(http.StatusOK)
+                        }</span>))
+
+                        <span class="cov0" title="0">oldResult := validateToken(handler, oldToken)
+                        newResult := validateToken(handler, newToken)
+
+                        fmt.Printf("    old token (after grace):  %d ✗ (correctly rejected)\n", oldResult)
+                        fmt.Printf("    new token:                %d ✓\n", newResult)</span>
+                })
+
+        <span class="cov0" title="0">demo.Section("How it works under the hood",
+                "```",
+                "CompositeKeyLookup",
+                "  ├── KeyStore (current keys)     ← new key lives here",
+                "  └── KidStore (grace period)     ← old key lives here temporarily",
+                "",
+                "Token arrives with kid header:",
+                "  1. Check KeyStore by kid → found? validate with that key",
+                "  2. Not found → check KidStore by kid → found and not expired? validate",
+                "  3. Not found anywhere → reject",
+                "```",
+                "",
+                "The kid (Key ID) in the JWT header is a RFC 7638 thumbprint of the signing",
+                "key. Each key has a unique kid, so the lookup is deterministic — there's no",
+                "ambiguity about which key to use for verification.",
+        )
+
+        demo.Section("What's next?",
+                "In [10 — Security](../10-security/), you'll see attack prevention:",
+                "algorithm confusion (CVE-2015-9235), cross-app token forgery, and",
+                "JWKS security properties.",
+        )
+
+        demo.Execute()</span>
+}
+
+// validateToken runs a token through the middleware and returns the HTTP status.
+func validateToken(handler http.Handler, token string) int <span class="cov0" title="0">{
+        rr := httptest.NewRecorder()
+        req := httptest.NewRequest("GET", "/resource", nil)
+        req.Header.Set("Authorization", "Bearer "+token)
+        handler.ServeHTTP(rr, req)
+        return rr.Code
+}</span>
+</pre>
+		
+		<pre class="file" id="file39" style="display: none">// Example 10: Security — Attack Prevention
+//
+// This example demonstrates real attacks against JWT-based auth systems and
+// how OneAuth prevents them. Each step shows the attack, why it works against
+// naive implementations, and how OneAuth's defenses block it.
+//
+// Run:   go run ./examples/10-security/
+// Docs:  Run with --readme to regenerate README.md
+//
+// See: https://nvd.nist.gov/vuln/detail/CVE-2015-9235 (algorithm confusion)
+package main
+
+import (
+        "bytes"
+        "crypto/rand"
+        "crypto/rsa"
+        "encoding/json"
+        "fmt"
+        "io"
+        "net/http"
+        "net/http/httptest"
+        "time"
+
+        "github.com/golang-jwt/jwt/v5"
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/oneauth/keys"
+        "github.com/panyam/oneauth/utils"
+)
+
+func main() <span class="cov0" title="0">{
+        var ks *keys.InMemoryKeyStore
+        var middleware *apiauth.APIMiddleware
+        var rsaPrivKey *rsa.PrivateKey
+        var pubPEM []byte
+
+        demo := demokit.New("10: Security — Attack Prevention").
+                Dir("10-security").
+                Description("Non-UI | No infrastructure needed | Standalone").
+                Actors(
+                        demokit.Actor("Legit", "Legitimate App"),
+                        demokit.Actor("Attacker", "Attacker"),
+                        demokit.Actor("RS", "Resource Server"),
+                )
+
+        demo.Section("About this example",
+                "This example demonstrates real JWT attacks and OneAuth's defenses.",
+                "Each attack is executed live — you'll see both the attack and the defense in action.",
+                "",
+                "**Attacks covered:**",
+                "1. Algorithm confusion (CVE-2015-9235) — the most famous JWT vulnerability",
+                "2. Cross-app token forgery — using one app's key with another app's client_id",
+                "3. `alg: none` — disabling signature verification entirely",
+                "4. JWKS private key leakage — checking that secrets stay secret",
+        )
+
+        // --- Setup ---
+        demo.Step("Set up KeyStore with an RS256 app and an HS256 app").
+                Ref(demokit.RFC7517).
+                Note("Two apps coexist: one with an RSA key pair (RS256), one with a shared secret (HS256). The resource server validates tokens from both.").
+                Run(func() </span><span class="cov0" title="0">{
+                        ks = keys.NewInMemoryKeyStore()
+
+                        // RS256 app
+                        rsaPrivKey, _ = rsa.GenerateKey(rand.Reader, 2048)
+                        pubPEM, _ = utils.EncodePublicKeyPEM(&amp;rsaPrivKey.PublicKey)
+                        ks.RegisterKey("app-rsa", pubPEM, "RS256")
+
+                        // HS256 app
+                        ks.RegisterKey("app-hmac", []byte("shared-secret-for-hs256-app"), "HS256")
+
+                        middleware = &amp;apiauth.APIMiddleware{KeyStore: ks}
+
+                        fmt.Printf("    app-rsa:  RS256 (public key registered)\n")
+                        fmt.Printf("    app-hmac: HS256 (shared secret registered)\n")
+                }</span>)
+
+        // --- Attack 1: Algorithm confusion ---
+        <span class="cov0" title="0">demo.Step("Attack 1: Algorithm confusion (CVE-2015-9235)").
+                Ref(demokit.CVE_2015_9235).
+                Ref(demokit.RFC7515).
+                Arrow("Attacker", "Attacker", "Craft JWT: alg=HS256, sign with RSA public key").
+                Arrow("Attacker", "RS", "Bearer: confused token").
+                DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
+                Note("The attack: The attacker knows the RSA public key (it's public, served via JWKS). They craft a JWT with alg:HS256 and sign it using the public key bytes as the HMAC secret. A naive server reads alg:HS256, grabs the stored key bytes, and verifies — which passes because the attacker used those same bytes.\n\nOneAuth's defense: The middleware checks that the token's alg header matches the KeyRecord.Algorithm. Store says RS256, token says HS256 → mismatch → rejected before any signature check.").
+                Run(func() </span><span class="cov0" title="0">{
+                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                w.WriteHeader(http.StatusOK)
+                        }</span>))
+
+                        // Legitimate RS256 token
+                        <span class="cov0" title="0">legit := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+                                "sub": "alice", "client_id": "app-rsa", "type": "access",
+                                "scopes": []string{"read"}, "exp": time.Now().Add(time.Hour).Unix(),
+                                "iat": time.Now().Unix(),
+                        })
+                        if kid, err := utils.ComputeKid(&amp;rsaPrivKey.PublicKey, "RS256"); err == nil </span><span class="cov0" title="0">{
+                                legit.Header["kid"] = kid
+                        }</span>
+                        <span class="cov0" title="0">legitToken, _ := legit.SignedString(rsaPrivKey)
+                        fmt.Printf("    Legitimate RS256 token: %d\n", validateToken(handler, legitToken))
+
+                        // Algorithm confusion: sign with public key as HMAC secret
+                        attack := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+                                "sub": "attacker", "client_id": "app-rsa", "type": "access",
+                                "scopes": []string{"admin"}, "exp": time.Now().Add(time.Hour).Unix(),
+                                "iat": time.Now().Unix(),
+                        })
+                        attackToken, _ := attack.SignedString(pubPEM) // public key as HMAC secret!
+                        fmt.Printf("    Algorithm confusion:    %d (blocked — alg mismatch)\n", validateToken(handler, attackToken))</span>
+                })
+
+        // --- Attack 2: alg:none ---
+        <span class="cov0" title="0">demo.Step("Attack 2: alg:none — no signature at all").
+                Ref(demokit.CVE_2015_9235).
+                Arrow("Attacker", "Attacker", "Craft JWT: alg=none, no signature").
+                Arrow("Attacker", "RS", "Bearer: unsigned token").
+                DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
+                Note("The attack: The attacker sends a JWT with alg:none — no signature at all. Some JWT libraries accept this as valid.\n\nOneAuth uses golang-jwt/v5 which rejects alg:none by default unless explicitly opted in with UnsafeAllowNoneSignatureType.").
+                Run(func() </span><span class="cov0" title="0">{
+                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                w.WriteHeader(http.StatusOK)
+                        }</span>))
+
+                        <span class="cov0" title="0">none := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+                                "sub": "attacker", "client_id": "app-rsa", "type": "access",
+                                "scopes": []string{"admin"}, "exp": time.Now().Add(time.Hour).Unix(),
+                                "iat": time.Now().Unix(),
+                        })
+                        noneToken, _ := none.SignedString(jwt.UnsafeAllowNoneSignatureType)
+                        fmt.Printf("    alg:none token: %d (blocked)\n", validateToken(handler, noneToken))</span>
+                })
+
+        // --- Attack 3: Cross-app forgery ---
+        <span class="cov0" title="0">demo.Step("Attack 3: Cross-app token forgery").
+                Arrow("Attacker", "Attacker", "Sign JWT with app-A's key but claim client_id=app-B").
+                Arrow("Attacker", "RS", "Bearer: cross-app token").
+                DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
+                Note("The attack: App A's key is compromised. The attacker signs a token claiming to be App B (client_id=app-B) using App A's key. If the resource server only checks the signature and not which app owns the key, the token validates.\n\nOneAuth's defense: The middleware checks that the kid's owning client matches the client_id claim. App A's key → kid owned by app-A → client_id claim says app-B → mismatch → rejected.").
+                Run(func() </span><span class="cov0" title="0">{
+                        // Register two apps
+                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+                        regHandler := registrar.Handler()
+
+                        var clientIDs [2]string
+                        var secrets [2]string
+                        for i, domain := range []string{"app-a.com", "app-b.com"} </span><span class="cov0" title="0">{
+                                body, _ := json.Marshal(map[string]any{"client_domain": domain})
+                                req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
+                                req.Header.Set("Content-Type", "application/json")
+                                rr := httptest.NewRecorder()
+                                regHandler.ServeHTTP(rr, req)
+                                var resp map[string]any
+                                json.NewDecoder(rr.Body).Decode(&amp;resp)
+                                clientIDs[i] = resp["client_id"].(string)
+                                secrets[i] = resp["client_secret"].(string)
+                        }</span>
+
+                        <span class="cov0" title="0">handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                                w.WriteHeader(http.StatusOK)
+                        }</span>))
+
+                        // Cross-app: sign with app A's secret, claim app B's client_id
+                        <span class="cov0" title="0">crossToken, _ := admin.MintResourceToken(
+                                "eve", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
+                        fmt.Printf("    Cross-app token (A's key, B's id): %d (blocked — kid/client_id mismatch)\n",
+                                validateToken(handler, crossToken))
+
+                        // Correct: app A's secret with app A's client_id
+                        correctToken, _ := admin.MintResourceToken(
+                                "alice", clientIDs[0], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
+                        fmt.Printf("    Correct token (A's key, A's id):   %d ✓\n",
+                                validateToken(handler, correctToken))</span>
+                })
+
+        // --- JWKS security ---
+        <span class="cov0" title="0">demo.Step("JWKS security: only public keys, never secrets").
+                Ref(demokit.RFC7517).
+                Arrow("Anyone", "AS", "GET /.well-known/jwks.json").
+                DashedArrow("AS", "Anyone", "{keys: [RSA public key only]}").
+                Note("JWKS serves only asymmetric public keys. HS256 secrets are excluded entirely. RSA keys include only public components (n, e) — private fields (d, p, q) are structurally absent from the JWK type.").
+                Run(func() </span><span class="cov0" title="0">{
+                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+                        srv := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))
+                        defer srv.Close()
+
+                        resp, _ := http.Get(srv.URL)
+                        body, _ := io.ReadAll(resp.Body)
+                        resp.Body.Close()
+
+                        var raw map[string]any
+                        json.Unmarshal(body, &amp;raw)
+                        jwksKeys := raw["keys"].([]any)
+
+                        fmt.Printf("    Total apps in KeyStore: 2 (RSA + HMAC)\n")
+                        fmt.Printf("    Keys in JWKS:           %d (only RSA — HMAC secret excluded)\n", len(jwksKeys))
+
+                        if len(jwksKeys) &gt; 0 </span><span class="cov0" title="0">{
+                                key := jwksKeys[0].(map[string]any)
+                                fmt.Printf("    kty: %s, alg: %s, key_ops: %v\n", key["kty"], key["alg"], key["key_ops"])
+
+                                leaked := false
+                                for _, field := range []string{"d", "p", "q", "dp", "dq", "qi"} </span><span class="cov0" title="0">{
+                                        if key[field] != nil </span><span class="cov0" title="0">{
+                                                fmt.Printf("    LEAK: private field %q found!\n", field)
+                                                leaked = true
+                                        }</span>
+                                }
+                                <span class="cov0" title="0">if !leaked </span><span class="cov0" title="0">{
+                                        fmt.Printf("    Private fields (d, p, q, dp, dq, qi): absent ✓\n")
+                                }</span>
+                        }
+                })
+
+        <span class="cov0" title="0">demo.Section("Summary of defenses",
+                "| Attack | How it works | OneAuth's defense |",
+                "|--------|-------------|------------------|",
+                "| Algorithm confusion (CVE-2015-9235) | Sign HS256 with RSA public key | alg must match KeyRecord.Algorithm |",
+                "| alg:none | No signature at all | golang-jwt/v5 rejects by default |",
+                "| Cross-app forgery | Sign with app A's key, claim app B | kid owner must match client_id claim |",
+                "| JWKS private key leak | Serve private key fields | JWK struct cannot carry private fields |",
+                "| HS256 secret in JWKS | Expose shared secret via JWKS | HS256 keys excluded from JWKS output |",
+                "",
+                "These defenses are built into the middleware and key management layers —",
+                "they're always active, not opt-in. You get them by using `APIMiddleware`",
+                "and `JWKSHandler`.",
+        )
+
+        demo.Section("End of the journey",
+                "You've completed all 10 examples! Here's what you've learned:",
+                "",
+                "| # | Concept | RFC |",
+                "|---|---------|-----|",
+                "| 01 | Client credentials — get a token | RFC 6749 §4.4 |",
+                "| 02 | Resource tokens — per-user JWTs | RFC 7519 |",
+                "| 03 | Asymmetric signing + JWKS discovery | RFC 7517, 7515 |",
+                "| 04 | AS metadata discovery | RFC 8414 |",
+                "| 05 | Token introspection + revocation | RFC 7662 |",
+                "| 06 | Dynamic client registration | RFC 7591 |",
+                "| 07 | Client SDK production patterns | — |",
+                "| 08 | Rich Authorization Requests | RFC 9396 |",
+                "| 09 | Key rotation with grace periods | RFC 7638 |",
+                "| 10 | Security — attack prevention | CVE-2015-9235 |",
+        )
+
+        demo.Execute()</span>
+}
+
+func validateToken(handler http.Handler, token string) int <span class="cov0" title="0">{
+        rr := httptest.NewRecorder()
+        req := httptest.NewRequest("GET", "/resource", nil)
+        req.Header.Set("Authorization", "Bearer "+token)
+        handler.ServeHTTP(rr, req)
+        return rr.Code
+}</span>
+</pre>
+		
+		<pre class="file" id="file40" style="display: none">// Package demokit provides an interactive step-through framework for OneAuth
+// examples. Each example defines a sequence of steps (with mermaid diagram
+// arrows) and optional sections (explanatory text). The same definitions
+// drive both the interactive CLI and the generated README.
+//
+// Single source of truth: step titles, arrows, and notes are defined in Go
+// code. The README's mermaid diagram and step documentation are generated
+// from these definitions — never maintained by hand.
+//
+// Usage:
+//
+//        demo := demokit.New("01: Client Credentials Flow").
+//            Description("Non-UI | No infrastructure needed").
+//            Actors(
+//                demokit.Actor("App", "Client App"),
+//                demokit.Actor("AS", "Auth Server"),
+//            )
+//        demo.Step("Register a client").
+//            Arrow("App", "AS", "POST /apps/register").
+//            Arrow("AS", "App", "{client_id, client_secret}").
+//            Note("The client gets credentials for later use.").
+//            Run(func() { fmt.Println("registered!") })
+//        demo.Execute()
+package demokit
+
+import (
+        "bufio"
+        "fmt"
+        "os"
+        "strings"
+)
+
+// ActorDef defines a participant in the sequence diagram.
+type ActorDef struct {
+        ID    string // Short identifier used in arrows (e.g., "AS")
+        Label string // Display label (e.g., "Auth Server")
+}
+
+// Actor creates an ActorDef.
+func Actor(id, label string) ActorDef <span class="cov0" title="0">{
+        return ActorDef{ID: id, Label: label}
+}</span>
+
+// item is a union type for the ordered sequence of steps and sections.
+type item interface {
+        isItem()
+}
+
+// Ref is a named reference (RFC, CVE, blog post, spec section, etc.).
+type Ref struct {
+        Name string // e.g., "RFC 7519 (JWT)" or "CVE-2015-9235"
+        URL  string // e.g., "https://www.rfc-editor.org/rfc/rfc7519"
+}
+
+// StepDef defines one executable step in the demo.
+type StepDef struct {
+        title  string
+        arrows []arrowDef
+        refs   []Ref
+        note   string
+        runFn  func()
+}
+
+type arrowDef struct {
+        from, to, label string
+        dashed          bool // --&gt;&gt; vs -&gt;&gt;
+}
+
+func (s *StepDef) isItem() {<span class="cov0" title="0">}</span>
+
+// Arrow adds a solid arrow (request) to the step's sequence diagram.
+func (s *StepDef) Arrow(from, to, label string) *StepDef <span class="cov0" title="0">{
+        s.arrows = append(s.arrows, arrowDef{from: from, to: to, label: label})
+        return s
+}</span>
+
+// DashedArrow adds a dashed arrow (response) to the step's sequence diagram.
+func (s *StepDef) DashedArrow(from, to, label string) *StepDef <span class="cov0" title="0">{
+        s.arrows = append(s.arrows, arrowDef{from: from, to: to, label: label, dashed: true})
+        return s
+}</span>
+
+// Ref adds a reference (RFC, CVE, spec section, blog post, etc.) to this step.
+// Use pre-defined constants from refs.go: demokit.RFC7519, demokit.CVE_2015_9235, etc.
+func (s *StepDef) Ref(ref Ref) *StepDef <span class="cov0" title="0">{
+        s.refs = append(s.refs, ref)
+        return s
+}</span>
+
+// Note adds explanatory text shown in both CLI and README.
+func (s *StepDef) Note(text string) *StepDef <span class="cov0" title="0">{
+        s.note = text
+        return s
+}</span>
+
+// Run sets the function to execute for this step.
+func (s *StepDef) Run(fn func()) *StepDef <span class="cov0" title="0">{
+        s.runFn = fn
+        return s
+}</span>
+
+// SectionDef is a non-executable block of explanatory content.
+type SectionDef struct {
+        title string
+        body  string
+}
+
+func (s *SectionDef) isItem() {<span class="cov0" title="0">}</span>
+
+// Demo is the top-level container for an interactive example.
+type Demo struct {
+        title       string
+        description string
+        dir         string // directory name for run commands in generated README
+        actors      []ActorDef
+        items       []item
+        stepCount   int
+}
+
+// New creates a new Demo with the given title.
+func New(title string) *Demo <span class="cov0" title="0">{
+        return &amp;Demo{title: title}
+}</span>
+
+// Description sets the one-line description shown in the CLI header.
+func (d *Demo) Description(desc string) *Demo <span class="cov0" title="0">{
+        d.description = desc
+        return d
+}</span>
+
+// Dir sets the directory name used in generated README run commands.
+// e.g., Dir("01-client-credentials") produces "go run ./examples/01-client-credentials/"
+func (d *Demo) Dir(name string) *Demo <span class="cov0" title="0">{
+        d.dir = name
+        return d
+}</span>
+
+// Actors sets the sequence diagram participants.
+func (d *Demo) Actors(actors ...ActorDef) *Demo <span class="cov0" title="0">{
+        d.actors = actors
+        return d
+}</span>
+
+// Step adds an executable step to the demo. Returns the StepDef for chaining.
+func (d *Demo) Step(title string) *StepDef <span class="cov0" title="0">{
+        s := &amp;StepDef{title: title}
+        d.items = append(d.items, s)
+        d.stepCount++
+        return s
+}</span>
+
+// Section adds a non-executable explanatory block. Lines are joined with
+// newlines, so you can write multi-paragraph markdown naturally:
+//
+//        demo.Section("How it works",
+//            "The auth server signs tokens with HS256.",
+//            "",
+//            "**Key insight:** Both servers share the same KeyStore.",
+//        )
+func (d *Demo) Section(title string, lines ...string) *Demo <span class="cov0" title="0">{
+        d.items = append(d.items, &amp;SectionDef{title: title, body: strings.Join(lines, "\n")})
+        return d
+}</span>
+
+// Execute runs the demo interactively — pausing between steps for Enter.
+// If --non-interactive is passed (or stdin is not a terminal), runs without pausing.
+func (d *Demo) Execute() <span class="cov0" title="0">{
+        interactive := isTerminal()
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if arg == "--non-interactive" </span><span class="cov0" title="0">{
+                        interactive = false
+                }</span>
+                <span class="cov0" title="0">if arg == "--readme" </span><span class="cov0" title="0">{
+                        fmt.Print(d.Markdown())
+                        return
+                }</span>
+        }
+
+        // Header
+        <span class="cov0" title="0">fmt.Printf("=== %s ===\n", d.title)
+        if d.description != "" </span><span class="cov0" title="0">{
+                fmt.Printf("    %s\n", d.description)
+        }</span>
+        <span class="cov0" title="0">fmt.Printf("    %d steps\n", d.stepCount)
+        fmt.Println()
+
+        reader := bufio.NewReader(os.Stdin)
+        stepNum := 0
+
+        for _, it := range d.items </span><span class="cov0" title="0">{
+                switch v := it.(type) </span>{
+                case *StepDef:<span class="cov0" title="0">
+                        stepNum++
+                        // Step header
+                        fmt.Printf("  Step %d/%d: %s", stepNum, d.stepCount, v.title)
+                        fmt.Printf("  [README → Step %d]\n", stepNum)
+
+                        // References
+                        if len(v.refs) &gt; 0 </span><span class="cov0" title="0">{
+                                fmt.Print("    Refs: ")
+                                for i, ref := range v.refs </span><span class="cov0" title="0">{
+                                        if i &gt; 0 </span><span class="cov0" title="0">{
+                                                fmt.Print(", ")
+                                        }</span>
+                                        <span class="cov0" title="0">fmt.Print(ref.Name)</span>
+                                }
+                                <span class="cov0" title="0">fmt.Println()</span>
+                        }
+
+                        // Diagram arrows
+                        <span class="cov0" title="0">for _, a := range v.arrows </span><span class="cov0" title="0">{
+                                arrow := "-&gt;&gt;"
+                                if a.dashed </span><span class="cov0" title="0">{
+                                        arrow = "--&gt;&gt;"
+                                }</span>
+                                <span class="cov0" title="0">fmt.Printf("    %s %s %s: %s\n", a.from, arrow, a.to, a.label)</span>
+                        }
+
+                        // Note
+                        <span class="cov0" title="0">if v.note != "" </span><span class="cov0" title="0">{
+                                fmt.Printf("\n    %s\n", v.note)
+                        }</span>
+
+                        // Pause
+                        <span class="cov0" title="0">if interactive </span><span class="cov0" title="0">{
+                                fmt.Print("\n    Press Enter to run this step...")
+                                reader.ReadString('\n')
+                        }</span>
+                        <span class="cov0" title="0">fmt.Println()
+
+                        // Execute
+                        if v.runFn != nil </span><span class="cov0" title="0">{
+                                v.runFn()
+                        }</span>
+                        <span class="cov0" title="0">fmt.Println()</span>
+
+                case *SectionDef:<span class="cov0" title="0">
+                        fmt.Printf("  --- %s ---\n", v.title)
+                        for _, line := range strings.Split(v.body, "\n") </span><span class="cov0" title="0">{
+                                fmt.Printf("    %s\n", line)
+                        }</span>
+                        <span class="cov0" title="0">fmt.Println()</span>
+                }
+        }
+
+        <span class="cov0" title="0">fmt.Println("=== Done ===")</span>
+}
+
+// Markdown generates the full README content from the demo definition.
+// This is the single source of truth — run with --readme to regenerate.
+func (d *Demo) Markdown() string <span class="cov0" title="0">{
+        var b strings.Builder
+
+        // Title and description
+        fmt.Fprintf(&amp;b, "# %s\n\n", d.title)
+        if d.description != "" </span><span class="cov0" title="0">{
+                fmt.Fprintf(&amp;b, "%s\n\n", d.description)
+        }</span>
+
+        // Collect steps for the summary
+        <span class="cov0" title="0">var steps []*StepDef
+        for _, it := range d.items </span><span class="cov0" title="0">{
+                if s, ok := it.(*StepDef); ok </span><span class="cov0" title="0">{
+                        steps = append(steps, s)
+                }</span>
+        }
+
+        // What you'll learn (from step notes)
+        <span class="cov0" title="0">hasNotes := false
+        for _, s := range steps </span><span class="cov0" title="0">{
+                if s.note != "" </span><span class="cov0" title="0">{
+                        hasNotes = true
+                        break</span>
+                }
+        }
+        <span class="cov0" title="0">if hasNotes </span><span class="cov0" title="0">{
+                b.WriteString("## What you'll learn\n\n")
+                for _, s := range steps </span><span class="cov0" title="0">{
+                        if s.note != "" </span><span class="cov0" title="0">{
+                                fmt.Fprintf(&amp;b, "- **%s** — %s\n", s.title, s.note)
+                        }</span>
+                }
+                <span class="cov0" title="0">b.WriteString("\n")</span>
+        }
+
+        // Sequence diagram
+        <span class="cov0" title="0">b.WriteString("## Flow\n\n```mermaid\nsequenceDiagram\n")
+        for _, a := range d.actors </span><span class="cov0" title="0">{
+                if a.ID != a.Label </span><span class="cov0" title="0">{
+                        fmt.Fprintf(&amp;b, "    participant %s as %s\n", a.ID, a.Label)
+                }</span> else<span class="cov0" title="0"> {
+                        fmt.Fprintf(&amp;b, "    participant %s\n", a.ID)
+                }</span>
+        }
+        <span class="cov0" title="0">stepNum := 0
+        for _, it := range d.items </span><span class="cov0" title="0">{
+                switch v := it.(type) </span>{
+                case *StepDef:<span class="cov0" title="0">
+                        stepNum++
+                        fmt.Fprintf(&amp;b, "\n    Note over %s,%s: Step %d: %s\n",
+                                d.actors[0].ID, d.actors[len(d.actors)-1].ID, stepNum, v.title)
+                        for _, a := range v.arrows </span><span class="cov0" title="0">{
+                                if a.dashed </span><span class="cov0" title="0">{
+                                        fmt.Fprintf(&amp;b, "    %s--&gt;&gt;%s: %s\n", a.from, a.to, a.label)
+                                }</span> else<span class="cov0" title="0"> {
+                                        fmt.Fprintf(&amp;b, "    %s-&gt;&gt;%s: %s\n", a.from, a.to, a.label)
+                                }</span>
+                        }
+                }
+        }
+        <span class="cov0" title="0">b.WriteString("```\n\n")
+
+        // Steps detail
+        b.WriteString("## Steps\n\n")
+        stepNum = 0
+        allRefs := make(map[string]Ref) // dedup by URL
+        for _, it := range d.items </span><span class="cov0" title="0">{
+                switch v := it.(type) </span>{
+                case *StepDef:<span class="cov0" title="0">
+                        stepNum++
+                        fmt.Fprintf(&amp;b, "### Step %d: %s\n\n", stepNum, v.title)
+                        if len(v.refs) &gt; 0 </span><span class="cov0" title="0">{
+                                b.WriteString("&gt; **References:** ")
+                                for i, ref := range v.refs </span><span class="cov0" title="0">{
+                                        if i &gt; 0 </span><span class="cov0" title="0">{
+                                                b.WriteString(", ")
+                                        }</span>
+                                        <span class="cov0" title="0">fmt.Fprintf(&amp;b, "[%s](%s)", ref.Name, ref.URL)
+                                        allRefs[ref.URL] = ref</span>
+                                }
+                                <span class="cov0" title="0">b.WriteString("\n\n")</span>
+                        }
+                        <span class="cov0" title="0">if v.note != "" </span><span class="cov0" title="0">{
+                                fmt.Fprintf(&amp;b, "%s\n\n", v.note)
+                        }</span>
+                case *SectionDef:<span class="cov0" title="0">
+                        fmt.Fprintf(&amp;b, "### %s\n\n%s\n\n", v.title, v.body)</span>
+                }
+        }
+
+        // Collected references (deduped)
+        <span class="cov0" title="0">if len(allRefs) &gt; 0 </span><span class="cov0" title="0">{
+                b.WriteString("## References\n\n")
+                for _, ref := range allRefs </span><span class="cov0" title="0">{
+                        fmt.Fprintf(&amp;b, "- [%s](%s)\n", ref.Name, ref.URL)
+                }</span>
+                <span class="cov0" title="0">b.WriteString("\n")</span>
+        }
+
+        // Run command
+        <span class="cov0" title="0">dir := d.dir
+        if dir == "" </span><span class="cov0" title="0">{
+                dir = "&lt;this-directory&gt;"
+        }</span>
+        <span class="cov0" title="0">b.WriteString("## Run it\n\n")
+        fmt.Fprintf(&amp;b, "```bash\ngo run ./examples/%s/\n```\n\n", dir)
+        b.WriteString("Pass `--non-interactive` to skip pauses:\n\n")
+        fmt.Fprintf(&amp;b, "```bash\ngo run ./examples/%s/ --non-interactive\n```\n", dir)
+
+        return b.String()</span>
+}
+
+// isTerminal returns true if stdin appears to be an interactive terminal.
+func isTerminal() bool <span class="cov0" title="0">{
+        fi, err := os.Stdin.Stat()
+        if err != nil </span><span class="cov0" title="0">{
+                return false
+        }</span>
+        <span class="cov0" title="0">return fi.Mode()&amp;os.ModeCharDevice != 0</span>
+}
+</pre>
+		
+		<pre class="file" id="file41" style="display: none">package httpauth
 
 import (
         "io"
@@ -6051,7 +9736,7 @@ func IsBodyTooLargeError(err error) bool <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file30" style="display: none">package httpauth
+		<pre class="file" id="file42" style="display: none">package httpauth
 
 import (
         "context"
@@ -6258,7 +9943,7 @@ func CSRFTemplateField(r *http.Request) template.HTML <span class="cov8" title="
 }</span>
 </pre>
 		
-		<pre class="file" id="file31" style="display: none">package httpauth
+		<pre class="file" id="file43" style="display: none">package httpauth
 
 import (
         "context"
@@ -6418,7 +10103,7 @@ func (a *Middleware) setLoggedInUserId(userId string, r *http.Request) *http.Req
 }</span>
 </pre>
 		
-		<pre class="file" id="file32" style="display: none">package httpauth
+		<pre class="file" id="file44" style="display: none">package httpauth
 
 import (
         "fmt"
@@ -6957,7 +10642,7 @@ func (a *OneAuth) GetLinkingUserID(r *http.Request) string <span class="cov0" ti
 }</span>
 </pre>
 		
-		<pre class="file" id="file33" style="display: none">package httpauth
+		<pre class="file" id="file45" style="display: none">package httpauth
 
 import "net/http"
 
@@ -7081,7 +10766,7 @@ func itoa(n int) string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file34" style="display: none">package keys
+		<pre class="file" id="file46" style="display: none">package keys
 
 import (
         "crypto/aes"
@@ -7290,7 +10975,7 @@ func isHMACAlgorithm(alg string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file35" style="display: none">package keys
+		<pre class="file" id="file47" style="display: none">package keys
 
 import (
         "crypto/sha256"
@@ -7405,7 +11090,7 @@ func (h *JWKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span cl
 }
 </pre>
 		
-		<pre class="file" id="file36" style="display: none">package keys
+		<pre class="file" id="file48" style="display: none">package keys
 
 import (
         "crypto"
@@ -7626,7 +11311,7 @@ func (s *JWKSKeyStore) GetExpectedAlg(clientID string) (string, error) <span cla
 }
 </pre>
 		
-		<pre class="file" id="file37" style="display: none">package keys
+		<pre class="file" id="file49" style="display: none">package keys
 
 import (
         "fmt"
@@ -7842,7 +11527,7 @@ func (s *InMemoryKeyStore) GetCurrentKid(clientID string) (string, error) <span 
 }
 </pre>
 		
-		<pre class="file" id="file38" style="display: none">package keys
+		<pre class="file" id="file50" style="display: none">package keys
 
 import (
         "sync"
@@ -7972,7 +11657,7 @@ func (c *CompositeKeyLookup) GetKeyByKid(kid string) (*KeyRecord, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file39" style="display: none">// Package keystoretest provides shared test suites for all KeyStore implementations.
+		<pre class="file" id="file51" style="display: none">// Package keystoretest provides shared test suites for all KeyStore implementations.
 // Each backend (inmem, gorm, fs, gae) calls these tests with its own factory function.
 package keystoretest
 
@@ -8342,7 +12027,7 @@ func TestRegisterAndGetAsymmetricKey(t *testing.T, factory Factory) <span class=
 }
 </pre>
 		
-		<pre class="file" id="file40" style="display: none">package localauth
+		<pre class="file" id="file52" style="display: none">package localauth
 
 import (
         "crypto/rand"
@@ -9032,7 +12717,7 @@ func parseIdentityKey(key string) []string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file41" style="display: none">package localauth
+		<pre class="file" id="file53" style="display: none">package localauth
 
 import (
         "encoding/json"
@@ -9719,7 +13404,7 @@ func (a *LocalAuth) HandleLinkCredentials(config LinkCredentialsConfig, getUser 
 }
 </pre>
 		
-		<pre class="file" id="file42" style="display: none">package localauth
+		<pre class="file" id="file54" style="display: none">package localauth
 
 import (
         "encoding/json"
@@ -9979,7 +13664,7 @@ func (a *LocalAuth) parseSignupForm(r *http.Request) (*core.Credentials, *core.A
 }
 </pre>
 		
-		<pre class="file" id="file43" style="display: none">package fs
+		<pre class="file" id="file55" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -10229,7 +13914,7 @@ func (s *FSAPIKeyStore) UpdateAPIKeyLastUsed(keyID string) error <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file44" style="display: none">package fs
+		<pre class="file" id="file56" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -10360,7 +14045,7 @@ func (s *FSChannelStore) GetChannelsByIdentity(identityKey string) ([]*core.Chan
 }
 </pre>
 		
-		<pre class="file" id="file45" style="display: none">package fs
+		<pre class="file" id="file57" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -10495,7 +14180,7 @@ func (s *FSIdentityStore) GetUserIdentities(userId string) ([]*core.Identity, er
 }
 </pre>
 		
-		<pre class="file" id="file46" style="display: none">package fs
+		<pre class="file" id="file58" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -10728,7 +14413,7 @@ func (s *FSKeyStore) GetCurrentKid(clientID string) (string, error) <span class=
 }
 </pre>
 		
-		<pre class="file" id="file47" style="display: none">package fs
+		<pre class="file" id="file59" style="display: none">package fs
 
 import (
         "crypto/sha256"
@@ -10888,18 +14573,19 @@ func (s *FSRefreshTokenStore) RotateRefreshToken(oldToken string) (*core.Refresh
         }</span>
 
         <span class="cov0" title="0">refreshToken := &amp;core.RefreshToken{
-                Token:      newToken,
-                TokenHash:  s.hashToken(newToken),
-                UserID:     old.UserID,
-                ClientID:   old.ClientID,
-                DeviceInfo: old.DeviceInfo,
-                Family:     old.Family,
-                Generation: old.Generation + 1,
-                Scopes:     old.Scopes,
-                CreatedAt:  now,
-                ExpiresAt:  now.Add(core.TokenExpiryRefreshToken),
-                LastUsedAt: now,
-                Revoked:    false,
+                Token:                newToken,
+                TokenHash:            s.hashToken(newToken),
+                UserID:               old.UserID,
+                ClientID:             old.ClientID,
+                DeviceInfo:           old.DeviceInfo,
+                Family:               old.Family,
+                Generation:           old.Generation + 1,
+                Scopes:               old.Scopes,
+                AuthorizationDetails: old.AuthorizationDetails,
+                CreatedAt:            now,
+                ExpiresAt:            now.Add(core.TokenExpiryRefreshToken),
+                LastUsedAt:           now,
+                Revoked:              false,
         }
 
         if err := s.saveToken(refreshToken); err != nil </span><span class="cov0" title="0">{
@@ -11066,7 +14752,7 @@ func (s *FSRefreshTokenStore) forEachToken(fn func(token *core.RefreshToken, pat
 }
 </pre>
 		
-		<pre class="file" id="file48" style="display: none">package fs
+		<pre class="file" id="file60" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -11204,7 +14890,7 @@ func (s *FSTokenStore) DeleteUserTokens(userID string, tokenType core.TokenType)
 }
 </pre>
 		
-		<pre class="file" id="file49" style="display: none">package fs
+		<pre class="file" id="file61" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -11312,7 +14998,7 @@ func (s *FSUserStore) SaveUser(user core.User) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file50" style="display: none">package fs
+		<pre class="file" id="file62" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -11604,7 +15290,7 @@ func (s *FSUsernameStore) ChangeUsername(oldUsername, newUsername, userID string
 }
 </pre>
 		
-		<pre class="file" id="file51" style="display: none">package fs
+		<pre class="file" id="file63" style="display: none">package fs
 
 import (
         "fmt"
@@ -11691,7 +15377,7 @@ func writeAtomicFile(path string, data []byte) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file52" style="display: none">// Package testutil provides reusable test infrastructure for oneauth
+		<pre class="file" id="file64" style="display: none">// Package testutil provides reusable test infrastructure for oneauth
 // integration tests. It is intended to be imported by downstream projects
 // (mcpkit, relay, etc.) as well as oneauth's own test suites.
 //
@@ -11883,7 +15569,7 @@ func ParseJWTHeader(t *testing.T, tokenStr string) map[string]any <span class="c
 }
 </pre>
 		
-		<pre class="file" id="file53" style="display: none">package testutil
+		<pre class="file" id="file65" style="display: none">package testutil
 
 import (
         "crypto/rand"
@@ -12146,7 +15832,7 @@ func (s *TestAuthServer) MintTokenForSubject(subject string, scopes []string) (s
 }
 </pre>
 		
-		<pre class="file" id="file54" style="display: none">package testutil
+		<pre class="file" id="file66" style="display: none">package testutil
 
 import (
         "time"
@@ -12225,7 +15911,7 @@ func (s *TestAuthServer) signToken(claims jwt.MapClaims) (string, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file55" style="display: none">package utils
+		<pre class="file" id="file67" style="display: none">package utils
 
 import (
         "crypto"
@@ -12407,7 +16093,7 @@ func SigningMethodForAlg(alg string) (jwt.SigningMethod, error) <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file56" style="display: none">package utils
+		<pre class="file" id="file68" style="display: none">package utils
 
 import (
         "bytes"
@@ -12575,7 +16261,7 @@ func excelDecode(encoded string, alpha string, revmap map[rune]uint) uint64 <spa
 }
 </pre>
 		
-		<pre class="file" id="file57" style="display: none">package utils
+		<pre class="file" id="file69" style="display: none">package utils
 
 import (
         "crypto"
@@ -12720,7 +16406,7 @@ func ecJWKToPublicKey(jwk JWK) (crypto.PublicKey, string, error) <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file58" style="display: none">package utils
+		<pre class="file" id="file70" style="display: none">package utils
 
 import (
         "crypto/ecdsa"

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>main</strong> | Commit: <code>945846a</code> | Date: 2026-04-16 21:48:39</div>
+<div class='meta'>Branch: <strong>feat/rar-phase1</strong> | Commit: <code>b554d82</code> | Date: 2026-04-27 01:13:54</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
@@ -31,11 +31,28 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Thu Apr 16 21:47:20 PDT 2026
+Started: Mon Apr 27 01:12:00 PDT 2026
 Starting PostgreSQL...
-018ad0f00f3bfb78c020910b3b19eb4545a419c4a38274fd74b5493275720646
+16839d43f60a3781432ec61d3cce21b23385fe6ae80ff7cce23ae5b9e2c07079
 Starting Keycloak...
-0a5727cf565205b3382aafcf38f804402771204311e19f5c42464a896cdb2803
+Unable to find image 'quay.io/keycloak/keycloak:26.6' locally
+26.6: Pulling from keycloak/keycloak
+aa06a88f8d3d: Pulling fs layer
+b45b14b2d95c: Pulling fs layer
+7c001a69653d: Pulling fs layer
+7f89c20ca4d5: Pulling fs layer
+12b9e5d4c972: Download complete
+aa06a88f8d3d: Download complete
+b45b14b2d95c: Download complete
+b45b14b2d95c: Pull complete
+7c001a69653d: Download complete
+7f89c20ca4d5: Download complete
+7c001a69653d: Pull complete
+aa06a88f8d3d: Pull complete
+7f89c20ca4d5: Pull complete
+Digest: sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
+Status: Downloaded newer image for quay.io/keycloak/keycloak:26.6
+a8e7e7d9fd525b97fefcd0d3211021f616e50c58d806efd789b49129d2572325
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -44,32 +61,43 @@ Starting Keycloak...
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.577s	coverage: 75.8% of statements
-ok  	github.com/panyam/oneauth/apiauth	6.231s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/client	7.228s	coverage: 83.3% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	0.493s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	2.192s	coverage: 4.5% of statements
-ok  	github.com/panyam/oneauth/examples	3.412s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/httpauth	1.134s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	5.024s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/admin	0.997s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	6.243s	coverage: 71.1% of statements
+ok  	github.com/panyam/oneauth/client	5.701s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.202s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	1.931s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	2.125s	coverage: [no statements]
+	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/04-discovery		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/05-introspection		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/06-dynamic-client-registration		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/07-client-sdk		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/08-rich-authorization-requests		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/demokit		coverage: 0.0% of statements
+ok  	github.com/panyam/oneauth/httpauth	1.079s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	3.655s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	8.524s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	3.091s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	4.615s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	2.611s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	2.210s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	8.879s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	2.355s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	5.181s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	3.950s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	4.311s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	19.388s
+ok  	github.com/panyam/oneauth/tests/e2e	19.684s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.888s
+ok  	github.com/panyam/oneauth/stores/gorm	1.226s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -80,7 +108,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.136s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.532s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -92,10 +120,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.136s
     ○ ░
     ░    gitleaks
 
-[90m9:48PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m9:48PM[0m [32mINF[0m [1m178 commits scanned.[0m
-[90m9:48PM[0m [32mINF[0m [1mscanned ~2871187 bytes (2.87 MB) in 676ms[0m
-[90m9:48PM[0m [32mINF[0m [1mno leaks found[0m
+[90m1:13AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m1:13AM[0m [32mINF[0m [1m187 commits scanned.[0m
+[90m1:13AM[0m [32mINF[0m [1mscanned ~3195271 bytes (3.20 MB) in 791ms[0m
+[90m1:13AM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -106,16 +134,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/16 21:48:03 Using in-memory KeyStore (not persistent)
-2026/04/16 21:48:03 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/16 21:48:03 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/16 21:48:03 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/16 21:48:29 
+2026/04/27 01:13:16 Using in-memory KeyStore (not persistent)
+2026/04/27 01:13:16 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 01:13:16 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 01:13:16 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 01:13:43 
 === EMAIL: Password Reset ===
-2026/04/16 21:48:29 To: zaproxy@example.com
-2026/04/16 21:48:29 Subject: Reset your password
-2026/04/16 21:48:29 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=5bf88a6371e1cbd7421cc8520984bad5b38b7c0c61209584cdf83e893691f80e
-2026/04/16 21:48:29 ==============================
+2026/04/27 01:13:43 To: zaproxy@example.com
+2026/04/27 01:13:43 Subject: Reset your password
+2026/04/27 01:13:43 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=b2152c5919fd480729ad04fa13631008b08c6249f99b50cf55198ec2aaeccec8
+2026/04/27 01:13:43 ==============================
+2026/04/27 01:13:43 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -179,51 +208,51 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-IGNORE: Cookie No HttpOnly Flag [10010] x 2 
+IGNORE: Cookie No HttpOnly Flag [10010] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Non-Storable Content [10049] x 7 
+IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-IGNORE: CSP: style-src unsafe-inline [10055] x 4 
+	http://host.docker.internal:19876/auth/signup (200 OK)
+	http://host.docker.internal:19876/robots.txt (404 Not Found)
+IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
-IGNORE: Session Management Response Identified [10112] x 3 
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Session Management Response Identified [10112] x 2 
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 16 
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Thu Apr 16 21:48:39 PDT 2026
+Finished: Mon Apr 27 01:13:52 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak
 </pre>

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,9 +1,26 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Thu Apr 16 21:47:20 PDT 2026
+Started: Mon Apr 27 01:12:00 PDT 2026
 Starting PostgreSQL...
-018ad0f00f3bfb78c020910b3b19eb4545a419c4a38274fd74b5493275720646
+16839d43f60a3781432ec61d3cce21b23385fe6ae80ff7cce23ae5b9e2c07079
 Starting Keycloak...
-0a5727cf565205b3382aafcf38f804402771204311e19f5c42464a896cdb2803
+Unable to find image 'quay.io/keycloak/keycloak:26.6' locally
+26.6: Pulling from keycloak/keycloak
+aa06a88f8d3d: Pulling fs layer
+b45b14b2d95c: Pulling fs layer
+7c001a69653d: Pulling fs layer
+7f89c20ca4d5: Pulling fs layer
+12b9e5d4c972: Download complete
+aa06a88f8d3d: Download complete
+b45b14b2d95c: Download complete
+b45b14b2d95c: Pull complete
+7c001a69653d: Download complete
+7f89c20ca4d5: Download complete
+7c001a69653d: Pull complete
+aa06a88f8d3d: Pull complete
+7f89c20ca4d5: Pull complete
+Digest: sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
+Status: Downloaded newer image for quay.io/keycloak/keycloak:26.6
+a8e7e7d9fd525b97fefcd0d3211021f616e50c58d806efd789b49129d2572325
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -12,32 +29,43 @@ Starting Keycloak...
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.577s	coverage: 75.8% of statements
-ok  	github.com/panyam/oneauth/apiauth	6.231s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/client	7.228s	coverage: 83.3% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	0.493s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	2.192s	coverage: 4.5% of statements
-ok  	github.com/panyam/oneauth/examples	3.412s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/httpauth	1.134s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	5.024s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/admin	0.997s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	6.243s	coverage: 71.1% of statements
+ok  	github.com/panyam/oneauth/client	5.701s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.202s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	1.931s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	2.125s	coverage: [no statements]
+	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/04-discovery		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/05-introspection		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/06-dynamic-client-registration		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/07-client-sdk		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/08-rich-authorization-requests		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/demokit		coverage: 0.0% of statements
+ok  	github.com/panyam/oneauth/httpauth	1.079s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	3.655s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	8.524s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	3.091s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	4.615s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	2.611s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	2.210s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	8.879s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	2.355s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	5.181s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	3.950s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	4.311s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	19.388s
+ok  	github.com/panyam/oneauth/tests/e2e	19.684s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.888s
+ok  	github.com/panyam/oneauth/stores/gorm	1.226s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -48,7 +76,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.136s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.532s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -60,10 +88,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.136s
     ○ ░
     ░    gitleaks
 
-[90m9:48PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m9:48PM[0m [32mINF[0m [1m178 commits scanned.[0m
-[90m9:48PM[0m [32mINF[0m [1mscanned ~2871187 bytes (2.87 MB) in 676ms[0m
-[90m9:48PM[0m [32mINF[0m [1mno leaks found[0m
+[90m1:13AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m1:13AM[0m [32mINF[0m [1m187 commits scanned.[0m
+[90m1:13AM[0m [32mINF[0m [1mscanned ~3195271 bytes (3.20 MB) in 791ms[0m
+[90m1:13AM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -74,16 +102,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/16 21:48:03 Using in-memory KeyStore (not persistent)
-2026/04/16 21:48:03 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/16 21:48:03 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/16 21:48:03 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/16 21:48:29 
+2026/04/27 01:13:16 Using in-memory KeyStore (not persistent)
+2026/04/27 01:13:16 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 01:13:16 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 01:13:16 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 01:13:43 
 === EMAIL: Password Reset ===
-2026/04/16 21:48:29 To: zaproxy@example.com
-2026/04/16 21:48:29 Subject: Reset your password
-2026/04/16 21:48:29 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=5bf88a6371e1cbd7421cc8520984bad5b38b7c0c61209584cdf83e893691f80e
-2026/04/16 21:48:29 ==============================
+2026/04/27 01:13:43 To: zaproxy@example.com
+2026/04/27 01:13:43 Subject: Reset your password
+2026/04/27 01:13:43 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=b2152c5919fd480729ad04fa13631008b08c6249f99b50cf55198ec2aaeccec8
+2026/04/27 01:13:43 ==============================
+2026/04/27 01:13:43 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -147,50 +176,50 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-IGNORE: Cookie No HttpOnly Flag [10010] x 2 
+IGNORE: Cookie No HttpOnly Flag [10010] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Non-Storable Content [10049] x 7 
+IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-IGNORE: CSP: style-src unsafe-inline [10055] x 4 
+	http://host.docker.internal:19876/auth/signup (200 OK)
+	http://host.docker.internal:19876/robots.txt (404 Not Found)
+IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
-IGNORE: Session Management Response Identified [10112] x 3 
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Session Management Response Identified [10112] x 2 
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
 	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 16 
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Thu Apr 16 21:48:39 PDT 2026
+Finished: Mon Apr 27 01:13:52 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak

--- a/tests/e2e/federated_flow_test.go
+++ b/tests/e2e/federated_flow_test.go
@@ -29,7 +29,7 @@ func TestFederated_MintAndValidate(t *testing.T) {
 
 	// Mint resource token
 	token, err := admin.MintResourceToken("fed-user@example.com", clientID, clientSecret,
-		admin.AppQuota{MaxRooms: 10}, []string{"collab"})
+		admin.AppQuota{MaxRooms: 10}, []string{"collab"}, nil)
 	require.NoError(t, err)
 
 	// Validate against resource server A
@@ -58,7 +58,7 @@ func TestFederated_WrongSecretRejected(t *testing.T) {
 
 	// Mint with wrong secret
 	token, err := admin.MintResourceToken("hacker@evil.com", clientID, "wrong-secret",
-		admin.AppQuota{}, []string{"read"})
+		admin.AppQuota{}, []string{"read"}, nil)
 	require.NoError(t, err)
 
 	req, _ := http.NewRequest("POST", env.ResourceAURL()+"/validate", nil)
@@ -82,7 +82,7 @@ func TestFederated_CrossResourceServer(t *testing.T) {
 	defer NewTestClient(env).Delete("/apps/" + clientID)
 
 	token, err := admin.MintResourceToken("user@example.com", clientID, clientSecret,
-		admin.AppQuota{}, []string{"read"})
+		admin.AppQuota{}, []string{"read"}, nil)
 	require.NoError(t, err)
 
 	for _, rsURL := range []string{env.ResourceAURL(), env.ResourceBURL()} {
@@ -106,7 +106,7 @@ func TestFederated_DeletedAppTokenRejected(t *testing.T) {
 	clientID, clientSecret := RegisterApp(t, env, "delete-fed.example.com")
 
 	token, err := admin.MintResourceToken("user@example.com", clientID, clientSecret,
-		admin.AppQuota{}, []string{"read"})
+		admin.AppQuota{}, []string{"read"}, nil)
 	require.NoError(t, err)
 
 	// Delete the app

--- a/tests/e2e/rar_test.go
+++ b/tests/e2e/rar_test.go
@@ -1,0 +1,238 @@
+package e2e_test
+
+// E2E tests for RFC 9396 Rich Authorization Requests.
+// These tests verify the full RAR flow through the auth server: register an app,
+// request a client_credentials token with authorization_details, introspect it,
+// and verify the details round-trip correctly.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRAR_ClientCredentials_FullFlow verifies the complete RAR flow:
+// 1. Register app via /apps/register
+// 2. Request client_credentials token with authorization_details via /api/token
+// 3. Verify authorization_details in response body
+// 4. Verify authorization_details in JWT claims
+// 5. Introspect the token and verify authorization_details in introspection response
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5
+func TestRAR_ClientCredentials_FullFlow(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "rar-flow.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	// Step 1: Request token with authorization_details (JSON body)
+	details := []map[string]any{
+		{
+			"type":    "payment_initiation",
+			"actions": []string{"initiate"},
+			"locations": []string{"https://bank.example.com/payments"},
+			"instructedAmount": map[string]any{
+				"currency": "EUR",
+				"amount":   "45.00",
+			},
+			"creditorName": "Merchant A",
+		},
+	}
+
+	body := map[string]any{
+		"grant_type":            "client_credentials",
+		"client_id":             clientID,
+		"client_secret":         clientSecret,
+		"scope":                 "payments",
+		"authorization_details": details,
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/api/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	tokenResp := ReadJSON(resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "token request failed: %v", tokenResp)
+
+	// Step 2: Verify authorization_details in response body
+	ad, ok := tokenResp["authorization_details"]
+	require.True(t, ok, "response missing authorization_details")
+	adArray := ad.([]any)
+	require.Len(t, adArray, 1)
+	adObj := adArray[0].(map[string]any)
+	assert.Equal(t, "payment_initiation", adObj["type"])
+	assert.Equal(t, "Merchant A", adObj["creditorName"])
+
+	// scope should also be present
+	assert.Equal(t, "payments", tokenResp["scope"])
+
+	// Step 3: Verify authorization_details in JWT
+	accessToken := tokenResp["access_token"].(string)
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(accessToken, jwt.MapClaims{})
+	require.NoError(t, err)
+	claims := parsed.Claims.(jwt.MapClaims)
+
+	jwtAD, ok := claims["authorization_details"]
+	require.True(t, ok, "JWT missing authorization_details claim")
+	jwtADArray := jwtAD.([]any)
+	require.Len(t, jwtADArray, 1)
+	assert.Equal(t, "payment_initiation", jwtADArray[0].(map[string]any)["type"])
+
+	// Step 4: Introspect and verify
+	form := url.Values{"token": {accessToken}}
+	introReq, _ := http.NewRequest("POST", env.BaseURL()+"/oauth/introspect",
+		strings.NewReader(form.Encode()))
+	introReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	introReq.SetBasicAuth(clientID, clientSecret)
+	introResp, err := http.DefaultClient.Do(introReq)
+	require.NoError(t, err)
+	introResult := ReadJSON(introResp)
+	require.Equal(t, http.StatusOK, introResp.StatusCode)
+	assert.Equal(t, true, introResult["active"])
+
+	introAD, ok := introResult["authorization_details"]
+	require.True(t, ok, "introspection response missing authorization_details")
+	introADArray := introAD.([]any)
+	require.Len(t, introADArray, 1)
+	assert.Equal(t, "payment_initiation", introADArray[0].(map[string]any)["type"])
+}
+
+// TestRAR_CoexistsWithScopes verifies that authorization_details and scope
+// can be used independently in the same token request.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-7
+func TestRAR_CoexistsWithScopes(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "rar-scope.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"scope":         "read write",
+		"authorization_details": []map[string]any{
+			{"type": "account_information", "actions": []string{"list_accounts"}},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/api/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	tokenResp := ReadJSON(resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Both scope and authorization_details should be present
+	assert.Equal(t, "read write", tokenResp["scope"])
+	ad := tokenResp["authorization_details"].([]any)
+	assert.Len(t, ad, 1)
+	assert.Equal(t, "account_information", ad[0].(map[string]any)["type"])
+}
+
+// TestRAR_InvalidType_Rejected verifies that authorization_details with a
+// missing type field are rejected with invalid_authorization_details error.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5.2
+func TestRAR_InvalidType_Rejected(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "rar-invalid.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"authorization_details": []map[string]any{
+			{"actions": []string{"read"}}, // missing "type"
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/api/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	errResp := ReadJSON(resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "invalid_authorization_details", errResp["error"])
+}
+
+// TestRAR_FormEncoded verifies that authorization_details can be sent as a
+// JSON-encoded string in a form-encoded request body.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-6.1
+func TestRAR_FormEncoded(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "rar-form.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	details := []map[string]any{
+		{"type": "signing_service", "actions": []string{"sign"}},
+	}
+	detailsJSON, _ := json.Marshal(details)
+
+	form := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_id":             {clientID},
+		"client_secret":         {clientSecret},
+		"authorization_details": {string(detailsJSON)},
+	}
+
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/api/token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	tokenResp := ReadJSON(resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "response: %v", tokenResp)
+
+	ad := tokenResp["authorization_details"].([]any)
+	require.Len(t, ad, 1)
+	assert.Equal(t, "signing_service", ad[0].(map[string]any)["type"])
+}
+
+// TestRAR_NoDetails_Unchanged verifies that existing token requests without
+// authorization_details continue to work exactly as before — no
+// authorization_details field appears in the response.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5
+func TestRAR_NoDetails_Unchanged(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "rar-compat.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"scope":         "read",
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/api/token",
+		strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	tokenResp := ReadJSON(resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, hasAD := tokenResp["authorization_details"]
+	assert.False(t, hasAD, "authorization_details should not appear when not requested")
+	assert.NotEmpty(t, tokenResp["access_token"])
+	assert.Equal(t, "read", tokenResp["scope"])
+}

--- a/tests/keycloak/interop_test.go
+++ b/tests/keycloak/interop_test.go
@@ -888,6 +888,142 @@ func TestKeycloak_RFC8414Proxy_SimplePathAlsoWorks(t *testing.T) {
 }
 
 // =============================================================================
+// RFC 9396 Backward Compatibility Tests
+// =============================================================================
+//
+// Keycloak does NOT support RFC 9396 Rich Authorization Requests on standard
+// OAuth flows (client_credentials, authorization_code) as of version 26.6.
+// The org.keycloak.rar package exists internally but is only used for OID4VCI
+// (Verifiable Credentials Issuance).
+//
+// These tests prove that OneAuth's RAR-aware middleware correctly handles
+// non-RAR tokens from external IdPs. They also act as a canary: when KC adds
+// RAR support (tracked: keycloak/keycloak#29340), the discovery test will fail,
+// alerting us to add full RAR interop tests against Keycloak.
+//
+// Migration path: when Keycloak adds RFC 9396 support, copy the test patterns
+// from rar_interop_test.go (RAR test issuer) and point them at Keycloak.
+// The RAR test issuer binary (cmd/rar-test-issuer) can then be retired.
+
+// TestKeycloak_Discovery_NoRARTypes verifies that Keycloak's discovery document
+// does NOT contain authorization_details_types_supported. This is a canary test:
+// when KC adds RAR, this test fails and prompts us to add RAR interop tests.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-10
+func TestKeycloak_Discovery_NoRARTypes(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	cfg := discoverOIDC(t)
+	// KC does not advertise RAR types — verify absence
+	// (the OIDCConfig struct may not have this field; check raw JSON)
+	resp, err := http.Get(realmURL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var raw map[string]any
+	require.NoError(t, decodeJSON(resp.Body, &raw))
+	_, hasRARTypes := raw["authorization_details_types_supported"]
+	assert.False(t, hasRARTypes,
+		"Keycloak should NOT advertise authorization_details_types_supported (if this fails, KC added RAR — time to add full RAR interop tests!)")
+	_ = cfg
+}
+
+// TestKeycloak_RARMiddleware_NilForNonRARToken verifies that when APIMiddleware
+// validates a normal Keycloak token (no authorization_details), the context
+// helper GetAuthorizationDetailsFromContext returns nil. Proves RAR-aware
+// middleware is backwards-compatible with non-RAR tokens.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-7
+func TestKeycloak_RARMiddleware_NilForNonRARToken(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	cfg := discoverOIDC(t)
+	tokenResp := getClientCredentialsToken(t, cfg.TokenEndpoint, confidentialClientID, confidentialClientSecret)
+
+	// Set up a JWKS-backed middleware pointing at Keycloak
+	jwksKS := keys.NewJWKSKeyStore(cfg.JWKSURI)
+	mw := &apiauth.APIMiddleware{KeyStore: jwksKS}
+
+	// Validate the token through middleware
+	var capturedDetails []any
+	handler := mw.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ad := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+		if ad != nil {
+			capturedDetails = make([]any, len(ad))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "token should validate successfully")
+	assert.Nil(t, capturedDetails, "authorization_details should be nil for non-RAR KC token")
+}
+
+// TestKeycloak_RequireAuthorizationDetails_RejectsNonRAR verifies that
+// RequireAuthorizationDetails correctly rejects a Keycloak token that does
+// not contain authorization_details. This proves enforcement works against
+// real-world tokens that lack RAR.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestKeycloak_RequireAuthorizationDetails_RejectsNonRAR(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	cfg := discoverOIDC(t)
+	tokenResp := getClientCredentialsToken(t, cfg.TokenEndpoint, confidentialClientID, confidentialClientSecret)
+
+	jwksKS := keys.NewJWKSKeyStore(cfg.JWKSURI)
+	mw := &apiauth.APIMiddleware{KeyStore: jwksKS}
+
+	handler := mw.RequireAuthorizationDetails("payment_initiation")(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code,
+		"RequireAuthorizationDetails should reject KC token without RAR")
+}
+
+// TestKeycloak_Introspection_NoAuthzDetails verifies that introspecting a
+// Keycloak token does not return an authorization_details field. Confirms
+// clean introspection for non-RAR tokens.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
+func TestKeycloak_Introspection_NoAuthzDetails(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	cfg := discoverOIDC(t)
+	tokenResp := getClientCredentialsToken(t, cfg.TokenEndpoint, confidentialClientID, confidentialClientSecret)
+
+	// Introspect via Keycloak's introspection endpoint
+	form := url.Values{"token": {tokenResp.AccessToken}}
+	req, _ := http.NewRequest("POST", cfg.IntrospectionEndpoint, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(confidentialClientID, confidentialClientSecret)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, true, result["active"])
+
+	_, hasAD := result["authorization_details"]
+	assert.False(t, hasAD, "KC introspection should not return authorization_details for non-RAR token")
+}
+
+// =============================================================================
 // Helpers
 // =============================================================================
 

--- a/tests/keycloak/rar_interop_test.go
+++ b/tests/keycloak/rar_interop_test.go
@@ -1,0 +1,607 @@
+package keycloak_test
+
+// RFC 9396 Rich Authorization Requests — conformance and interop tests.
+//
+// These tests run against the RAR test issuer (cmd/rar-test-issuer), a minimal
+// OneAuth-based AS that supports RFC 9396. The issuer runs in Docker alongside
+// Keycloak, serving on port 8181 (configurable via RAR_ISSUER_URL).
+//
+// The tests prove that OneAuth resource servers can validate RAR tokens issued
+// by an external AS over real HTTP — not httptest, not in-process.
+//
+// Migration path: when Keycloak adds RFC 9396 support on standard OAuth flows
+// (tracked: keycloak/keycloak#29340), duplicate these tests pointing at Keycloak
+// to prove cross-vendor interop. Then retire the RAR test issuer binary.
+//
+// Conformance coverage (RFC 9396 sections):
+//   §2   — authorization_details structure and type field
+//   §5   — token endpoint: request and response
+//   §5.2 — error response: invalid_authorization_details
+//   §6.1 — form-encoded authorization_details parameter
+//   §7   — coexistence with scope parameter
+//   §9.1 — token introspection with authorization_details
+//   §10  — AS metadata: authorization_details_types_supported
+//   §12  — security: tampered authorization_details
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// §10 — AS Metadata Discovery
+// =============================================================================
+
+// TestRAR_Discovery_TypesSupported verifies that the RAR test issuer advertises
+// authorization_details_types_supported in its AS metadata, per RFC 9396 §10.
+// When migrating to Keycloak, this test should pass if KC adds RAR.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-10
+func TestRAR_Discovery_TypesSupported(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	resp, err := http.Get(rarIssuerURL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	// authorization_details_types_supported MUST be present
+	rawTypes, ok := meta["authorization_details_types_supported"]
+	require.True(t, ok, "AS metadata must include authorization_details_types_supported")
+
+	types := rawTypes.([]any)
+	assert.Contains(t, types, "payment_initiation")
+	assert.Contains(t, types, "account_information")
+	assert.Contains(t, types, "signing_service")
+
+	// Standard fields should also be present
+	assert.NotEmpty(t, meta["issuer"])
+	assert.NotEmpty(t, meta["token_endpoint"])
+	assert.NotEmpty(t, meta["jwks_uri"])
+}
+
+// =============================================================================
+// §5 — Token Endpoint: Request and Response
+// =============================================================================
+
+// TestRAR_TokenRequest_WithDetails verifies that the token endpoint accepts
+// authorization_details in a JSON request body and returns them in the response.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5
+func TestRAR_TokenRequest_WithDetails(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{
+				"type":    "payment_initiation",
+				"actions": []string{"initiate"},
+				"locations": []string{"https://bank.example.com/payments"},
+				"instructedAmount": map[string]any{
+					"currency": "EUR",
+					"amount":   "45.00",
+				},
+				"creditorName": "Merchant A",
+			},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(rarIssuerURL()+"/api/token", "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	// Response MUST include authorization_details (RFC 9396 §5)
+	ad, ok := tokenResp["authorization_details"]
+	require.True(t, ok, "token response must include authorization_details")
+	adArray := ad.([]any)
+	require.Len(t, adArray, 1)
+
+	adObj := adArray[0].(map[string]any)
+	assert.Equal(t, "payment_initiation", adObj["type"])
+	assert.Equal(t, "Merchant A", adObj["creditorName"])
+
+	// access_token must be present
+	assert.NotEmpty(t, tokenResp["access_token"])
+	assert.Equal(t, "Bearer", tokenResp["token_type"])
+}
+
+// TestRAR_TokenRequest_MultipleDetails verifies that multiple authorization_details
+// objects can be requested and returned in a single token request.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestRAR_TokenRequest_MultipleDetails(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{"type": "payment_initiation", "actions": []string{"initiate"}},
+			{"type": "account_information", "actions": []string{"list_accounts", "read_balances"}},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(rarIssuerURL()+"/api/token", "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	adArray := tokenResp["authorization_details"].([]any)
+	assert.Len(t, adArray, 2, "both authorization_details objects should be returned")
+	assert.Equal(t, "payment_initiation", adArray[0].(map[string]any)["type"])
+	assert.Equal(t, "account_information", adArray[1].(map[string]any)["type"])
+}
+
+// =============================================================================
+// §6.1 — Form-Encoded Request
+// =============================================================================
+
+// TestRAR_TokenRequest_FormEncoded verifies that authorization_details can be
+// sent as a JSON-encoded string in a form-encoded request body. RFC 9396 §6.1
+// specifies this encoding for non-JSON token endpoints.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-6.1
+func TestRAR_TokenRequest_FormEncoded(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	details := []map[string]any{
+		{"type": "signing_service", "actions": []string{"sign"}, "documentHash": "abc123"},
+	}
+	detailsJSON, _ := json.Marshal(details)
+
+	form := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_id":             {rarClientID},
+		"client_secret":         {rarClientSecret},
+		"authorization_details": {string(detailsJSON)},
+	}
+
+	resp, err := http.PostForm(rarIssuerURL()+"/api/token", form)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	adArray := tokenResp["authorization_details"].([]any)
+	require.Len(t, adArray, 1)
+	assert.Equal(t, "signing_service", adArray[0].(map[string]any)["type"])
+}
+
+// =============================================================================
+// §7 — Coexistence with Scope
+// =============================================================================
+
+// TestRAR_CoexistsWithScope verifies that authorization_details and scope can
+// be sent together in the same request and both appear in the response.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-7
+func TestRAR_CoexistsWithScope(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"scope":         "read write",
+		"authorization_details": []map[string]any{
+			{"type": "payment_initiation", "actions": []string{"initiate"}},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(rarIssuerURL()+"/api/token", "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	assert.Equal(t, "read write", tokenResp["scope"], "scope must be returned independently")
+	adArray := tokenResp["authorization_details"].([]any)
+	assert.Len(t, adArray, 1)
+}
+
+// =============================================================================
+// §5.2 — Error Response
+// =============================================================================
+
+// TestRAR_Error_MissingType verifies that the AS returns
+// invalid_authorization_details when the type field is missing.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5.2
+func TestRAR_Error_MissingType(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{"actions": []string{"read"}}, // missing "type"
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(rarIssuerURL()+"/api/token", "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var errResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+	assert.Equal(t, "invalid_authorization_details", errResp["error"],
+		"missing type must produce invalid_authorization_details error")
+}
+
+// TestRAR_Error_InvalidFormJSON verifies that malformed JSON in the
+// form-encoded authorization_details parameter produces an error.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-6.1
+func TestRAR_Error_InvalidFormJSON(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	form := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_id":             {rarClientID},
+		"client_secret":         {rarClientSecret},
+		"authorization_details": {"not valid json"},
+	}
+
+	resp, err := http.PostForm(rarIssuerURL()+"/api/token", form)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var errResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+	assert.Equal(t, "invalid_authorization_details", errResp["error"])
+}
+
+// =============================================================================
+// JWT Claims — authorization_details in the access token
+// =============================================================================
+
+// TestRAR_JWT_ContainsAuthorizationDetails verifies that the issued JWT
+// access token contains the authorization_details claim with the correct
+// structure, including API-specific extension fields.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestRAR_JWT_ContainsAuthorizationDetails(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{
+				"type":    "payment_initiation",
+				"actions": []string{"initiate"},
+				"instructedAmount": map[string]any{
+					"currency": "EUR",
+					"amount":   "123.50",
+				},
+			},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(rarIssuerURL()+"/api/token", "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	// Decode JWT claims without verification (we verify via JWKS below)
+	claims := parseJWTClaims(t, tokenResp["access_token"].(string))
+
+	adRaw, ok := claims["authorization_details"]
+	require.True(t, ok, "JWT must contain authorization_details claim")
+
+	adArray := adRaw.([]any)
+	require.Len(t, adArray, 1)
+
+	adObj := adArray[0].(map[string]any)
+	assert.Equal(t, "payment_initiation", adObj["type"])
+	assert.Equal(t, []any{"initiate"}, adObj["actions"])
+
+	// Extension field must be preserved
+	amount := adObj["instructedAmount"].(map[string]any)
+	assert.Equal(t, "EUR", amount["currency"])
+	assert.Equal(t, "123.50", amount["amount"])
+}
+
+// =============================================================================
+// JWKS Validation — cross-server token verification
+// =============================================================================
+
+// TestRAR_JWKS_ValidateToken verifies that a token issued by the RAR test
+// issuer can be validated by APIMiddleware using the issuer's JWKS endpoint.
+// This is the core interop test: token crosses a real HTTP boundary,
+// JWKS is fetched over HTTP, validation is done by a separate process.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestRAR_JWKS_ValidateToken(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	// Discover JWKS URI from the issuer
+	cfg := discoverRARIssuer(t)
+
+	// Get a RAR token
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{"type": "account_information", "actions": []string{"list_accounts"}},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(cfg.TokenEndpoint, "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+	accessToken := tokenResp["access_token"].(string)
+
+	// Validate via APIMiddleware + JWKSKeyStore (separate "resource server")
+	jwksKS := keys.NewJWKSKeyStore(cfg.JWKSURI)
+	mw := &apiauth.APIMiddleware{KeyStore: jwksKS}
+
+	var capturedDetails []core.AuthorizationDetail
+	handler := mw.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedDetails = apiauth.GetAuthorizationDetailsFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "RAR token should validate via JWKS")
+	require.Len(t, capturedDetails, 1, "authorization_details should be extracted from token")
+	assert.Equal(t, "account_information", capturedDetails[0].Type)
+	assert.Equal(t, []string{"list_accounts"}, capturedDetails[0].Actions)
+}
+
+// TestRAR_JWKS_RequireAuthorizationDetails verifies that
+// RequireAuthorizationDetails middleware correctly enforces type requirements
+// on tokens from an external RAR-capable AS.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-2
+func TestRAR_JWKS_RequireAuthorizationDetails(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	cfg := discoverRARIssuer(t)
+
+	// Get a token with payment_initiation
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{"type": "payment_initiation", "actions": []string{"initiate"}},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(cfg.TokenEndpoint, "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+	accessToken := tokenResp["access_token"].(string)
+
+	jwksKS := keys.NewJWKSKeyStore(cfg.JWKSURI)
+	mw := &apiauth.APIMiddleware{KeyStore: jwksKS}
+
+	// Require the type that IS in the token — should pass
+	t.Run("matching_type_passes", func(t *testing.T) {
+		handler := mw.RequireAuthorizationDetails("payment_initiation")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		)
+		req := httptest.NewRequest("GET", "/payments", nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	// Require a type that is NOT in the token — should reject
+	t.Run("wrong_type_rejected", func(t *testing.T) {
+		handler := mw.RequireAuthorizationDetails("account_information")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		)
+		req := httptest.NewRequest("GET", "/accounts", nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+}
+
+// =============================================================================
+// §9.1 — Token Introspection
+// =============================================================================
+
+// TestRAR_Introspection_IncludesDetails verifies that introspecting a RAR
+// token returns authorization_details in the introspection response, per
+// RFC 9396 §9.1.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
+func TestRAR_Introspection_IncludesDetails(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	cfg := discoverRARIssuer(t)
+
+	// Get a RAR token
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"authorization_details": []map[string]any{
+			{"type": "payment_initiation", "actions": []string{"initiate"}, "creditorName": "Alice"},
+		},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	tokenResp, err := http.Post(cfg.TokenEndpoint, "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+
+	var tr map[string]any
+	require.NoError(t, json.NewDecoder(tokenResp.Body).Decode(&tr))
+	accessToken := tr["access_token"].(string)
+
+	// Introspect using the introspection client credentials
+	form := url.Values{"token": {accessToken}}
+	introReq, _ := http.NewRequest("POST", cfg.IntrospectionEndpoint,
+		strings.NewReader(form.Encode()))
+	introReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	introReq.SetBasicAuth(rarIntroClientID, rarIntroSecret)
+
+	introResp, err := http.DefaultClient.Do(introReq)
+	require.NoError(t, err)
+	defer introResp.Body.Close()
+	require.Equal(t, http.StatusOK, introResp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(introResp.Body).Decode(&result))
+	assert.Equal(t, true, result["active"])
+
+	// authorization_details MUST be in introspection response
+	ad, ok := result["authorization_details"]
+	require.True(t, ok, "introspection must include authorization_details")
+	adArray := ad.([]any)
+	require.Len(t, adArray, 1)
+	assert.Equal(t, "payment_initiation", adArray[0].(map[string]any)["type"])
+	assert.Equal(t, "Alice", adArray[0].(map[string]any)["creditorName"])
+}
+
+// TestRAR_Introspection_NoDetailsWhenAbsent verifies that introspecting a
+// token WITHOUT authorization_details does not include the field.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
+func TestRAR_Introspection_NoDetailsWhenAbsent(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	cfg := discoverRARIssuer(t)
+
+	// Get a token WITHOUT authorization_details
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"scope":         "read",
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	tokenResp, err := http.Post(cfg.TokenEndpoint, "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+
+	var tr map[string]any
+	require.NoError(t, json.NewDecoder(tokenResp.Body).Decode(&tr))
+
+	// Introspect
+	form := url.Values{"token": {tr["access_token"].(string)}}
+	introReq, _ := http.NewRequest("POST", cfg.IntrospectionEndpoint,
+		strings.NewReader(form.Encode()))
+	introReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	introReq.SetBasicAuth(rarIntroClientID, rarIntroSecret)
+
+	introResp, err := http.DefaultClient.Do(introReq)
+	require.NoError(t, err)
+	defer introResp.Body.Close()
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(introResp.Body).Decode(&result))
+	assert.Equal(t, true, result["active"])
+
+	_, hasAD := result["authorization_details"]
+	assert.False(t, hasAD, "introspection should not include authorization_details when token has none")
+}
+
+// =============================================================================
+// Backward Compatibility — no RAR
+// =============================================================================
+
+// TestRAR_NoDetails_StillWorks verifies that the RAR-capable issuer correctly
+// handles token requests without authorization_details — backward compat.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396#section-5
+func TestRAR_NoDetails_StillWorks(t *testing.T) {
+	skipIfRARIssuerNotRunning(t)
+
+	body := map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     rarClientID,
+		"client_secret": rarClientSecret,
+		"scope":         "read write",
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	resp, err := http.Post(rarIssuerURL()+"/api/token", "application/json",
+		strings.NewReader(string(bodyJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	_, hasAD := tokenResp["authorization_details"]
+	assert.False(t, hasAD, "authorization_details should not appear when not requested")
+	assert.NotEmpty(t, tokenResp["access_token"])
+	assert.Equal(t, "read write", tokenResp["scope"])
+}

--- a/tests/keycloak/testutil_test.go
+++ b/tests/keycloak/testutil_test.go
@@ -23,14 +23,21 @@ import (
 )
 
 const (
-	defaultKeycloakURL = "http://localhost:8180"
-	realmName          = "oneauth-test"
+	defaultKeycloakURL  = "http://localhost:8180"
+	defaultRARIssuerURL = "http://localhost:8181"
+	realmName           = "oneauth-test"
 
-	// Clients defined in realm.json
+	// Clients defined in realm.json (Keycloak)
 	confidentialClientID     = "test-confidential"
 	confidentialClientSecret = "test-secret-for-confidential-client"
 	audienceClientID         = "test-audience"
 	audienceClientSecret     = "test-audience-secret"
+
+	// Clients pre-registered in rar-test-issuer
+	rarClientID        = "rar-test-client"
+	rarClientSecret    = "rar-test-secret"
+	rarIntroClientID   = "rar-introspect-client"
+	rarIntroSecret     = "rar-introspect-secret"
 
 	// Test user defined in realm.json
 	testUsername = "testuser"
@@ -106,4 +113,37 @@ func parseJWTClaims(t *testing.T, tokenStr string) map[string]any {
 func parseJWTHeader(t *testing.T, tokenStr string) map[string]any {
 	t.Helper()
 	return testutil.ParseJWTHeader(t, tokenStr)
+}
+
+// =============================================================================
+// RAR Test Issuer helpers
+// =============================================================================
+
+// rarIssuerURL returns the RAR test issuer URL from env or default.
+func rarIssuerURL() string {
+	if u := os.Getenv("RAR_ISSUER_URL"); u != "" {
+		return u
+	}
+	return defaultRARIssuerURL
+}
+
+// skipIfRARIssuerNotRunning checks if the RAR test issuer is reachable and
+// skips the test if not. Run 'make uprar' to start it.
+func skipIfRARIssuerNotRunning(t *testing.T) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(rarIssuerURL() + "/_ah/health")
+	if err != nil {
+		t.Skipf("RAR test issuer not reachable at %s: %v (run 'make uprar' to start)", rarIssuerURL(), err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Skipf("RAR test issuer not ready (status %d)", resp.StatusCode)
+	}
+}
+
+// discoverRARIssuer fetches OIDC discovery from the RAR test issuer.
+func discoverRARIssuer(t *testing.T) testutil.OIDCConfig {
+	t.Helper()
+	return testutil.DiscoverOIDC(t, rarIssuerURL())
 }


### PR DESCRIPTION
## Summary

Full RFC 9396 Rich Authorization Requests support for OneAuth — all 7 phases in one PR.

### Phase 1-3: Data Model + Token Endpoint + Introspection
- **Data model** (`core/authorization_details.go`): `AuthorizationDetail` struct with custom JSON marshal/unmarshal (extension flattening), validation, `FilterByType`, `ErrInvalidAuthorizationDetails`
- **Token endpoint** (`apiauth/auth.go`): Parses `authorization_details` from form-encoded (JSON string) and JSON bodies, validates, embeds in JWT, returns in response, `standardClaims` guard
- **Introspection** (`apiauth/introspection.go`): Includes `authorization_details` in introspection response
- **All store backends** (FS, GORM, GAE): Carry `authorization_details` through refresh token rotation

### Phase 4: AS Metadata + DCR
- `authorization_details_types_supported` on `ASServerMetadata` (RFC 8414)
- `authorization_details_types` on `DCRRequest`/`DCRResponse` (RFC 7591)
- Stored per-client on `AppRegistration`

### Phase 5: Middleware Enforcement
- `GetAuthorizationDetailsFromContext()` context helper
- `RequireAuthorizationDetails(requiredTypes ...string)` middleware
- Refactored `ValidateToken`/`RequireScopes`/`Optional` to use shared `setAuthContext()`

### Phase 6: Resource Token Minting
- `MintResourceToken`/`MintResourceTokenWithKey` accept `authzDetails` parameter
- Embedded as `authorization_details` JWT claim

### Phase 7: Client SDK
- `AuthorizationDetails` on `ServerCredential` and `ClientCredentialsSource`
- `authorization_details` parsed from token response in `OAuth2TokenResponse`
- `parseAuthzDetailsFromRaw()` converts raw JSON to typed structs

### Backwards Compatibility
All new fields are `omitempty`. Existing requests/tokens without `authorization_details` work exactly as before. Signature changes to `CreateAccessToken` and `MintResourceToken` require `, nil` at existing call sites (all updated in this PR).

## Test plan
- [x] 7 unit tests — `core/authorization_details_test.go` (marshal, unmarshal, validate, filter)
- [x] 8 unit tests — `apiauth/auth_rar_test.go` (token endpoint RAR, form-encoded, invalid, guard, introspection)
- [x] 5 E2E tests — `tests/e2e/rar_test.go` (full flow, scope coexistence, invalid type, form-encoded, backwards compat)
- [x] All existing tests pass (20+ call sites updated for signature changes)
- [x] `go test ./...` — all 13 modules pass
- [x] Sub-module builds verified (stores/gorm, stores/gae, cmd/*)

## Follow-up issues
- #92 — Keycloak interop tests for RAR
- #93 — Runnable examples for RAR

Closes #91, refs #87