### PR TITLE
feat: Token revocation endpoint (RFC 7009)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ Separate Go module (`tests/keycloak/go.mod`) proving APIMiddleware + JWKSKeyStor
 |----------|---------|-----|
 | `POST /api/token` (client_credentials) | `APIAuth.ServeHTTP` (accepts form-encoded + JSON) | RFC 6749 §4.4 |
 | `POST /oauth/introspect` | `IntrospectionHandler` | RFC 7662 |
+| `POST /oauth/revoke` | `RevocationHandler` | RFC 7009 |
 | `GET /.well-known/openid-configuration` | `NewASMetadataHandler` | RFC 8414 |
 | `GET /.well-known/jwks.json` | `JWKSHandler` | RFC 7517 |
 | `GET /.well-known/oauth-protected-resource` | `NewProtectedResourceHandler` (resource servers) | RFC 9728 |

--- a/apiauth/revocation.go
+++ b/apiauth/revocation.go
@@ -1,0 +1,181 @@
+package apiauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+)
+
+// RevocationHandler implements OAuth 2.0 Token Revocation (RFC 7009).
+// Clients POST a token to this endpoint to notify the AS that the token
+// is no longer needed. The AS revokes it so that subsequent introspection
+// or validation attempts fail.
+//
+// The handler:
+//   - Accepts POST with application/x-www-form-urlencoded body (token=...&token_type_hint=...)
+//   - Authenticates the caller via ClientKeyStore (Basic auth or client_secret_post)
+//   - Revokes access tokens via the Blacklist (jti-based)
+//   - Revokes refresh tokens via the RefreshTokenStore
+//   - Always returns 200 OK — never reveals whether the token existed (RFC 7009 §2.2)
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+type RevocationHandler struct {
+	// Auth is the APIAuth instance used to parse and validate access tokens.
+	Auth *APIAuth
+
+	// ClientKeyStore authenticates callers of the revocation endpoint.
+	// Clients must present valid client_id + client_secret via HTTP Basic auth
+	// or as form parameters (client_secret_post). If nil, all callers are rejected.
+	ClientKeyStore keys.KeyLookup
+}
+
+// ServeHTTP handles POST /oauth/revoke per RFC 7009.
+func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse form body
+	if err := r.ParseForm(); err != nil {
+		h.okResponse(w) // don't leak parse errors
+		return
+	}
+
+	// Authenticate the caller — try Basic auth first, then form params
+	clientID, clientSecret, hasBasic := r.BasicAuth()
+	if !hasBasic {
+		clientID = r.FormValue("client_id")
+		clientSecret = r.FormValue("client_secret")
+	}
+	if clientID == "" {
+		w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
+		h.errorResponse(w, "invalid_client", "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if err := h.authenticateCaller(clientID, clientSecret); err != nil {
+		w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
+		h.errorResponse(w, "invalid_client", "Invalid client credentials", http.StatusUnauthorized)
+		return
+	}
+
+	// Extract token and hint
+	token := r.FormValue("token")
+	if token == "" {
+		// RFC 7009 §2.1: "token" is required, but we still return 200
+		h.okResponse(w)
+		return
+	}
+	hint := r.FormValue("token_type_hint")
+
+	// Revoke based on hint (or try both if no hint)
+	switch hint {
+	case "refresh_token":
+		h.revokeRefreshToken(token)
+	case "access_token":
+		h.revokeAccessToken(token)
+	default:
+		// No hint — try refresh token first (cheaper), then access token
+		if !h.revokeRefreshToken(token) {
+			h.revokeAccessToken(token)
+		}
+	}
+
+	// RFC 7009 §2.2: "The authorization server responds with HTTP status
+	// code 200 for both the case where the token was successfully revoked
+	// and the case where the client submitted an invalid token."
+	h.okResponse(w)
+}
+
+// revokeRefreshToken attempts to revoke a refresh token. Returns true if the
+// token was found in the refresh token store (whether revoked now or already revoked).
+func (h *RevocationHandler) revokeRefreshToken(token string) bool {
+	if h.Auth == nil || h.Auth.RefreshTokenStore == nil {
+		return false
+	}
+	// Check if this token exists as a refresh token first
+	rt, err := h.Auth.RefreshTokenStore.GetRefreshToken(token)
+	if err != nil || rt == nil {
+		return false // not a refresh token
+	}
+	// Found it — revoke if not already revoked
+	if !rt.Revoked {
+		h.Auth.RefreshTokenStore.RevokeRefreshToken(token)
+	}
+	return true
+}
+
+// revokeAccessToken attempts to revoke a JWT access token by extracting its
+// jti claim and adding it to the blacklist.
+func (h *RevocationHandler) revokeAccessToken(token string) {
+	if h.Auth == nil || h.Auth.Blacklist == nil {
+		return
+	}
+
+	// Parse JWT without full validation — we just need jti and exp.
+	// The token might be expired already (that's fine, we still blacklist it
+	// to handle clock skew).
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return // not a JWT — silently ignore per RFC 7009
+	}
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		return
+	}
+
+	jti, ok := claims["jti"].(string)
+	if !ok || jti == "" {
+		return // no jti — can't blacklist
+	}
+
+	// Extract expiry for blacklist TTL
+	expiry := time.Now().Add(core.TokenExpiryAccessToken) // default
+	if exp, err := claims.GetExpirationTime(); err == nil && exp != nil {
+		expiry = exp.Time
+	}
+
+	h.Auth.Blacklist.Revoke(jti, expiry)
+}
+
+// authenticateCaller verifies the caller's credentials against the ClientKeyStore.
+func (h *RevocationHandler) authenticateCaller(clientID, clientSecret string) error {
+	if h.ClientKeyStore == nil {
+		return errInvalidClient
+	}
+	rec, err := h.ClientKeyStore.GetKey(clientID)
+	if err != nil || rec == nil {
+		return errInvalidClient
+	}
+	storedKey, ok := rec.Key.([]byte)
+	if !ok {
+		return errInvalidClient
+	}
+	if !constantTimeEqual(string(storedKey), clientSecret) {
+		return errInvalidClient
+	}
+	return nil
+}
+
+// okResponse sends 200 OK with no body (RFC 7009 §2.2).
+func (h *RevocationHandler) okResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// errorResponse sends a JSON error (only for auth failures — token errors always get 200).
+func (h *RevocationHandler) errorResponse(w http.ResponseWriter, errCode, description string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":             errCode,
+		"error_description": description,
+	})
+}

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -1,0 +1,270 @@
+package apiauth_test
+
+// Tests for the Token Revocation endpoint (RFC 7009).
+// The revocation endpoint allows clients to notify the AS that a token
+// is no longer needed. The AS blacklists access tokens (jti-based) and
+// revokes refresh tokens.
+//
+// Key RFC 7009 requirements tested:
+//   - Always returns 200 OK (even for invalid tokens)
+//   - Never reveals whether the token existed
+//   - Requires client authentication
+//   - Supports token_type_hint
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRevocation creates a RevocationHandler with an APIAuth that can
+// mint tokens, a blacklist for access token revocation, and a refresh
+// token store.
+func setupRevocation(t *testing.T) (*apiauth.RevocationHandler, *apiauth.APIAuth, *apiauth.IntrospectionHandler) {
+	t.Helper()
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{
+		ClientID:  "revoke-client",
+		Key:       []byte("revoke-client-secret"),
+		Algorithm: "HS256",
+	})
+
+	blacklist := core.NewInMemoryBlacklist()
+	refreshStore := newInMemoryRefreshStore()
+
+	auth := &apiauth.APIAuth{
+		JWTSecretKey:      "revocation-test-secret-32chars-m!",
+		JWTIssuer:         "test-issuer",
+		Blacklist:         blacklist,
+		RefreshTokenStore: refreshStore,
+		ClientKeyStore:    ks,
+	}
+
+	revHandler := &apiauth.RevocationHandler{
+		Auth:           auth,
+		ClientKeyStore: ks,
+	}
+
+	introHandler := &apiauth.IntrospectionHandler{
+		Auth:           auth,
+		ClientKeyStore: ks,
+	}
+
+	return revHandler, auth, introHandler
+}
+
+// postRevoke sends a form-encoded POST to the revocation handler.
+func postRevoke(t *testing.T, handler http.Handler, token, hint, clientID, clientSecret string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"token": {token}}
+	if hint != "" {
+		form.Set("token_type_hint", hint)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/revoke",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if clientID != "" {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestRevocation_AccessToken verifies that revoking an access token causes
+// subsequent introspection to return active: false.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestRevocation_AccessToken(t *testing.T) {
+	revHandler, auth, introHandler := setupRevocation(t)
+
+	// Mint an access token
+	token, _, err := auth.CreateAccessToken("user-1", []string{"read"}, nil)
+	require.NoError(t, err)
+
+	// Verify it's active via introspection
+	rr := postIntrospect(t, introHandler, token, "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"active":true`)
+
+	// Revoke it
+	rr = postRevoke(t, revHandler, token, "access_token", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Introspect again — should be inactive
+	rr = postIntrospect(t, introHandler, token, "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"active":false`)
+}
+
+// TestRevocation_RefreshToken verifies that revoking a refresh token makes
+// it unusable for token refresh.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestRevocation_RefreshToken(t *testing.T) {
+	revHandler, auth, _ := setupRevocation(t)
+
+	// Create a refresh token
+	rt, err := auth.RefreshTokenStore.CreateRefreshToken("user-1", "revoke-client", nil, []string{"read"})
+	require.NoError(t, err)
+
+	// Revoke it
+	rr := postRevoke(t, revHandler, rt.Token, "refresh_token", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Try to get the refresh token — should be revoked
+	got, err := auth.RefreshTokenStore.GetRefreshToken(rt.Token)
+	require.NoError(t, err)
+	assert.True(t, got.Revoked, "refresh token should be revoked")
+}
+
+// TestRevocation_NoHint verifies that without a token_type_hint, the handler
+// tries refresh token first, then access token.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.1
+func TestRevocation_NoHint(t *testing.T) {
+	revHandler, auth, introHandler := setupRevocation(t)
+
+	// Mint an access token and revoke with no hint
+	token, _, err := auth.CreateAccessToken("user-2", []string{"write"}, nil)
+	require.NoError(t, err)
+
+	rr := postRevoke(t, revHandler, token, "", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Should be revoked (handler tried refresh first, failed, then tried access token)
+	rr = postIntrospect(t, introHandler, token, "revoke-client", "revoke-client-secret")
+	assert.Contains(t, rr.Body.String(), `"active":false`)
+}
+
+// TestRevocation_AlreadyRevoked verifies that revoking an already-revoked
+// token still returns 200 OK per RFC 7009 §2.2.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.2
+func TestRevocation_AlreadyRevoked(t *testing.T) {
+	revHandler, auth, _ := setupRevocation(t)
+
+	token, _, _ := auth.CreateAccessToken("user-3", []string{"read"}, nil)
+
+	// Revoke twice — both should succeed
+	rr := postRevoke(t, revHandler, token, "access_token", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	rr = postRevoke(t, revHandler, token, "access_token", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestRevocation_GarbageToken verifies that submitting an invalid token
+// returns 200 OK — the AS never reveals whether the token existed.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.2
+func TestRevocation_GarbageToken(t *testing.T) {
+	revHandler, _, _ := setupRevocation(t)
+
+	rr := postRevoke(t, revHandler, "not-a-real-token", "", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestRevocation_EmptyToken verifies that submitting an empty token
+// returns 200 OK.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.1
+func TestRevocation_EmptyToken(t *testing.T) {
+	revHandler, _, _ := setupRevocation(t)
+
+	rr := postRevoke(t, revHandler, "", "", "revoke-client", "revoke-client-secret")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestRevocation_NoAuth verifies that an unauthenticated request is rejected
+// with 401 Unauthorized.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.1
+func TestRevocation_NoAuth(t *testing.T) {
+	revHandler, _, _ := setupRevocation(t)
+
+	rr := postRevoke(t, revHandler, "some-token", "", "", "")
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestRevocation_BadAuth verifies that invalid credentials are rejected.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.1
+func TestRevocation_BadAuth(t *testing.T) {
+	revHandler, _, _ := setupRevocation(t)
+
+	rr := postRevoke(t, revHandler, "some-token", "", "revoke-client", "wrong-secret")
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestRevocation_MethodNotAllowed verifies that GET is rejected with 405.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestRevocation_MethodNotAllowed(t *testing.T) {
+	revHandler, _, _ := setupRevocation(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/revoke", nil)
+	rr := httptest.NewRecorder()
+	revHandler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// --- In-memory refresh token store for tests ---
+
+type inMemoryRefreshStore struct {
+	tokens map[string]*core.RefreshToken
+}
+
+func newInMemoryRefreshStore() *inMemoryRefreshStore {
+	return &inMemoryRefreshStore{tokens: make(map[string]*core.RefreshToken)}
+}
+
+func (s *inMemoryRefreshStore) CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
+	token, _ := core.GenerateSecureToken()
+	rt := &core.RefreshToken{
+		Token:    token,
+		UserID:   userID,
+		ClientID: clientID,
+		Scopes:   scopes,
+	}
+	s.tokens[token] = rt
+	return rt, nil
+}
+
+func (s *inMemoryRefreshStore) GetRefreshToken(token string) (*core.RefreshToken, error) {
+	rt, ok := s.tokens[token]
+	if !ok {
+		return nil, core.ErrTokenNotFound
+	}
+	return rt, nil
+}
+
+func (s *inMemoryRefreshStore) RevokeRefreshToken(token string) error {
+	rt, ok := s.tokens[token]
+	if !ok {
+		return nil // don't reveal
+	}
+	rt.Revoked = true
+	return nil
+}
+
+func (s *inMemoryRefreshStore) RotateRefreshToken(old string) (*core.RefreshToken, error) {
+	return nil, core.ErrTokenNotFound
+}
+
+func (s *inMemoryRefreshStore) RevokeUserTokens(userID string) error { return nil }
+func (s *inMemoryRefreshStore) RevokeTokenFamily(family string) error { return nil }
+func (s *inMemoryRefreshStore) GetUserTokens(userID string) ([]*core.RefreshToken, error) {
+	return nil, nil
+}
+func (s *inMemoryRefreshStore) CleanupExpiredTokens() error { return nil }

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -245,6 +245,13 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 	}
 	mux.Handle("POST /oauth/introspect", introspectionHandler)
 
+	// Token Revocation (RFC 7009)
+	revocationHandler := &apiauth.RevocationHandler{
+		Auth:           e.apiAuth,
+		ClientKeyStore: e.KeyStore,
+	}
+	mux.Handle("POST /oauth/revoke", revocationHandler)
+
 	// JWKS
 	jwksHandler := &keys.JWKSHandler{KeyStore: e.KeyStore}
 	mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
@@ -264,6 +271,7 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 		TokenEndpoint:                  baseURL + "/oauth/token",
 		JWKSURI:                        baseURL + "/.well-known/jwks.json",
 		IntrospectionEndpoint:          baseURL + "/oauth/introspect",
+		RevocationEndpoint:            baseURL + "/oauth/revoke",
 		RegistrationEndpoint:           baseURL + "/apps/register",
 		ScopesSupported:                []string{"read", "write", "admin"},
 		GrantTypesSupported:            []string{"authorization_code", "password", "refresh_token", "client_credentials"},

--- a/tests/e2e/revocation_test.go
+++ b/tests/e2e/revocation_test.go
@@ -1,0 +1,153 @@
+package e2e_test
+
+// E2E tests for OAuth 2.0 Token Revocation (RFC 7009).
+// These tests verify the full revocation flow through the auth server:
+// get a token, revoke it via /oauth/revoke, verify it's no longer valid.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRevocation_E2E_AccessToken verifies the full access token revocation
+// flow: get a token, revoke it, then introspect to confirm it's inactive.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestRevocation_E2E_AccessToken(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "revoke-e2e.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	// Get a token
+	body, _ := json.Marshal(map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"scope":         "read",
+	})
+	tokenResp, _ := http.Post(env.BaseURL()+"/api/token", "application/json",
+		strings.NewReader(string(body)))
+	tokenData := ReadJSON(tokenResp)
+	accessToken := tokenData["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	// Introspect — should be active
+	introResp := introspectToken(t, env, accessToken, clientID, clientSecret)
+	assert.Equal(t, true, introResp["active"])
+
+	// Revoke via /oauth/revoke
+	revokeResp := revokeToken(t, env, accessToken, "access_token", clientID, clientSecret)
+	assert.Equal(t, http.StatusOK, revokeResp.StatusCode)
+
+	// Introspect again — should be inactive
+	introResp = introspectToken(t, env, accessToken, clientID, clientSecret)
+	assert.Equal(t, false, introResp["active"])
+}
+
+// TestRevocation_E2E_RefreshToken verifies that a revoked refresh token
+// cannot be used to obtain new access tokens.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestRevocation_E2E_RefreshToken(t *testing.T) {
+	env := NewTestEnv(t)
+
+	// Create a user and get a token pair (access + refresh)
+	email, password := CreateTestUser(t, env, "revoke-refresh")
+
+	body, _ := json.Marshal(map[string]any{
+		"grant_type": "password",
+		"username":   email,
+		"password":   password,
+	})
+	tokenResp, _ := http.Post(env.BaseURL()+"/api/token", "application/json",
+		strings.NewReader(string(body)))
+	tokenData := ReadJSON(tokenResp)
+	refreshToken := tokenData["refresh_token"].(string)
+	require.NotEmpty(t, refreshToken)
+
+	// Revoke the refresh token
+	// Use empty client creds — the E2E auth server's revocation handler
+	// accepts the app registered via password grant path
+	// Actually we need a registered client for auth. Let's register one.
+	clientID, clientSecret := RegisterApp(t, env, "revoke-rt.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	revokeResp := revokeToken(t, env, refreshToken, "refresh_token", clientID, clientSecret)
+	assert.Equal(t, http.StatusOK, revokeResp.StatusCode)
+
+	// Try to refresh — should fail
+	refreshBody, _ := json.Marshal(map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	})
+	refreshResp, _ := http.Post(env.BaseURL()+"/api/token", "application/json",
+		strings.NewReader(string(refreshBody)))
+	refreshData := ReadJSON(refreshResp)
+	assert.Equal(t, "invalid_grant", refreshData["error"],
+		"revoked refresh token should not be usable")
+}
+
+// TestRevocation_E2E_Discovery verifies that the revocation_endpoint is
+// advertised in AS metadata.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestRevocation_E2E_Discovery(t *testing.T) {
+	env := NewTestEnv(t)
+
+	resp, err := http.Get(env.BaseURL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	meta := ReadJSON(resp)
+
+	revEndpoint, ok := meta["revocation_endpoint"]
+	require.True(t, ok, "AS metadata must include revocation_endpoint")
+	assert.Contains(t, revEndpoint.(string), "/oauth/revoke")
+}
+
+// TestRevocation_E2E_GarbageToken verifies that revoking a garbage token
+// returns 200 OK without revealing any information.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2.2
+func TestRevocation_E2E_GarbageToken(t *testing.T) {
+	env := NewTestEnv(t)
+	clientID, clientSecret := RegisterApp(t, env, "revoke-garbage.example.com")
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	revokeResp := revokeToken(t, env, "not-a-real-token-at-all", "", clientID, clientSecret)
+	assert.Equal(t, http.StatusOK, revokeResp.StatusCode)
+}
+
+// --- Helpers ---
+
+func revokeToken(t *testing.T, env *TestEnv, token, hint, clientID, clientSecret string) *http.Response {
+	t.Helper()
+	form := url.Values{"token": {token}}
+	if hint != "" {
+		form.Set("token_type_hint", hint)
+	}
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/oauth/revoke",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, clientSecret)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func introspectToken(t *testing.T, env *TestEnv, token, clientID, clientSecret string) map[string]any {
+	t.Helper()
+	form := url.Values{"token": {token}}
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/oauth/introspect",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, clientSecret)
+	resp, _ := http.DefaultClient.Do(req)
+	return ReadJSON(resp)
+}

--- a/tests/keycloak/interop_test.go
+++ b/tests/keycloak/interop_test.go
@@ -888,6 +888,72 @@ func TestKeycloak_RFC8414Proxy_SimplePathAlsoWorks(t *testing.T) {
 }
 
 // =============================================================================
+// RFC 7009 Token Revocation Tests
+// =============================================================================
+
+// TestKeycloak_Discovery_RevocationEndpoint verifies that Keycloak advertises
+// a revocation_endpoint in its discovery document.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+func TestKeycloak_Discovery_RevocationEndpoint(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	resp, err := http.Get(realmURL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var raw map[string]any
+	require.NoError(t, decodeJSON(resp.Body, &raw))
+	revEndpoint, ok := raw["revocation_endpoint"]
+	require.True(t, ok, "Keycloak should advertise revocation_endpoint")
+	assert.Contains(t, revEndpoint.(string), "revoke", "revocation endpoint URL should contain 'revoke'")
+}
+
+// TestKeycloak_Revocation verifies that revoking a Keycloak-issued token
+// via KC's revocation endpoint makes it inactive on introspection.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009#section-2
+func TestKeycloak_Revocation(t *testing.T) {
+	skipIfKeycloakNotRunning(t)
+
+	cfg := discoverOIDC(t)
+	tokenResp := getClientCredentialsToken(t, cfg.TokenEndpoint, confidentialClientID, confidentialClientSecret)
+
+	// Discover revocation endpoint
+	resp, _ := http.Get(realmURL() + "/.well-known/openid-configuration")
+	var raw map[string]any
+	decodeJSON(resp.Body, &raw)
+	resp.Body.Close()
+	revEndpoint := raw["revocation_endpoint"].(string)
+
+	// Revoke via KC's endpoint
+	form := url.Values{
+		"token":           {tokenResp.AccessToken},
+		"token_type_hint": {"access_token"},
+	}
+	req, _ := http.NewRequest("POST", revEndpoint, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(confidentialClientID, confidentialClientSecret)
+	revResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	revResp.Body.Close()
+	assert.Equal(t, http.StatusOK, revResp.StatusCode, "KC revocation should return 200")
+
+	// Introspect — should be inactive after revocation
+	introForm := url.Values{"token": {tokenResp.AccessToken}}
+	introReq, _ := http.NewRequest("POST", cfg.IntrospectionEndpoint, strings.NewReader(introForm.Encode()))
+	introReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	introReq.SetBasicAuth(confidentialClientID, confidentialClientSecret)
+	introResp, _ := http.DefaultClient.Do(introReq)
+	var introResult map[string]any
+	json.NewDecoder(introResp.Body).Decode(&introResult)
+	introResp.Body.Close()
+
+	assert.Equal(t, false, introResult["active"],
+		"token should be inactive after revocation via KC endpoint")
+}
+
+// =============================================================================
 // RFC 9396 Backward Compatibility Tests
 // =============================================================================
 //


### PR DESCRIPTION
## Summary

Adds `POST /oauth/revoke` per RFC 7009. Clients can revoke their own access tokens (via blacklist) and refresh tokens (via store) using the standard endpoint.

- 9 unit tests + 4 E2E tests + 2 Keycloak interop tests
- Always returns 200 OK — never reveals if token existed
- Client authentication via Basic auth or client_secret_post
- Supports token_type_hint (access_token / refresh_token)

## Test plan
- [x] Unit: access/refresh/no-hint/already-revoked/garbage/empty/noauth/badauth/405
- [x] E2E: revoke→introspect inactive, revoke refresh→refresh fails, discovery, garbage
- [x] KC: discovery has revocation_endpoint, revoke KC token→introspect inactive

Closes #96