### PR TITLE
arch: Transport-agnostic OneAuth core — Phase 1

### DIFF
--- a/apiauth/client_authenticator.go
+++ b/apiauth/client_authenticator.go
@@ -1,0 +1,35 @@
+package apiauth
+
+import (
+	"github.com/panyam/oneauth/keys"
+)
+
+// clientAuthenticator implements ClientAuthenticator using a KeyLookup
+// with constant-time secret comparison.
+type clientAuthenticator struct {
+	keyLookup keys.KeyLookup
+}
+
+// NewClientAuthenticator creates a ClientAuthenticator backed by a KeyLookup.
+func NewClientAuthenticator(kl keys.KeyLookup) ClientAuthenticator {
+	return &clientAuthenticator{keyLookup: kl}
+}
+
+// AuthenticateClient verifies client_id + client_secret.
+func (a *clientAuthenticator) AuthenticateClient(clientID, clientSecret string) error {
+	if a.keyLookup == nil {
+		return errInvalidClient
+	}
+	rec, err := a.keyLookup.GetKey(clientID)
+	if err != nil || rec == nil {
+		return errInvalidClient
+	}
+	storedKey, ok := rec.Key.([]byte)
+	if !ok {
+		return errInvalidClient
+	}
+	if !constantTimeEqual(string(storedKey), clientSecret) {
+		return errInvalidClient
+	}
+	return nil
+}

--- a/apiauth/hooks.go
+++ b/apiauth/hooks.go
@@ -1,0 +1,113 @@
+package apiauth
+
+// Hooks provides lifecycle callbacks for OneAuth operations.
+// Grouped by concern — each implementation receives only its relevant group.
+// All callbacks are optional — nil callbacks are no-ops.
+//
+// Configure all hooks in one place on OneAuth.Hooks. Callers set only
+// what they need:
+//
+//	oa := NewOneAuth(OneAuthConfig{
+//	    Hooks: Hooks{
+//	        Token: TokenHooks{
+//	            OnRevoked: func(token, hint string) { audit.Log("revoked", token) },
+//	        },
+//	    },
+//	})
+//
+// See: https://github.com/panyam/oneauth/issues/110
+type Hooks struct {
+	Token    TokenHooks
+	Auth     AuthHooks
+	Client   ClientHooks
+	Security SecurityHooks
+}
+
+// TokenHooks fires on token lifecycle events.
+type TokenHooks struct {
+	// OnIssued fires after an access token is successfully created.
+	// subject is the token's sub claim, grantType is the OAuth grant used.
+	OnIssued func(subject, grantType string)
+
+	// OnRefreshed fires after a refresh token is rotated and a new access token issued.
+	OnRefreshed func(subject string)
+
+	// OnRevoked fires after a token is successfully revoked.
+	// hint is the token_type_hint ("access_token", "refresh_token", or "").
+	OnRevoked func(token, hint string)
+}
+
+// AuthHooks fires on authentication events.
+type AuthHooks struct {
+	// OnLoginSuccess fires after a user successfully authenticates
+	// (password grant, auth code exchange).
+	OnLoginSuccess func(userID string)
+
+	// OnLoginFailure fires after a failed authentication attempt.
+	OnLoginFailure func(username string, err error)
+
+	// OnScopeStepUp fires when additional scopes are requested and granted.
+	// from is the original scope set, to is the expanded set.
+	OnScopeStepUp func(subject string, from, to []string)
+}
+
+// ClientHooks fires on client management events.
+type ClientHooks struct {
+	// OnRegistered fires after a new client is registered (DCR or proprietary).
+	// method is "dcr" or "register".
+	OnRegistered func(clientID, method string)
+
+	// OnDeleted fires after a client is deleted.
+	OnDeleted func(clientID string)
+
+	// OnKeyRotated fires after a client's signing key is rotated.
+	OnKeyRotated func(clientID string)
+}
+
+// SecurityHooks fires on security-relevant events.
+// Use these for alerting, audit logging, and intrusion detection.
+type SecurityHooks struct {
+	// OnTokenRejected fires when a token fails validation.
+	// reason describes why (expired, bad signature, revoked, etc.).
+	OnTokenRejected func(reason string)
+
+	// OnBlacklistHit fires when a revoked token is presented.
+	// This indicates token reuse after revocation — potential theft.
+	OnBlacklistHit func(jti string)
+
+	// OnAlgorithmMismatch fires when a token's alg header doesn't match
+	// the stored key's algorithm. This is the CVE-2015-9235 attack vector.
+	OnAlgorithmMismatch func(expected, got string)
+}
+
+// --- Hook helpers (fire if non-nil) ---
+
+func (h *TokenHooks) fireOnIssued(subject, grantType string) {
+	if h != nil && h.OnIssued != nil {
+		h.OnIssued(subject, grantType)
+	}
+}
+
+func (h *TokenHooks) fireOnRevoked(token, hint string) {
+	if h != nil && h.OnRevoked != nil {
+		h.OnRevoked(token, hint)
+	}
+}
+
+func (h *SecurityHooks) fireOnTokenRejected(reason string) {
+	if h != nil && h.OnTokenRejected != nil {
+		h.OnTokenRejected(reason)
+	}
+}
+
+func (h *SecurityHooks) fireOnBlacklistHit(jti string) {
+	if h != nil && h.OnBlacklistHit != nil {
+		h.OnBlacklistHit(jti)
+	}
+}
+
+func (h *SecurityHooks) fireOnAlgorithmMismatch(expected, got string) {
+	if h != nil && h.OnAlgorithmMismatch != nil {
+		h.OnAlgorithmMismatch(expected, got)
+	}
+}

--- a/apiauth/interfaces.go
+++ b/apiauth/interfaces.go
@@ -1,0 +1,92 @@
+package apiauth
+
+import (
+	"github.com/panyam/oneauth/core"
+)
+
+// Transport-independent interfaces for OneAuth operations.
+// Each interface represents a focused capability. Implementations take only
+// the dependencies they need (Option A — composed interfaces, no god objects).
+//
+// HTTP handlers, gRPC interceptors, and MCP auth managers are thin transport
+// bindings over these interfaces.
+//
+// See: https://github.com/panyam/oneauth/issues/110
+
+// TokenIssuer creates signed access tokens.
+type TokenIssuer interface {
+	// CreateAccessToken mints a JWT with the given subject, scopes, and
+	// optional RFC 9396 authorization_details.
+	// Returns the signed token string and expiry in seconds.
+	CreateAccessToken(subject string, scopes []string, details []core.AuthorizationDetail) (token string, expiresIn int64, err error)
+
+	// ClientCredentials performs the full client_credentials grant:
+	// authenticates the client, validates scopes/details, and returns a token response.
+	ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error)
+}
+
+// TokenValidator validates tokens and checks authorization.
+type TokenValidator interface {
+	// ValidateToken parses and validates a token string (JWT signature,
+	// expiry, issuer, audience, blacklist). Returns the token's claims.
+	ValidateToken(token string) (*TokenInfo, error)
+
+	// CheckScopes validates a token and verifies it contains all required scopes.
+	// Returns an error if the token is invalid or scopes are insufficient.
+	CheckScopes(token string, required []string) error
+
+	// CheckAuthorizationDetails validates a token and verifies it contains
+	// authorization_details entries for all required types (RFC 9396).
+	CheckAuthorizationDetails(token string, requiredTypes []string) error
+}
+
+// TokenIntrospector inspects tokens per RFC 7662.
+type TokenIntrospector interface {
+	// Introspect checks a token's validity and returns its claims.
+	// Returns {Active: false} for any invalid token (never reveals why).
+	Introspect(token string) (*IntrospectionResult, error)
+}
+
+// TokenRevoker revokes tokens per RFC 7009.
+type TokenRevoker interface {
+	// Revoke invalidates a token. The tokenTypeHint ("access_token" or
+	// "refresh_token") guides which store to check first. Empty hint
+	// tries both.
+	Revoke(token, tokenTypeHint string) error
+}
+
+// ClientAuthenticator verifies client credentials.
+// Used by transport bindings to authenticate callers of protected endpoints
+// (introspection, revocation, DCR).
+type ClientAuthenticator interface {
+	// AuthenticateClient verifies the client_id and client_secret.
+	AuthenticateClient(clientID, clientSecret string) error
+}
+
+// --- Result types ---
+
+// TokenInfo holds the validated claims extracted from a token.
+// Returned by TokenValidator.ValidateToken.
+type TokenInfo struct {
+	// UserID is the subject (sub claim) — a user ID or client_id.
+	UserID string
+
+	// Scopes are the granted scopes from the token.
+	Scopes []string
+
+	// AuthorizationDetails are the RFC 9396 authorization_details from the token.
+	// Nil if the token has no authorization_details.
+	AuthorizationDetails []core.AuthorizationDetail
+
+	// CustomClaims are non-standard JWT claims (everything not in standardClaims).
+	CustomClaims map[string]any
+
+	// AuthType is "jwt" or "api_key".
+	AuthType string
+}
+
+// Note: IntrospectionResult is defined in introspection_client.go.
+// TokenIntrospector.Introspect returns the same type used by
+// IntrospectionValidator (the HTTP client). This keeps the result
+// consistent regardless of whether introspection is done locally
+// (via TokenIntrospector) or remotely (via IntrospectionValidator).

--- a/apiauth/oneauth.go
+++ b/apiauth/oneauth.go
@@ -1,0 +1,118 @@
+package apiauth
+
+import (
+	"time"
+
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+)
+
+// OneAuth is the transport-independent core of the authentication system.
+// It composes focused interfaces (Option A — no god object) and wires
+// hooks for lifecycle callbacks.
+//
+// Use NewOneAuth to create an instance with all dependencies wired.
+// Transport bindings (HTTP handlers, gRPC interceptors, MCP auth) are
+// thin wrappers over these interfaces.
+//
+// Library usage (no HTTP):
+//
+//	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{...})
+//	token, _, _ := oa.Issuer.CreateAccessToken("alice", []string{"read"}, nil)
+//	info, _ := oa.Validator.ValidateToken(token)
+//	result, _ := oa.Introspector.Introspect(token)
+//	oa.Revoker.Revoke(token, "access_token")
+//
+// See: https://github.com/panyam/oneauth/issues/110
+type OneAuth struct {
+	// Core operation interfaces — each has minimal dependencies.
+	Issuer       TokenIssuer
+	Validator    TokenValidator
+	Introspector TokenIntrospector
+	Revoker      TokenRevoker
+	Authenticator ClientAuthenticator
+
+	// Shared state — available for transport bindings that need direct access.
+	KeyStore     keys.KeyStorage
+	Blacklist    core.TokenBlacklist
+	RefreshStore core.RefreshTokenStore
+
+	// Hooks — lifecycle callbacks grouped by concern.
+	Hooks Hooks
+}
+
+// OneAuthConfig holds the dependencies for creating a OneAuth instance.
+type OneAuthConfig struct {
+	// Key management
+	KeyStore keys.KeyStorage // required — stores client keys
+
+	// Signing configuration
+	SigningKey any    // []byte for HS256, *rsa.PrivateKey for RS256, etc.
+	SigningAlg string // "HS256", "RS256", "ES256" — default "HS256"
+
+	// JWT configuration
+	Issuer       string        // JWT iss claim
+	Audience     string        // JWT aud claim (optional)
+	AccessExpiry time.Duration // default 15 minutes
+
+	// Token lifecycle
+	Blacklist    core.TokenBlacklist    // for access token revocation (optional)
+	RefreshStore core.RefreshTokenStore // for refresh token management (optional)
+
+	// Hooks — lifecycle callbacks
+	Hooks Hooks
+}
+
+// NewOneAuth creates a fully wired OneAuth instance.
+// All implementations receive only the interfaces they need.
+func NewOneAuth(cfg OneAuthConfig) *OneAuth {
+	signingAlg := cfg.SigningAlg
+	if signingAlg == "" {
+		signingAlg = "HS256"
+	}
+
+	// Wire the issuer — needs signing config + client key lookup
+	issuer := NewJWTIssuer(JWTIssuerConfig{
+		SigningKey:      cfg.SigningKey,
+		SigningAlg:      signingAlg,
+		Issuer:          cfg.Issuer,
+		Audience:        cfg.Audience,
+		AccessExpiry:    cfg.AccessExpiry,
+		ClientKeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
+		Hooks:           cfg.Hooks.Token,
+	})
+
+	// Wire the validator — needs read-only key lookup + blacklist
+	validator := NewJWTValidator(JWTValidatorConfig{
+		KeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
+		Blacklist: cfg.Blacklist,
+		Issuer:    cfg.Issuer,
+		Audience:  cfg.Audience,
+		Hooks:     cfg.Hooks.Security,
+	})
+
+	// Wire the introspector — needs only the validator
+	introspector := NewTokenIntrospector(validator)
+
+	// Wire the revoker — needs blacklist + refresh store
+	revoker := NewTokenRevoker(TokenRevokerConfig{
+		Blacklist:    cfg.Blacklist,
+		RefreshStore: cfg.RefreshStore,
+		Hooks:        cfg.Hooks.Token,
+	})
+
+	// Wire the client authenticator — needs key lookup
+	authenticator := NewClientAuthenticator(cfg.KeyStore)
+
+	return &OneAuth{
+		Issuer:        issuer,
+		Validator:     validator,
+		Introspector:  introspector,
+		Revoker:       revoker,
+		Authenticator: authenticator,
+		KeyStore:      cfg.KeyStore,
+		Blacklist:     cfg.Blacklist,
+		RefreshStore:  cfg.RefreshStore,
+		Hooks:         cfg.Hooks,
+	}
+}

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -1,0 +1,318 @@
+package apiauth_test
+
+// Tests for the transport-independent OneAuth core.
+// These tests prove that all auth operations work as library calls
+// without any HTTP server, handler, or middleware.
+//
+// See: https://github.com/panyam/oneauth/issues/110
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestOneAuth creates a OneAuth instance for testing with in-memory stores.
+func newTestOneAuth(t *testing.T) *apiauth.OneAuth {
+	t.Helper()
+
+	// The signing key is also stored in the KeyStore so the validator
+	// can look it up by kid. The issuer field in KeyStore is the server's
+	// own identity — tokens minted by CreateAccessToken get kid from this key.
+	signingSecret := []byte("test-signing-secret-32chars-min!")
+
+	ks := keys.NewInMemoryKeyStore()
+	// Server's own signing key (for validating self-issued tokens)
+	ks.PutKey(&keys.KeyRecord{
+		ClientID:  "test-issuer",
+		Key:       signingSecret,
+		Algorithm: "HS256",
+	})
+	// A registered client (for client_credentials tests)
+	ks.PutKey(&keys.KeyRecord{
+		ClientID:  "test-client",
+		Key:       []byte("test-client-secret-32chars-min!!"),
+		Algorithm: "HS256",
+	})
+
+	return apiauth.NewOneAuth(apiauth.OneAuthConfig{
+		KeyStore:     ks,
+		SigningKey:    signingSecret,
+		SigningAlg:    "HS256",
+		Issuer:       "test-issuer",
+		Blacklist:    core.NewInMemoryBlacklist(),
+		RefreshStore: newInMemoryRefreshStore(),
+	})
+}
+
+// TestOneAuth_CreateAccessToken verifies that tokens can be minted
+// via the library without any HTTP endpoint.
+//
+// See: https://github.com/panyam/oneauth/issues/110
+func TestOneAuth_CreateAccessToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	token, expiresIn, err := oa.Issuer.CreateAccessToken("alice", []string{"read", "write"}, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+	assert.True(t, expiresIn > 0)
+}
+
+// TestOneAuth_ValidateToken verifies that tokens can be validated
+// via the library without any HTTP middleware.
+//
+// See: https://github.com/panyam/oneauth/issues/110
+func TestOneAuth_ValidateToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	token, _, err := oa.Issuer.CreateAccessToken("bob", []string{"read"}, nil)
+	require.NoError(t, err)
+
+	info, err := oa.Validator.ValidateToken(token)
+	require.NoError(t, err)
+	assert.Equal(t, "bob", info.UserID)
+	assert.Equal(t, []string{"read"}, info.Scopes)
+	assert.Equal(t, "jwt", info.AuthType)
+}
+
+// TestOneAuth_ValidateToken_WithRAR verifies that RFC 9396
+// authorization_details are extracted from tokens via library calls.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+func TestOneAuth_ValidateToken_WithRAR(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	details := []core.AuthorizationDetail{
+		{Type: "payment_initiation", Actions: []string{"initiate"}},
+	}
+	token, _, err := oa.Issuer.CreateAccessToken("alice", []string{"payments"}, details)
+	require.NoError(t, err)
+
+	info, err := oa.Validator.ValidateToken(token)
+	require.NoError(t, err)
+	require.Len(t, info.AuthorizationDetails, 1)
+	assert.Equal(t, "payment_initiation", info.AuthorizationDetails[0].Type)
+}
+
+// TestOneAuth_Introspect verifies that token introspection works
+// via the library without any HTTP endpoint.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7662
+func TestOneAuth_Introspect(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	token, _, _ := oa.Issuer.CreateAccessToken("charlie", []string{"read"}, nil)
+
+	result, err := oa.Introspector.Introspect(token)
+	require.NoError(t, err)
+	assert.True(t, result.Active)
+	assert.Equal(t, "charlie", result.Sub)
+	assert.Contains(t, result.Scope, "read")
+}
+
+// TestOneAuth_Introspect_Invalid verifies that introspecting a garbage
+// token returns {Active: false} without an error.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7662
+func TestOneAuth_Introspect_Invalid(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	result, err := oa.Introspector.Introspect("garbage-token")
+	require.NoError(t, err)
+	assert.False(t, result.Active)
+}
+
+// TestOneAuth_Revoke_AccessToken verifies that revoking an access token
+// makes it fail validation and introspection — all via library calls.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+func TestOneAuth_Revoke_AccessToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	token, _, _ := oa.Issuer.CreateAccessToken("dave", []string{"read"}, nil)
+
+	// Valid before revocation
+	result, _ := oa.Introspector.Introspect(token)
+	assert.True(t, result.Active)
+
+	// Revoke
+	err := oa.Revoker.Revoke(token, "access_token")
+	require.NoError(t, err)
+
+	// Invalid after revocation
+	result, _ = oa.Introspector.Introspect(token)
+	assert.False(t, result.Active)
+
+	// Validation also fails
+	_, err = oa.Validator.ValidateToken(token)
+	assert.Error(t, err)
+}
+
+// TestOneAuth_Revoke_RefreshToken verifies that refresh token revocation
+// works via the library.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+func TestOneAuth_Revoke_RefreshToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	rt, err := oa.RefreshStore.CreateRefreshToken("eve", "test-client", nil, []string{"read"})
+	require.NoError(t, err)
+
+	err = oa.Revoker.Revoke(rt.Token, "refresh_token")
+	require.NoError(t, err)
+
+	got, _ := oa.RefreshStore.GetRefreshToken(rt.Token)
+	assert.True(t, got.Revoked)
+}
+
+// TestOneAuth_ClientCredentials verifies the full client_credentials
+// grant via library calls — no HTTP.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+func TestOneAuth_ClientCredentials(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	resp, err := oa.Issuer.ClientCredentials(
+		"test-client", "test-client-secret-32chars-min!!",
+		[]string{"read", "write"}, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccessToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, "read write", resp.Scope)
+
+	// Token should be valid
+	info, err := oa.Validator.ValidateToken(resp.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "test-client", info.UserID) // sub = client_id for CC
+}
+
+// TestOneAuth_ClientCredentials_BadSecret verifies that bad credentials
+// are rejected.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+func TestOneAuth_ClientCredentials_BadSecret(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	_, err := oa.Issuer.ClientCredentials("test-client", "wrong-secret", nil, nil)
+	assert.Error(t, err)
+}
+
+// TestOneAuth_CheckScopes verifies scope enforcement via library calls.
+func TestOneAuth_CheckScopes(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	token, _, _ := oa.Issuer.CreateAccessToken("frank", []string{"read"}, nil)
+
+	assert.NoError(t, oa.Validator.CheckScopes(token, []string{"read"}))
+	assert.Error(t, oa.Validator.CheckScopes(token, []string{"write"}))
+	assert.Error(t, oa.Validator.CheckScopes(token, []string{"read", "write"}))
+}
+
+// TestOneAuth_CheckAuthorizationDetails verifies RAR enforcement via library calls.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9396
+func TestOneAuth_CheckAuthorizationDetails(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	details := []core.AuthorizationDetail{
+		{Type: "payment_initiation", Actions: []string{"initiate"}},
+	}
+	token, _, _ := oa.Issuer.CreateAccessToken("grace", []string{"payments"}, details)
+
+	assert.NoError(t, oa.Validator.CheckAuthorizationDetails(token, []string{"payment_initiation"}))
+	assert.Error(t, oa.Validator.CheckAuthorizationDetails(token, []string{"account_information"}))
+}
+
+// TestOneAuth_Hooks_OnIssued verifies that the OnIssued hook fires
+// when a token is created.
+func TestOneAuth_Hooks_OnIssued(t *testing.T) {
+	var firedSubject, firedGrant string
+	secret := []byte("hooks-test-secret-32chars-min!!!")
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{ClientID: "test", Key: secret, Algorithm: "HS256"})
+	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
+		KeyStore:   ks,
+		SigningKey:  secret,
+		Issuer:     "test",
+		Blacklist:  core.NewInMemoryBlacklist(),
+		Hooks: apiauth.Hooks{
+			Token: apiauth.TokenHooks{
+				OnIssued: func(subject, grantType string) {
+					firedSubject = subject
+					firedGrant = grantType
+				},
+			},
+		},
+	})
+
+	oa.Issuer.CreateAccessToken("hook-user", []string{"read"}, nil)
+	assert.Equal(t, "hook-user", firedSubject)
+	assert.Equal(t, "direct", firedGrant)
+}
+
+// TestOneAuth_Hooks_OnRevoked verifies that the OnRevoked hook fires
+// when a token is revoked.
+func TestOneAuth_Hooks_OnRevoked(t *testing.T) {
+	var firedHint string
+	ks := keys.NewInMemoryKeyStore()
+	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
+		KeyStore:   ks,
+		SigningKey:  []byte("hooks-test-secret-32chars-min!!!"),
+		Issuer:     "test",
+		Blacklist:  core.NewInMemoryBlacklist(),
+		Hooks: apiauth.Hooks{
+			Token: apiauth.TokenHooks{
+				OnRevoked: func(token, hint string) {
+					firedHint = hint
+				},
+			},
+		},
+	})
+
+	token, _, _ := oa.Issuer.CreateAccessToken("user-1", []string{"read"}, nil)
+	oa.Revoker.Revoke(token, "access_token")
+	assert.Equal(t, "access_token", firedHint)
+}
+
+// TestOneAuth_Hooks_OnBlacklistHit verifies that the OnBlacklistHit hook
+// fires when a revoked token is presented for validation.
+func TestOneAuth_Hooks_OnBlacklistHit(t *testing.T) {
+	var firedJTI string
+	secret := []byte("hooks-test-secret-32chars-min!!!")
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{ClientID: "test", Key: secret, Algorithm: "HS256"})
+	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
+		KeyStore:   ks,
+		SigningKey:  secret,
+		Issuer:     "test",
+		Blacklist:  core.NewInMemoryBlacklist(),
+		Hooks: apiauth.Hooks{
+			Security: apiauth.SecurityHooks{
+				OnBlacklistHit: func(jti string) {
+					firedJTI = jti
+				},
+			},
+		},
+	})
+
+	token, _, _ := oa.Issuer.CreateAccessToken("user-2", []string{"read"}, nil)
+	oa.Revoker.Revoke(token, "access_token")
+
+	// Try to validate the revoked token — should trigger blacklist hit hook
+	_, err := oa.Validator.ValidateToken(token)
+	assert.Error(t, err)
+	assert.NotEmpty(t, firedJTI, "OnBlacklistHit should have fired")
+}
+
+// TestOneAuth_AuthenticateClient verifies client authentication via library call.
+func TestOneAuth_AuthenticateClient(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	assert.NoError(t, oa.Authenticator.AuthenticateClient("test-client", "test-client-secret-32chars-min!!"))
+	assert.Error(t, oa.Authenticator.AuthenticateClient("test-client", "wrong"))
+	assert.Error(t, oa.Authenticator.AuthenticateClient("unknown", "secret"))
+}

--- a/apiauth/token_introspector.go
+++ b/apiauth/token_introspector.go
@@ -1,0 +1,81 @@
+package apiauth
+
+import (
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// tokenIntrospector implements TokenIntrospector using local JWT validation.
+// Depends only on TokenValidator (for token checking) — no HTTP, no transport.
+type tokenIntrospector struct {
+	validator TokenValidator
+}
+
+// NewTokenIntrospector creates a TokenIntrospector backed by a TokenValidator.
+func NewTokenIntrospector(v TokenValidator) TokenIntrospector {
+	return &tokenIntrospector{validator: v}
+}
+
+// Introspect checks a token and returns the result per RFC 7662.
+// Returns {Active: false} for any invalid token — never reveals why.
+func (ti *tokenIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) {
+	info, err := ti.validator.ValidateToken(tokenString)
+	if err != nil {
+		return &IntrospectionResult{Active: false}, nil
+	}
+
+	// Parse raw claims for the full introspection response
+	// (ValidateToken strips standard claims from custom, but introspection
+	// needs them all)
+	rawClaims := parseRawJWTClaims(tokenString)
+
+	result := &IntrospectionResult{
+		Active:    true,
+		Sub:       info.UserID,
+		TokenType: "access_token",
+	}
+
+	// Add scope as space-separated string
+	if len(info.Scopes) > 0 {
+		result.Scope = strings.Join(info.Scopes, " ")
+	}
+
+	// Add standard claims from raw token
+	if rawClaims != nil {
+		if v, ok := rawClaims["iss"].(string); ok {
+			result.Iss = v
+		}
+		if v, ok := rawClaims["exp"].(float64); ok {
+			result.Exp = int64(v)
+		}
+		if v, ok := rawClaims["iat"].(float64); ok {
+			result.Iat = int64(v)
+		}
+		if v, ok := rawClaims["jti"].(string); ok {
+			result.Jti = v
+		}
+		if v, ok := rawClaims["aud"]; ok {
+			result.Aud = v
+		}
+		if v, ok := rawClaims["client_id"].(string); ok {
+			result.ClientID = v
+		}
+	}
+
+	return result, nil
+}
+
+// parseRawJWTClaims extracts all claims from a JWT without validation.
+func parseRawJWTClaims(tokenStr string) map[string]any {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		return nil
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil
+	}
+	return claims
+}

--- a/apiauth/token_revoker.go
+++ b/apiauth/token_revoker.go
@@ -1,0 +1,98 @@
+package apiauth
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/core"
+)
+
+// tokenRevoker implements TokenRevoker using a blacklist (for access tokens)
+// and a RefreshTokenStore (for refresh tokens).
+// Depends only on Blacklist + RefreshTokenStore — no HTTP, no transport.
+type tokenRevoker struct {
+	blacklist    core.TokenBlacklist
+	refreshStore core.RefreshTokenStore
+	hooks        TokenHooks
+}
+
+// TokenRevokerConfig configures a tokenRevoker.
+type TokenRevokerConfig struct {
+	Blacklist    core.TokenBlacklist
+	RefreshStore core.RefreshTokenStore
+	Hooks        TokenHooks
+}
+
+// NewTokenRevoker creates a TokenRevoker.
+func NewTokenRevoker(cfg TokenRevokerConfig) TokenRevoker {
+	return &tokenRevoker{
+		blacklist:    cfg.Blacklist,
+		refreshStore: cfg.RefreshStore,
+		hooks:        cfg.Hooks,
+	}
+}
+
+// Revoke invalidates a token. Tries refresh token first if no hint or
+// hint is "refresh_token", then tries access token blacklisting.
+func (r *tokenRevoker) Revoke(token, tokenTypeHint string) error {
+	switch tokenTypeHint {
+	case "refresh_token":
+		r.revokeRefreshToken(token)
+	case "access_token":
+		r.revokeAccessToken(token)
+	default:
+		// No hint — try refresh first (cheaper lookup), then access
+		if !r.revokeRefreshToken(token) {
+			r.revokeAccessToken(token)
+		}
+	}
+
+	r.hooks.fireOnRevoked(token, tokenTypeHint)
+	return nil
+}
+
+// revokeRefreshToken attempts to revoke a refresh token. Returns true if
+// the token was found in the refresh store.
+func (r *tokenRevoker) revokeRefreshToken(token string) bool {
+	if r.refreshStore == nil {
+		return false
+	}
+	rt, err := r.refreshStore.GetRefreshToken(token)
+	if err != nil || rt == nil {
+		return false
+	}
+	if !rt.Revoked {
+		r.refreshStore.RevokeRefreshToken(token)
+	}
+	return true
+}
+
+// revokeAccessToken blacklists a JWT access token by its jti claim.
+func (r *tokenRevoker) revokeAccessToken(token string) {
+	if r.blacklist == nil {
+		return
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return
+	}
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		return
+	}
+
+	jti, ok := claims["jti"].(string)
+	if !ok || jti == "" {
+		return
+	}
+
+	expiry := time.Now().Add(core.TokenExpiryAccessToken)
+	if exp, err := claims.GetExpirationTime(); err == nil && exp != nil {
+		expiry = exp.Time
+	}
+
+	r.blacklist.Revoke(jti, expiry)
+}

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -1,0 +1,342 @@
+package apiauth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+// jwtValidator implements TokenValidator using local JWT validation.
+// Dependencies are explicit and minimal: KeyLookup (read-only), Blacklist,
+// issuer/audience config, and security hooks.
+type jwtValidator struct {
+	keyLookup keys.KeyLookup
+	blacklist core.TokenBlacklist
+	issuer    string
+	audience  string
+	hooks     SecurityHooks
+}
+
+// JWTValidatorConfig configures a jwtValidator.
+type JWTValidatorConfig struct {
+	KeyLookup keys.KeyLookup
+	Blacklist core.TokenBlacklist
+	Issuer    string
+	Audience  string
+	Hooks     SecurityHooks
+}
+
+// NewJWTValidator creates a TokenValidator that validates JWTs locally.
+func NewJWTValidator(cfg JWTValidatorConfig) TokenValidator {
+	return &jwtValidator{
+		keyLookup: cfg.KeyLookup,
+		blacklist: cfg.Blacklist,
+		issuer:    cfg.Issuer,
+		audience:  cfg.Audience,
+		hooks:     cfg.Hooks,
+	}
+}
+
+// ValidateToken parses and validates a JWT, returning the extracted claims.
+func (v *jwtValidator) ValidateToken(tokenString string) (*TokenInfo, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		return v.resolveKey(token)
+	})
+	if err != nil {
+		v.hooks.fireOnTokenRejected(fmt.Sprintf("parse error: %v", err))
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+	if !token.Valid {
+		v.hooks.fireOnTokenRejected("token validation failed")
+		return nil, fmt.Errorf("token validation failed")
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("invalid claims")
+	}
+
+	// Verify token type
+	if tokenType, ok := claims["type"].(string); ok && tokenType != "access" {
+		v.hooks.fireOnTokenRejected("invalid token type")
+		return nil, fmt.Errorf("invalid token type")
+	}
+
+	// Verify issuer
+	if v.issuer != "" {
+		if iss, ok := claims["iss"].(string); !ok || iss != v.issuer {
+			v.hooks.fireOnTokenRejected("invalid issuer")
+			return nil, fmt.Errorf("invalid issuer")
+		}
+	}
+
+	// Verify audience
+	if v.audience != "" {
+		if !matchesAudience(claims, v.audience) {
+			v.hooks.fireOnTokenRejected("invalid audience")
+			return nil, fmt.Errorf("invalid audience")
+		}
+	}
+
+	// Extract subject
+	userID, ok := claims["sub"].(string)
+	if !ok || userID == "" {
+		return nil, fmt.Errorf("missing subject")
+	}
+
+	// Extract scopes
+	var scopes []string
+	if scopesRaw, ok := claims["scopes"].([]any); ok {
+		scopes = make([]string, 0, len(scopesRaw))
+		for _, s := range scopesRaw {
+			if str, ok := s.(string); ok {
+				scopes = append(scopes, str)
+			}
+		}
+	}
+
+	// Extract authorization_details (RFC 9396)
+	var authzDetails []core.AuthorizationDetail
+	if adRaw, ok := claims["authorization_details"].([]any); ok {
+		authzDetails = parseAuthorizationDetailsFromClaims(adRaw)
+	}
+
+	// Extract custom claims
+	customClaims := make(map[string]any)
+	for k, v := range claims {
+		if !standardClaims[k] {
+			customClaims[k] = v
+		}
+	}
+
+	// Check blacklist
+	if v.blacklist != nil {
+		if jti, ok := claims["jti"].(string); ok && jti != "" {
+			if v.blacklist.IsRevoked(jti) {
+				v.hooks.fireOnBlacklistHit(jti)
+				v.hooks.fireOnTokenRejected("token has been revoked")
+				return nil, fmt.Errorf("token has been revoked")
+			}
+		}
+	}
+
+	return &TokenInfo{
+		UserID:               userID,
+		Scopes:               scopes,
+		AuthorizationDetails: authzDetails,
+		CustomClaims:         customClaims,
+		AuthType:             "jwt",
+	}, nil
+}
+
+// CheckScopes validates a token and verifies it contains all required scopes.
+func (v *jwtValidator) CheckScopes(token string, required []string) error {
+	info, err := v.ValidateToken(token)
+	if err != nil {
+		return err
+	}
+	if !core.ContainsAllScopes(info.Scopes, required) {
+		return fmt.Errorf("insufficient scope: requires %v, has %v", required, info.Scopes)
+	}
+	return nil
+}
+
+// CheckAuthorizationDetails validates a token and verifies it contains
+// authorization_details entries for all required types.
+func (v *jwtValidator) CheckAuthorizationDetails(token string, requiredTypes []string) error {
+	info, err := v.ValidateToken(token)
+	if err != nil {
+		return err
+	}
+	grantedTypes := make(map[string]bool)
+	for _, ad := range info.AuthorizationDetails {
+		grantedTypes[ad.Type] = true
+	}
+	for _, reqType := range requiredTypes {
+		if !grantedTypes[reqType] {
+			return fmt.Errorf("missing required authorization_details type: %s", reqType)
+		}
+	}
+	return nil
+}
+
+// resolveKey finds the appropriate signing key for a JWT token.
+func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) {
+	if v.keyLookup == nil {
+		return nil, fmt.Errorf("no key store configured")
+	}
+
+	// Try kid-based lookup first
+	if kid, ok := token.Header["kid"].(string); ok && kid != "" {
+		rec, err := v.keyLookup.GetKeyByKid(kid)
+		if err == nil && rec != nil {
+			if token.Header["alg"] != rec.Algorithm {
+				v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
+				return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
+			}
+			// Cross-check kid owner vs client_id claim
+			if rec.ClientID != "" {
+				if claims, ok := token.Claims.(jwt.MapClaims); ok {
+					if claimClientID, _ := claims["client_id"].(string); claimClientID != "" && claimClientID != rec.ClientID {
+						return nil, fmt.Errorf("kid owner %q does not match client_id claim %q", rec.ClientID, claimClientID)
+					}
+				}
+			}
+			return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)
+		}
+	}
+
+	// Fall back to client_id claim
+	if claims, ok := token.Claims.(jwt.MapClaims); ok {
+		if clientID, ok := claims["client_id"].(string); ok && clientID != "" {
+			rec, err := v.keyLookup.GetKey(clientID)
+			if err == nil && rec != nil {
+				if token.Header["alg"] != rec.Algorithm {
+					v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
+					return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
+				}
+				return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no key found for token")
+}
+
+// jwtIssuer implements TokenIssuer using JWT signing.
+type jwtIssuer struct {
+	signingKey    any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
+	signingAlg    string // "HS256", "RS256", "ES256"
+	issuer        string
+	audience      string
+	accessExpiry  time.Duration
+	clientKeyLookup keys.KeyLookup
+	hooks         TokenHooks
+}
+
+// JWTIssuerConfig configures a jwtIssuer.
+type JWTIssuerConfig struct {
+	SigningKey      any
+	SigningAlg      string
+	Issuer         string
+	Audience       string
+	AccessExpiry   time.Duration
+	ClientKeyLookup keys.KeyLookup // for client_credentials authentication
+	Hooks          TokenHooks
+}
+
+// NewJWTIssuer creates a TokenIssuer that signs JWTs.
+func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer {
+	expiry := cfg.AccessExpiry
+	if expiry == 0 {
+		expiry = core.TokenExpiryAccessToken
+	}
+	return &jwtIssuer{
+		signingKey:      cfg.SigningKey,
+		signingAlg:      cfg.SigningAlg,
+		issuer:          cfg.Issuer,
+		audience:        cfg.Audience,
+		accessExpiry:    expiry,
+		clientKeyLookup: cfg.ClientKeyLookup,
+		hooks:           cfg.Hooks,
+	}
+}
+
+// CreateAccessToken mints a signed JWT.
+func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details []core.AuthorizationDetail) (string, int64, error) {
+	now := time.Now()
+	expiresAt := now.Add(i.accessExpiry)
+
+	jti, err := core.GenerateSecureToken()
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to generate jti: %w", err)
+	}
+
+	claims := jwt.MapClaims{
+		"sub":    subject,
+		"type":   "access",
+		"scopes": scopes,
+		"jti":    jti,
+		"iat":    now.Unix(),
+		"exp":    expiresAt.Unix(),
+	}
+	if len(details) > 0 {
+		claims["authorization_details"] = details
+	}
+	if i.issuer != "" {
+		claims["iss"] = i.issuer
+	}
+	if i.audience != "" {
+		claims["aud"] = i.audience
+	}
+
+	signingMethod, err := utils.SigningMethodForAlg(i.signingAlg)
+	if err != nil {
+		// Fall back to HS256 for []byte keys
+		if _, ok := i.signingKey.([]byte); ok {
+			signingMethod = jwt.SigningMethodHS256
+		} else {
+			return "", 0, fmt.Errorf("invalid signing algorithm: %w", err)
+		}
+	}
+
+	token := jwt.NewWithClaims(signingMethod, claims)
+	if kid, kidErr := utils.ComputeKid(i.signingKey, signingMethod.Alg()); kidErr == nil {
+		token.Header["kid"] = kid
+	}
+
+	tokenString, err := token.SignedString(i.signingKey)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	i.hooks.fireOnIssued(subject, "direct")
+	return tokenString, int64(i.accessExpiry.Seconds()), nil
+}
+
+// ClientCredentials performs the client_credentials grant.
+func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error) {
+	if i.clientKeyLookup == nil {
+		return nil, fmt.Errorf("client_credentials not configured")
+	}
+
+	// Authenticate client
+	rec, err := i.clientKeyLookup.GetKey(clientID)
+	if err != nil || rec == nil {
+		return nil, fmt.Errorf("invalid_client: unknown client")
+	}
+	storedKey, ok := rec.Key.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("invalid_client: client does not support secret authentication")
+	}
+	if !constantTimeEqual(string(storedKey), clientSecret) {
+		return nil, fmt.Errorf("invalid_client: invalid credentials")
+	}
+
+	// Validate authorization_details
+	if err := core.ValidateAll(details); err != nil {
+		return nil, err
+	}
+
+	// Create token
+	tokenStr, expiresIn, err := i.CreateAccessToken(clientID, scopes, details)
+	if err != nil {
+		return nil, err
+	}
+
+	i.hooks.fireOnIssued(clientID, "client_credentials")
+
+	resp := &core.TokenPair{
+		AccessToken:          tokenStr,
+		TokenType:            "Bearer",
+		ExpiresIn:            expiresIn,
+		Scope:                strings.Join(scopes, " "),
+		AuthorizationDetails: details,
+	}
+	return resp, nil
+}


### PR DESCRIPTION
## Summary

Adds a transport-independent core for OneAuth. All auth operations (mint, validate, introspect, revoke, authenticate) are now available as library calls without HTTP.

### Design: Option A — Composed Interfaces

Each implementation takes only the interfaces it needs. No god object.

```go
oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{...})

// Library calls — no HTTP server needed
token, _, _ := oa.Issuer.CreateAccessToken("alice", []string{"read"}, nil)
info, _ := oa.Validator.ValidateToken(token)
result, _ := oa.Introspector.Introspect(token)
oa.Revoker.Revoke(token, "access_token")
```

### Hooks — grouped lifecycle callbacks

```go
oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
    Hooks: apiauth.Hooks{
        Token:    apiauth.TokenHooks{OnRevoked: func(t, h string) { audit.Log(t) }},
        Security: apiauth.SecurityHooks{OnBlacklistHit: func(jti string) { alert(jti) }},
    },
})
```

### Phase 1 is purely additive

- 8 new files, zero changes to existing code
- All existing tests pass unchanged
- HTTP handlers untouched — Phase 2 will refactor them to delegate

## Test plan

- [x] 15 new library-only tests (no HTTP involved)
- [x] All existing tests pass unchanged (apiauth, core, admin, keys, client, e2e)
- [x] Zero relaxed assertions

## Follow-up (Phase 2)
Refactor HTTP handlers (`APIAuth.ServeHTTP`, `IntrospectionHandler`, `RevocationHandler`) to be thin wrappers over the OneAuth core. Update `cmd/oneauth-server`.

Refs #110