### PR TITLE
arch: OneAuth core Phase 2 — HTTP handlers delegate to core interfaces

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,7 +1,7 @@
 # OneAuth
 
 ## Version
-0.0.64
+0.0.77
 
 ## Provides
 - local-authentication: Email/password authentication with signup policy, rate limiting, account lockout
@@ -28,6 +28,11 @@
 - token-blacklist: JWT revocation via jti-based blacklist
 - encryption-at-rest: AES-256-GCM encryption of HS256 secrets via EncryptedKeyStorage
 - security-headers: HSTS, CSP, X-Frame-Options middleware
+- rich-authorization-requests: RFC 9396 authorization_details on token endpoint, introspection, middleware enforcement
+- token-revocation: RFC 7009 endpoint for access and refresh token revocation
+- transport-agnostic-core: OneAuth struct with composed interfaces (TokenIssuer, TokenValidator, TokenIntrospector, TokenRevoker) — usable without HTTP
+- lifecycle-hooks: Grouped callbacks (TokenHooks, AuthHooks, ClientHooks, SecurityHooks) for audit, alerting, integration
+- interactive-examples: 10 progressive examples with demokit framework, mermaid diagrams, RFC references
 - client-sdk: AuthClient with credential store, auto-refresh, browser login
 - test-infrastructure: Reusable testutil package with TestAuthServer (RSA, JWKS, AS metadata) and shared OAuth helpers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,302 +2,79 @@
 
 ## What is OneAuth?
 
-Go authentication library with unified local/OAuth auth, multi-tenant JWT (KeyStore with HS256/RS256/ES256), and an App Registration API for federated resource server auth. Three storage backends: filesystem, GORM (SQL), and GAE/Datastore.
+Go authentication library with unified local/OAuth auth, multi-tenant JWT, and federated resource server auth. See [README.md](README.md) for full overview.
 
 ## Repository Structure
 
-```
-oneauth/
-├── doc.go                # Package overview (routes to subpackages)
-├── core/                 # Foundation types: User, Identity, Channel, store interfaces,
-│                         #   tokens, credentials, scopes, email, context helpers
-├── keys/                 # Key storage: KeyRecord, KeyLookup, KeyStorage, InMemoryKeyStore,
-│                         #   EncryptedKeyStorage, KidStore, JWKSHandler, JWKSKeyStore
-├── admin/                # Admin auth: AdminAuth, AppRegistrar, MintResourceToken
-├── apiauth/              # API auth: APIAuth, APIMiddleware, context helpers
-├── localauth/            # Local auth: LocalAuth, signup, helpers (NewCreateUserFunc, etc.)
-├── httpauth/             # HTTP middleware: Middleware, CSRFMiddleware, OneAuth session mux
-├── utils/                # Crypto helpers (PEM encode/decode, DecodeVerifyKey, key generation, JWK conversion)
-├── stores/
-│   ├── fs/               # File-based stores + FSKeyStore
-│   ├── gorm/             # GORM SQL stores + GORMKeyStore + SigningKeyModel
-│   └── gae/              # Google Datastore stores + GAEKeyStore
-├── testutil/             # Reusable test infrastructure: TestAuthServer, OAuth helpers
-├── keystoretest/         # Shared WritableKeyStore test suite (factory pattern)
-├── client/               # Client SDK (CredentialStore, AuthClient, HTTPClient)
-│   └── stores/fs/        # FS-based credential store
-├── grpc/                 # gRPC auth interceptors
-├── oauth2/               # OAuth2 provider implementations
-├── cmd/oneauth-server/   # Reference server (config-driven, deployable)
-│   ├── main.go           # Wiring: KeyStore + AdminAuth + AppRegistrar
-│   ├── config.go         # YAML config + ${ENV_VAR:-default} substitution
-│   ├── Dockerfile
-│   └── deploy-examples/  # GAE, Docker Compose, Kubernetes
-├── tests/integration/    # Pytest integration tests (against live server)
-└── Makefile
-```
+Each subpackage has a `SUMMARY.md` with detailed contents.
 
-### Dependency DAG (strictly acyclic)
+| Package | What | Details |
+|---------|------|---------|
+| `core/` | Foundation types, store interfaces, tokens, scopes, RFC 9396 AuthorizationDetail | [core/SUMMARY.md](core/SUMMARY.md) |
+| `keys/` | Key storage, JWKS, EncryptedKeyStorage, KidStore | [keys/SUMMARY.md](keys/SUMMARY.md) |
+| `admin/` | AdminAuth, AppRegistrar, DCR (RFC 7591), MintResourceToken | [admin/SUMMARY.md](admin/SUMMARY.md) |
+| `apiauth/` | APIAuth, APIMiddleware, OneAuth core, introspection, revocation | [apiauth/SUMMARY.md](apiauth/SUMMARY.md) |
+| `localauth/` | Local auth (signup, login, password reset) | [localauth/SUMMARY.md](localauth/SUMMARY.md) |
+| `httpauth/` | HTTP middleware, CSRF, session management | [httpauth/SUMMARY.md](httpauth/SUMMARY.md) |
+| `client/` | Client SDK (AuthClient, ClientCredentialsSource, discovery) | [client/SUMMARY.md](client/SUMMARY.md) |
+| `stores/` | FS, GORM, GAE backend implementations | `stores/*/SUMMARY.md` |
+| `examples/` | 10 progressive interactive examples with demokit | [examples/README.md](examples/README.md) |
+| `tests/keycloak/` | Keycloak interop + RAR conformance tests | [tests/keycloak/README.md](tests/keycloak/README.md) |
+| `cmd/oneauth-server/` | Config-driven reference server | `cmd/oneauth-server/config.go` |
+| `cmd/rar-test-issuer/` | Minimal RAR-capable AS for interop testing | `cmd/rar-test-issuer/main.go` header |
 
-```
-              core
-            / | \  \
-           /  |  \  \
-        keys  |  localauth
-        / \   |
-       /   \  |
-    admin  apiauth
-              |
-           httpauth
-```
+## Multi-Module Structure
 
-Each subpackage has a `SUMMARY.md` describing its contents.
+Go workspace with separate sub-modules for heavy backends. See `go.work` for the full list. Sub-modules have `replace` directives for local dev. See [docs/MIGRATION.md](docs/MIGRATION.md) for consumer guide.
 
-### Multi-Module Structure
-
-The repo is a Go workspace with multiple modules. The core module is lightweight (~6 deps). Heavy backends are separate sub-modules:
-
-| Module | Heavy Deps |
-|--------|-----------|
-| `github.com/panyam/oneauth` (core) | None — jwt, scs, x/crypto, x/oauth2 only |
-| `stores/gorm` | gorm.io/gorm, postgres/sqlite drivers |
-| `stores/gae` | cloud.google.com/go/datastore + GCP SDK |
-| `saml` | crewjam/saml |
-| `grpc` | google.golang.org/grpc |
-| `oauth2` | golang.org/x/oauth2/google |
-| `cmd/*` | Various (integration points) |
-
-`go.work` at root enables local multi-module dev. Sub-modules have `replace` directives for `go mod tidy` compatibility. See [docs/MIGRATION.md](docs/MIGRATION.md) for consumer migration guide.
-
-**Publish workflow:** `make norep` → tag all modules → push → `make rep` → `make tidy`
-
-### Releasing Sub-Modules (gotcha)
-
-Sub-module `go.mod` files contain `replace github.com/panyam/oneauth => ../..` so local dev works against unreleased root changes, but the `require github.com/panyam/oneauth vX.Y.Z` line must point to a **real, released root tag** — Go ignores `replace` directives in non-main (dependency) modules, so downstream consumers need a resolvable version.
-
-**The v0.0.0 and stale-require bug**: before `scripts/verify-submodule-deps.sh` was added, sub-module go.mod files drifted — some referenced `v0.0.0` (tests/keycloak pseudo-version style), others referenced `v0.0.39` (unchanged across many root releases up to v0.0.69). This worked locally but broke any downstream consumer doing `go get github.com/panyam/oneauth/stores/gorm@vX.Y.Z`. Caught by `make verify-submodule-deps` (wired into `make test` and optional pre-push hook).
-
-**Release order** when cutting a new root tag (N=current number):
-1. Commit root-only changes.
-2. Tag root: `git tag -a v0.0.N -m "v0.0.N"`.
-3. Push the root tag: `git push origin v0.0.N`.
-4. In each sub-module's `go.mod`, bump `require github.com/panyam/oneauth vX.Y.Z` to the new root tag. Keep the `replace` line. For sub-modules that cross-reference (e.g., `cmd/oneauth-server` requires `stores/gorm`), also bump the cross-sub-module require to match.
-5. Run `go mod tidy` in each sub-module (or `make tidy`).
-6. Commit: `chore: bump sub-modules to v0.0.N`.
-7. Tag each sub-module: `git tag -a stores/gorm/v0.0.N -m "stores/gorm/v0.0.N"`, same for `stores/gae`, `cmd/oneauth-server`, `cmd/demo-hostapp`, `cmd/demo-resource-server`. Sub-module tag numbers historically track root exactly.
-8. Push the sub-module tags.
-
-**Don't retag published sub-module versions.** Go module proxies cache aggressively; retagging `stores/gorm/v0.0.68` after the fact is a known footgun that breaks existing fetches. Ship a new version instead.
-
-**Test modules are not tagged.** `tests/keycloak` uses a zero pseudo-version for its root requirement — it's a test harness, not published, so it's excluded from the verification script.
-
-See [mcpkit#189](https://github.com/panyam/mcpkit/issues/189) for the same bug in a sibling repo.
-
-## Build & Test Commands
+## Build & Test
 
 ```bash
-# Multi-module (all modules at once)
-make ball          # Build all modules (binaries → build/)
-make tallmods      # Test all modules
-make tidy          # go mod tidy all modules
-make deps          # Show core module dep count
-
-# Testing — individual stages (each runnable standalone)
-make test          # Go unit tests (root module packages)
-make lint          # staticcheck code quality
-make unit          # Unit tests + sub-modules (race detector)
-make e2e           # E2E tests (in-process auth + resource servers, race detector)
-make postgres      # PostgreSQL/GORM tests (needs Docker PG running)
-make datastore     # Datastore tests (needs GCP credentials)
-make keycloak      # Keycloak interop tests (waits for Docker KC)
-make secrets       # gitleaks secret scanning
-make vulncheck     # govulncheck vulnerability check
-make zap           # ZAP baseline security scan
-
-# Testing — composite targets
-make test-hard     # Full suite: unit + e2e + secret scan + keycloak
-make testall       # Everything: all 9 stages above + HTML report
-
-# Testing — legacy / infra helpers
-make testpg        # GORM tests against PostgreSQL (auto-starts Docker)
-make testds        # GAE tests against Datastore emulator (auto-starts Docker)
-make testrealDS    # GAE tests against real Datastore (needs credentials)
-make testkcl       # Keycloak interop tests (auto-starts Docker, ~15s startup)
-make upkcl         # Start Keycloak container only
-make downkcl       # Stop Keycloak container
-make kcllogs       # Tail Keycloak container logs
-
-# Security scanning
-make audit         # Full security audit: vulncheck + gosec + secrets + race detection
-make seccheck      # gosec security patterns
-
-# Publishing
-make norep         # Remove replace directives (before tagging releases)
-make rep           # Restore replace directives (after publishing)
-
-# Infrastructure
-make deploygae     # Deploy to GAE (project: oneauthsvc)
-make gaelogs       # Tail GAE logs
+make test          # Unit tests
+make e2e           # E2E tests (in-process)
+make testkcl       # Keycloak + RAR issuer interop (auto-starts Docker)
+make testall       # Everything (9 stages + report)
+make tag V=v0.0.X  # Tag all modules
+make pushtag V=v0.0.X  # Push all tags
 ```
 
-### E2E Tests (`tests/e2e/`)
+Full command reference: see `Makefile` header comments and `make help` (if available).
 
-In-process e2e tests using `httptest.NewServer`. Auth server + 2 resource servers start in ~2s, race detector works across all servers. Remote mode: `TEST_BASE_URL=https://... make e2e` for deployed server testing.
+## Key Architecture Decisions
 
-**Always use `NewAppRegistrar()`** constructor (not struct literal) — the map must be initialized to avoid data races under concurrent requests.
+- **Client library, not a proxy** — embeddable, no extra service to operate
+- **Transport-independent core** — `OneAuth` struct with `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker` interfaces. HTTP handlers are thin wrappers. See [#110](https://github.com/panyam/oneauth/issues/110).
+- **Storage-agnostic** — interface-based, three backends (FS, GORM, GAE)
+- **Composed interfaces** — no god objects. Each implementation takes only the deps it needs.
+- **Grouped hooks** — `TokenHooks`, `AuthHooks`, `ClientHooks`, `SecurityHooks`. See `apiauth/hooks.go`.
 
-## Import Map (Post-Reorganization)
-
-| What | Import |
-|---|---|
-| User, Identity, Channel, store interfaces, tokens, credentials, scopes, UnionScopes, AuthorizationDetail (RFC 9396) | `"github.com/panyam/oneauth/core"` |
-| KeyStorage, KeyRecord, InMemoryKeyStore, EncryptedKeyStorage, JWKSHandler | `"github.com/panyam/oneauth/keys"` |
-| AdminAuth, AppRegistrar, MintResourceToken, AppQuota | `"github.com/panyam/oneauth/admin"` |
-| APIAuth, APIMiddleware, IntrospectionHandler, ProtectedResourceMetadata, ASServerMetadata | `"github.com/panyam/oneauth/apiauth"` |
-| LocalAuth, NewCreateUserFunc, NewCredentialsValidator | `"github.com/panyam/oneauth/localauth"` |
-| Middleware, CSRFMiddleware, CSRFTemplateField, OneAuth | `"github.com/panyam/oneauth/httpauth"` |
-| AuthClient, DiscoverAS, LoginWithBrowser, ClientCredentialsToken, FollowRedirects, SelectAuthMethod, TokenEndpointAuthMethod, WithASMetadata, RegisterClient, ClientRegistrationRequest, ClientRegistrationResponse, ClientCredentialsSource, TokenSource, ScopeAwareTokenSource, ValidateHTTPS, IsLocalhost, ValidateCIMDURL | `"github.com/panyam/oneauth/client"` |
-| TestAuthServer, NewTestAuthServer, GetClientCredentialsToken, DiscoverOIDC | `"github.com/panyam/oneauth/testutil"` |
-
-## Key Patterns
-
-### Shared Test Suites (Factory Pattern)
-`keystoretest.RunAll(t, factory)` runs identical tests against any `KeyStorage` implementation. Each backend test file creates a factory that returns its store type. This is the pattern to follow for any new interface with multiple backends.
-
-### Three-Backend Store Pattern
-Every persistent interface (UserStore, IdentityStore, ChannelStore, KeyStorage) has three implementations: `stores/fs/`, `stores/gorm/`, `stores/gae/`. New store types must implement all three. GORM models use dialect-agnostic column types — never use `type:blob` (fails on PostgreSQL), let GORM auto-select.
-
-Store backends import `core/` for entity types and `keys/` for key types.
-
-### Config-Driven Reference Server
-`cmd/oneauth-server/` uses YAML config with `${ENV_VAR:-default}` substitution. On GAE (no config file), falls back to `configFromEnv()` which reads all config from env vars. The server supports memory, fs, gorm (postgres only — sqlite requires CGO), and gae keystores.
-
-### KeyStorage / KeyLookup Interfaces (in keys/)
-The key storage layer uses two focused interfaces instead of a single god interface:
-- `KeyLookup` (read-only): `GetKey(clientID)` + `GetKeyByKid(kid)` → returns `*KeyRecord`
-- `KeyStorage` (read+write): embeds `KeyLookup` + `PutKey`, `DeleteKey`, `ListKeyIDs`
-- `KeyRecord` struct: `{ClientID, Key, Algorithm, Kid}` — all fields in one place
-
-All backends (InMemory, GORM, FS, GAE) implement `KeyStorage`. `JWKSKeyStore` and `KidStore` implement only `KeyLookup`.
-
-Backward-compatible alias methods (`RegisterKey`, `GetVerifyKey`, `GetExpectedAlg`, `ListKeys`) exist on all backends for migration. Prefer the new `KeyStorage` methods in new code.
-
-### EncryptedKeyStorage (Decorator Pattern, in keys/)
-`EncryptedKeyStorage` wraps any `KeyStorage` to encrypt HS256 secrets at rest using AES-256-GCM. Kid is computed from plaintext before encryption. Configured via `ONEAUTH_MASTER_KEY` env var (64 hex chars = 32 bytes). Plaintext fallback on read enables migration. See [JWT_SIGNING.md](docs/JWT_SIGNING.md#encryption-at-rest-encryptedkeystore) for details.
-
-### kid (Key ID) in JWTs
-All minted JWTs include a `kid` header (RFC 7638 thumbprint). `APIMiddleware` tries kid-based lookup first (`GetKeyByKid`), then falls back to `client_id` claim (`GetKey`). Legacy tokens without `kid` still work. Key rotation uses `KidStore` to retain old keys with a grace period expiry.
-
-### AdminAuth Interface (in admin/)
-`AdminAuth.Authenticate(r *http.Request) error` — constant-time API key comparison (`crypto/subtle`). Implementations: `APIKeyAuth` (reads `X-Admin-Key` header), `NoAuth` (dev only). On GAE, the API key is fetched from Secret Manager at startup if `ADMIN_API_KEY` env var is not set.
-
-### BasicUser (in core/)
-`BasicUser` has exported fields `ID` and `ProfileData` (not the original unexported `id`/`profile`). This was changed during the subpackage reorganization for cross-package access.
-
-### Keycloak Interop Tests (`tests/keycloak/`)
-
-Separate Go module (`tests/keycloak/go.mod`) proving APIMiddleware + JWKSKeyStore validate Keycloak-issued tokens. Runs with `make testkcl` (auto-starts Docker). Tests skip gracefully when Keycloak is not running — `make test` and `make e2e` are unaffected.
-
-**Gotcha:** `tests/keycloak/` is a separate Go module. Must `cd` into it or use `GOWORK=off` when running directly. The Makefile handles this.
-
-### Standards Endpoints (on the auth server)
+## Standards Compliance
 
 | Endpoint | Handler | RFC |
 |----------|---------|-----|
-| `POST /api/token` (client_credentials) | `APIAuth.ServeHTTP` (accepts form-encoded + JSON) | RFC 6749 §4.4 |
+| `POST /api/token` | `APIAuth.ServeHTTP` | RFC 6749 |
 | `POST /oauth/introspect` | `IntrospectionHandler` | RFC 7662 |
 | `POST /oauth/revoke` | `RevocationHandler` | RFC 7009 |
 | `GET /.well-known/openid-configuration` | `NewASMetadataHandler` | RFC 8414 |
 | `GET /.well-known/jwks.json` | `JWKSHandler` | RFC 7517 |
-| `GET /.well-known/oauth-protected-resource` | `NewProtectedResourceHandler` (resource servers) | RFC 9728 |
-| `POST /apps/dcr` | `DCRHandler` (via `AppRegistrar.Handler()`) | RFC 7591 |
+| `GET /.well-known/oauth-protected-resource` | `NewProtectedResourceHandler` | RFC 9728 |
+| `POST /apps/dcr` | `DCRHandler` | RFC 7591 |
 
-**Client-side validators** (resource servers use these instead of local JWT validation):
-- `IntrospectionValidator` — calls remote `/oauth/introspect`, integrates into `APIMiddleware.Introspection` as fallback. Optional `CacheTTL`.
-
-### Client SDK Discovery + Browser Login
-
-```go
-// Auto-discover endpoints
-meta, _ := client.DiscoverAS("https://auth.example.com")
-
-// Browser-based login for CLI tools (loopback redirect + PKCE)
-cred, _ := authClient.LoginWithBrowser(client.BrowserLoginConfig{
-    ClientID: "my-cli",
-    Scopes:   []string{"openid", "read"},
-})
-
-// Headless login for CI/testing (#71) — follows HTTP redirects instead of browser
-cred, _ := authClient.LoginWithBrowser(client.BrowserLoginConfig{
-    ClientID:    "my-cli",
-    OpenBrowser: client.FollowRedirects(nil),
-})
-
-// Confidential client auth code flow (#72) — negotiates auth method from AS metadata
-cred, _ := authClient.LoginWithBrowser(client.BrowserLoginConfig{
-    ClientID:     "my-app",
-    ClientSecret: "app-secret",
-    OpenBrowser:  client.FollowRedirects(nil),
-})
-
-// Explicit endpoints with auth method override (#74) — for callers that do
-// their own discovery (e.g., PRM→AS metadata) and pass endpoints directly
-cred, _ := authClient.LoginWithBrowser(client.BrowserLoginConfig{
-    ClientID:                 "my-app",
-    ClientSecret:             "app-secret",
-    AuthorizationEndpoint:    "https://auth.example.com/authorize",
-    TokenEndpoint:            "https://auth.example.com/token",
-    TokenEndpointAuthMethods: []string{"client_secret_post"},
-    OpenBrowser:              client.FollowRedirects(nil),
-})
-
-// Machine-to-machine with auth method negotiation (#72)
-authClient := client.NewAuthClient(serverURL, store,
-    client.WithASMetadata(meta))  // enables auth method negotiation
-cred, _ := authClient.ClientCredentialsToken("svc-id", "secret", []string{"read"})
-```
-
-## GAE Deployment Notes
-
-- Runtime: `go124` (not go125 — doesn't exist yet)
-- No sqlite in reference server — `mattn/go-sqlite3` requires CGO, unavailable on GAE standard
-- Health endpoint: `/_ah/health` (GAE intercepts `/healthz`)
-- Deploy from repo root: `gcloud app deploy --appyaml=cmd/oneauth-server/deploy-examples/gae/app.yaml --project=oneauthsvc .`
-- Source must be module root (not the app.yaml directory) so `main: ./cmd/oneauth-server` resolves
-- GAE project: `oneauthsvc` (us-west1, free tier: F1 instance, scale-to-zero)
-- Admin key stored in Secret Manager: `oneauth-admin-key`
-
-## Federated Auth Architecture
-
-Three projects collaborate:
-1. **oneauth** (this repo) — shared auth library + App Registration API
-2. **massrelay** — WebSocket relay (a resource server), validates resource-scoped JWTs using KeyStore
-3. **excaliframe** (document app) — registers as an App, mints resource tokens for users
-
-Flow: App registers with oneauth-server → gets `client_id` + `client_secret` (HS256) or registers a public key (RS256/ES256) → App authenticates users locally → mints resource-scoped JWTs with `admin.MintResourceToken()` or `admin.MintResourceTokenWithKey()` → resource server validates using shared KeyStore or JWKS discovery (`/.well-known/jwks.json`).
-
-## Memories
-
-Design lessons and feedback from past sessions are in `memories/`. See `memories/MEMORY.md` for the index. These are checked into the repo so they're available to all collaborators.
-
-**Important:** Always save memories to the `memories/` folder in this repo (not `~/.claude/`). This keeps them version-controlled and available to all collaborators. Update `memories/MEMORY.md` index when adding new entries.
+RFC 9396 (Rich Authorization Requests) supported on token endpoint, introspection, and middleware. See `core/authorization_details.go`.
 
 ## Conventions
 
-- Update SUMMARY.md, NEXTSTEPS.md, ROADMAP.md with each PR
-- Each subpackage has a SUMMARY.md for LLM discoverability
-- GitHub issues track all planned work with priority levels (P0/P1/P2)
-- Use `GH_TOKEN="$GH_PERSONAL_TOKEN"` for gh CLI (Enterprise Managed User)
-- PostgreSQL test container: `arm64v8/postgres:18.1` on port 5433
-- Datastore test credentials: `~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json`
-- **Security tests must include `// See:` links** to the relevant RFC, CVE, CWE, or OWASP reference in each test function's doc comment. This makes it easy to trace why a test exists and what attack it prevents. Example: `// See: https://nvd.nist.gov/vuln/detail/CVE-2015-9235`
-- Keycloak interop tests: `quay.io/keycloak/keycloak:26.6` on port 8180, realm config at `tests/keycloak/realm.json`
-- RAR test issuer (`cmd/rar-test-issuer`): port 8181, RFC 9396 interop tests. See `cmd/rar-test-issuer/main.go` header and `tests/keycloak/rar_interop_test.go` for details and KC migration path.
-- **`type: "access"` claim is OneAuth-specific** — external IdP tokens (Keycloak, Auth0) don't have it. The check accepts tokens without the claim; only rejects tokens with `type` set to something other than `"access"` (e.g., refresh tokens).
-- **`aud` claim may be string or array** (RFC 7519 §4.1.3) — `matchesAudience()` helper handles both. Keycloak/Auth0/Azure AD send arrays.
-- **Separate Go modules** (`tests/keycloak/`, `stores/gorm/`, `stores/gae/`, etc.) need `GOWORK=off` or `cd` into the module dir when running outside `go.work`.
-- **`make lint`** uses `GOFLAGS=-buildvcs=false` to work in worktrees.
-- **PKCE functions in `client/`** are inlined (not imported from `oauth2/` sub-module) to avoid cross-module dependency. The `oauth2/` sub-module has heavy deps (`golang.org/x/oauth2`).
-- **Token endpoint accepts both form-encoded and JSON** — `APIAuth.ServeHTTP` routes on `Content-Type`: `application/x-www-form-urlencoded` (RFC 6749 standard) or JSON (legacy/convenience). Standard OAuth clients (Keycloak, Auth0, testutil helpers) send form-encoded.
-- **RFC 9396 Rich Authorization Requests** — `authorization_details` parameter is supported on token requests (both form-encoded as a JSON string, and JSON body). The granted details are returned in the token response and embedded in the JWT as an `authorization_details` claim. Introspection responses also include it. `CreateAccessToken` takes `authzDetails []core.AuthorizationDetail` as a third parameter. `standardClaims` guard prevents `CustomClaimsFunc` from overriding it.
-- **Legacy `/api/token` JSON endpoint** — retained for `Login` and `refreshTokenLocked` backward compat. E2E tests now have `/oauth/token` (form-encoded, standards-compliant) for auth code and client_credentials flows. The legacy JSON path (`requestToken`) can be removed once the CLI client (`cmd/oneauth-cli`) migrates to form-encoded requests — tracked as a future cleanup item.
+- Each subpackage has a `SUMMARY.md` for LLM discoverability
+- Security tests must include `// See:` links to RFC/CVE/CWE references
+- Use `GH_TOKEN="$GH_PERSONAL_TOKEN"` for gh CLI
+- Keycloak: `quay.io/keycloak/keycloak:26.6` on port 8180
+- RAR test issuer: port 8181. See `cmd/rar-test-issuer/main.go` for details.
+- Sub-modules need `GOWORK=off` when running outside workspace
+
+## Federated Auth Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) or the [examples/README.md](examples/README.md) Cast of Characters for the full picture. Three projects collaborate: oneauth (auth library), massrelay (WebSocket relay), excaliframe (document app).
+
+## Memories
+
+Design lessons from past sessions in `memories/`. See `memories/MEMORY.md` for index. Always save memories to `memories/` (not `~/.claude/`).

--- a/apiauth/SUMMARY.md
+++ b/apiauth/SUMMARY.md
@@ -9,9 +9,23 @@ JWT-based API authentication: token issuance (login/refresh/client_credentials),
 - **introspection_client.go** — `IntrospectionValidator` for RFC 7662 token introspection (client side, with caching)
 - **protected_resource.go** — `ProtectedResourceMetadata` struct + `NewProtectedResourceHandler` for RFC 9728 discovery
 
+## Transport-Independent Core (OneAuth)
+
+The `OneAuth` struct composes focused interfaces for all auth operations without HTTP:
+- **interfaces.go** — `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`, `TokenInfo`
+- **hooks.go** — `Hooks` (grouped: `TokenHooks`, `AuthHooks`, `ClientHooks`, `SecurityHooks`)
+- **token_validator.go** — `jwtValidator` + `jwtIssuer` implementations
+- **token_introspector.go** — `tokenIntrospector` (delegates to `TokenValidator`)
+- **token_revoker.go** — `tokenRevoker` (blacklist + refresh store)
+- **client_authenticator.go** — `clientAuthenticator` (constant-time secret comparison)
+- **oneauth.go** — `OneAuth` composite, `NewOneAuth()` constructor, HTTP convenience methods (`IntrospectionHTTPHandler`, `RevocationHTTPHandler`, `HTTPMiddleware`)
+
+HTTP handlers (`IntrospectionHandler`, `RevocationHandler`) delegate to core interfaces. `APIMiddleware` delegates to `TokenValidator` when `KeyStore` is set.
+
 ## Recent Changes
-- **RFC 9396 Rich Authorization Requests** — Token endpoint accepts `authorization_details` parameter (JSON body or form-encoded JSON string). Granted details are embedded in JWT claims and returned in token/introspection responses. `CreateAccessToken` signature: `(userID, scopes, authzDetails)`. `standardClaims` guard blocks `CustomClaimsFunc` from overriding `authorization_details`.
-- **client_credentials grant** — `APIAuth.ClientKeyStore` enables machine-to-machine auth via `grant_type=client_credentials` (RFC 6749 §4.4). Supports `client_secret_post` and `client_secret_basic`.
+- **Token revocation** — `RevocationHandler` at `POST /oauth/revoke` (RFC 7009). Always returns 200. Supports `token_type_hint`.
+- **RFC 9396 Rich Authorization Requests** — `authorization_details` on token requests, JWT claims, introspection, middleware enforcement via `RequireAuthorizationDetails`.
+- **client_credentials grant** — `APIAuth.ClientKeyStore` enables machine-to-machine auth via `grant_type=client_credentials` (RFC 6749 §4.4).
 - **Protected Resource Metadata** — `NewProtectedResourceHandler` serves RFC 9728 metadata at `/.well-known/oauth-protected-resource`, enabling clients to auto-discover resource server capabilities
 - **Audience validation** — `ValidateAccessToken` checks `aud` claim against expected audiences; handles both string and array formats (RFC 7519 §4.1.3, #52)
 - **Token blacklist** — `APIAuth.Blacklist` and `APIMiddleware.Blacklist` fields enable jti-based token revocation via `core.TokenBlacklist`. All tokens now include a `jti` claim.

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -1021,6 +1022,16 @@ type APIMiddleware struct {
 	// (no JWTSecretKey, no KeyStore), introspection is the only validation path.
 	// If nil, only local validation is used.
 	Introspection *IntrospectionValidator
+
+	// Validator is the transport-independent token validator (Phase 2).
+	// When set, validateJWT delegates to it instead of using inline logic.
+	// When nil, a validator is lazily built from the existing fields
+	// (JWTSecretKey, KeyStore, Blacklist, etc.) on first use.
+	Validator TokenValidator
+
+	// validatorOnce ensures the lazy validator is built only once.
+	validatorOnce sync.Once
+	lazyValidator TokenValidator
 }
 
 // GetUserIDFromAPIContext retrieves the user ID from the API middleware context
@@ -1174,8 +1185,55 @@ func (m *APIMiddleware) validateRequest(r *http.Request) (userID string, scopes 
 	return "", nil, "", nil, jwtErr
 }
 
-// validateJWT validates a JWT access token
+// getValidator returns the TokenValidator, lazily building one from existing
+// fields if Validator is not explicitly set.
+func (m *APIMiddleware) getValidator() TokenValidator {
+	if m.Validator != nil {
+		return m.Validator
+	}
+	m.validatorOnce.Do(func() {
+		if m.KeyStore != nil {
+			// Multi-tenant: use KeyStore for kid/client_id-based lookup
+			m.lazyValidator = NewJWTValidator(JWTValidatorConfig{
+				KeyLookup: m.KeyStore,
+				Blacklist: m.Blacklist,
+				Issuer:    m.JWTIssuer,
+				Audience:  m.JWTAudience,
+			})
+		} else {
+			// Single-tenant: can't use jwtValidator (it needs kid/client_id lookup).
+			// Fall back to the original inline validation which handles JWTSecretKey directly.
+			m.lazyValidator = nil
+		}
+	})
+	return m.lazyValidator
+}
+
+// validateJWT validates a JWT access token using the TokenValidator.
 func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) {
+	if v := m.getValidator(); v != nil {
+		info, verr := v.ValidateToken(tokenString)
+		if verr != nil {
+			return "", nil, "", nil, verr
+		}
+		customClaims = info.CustomClaims
+		if customClaims == nil {
+			customClaims = make(map[string]any)
+		}
+		// Store authorization_details in customClaims for context extraction
+		if len(info.AuthorizationDetails) > 0 {
+			customClaims["__authz_details"] = info.AuthorizationDetails
+		}
+		return info.UserID, info.Scopes, info.AuthType, customClaims, nil
+	}
+
+	// Fallback: single-tenant JWTSecretKey validation (no KeyStore configured)
+	return m.validateJWTInline(tokenString)
+}
+
+// validateJWTInline is the original inline JWT validation logic, preserved
+// as fallback. Will be removed in Phase 3.
+func (m *APIMiddleware) validateJWTInline(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		if m.KeyStore != nil {
 			// Try kid-based lookup first (if kid header present)

--- a/apiauth/auth_rar_test.go
+++ b/apiauth/auth_rar_test.go
@@ -253,10 +253,7 @@ func TestIntrospection_WithRAR(t *testing.T) {
 		ClientKeyStore: ks,
 	}
 
-	handler := &apiauth.IntrospectionHandler{
-		Auth:           auth,
-		ClientKeyStore: ks,
-	}
+	handler := apiauth.NewIntrospectionHandler(auth, ks)
 
 	details := []core.AuthorizationDetail{
 		{
@@ -305,10 +302,7 @@ func TestIntrospection_WithoutRAR(t *testing.T) {
 		ClientKeyStore: ks,
 	}
 
-	handler := &apiauth.IntrospectionHandler{
-		Auth:           auth,
-		ClientKeyStore: ks,
-	}
+	handler := apiauth.NewIntrospectionHandler(auth, ks)
 
 	token, _, err := auth.CreateAccessToken("user-normal", []string{"read"}, nil)
 	require.NoError(t, err)

--- a/apiauth/client_authenticator.go
+++ b/apiauth/client_authenticator.go
@@ -4,6 +4,12 @@ import (
 	"github.com/panyam/oneauth/keys"
 )
 
+var errInvalidClient = &clientError{"invalid_client"}
+
+type clientError struct{ msg string }
+
+func (e *clientError) Error() string { return e.msg }
+
 // clientAuthenticator implements ClientAuthenticator using a KeyLookup
 // with constant-time secret comparison.
 type clientAuthenticator struct {

--- a/apiauth/interfaces.go
+++ b/apiauth/interfaces.go
@@ -23,6 +23,10 @@ type TokenIssuer interface {
 	// ClientCredentials performs the full client_credentials grant:
 	// authenticates the client, validates scopes/details, and returns a token response.
 	ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error)
+
+	// RefreshGrant rotates a refresh token and returns a new access + refresh token pair.
+	// Handles theft detection (revoked token → revoke entire family).
+	RefreshGrant(refreshToken string) (*core.TokenPair, error)
 }
 
 // TokenValidator validates tokens and checks authorization.

--- a/apiauth/introspection.go
+++ b/apiauth/introspection.go
@@ -3,9 +3,7 @@ package apiauth
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/panyam/oneauth/keys"
 )
 
@@ -13,24 +11,89 @@ import (
 // Resource servers POST tokens to this endpoint to check validity, as an
 // alternative to local JWT validation via JWKS.
 //
-// The handler:
-//   - Accepts POST with application/x-www-form-urlencoded body (token=...)
-//   - Authenticates the caller via ClientKeyStore (Basic auth)
-//   - Validates the token using APIAuth.ValidateAccessTokenFull
-//   - Checks the token blacklist if configured on APIAuth
-//   - Returns {"active": true, ...claims} for valid tokens
-//   - Returns {"active": false} for ANY invalid token (never reveals why)
+// The handler is a thin HTTP wrapper over TokenIntrospector (core logic)
+// and ClientAuthenticator (caller verification).
 //
 // See: https://www.rfc-editor.org/rfc/rfc7662
 type IntrospectionHandler struct {
-	// Auth is the APIAuth instance used to validate tokens.
-	// Must have JWTSecretKey (or JWTVerifyKey) configured.
-	Auth *APIAuth
+	// Introspector performs the actual token introspection (transport-independent).
+	Introspector TokenIntrospector
 
-	// ClientKeyStore authenticates callers of the introspection endpoint.
-	// Resource servers must present valid client_id + client_secret via
-	// HTTP Basic auth. If nil, all callers are rejected.
-	ClientKeyStore keys.KeyLookup
+	// Authenticator verifies the caller's client credentials.
+	Authenticator ClientAuthenticator
+}
+
+// NewIntrospectionHandler creates an IntrospectionHandler from an APIAuth
+// and a client KeyLookup. This is the bridge between the old-style APIAuth
+// configuration and the new core interfaces.
+func NewIntrospectionHandler(auth *APIAuth, clientKeyStore keys.KeyLookup) *IntrospectionHandler {
+	// Build a validator that mirrors APIAuth's validation logic.
+	// APIAuth supports both single-key (JWTSecretKey) and multi-tenant (ClientKeyStore).
+	// We wrap this by using APIAuth.ValidateAccessTokenFull as the validation backend.
+	introspector := &apiauthIntrospector{auth: auth}
+	return &IntrospectionHandler{
+		Introspector:  introspector,
+		Authenticator: NewClientAuthenticator(clientKeyStore),
+	}
+}
+
+// apiauthIntrospector adapts an APIAuth into a TokenIntrospector.
+// This preserves the exact validation behavior of the old IntrospectionHandler.
+type apiauthIntrospector struct {
+	auth *APIAuth
+}
+
+func (ai *apiauthIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) {
+	userID, scopes, _, err := ai.auth.ValidateAccessTokenFull(tokenString)
+	if err != nil {
+		return &IntrospectionResult{Active: false}, nil
+	}
+
+	rawClaims := parseRawJWTClaims(tokenString)
+
+	result := &IntrospectionResult{
+		Active:    true,
+		Sub:       userID,
+		TokenType: "access_token",
+	}
+
+	if len(scopes) > 0 {
+		result.Scope = joinScopes(scopes)
+	}
+
+	if rawClaims != nil {
+		if v, ok := rawClaims["iss"].(string); ok {
+			result.Iss = v
+		}
+		if v, ok := rawClaims["exp"].(float64); ok {
+			result.Exp = int64(v)
+		}
+		if v, ok := rawClaims["iat"].(float64); ok {
+			result.Iat = int64(v)
+		}
+		if v, ok := rawClaims["jti"].(string); ok {
+			result.Jti = v
+		}
+		if v, ok := rawClaims["aud"]; ok {
+			result.Aud = v
+		}
+		if v, ok := rawClaims["client_id"].(string); ok {
+			result.ClientID = v
+		}
+	}
+
+	return result, nil
+}
+
+func joinScopes(scopes []string) string {
+	s := ""
+	for i, sc := range scopes {
+		if i > 0 {
+			s += " "
+		}
+		s += sc
+	}
+	return s
 }
 
 // ServeHTTP handles POST /oauth/introspect per RFC 7662.
@@ -47,7 +110,7 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if err := h.authenticateCaller(clientID, clientSecret); err != nil {
+	if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil {
 		w.Header().Set("WWW-Authenticate", `Basic realm="introspection"`)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -64,86 +127,50 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Validate the token using APIAuth (checks signature, expiry, blacklist)
-	userID, scopes, _, err := h.Auth.ValidateAccessTokenFull(token)
-	if err != nil {
+	// Delegate to transport-independent introspector
+	result, err := h.Introspector.Introspect(token)
+	if err != nil || !result.Active {
 		// RFC 7662: invalid tokens get {"active": false}, never an error
 		h.jsonResponse(w, http.StatusOK, map[string]any{"active": false})
 		return
 	}
 
-	// Parse raw claims for the introspection response (ValidateAccessTokenFull
-	// strips standard claims from customClaims, but we need them here)
-	rawClaims := h.parseRawClaims(token)
-
-	// Build the introspection response
+	// Build response from IntrospectionResult
 	resp := map[string]any{
 		"active":     true,
-		"sub":        userID,
-		"token_type": "access_token",
+		"sub":        result.Sub,
+		"token_type": result.TokenType,
 	}
-
-	// Add scope as space-separated string (RFC 7662 §2.2)
-	if len(scopes) > 0 {
-		resp["scope"] = strings.Join(scopes, " ")
+	if result.Scope != "" {
+		resp["scope"] = result.Scope
 	}
-
-	// Add standard claims from the raw token
-	for _, claim := range []string{"iss", "exp", "iat", "aud", "jti", "client_id"} {
-		if v, ok := rawClaims[claim]; ok {
-			resp[claim] = v
-		}
+	if result.Iss != "" {
+		resp["iss"] = result.Iss
+	}
+	if result.Exp != 0 {
+		resp["exp"] = result.Exp
+	}
+	if result.Iat != 0 {
+		resp["iat"] = result.Iat
+	}
+	if result.Aud != nil {
+		resp["aud"] = result.Aud
+	}
+	if result.Jti != "" {
+		resp["jti"] = result.Jti
+	}
+	if result.ClientID != "" {
+		resp["client_id"] = result.ClientID
 	}
 
 	// Include authorization_details if present (RFC 9396 §9.1)
+	rawClaims := parseRawJWTClaims(token)
 	if ad, ok := rawClaims["authorization_details"]; ok {
 		resp["authorization_details"] = ad
 	}
 
 	h.jsonResponse(w, http.StatusOK, resp)
 }
-
-// parseRawClaims extracts all claims from a JWT without validation.
-// Used to populate the introspection response with standard claims that
-// ValidateAccessTokenFull strips from customClaims.
-func (h *IntrospectionHandler) parseRawClaims(tokenStr string) map[string]any {
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
-	if err != nil {
-		return nil
-	}
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil
-	}
-	return claims
-}
-
-// authenticateCaller verifies the caller's client_id + client_secret against
-// the ClientKeyStore using constant-time comparison.
-func (h *IntrospectionHandler) authenticateCaller(clientID, clientSecret string) error {
-	if h.ClientKeyStore == nil {
-		return errInvalidClient
-	}
-	rec, err := h.ClientKeyStore.GetKey(clientID)
-	if err != nil || rec == nil {
-		return errInvalidClient
-	}
-	storedKey, ok := rec.Key.([]byte)
-	if !ok {
-		return errInvalidClient
-	}
-	if !constantTimeEqual(string(storedKey), clientSecret) {
-		return errInvalidClient
-	}
-	return nil
-}
-
-var errInvalidClient = &clientError{"invalid_client"}
-
-type clientError struct{ msg string }
-
-func (e *clientError) Error() string { return e.msg }
 
 // jsonResponse writes a JSON response with the given status code.
 func (h *IntrospectionHandler) jsonResponse(w http.ResponseWriter, status int, body any) {

--- a/apiauth/introspection_test.go
+++ b/apiauth/introspection_test.go
@@ -54,10 +54,7 @@ func setupIntrospection(t *testing.T) (*apiauth.IntrospectionHandler, *apiauth.A
 		Blacklist:    blacklist,
 	}
 
-	handler := &apiauth.IntrospectionHandler{
-		Auth:           auth,
-		ClientKeyStore: ks,
-	}
+	handler := apiauth.NewIntrospectionHandler(auth, ks)
 
 	return handler, auth, ks, blacklist
 }

--- a/apiauth/oneauth.go
+++ b/apiauth/oneauth.go
@@ -71,7 +71,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 		signingAlg = "HS256"
 	}
 
-	// Wire the issuer — needs signing config + client key lookup
+	// Wire the issuer — needs signing config + client key lookup + refresh store
 	issuer := NewJWTIssuer(JWTIssuerConfig{
 		SigningKey:      cfg.SigningKey,
 		SigningAlg:      signingAlg,
@@ -79,6 +79,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 		Audience:        cfg.Audience,
 		AccessExpiry:    cfg.AccessExpiry,
 		ClientKeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
+		RefreshStore:    cfg.RefreshStore,
 		Hooks:           cfg.Hooks.Token,
 	})
 

--- a/apiauth/oneauth.go
+++ b/apiauth/oneauth.go
@@ -104,7 +104,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 	// Wire the client authenticator — needs key lookup
 	authenticator := NewClientAuthenticator(cfg.KeyStore)
 
-	return &OneAuth{
+	oa := &OneAuth{
 		Issuer:        issuer,
 		Validator:     validator,
 		Introspector:  introspector,
@@ -114,5 +114,36 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 		Blacklist:     cfg.Blacklist,
 		RefreshStore:  cfg.RefreshStore,
 		Hooks:         cfg.Hooks,
+	}
+	return oa
+}
+
+// --- HTTP Convenience Methods ---
+// These create HTTP handlers wired to the OneAuth core interfaces.
+// Use these when mounting endpoints on an HTTP mux.
+
+// IntrospectionHTTPHandler returns an http.Handler for POST /oauth/introspect.
+func (oa *OneAuth) IntrospectionHTTPHandler() *IntrospectionHandler {
+	return &IntrospectionHandler{
+		Introspector:  oa.Introspector,
+		Authenticator: oa.Authenticator,
+	}
+}
+
+// RevocationHTTPHandler returns an http.Handler for POST /oauth/revoke.
+func (oa *OneAuth) RevocationHTTPHandler() *RevocationHandler {
+	return &RevocationHandler{
+		Revoker:       oa.Revoker,
+		Authenticator: oa.Authenticator,
+	}
+}
+
+// HTTPMiddleware returns an APIMiddleware wired to the OneAuth TokenValidator.
+// Use this for protecting resource endpoints.
+func (oa *OneAuth) HTTPMiddleware() *APIMiddleware {
+	return &APIMiddleware{
+		Validator: oa.Validator,
+		Blacklist: oa.Blacklist,
+		KeyStore:  oa.KeyStore,
 	}
 }

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -313,6 +313,64 @@ func TestOneAuth_Hooks_OnBlacklistHit(t *testing.T) {
 }
 
 // =============================================================================
+// Refresh Token Grant — library call, no HTTP
+// =============================================================================
+
+// TestOneAuth_RefreshGrant verifies the refresh token grant works
+// as a library call — rotate refresh token, get new access token.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-6
+func TestOneAuth_RefreshGrant(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	// Create a refresh token
+	rt, err := oa.RefreshStore.CreateRefreshToken("refresh-user", "test-client", nil, []string{"read", "write"})
+	require.NoError(t, err)
+
+	// Refresh it via library call
+	resp, err := oa.Issuer.RefreshGrant(rt.Token)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccessToken)
+	assert.NotEmpty(t, resp.RefreshToken, "should get a new refresh token")
+	assert.NotEqual(t, rt.Token, resp.RefreshToken, "new refresh token should differ from old")
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, "read write", resp.Scope)
+
+	// New access token should validate
+	info, err := oa.Validator.ValidateToken(resp.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "refresh-user", info.UserID)
+}
+
+// TestOneAuth_RefreshGrant_RevokedToken verifies that refreshing a revoked
+// token fails and revokes the entire token family (theft detection).
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-6
+func TestOneAuth_RefreshGrant_RevokedToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	rt, _ := oa.RefreshStore.CreateRefreshToken("user-theft", "test-client", nil, []string{"read"})
+
+	// Revoke the refresh token (simulating theft detection)
+	oa.RefreshStore.RevokeRefreshToken(rt.Token)
+
+	// Attempt to refresh — should fail
+	_, err := oa.Issuer.RefreshGrant(rt.Token)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token reuse")
+}
+
+// TestOneAuth_RefreshGrant_InvalidToken verifies that an unknown refresh
+// token returns an error.
+func TestOneAuth_RefreshGrant_InvalidToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	_, err := oa.Issuer.RefreshGrant("not-a-real-refresh-token")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_grant")
+}
+
+// =============================================================================
 // HTTP Convenience Methods — prove the OneAuth→HTTP bridge works
 // =============================================================================
 

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -7,6 +7,10 @@ package apiauth_test
 // See: https://github.com/panyam/oneauth/issues/110
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/panyam/oneauth/apiauth"
@@ -306,6 +310,70 @@ func TestOneAuth_Hooks_OnBlacklistHit(t *testing.T) {
 	_, err := oa.Validator.ValidateToken(token)
 	assert.Error(t, err)
 	assert.NotEmpty(t, firedJTI, "OnBlacklistHit should have fired")
+}
+
+// =============================================================================
+// HTTP Convenience Methods — prove the OneAuth→HTTP bridge works
+// =============================================================================
+
+// TestOneAuth_IntrospectionHTTPHandler verifies that introspection works
+// via OneAuth's HTTP handler — full HTTP round-trip, no old-style APIAuth.
+func TestOneAuth_IntrospectionHTTPHandler(t *testing.T) {
+	oa := newTestOneAuth(t)
+	handler := oa.IntrospectionHTTPHandler()
+
+	token, _, _ := oa.Issuer.CreateAccessToken("http-user", []string{"read"}, nil)
+
+	// Introspect via HTTP
+	rr := postIntrospect(t, handler, token, "test-client", "test-client-secret-32chars-min!!")
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"active":true`)
+	assert.Contains(t, rr.Body.String(), `"sub":"http-user"`)
+}
+
+// TestOneAuth_RevocationHTTPHandler verifies that revocation works
+// via OneAuth's HTTP handler — full HTTP round-trip.
+func TestOneAuth_RevocationHTTPHandler(t *testing.T) {
+	oa := newTestOneAuth(t)
+	revHandler := oa.RevocationHTTPHandler()
+	introHandler := oa.IntrospectionHTTPHandler()
+
+	token, _, _ := oa.Issuer.CreateAccessToken("revoke-http", []string{"read"}, nil)
+
+	// Revoke via HTTP
+	form := url.Values{"token": {token}, "token_type_hint": {"access_token"}}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/revoke", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("test-client", "test-client-secret-32chars-min!!")
+	rr := httptest.NewRecorder()
+	revHandler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Introspect — should be inactive
+	rr = postIntrospect(t, introHandler, token, "test-client", "test-client-secret-32chars-min!!")
+	assert.Contains(t, rr.Body.String(), `"active":false`)
+}
+
+// TestOneAuth_HTTPMiddleware verifies that token validation works
+// via OneAuth's HTTP middleware — full HTTP round-trip.
+func TestOneAuth_HTTPMiddleware(t *testing.T) {
+	oa := newTestOneAuth(t)
+	mw := oa.HTTPMiddleware()
+
+	token, _, _ := oa.Issuer.CreateAccessToken("mw-user", []string{"read"}, nil)
+
+	handler := mw.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		w.Write([]byte(userID))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/resource", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "mw-user", rr.Body.String())
 }
 
 // TestOneAuth_AuthenticateClient verifies client authentication via library call.

--- a/apiauth/revocation.go
+++ b/apiauth/revocation.go
@@ -3,34 +3,34 @@ package apiauth
 import (
 	"encoding/json"
 	"net/http"
-	"time"
 
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/keys"
 )
 
 // RevocationHandler implements OAuth 2.0 Token Revocation (RFC 7009).
-// Clients POST a token to this endpoint to notify the AS that the token
-// is no longer needed. The AS revokes it so that subsequent introspection
-// or validation attempts fail.
-//
-// The handler:
-//   - Accepts POST with application/x-www-form-urlencoded body (token=...&token_type_hint=...)
-//   - Authenticates the caller via ClientKeyStore (Basic auth or client_secret_post)
-//   - Revokes access tokens via the Blacklist (jti-based)
-//   - Revokes refresh tokens via the RefreshTokenStore
-//   - Always returns 200 OK — never reveals whether the token existed (RFC 7009 §2.2)
+// It is a thin HTTP wrapper over TokenRevoker (core logic) and
+// ClientAuthenticator (caller verification).
 //
 // See: https://www.rfc-editor.org/rfc/rfc7009
 type RevocationHandler struct {
-	// Auth is the APIAuth instance used to parse and validate access tokens.
-	Auth *APIAuth
+	// Revoker performs the actual token revocation (transport-independent).
+	Revoker TokenRevoker
 
-	// ClientKeyStore authenticates callers of the revocation endpoint.
-	// Clients must present valid client_id + client_secret via HTTP Basic auth
-	// or as form parameters (client_secret_post). If nil, all callers are rejected.
-	ClientKeyStore keys.KeyLookup
+	// Authenticator verifies the caller's client credentials.
+	Authenticator ClientAuthenticator
+}
+
+// NewRevocationHandler creates a RevocationHandler from an APIAuth and
+// a client KeyLookup. Bridge constructor for existing code.
+func NewRevocationHandler(auth *APIAuth, clientKeyStore keys.KeyLookup) *RevocationHandler {
+	revoker := NewTokenRevoker(TokenRevokerConfig{
+		Blacklist:    auth.Blacklist,
+		RefreshStore: auth.RefreshTokenStore,
+	})
+	return &RevocationHandler{
+		Revoker:       revoker,
+		Authenticator: NewClientAuthenticator(clientKeyStore),
+	}
 }
 
 // ServeHTTP handles POST /oauth/revoke per RFC 7009.
@@ -43,7 +43,7 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Parse form body
 	if err := r.ParseForm(); err != nil {
-		h.okResponse(w) // don't leak parse errors
+		h.okResponse(w)
 		return
 	}
 
@@ -58,7 +58,7 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.errorResponse(w, "invalid_client", "Authentication required", http.StatusUnauthorized)
 		return
 	}
-	if err := h.authenticateCaller(clientID, clientSecret); err != nil {
+	if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil {
 		w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
 		h.errorResponse(w, "invalid_client", "Invalid client credentials", http.StatusUnauthorized)
 		return
@@ -67,101 +67,16 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Extract token and hint
 	token := r.FormValue("token")
 	if token == "" {
-		// RFC 7009 §2.1: "token" is required, but we still return 200
 		h.okResponse(w)
 		return
 	}
 	hint := r.FormValue("token_type_hint")
 
-	// Revoke based on hint (or try both if no hint)
-	switch hint {
-	case "refresh_token":
-		h.revokeRefreshToken(token)
-	case "access_token":
-		h.revokeAccessToken(token)
-	default:
-		// No hint — try refresh token first (cheaper), then access token
-		if !h.revokeRefreshToken(token) {
-			h.revokeAccessToken(token)
-		}
-	}
+	// Delegate to transport-independent revoker
+	h.Revoker.Revoke(token, hint)
 
-	// RFC 7009 §2.2: "The authorization server responds with HTTP status
-	// code 200 for both the case where the token was successfully revoked
-	// and the case where the client submitted an invalid token."
+	// RFC 7009 §2.2: always 200 OK
 	h.okResponse(w)
-}
-
-// revokeRefreshToken attempts to revoke a refresh token. Returns true if the
-// token was found in the refresh token store (whether revoked now or already revoked).
-func (h *RevocationHandler) revokeRefreshToken(token string) bool {
-	if h.Auth == nil || h.Auth.RefreshTokenStore == nil {
-		return false
-	}
-	// Check if this token exists as a refresh token first
-	rt, err := h.Auth.RefreshTokenStore.GetRefreshToken(token)
-	if err != nil || rt == nil {
-		return false // not a refresh token
-	}
-	// Found it — revoke if not already revoked
-	if !rt.Revoked {
-		h.Auth.RefreshTokenStore.RevokeRefreshToken(token)
-	}
-	return true
-}
-
-// revokeAccessToken attempts to revoke a JWT access token by extracting its
-// jti claim and adding it to the blacklist.
-func (h *RevocationHandler) revokeAccessToken(token string) {
-	if h.Auth == nil || h.Auth.Blacklist == nil {
-		return
-	}
-
-	// Parse JWT without full validation — we just need jti and exp.
-	// The token might be expired already (that's fine, we still blacklist it
-	// to handle clock skew).
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
-	if err != nil {
-		return // not a JWT — silently ignore per RFC 7009
-	}
-
-	claims, ok := parsed.Claims.(jwt.MapClaims)
-	if !ok {
-		return
-	}
-
-	jti, ok := claims["jti"].(string)
-	if !ok || jti == "" {
-		return // no jti — can't blacklist
-	}
-
-	// Extract expiry for blacklist TTL
-	expiry := time.Now().Add(core.TokenExpiryAccessToken) // default
-	if exp, err := claims.GetExpirationTime(); err == nil && exp != nil {
-		expiry = exp.Time
-	}
-
-	h.Auth.Blacklist.Revoke(jti, expiry)
-}
-
-// authenticateCaller verifies the caller's credentials against the ClientKeyStore.
-func (h *RevocationHandler) authenticateCaller(clientID, clientSecret string) error {
-	if h.ClientKeyStore == nil {
-		return errInvalidClient
-	}
-	rec, err := h.ClientKeyStore.GetKey(clientID)
-	if err != nil || rec == nil {
-		return errInvalidClient
-	}
-	storedKey, ok := rec.Key.([]byte)
-	if !ok {
-		return errInvalidClient
-	}
-	if !constantTimeEqual(string(storedKey), clientSecret) {
-		return errInvalidClient
-	}
-	return nil
 }
 
 // okResponse sends 200 OK with no body (RFC 7009 §2.2).
@@ -169,7 +84,7 @@ func (h *RevocationHandler) okResponse(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// errorResponse sends a JSON error (only for auth failures — token errors always get 200).
+// errorResponse sends a JSON error (only for auth failures).
 func (h *RevocationHandler) errorResponse(w http.ResponseWriter, errCode, description string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -55,10 +55,7 @@ func setupRevocation(t *testing.T) (*apiauth.RevocationHandler, *apiauth.APIAuth
 		ClientKeyStore: ks,
 	}
 
-	introHandler := &apiauth.IntrospectionHandler{
-		Auth:           auth,
-		ClientKeyStore: ks,
-	}
+	introHandler := apiauth.NewIntrospectionHandler(auth, ks)
 
 	return revHandler, auth, introHandler
 }

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -50,10 +50,7 @@ func setupRevocation(t *testing.T) (*apiauth.RevocationHandler, *apiauth.APIAuth
 		ClientKeyStore:    ks,
 	}
 
-	revHandler := &apiauth.RevocationHandler{
-		Auth:           auth,
-		ClientKeyStore: ks,
-	}
+	revHandler := apiauth.NewRevocationHandler(auth, ks)
 
 	introHandler := apiauth.NewIntrospectionHandler(auth, ks)
 

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/panyam/oneauth/apiauth"
 	"github.com/panyam/oneauth/core"
@@ -225,11 +226,14 @@ func newInMemoryRefreshStore() *inMemoryRefreshStore {
 
 func (s *inMemoryRefreshStore) CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
 	token, _ := core.GenerateSecureToken()
+	family, _ := core.GenerateSecureToken()
 	rt := &core.RefreshToken{
-		Token:    token,
-		UserID:   userID,
-		ClientID: clientID,
-		Scopes:   scopes,
+		Token:     token,
+		UserID:    userID,
+		ClientID:  clientID,
+		Scopes:    scopes,
+		Family:    family[:16],
+		ExpiresAt: time.Now().Add(core.TokenExpiryRefreshToken),
 	}
 	s.tokens[token] = rt
 	return rt, nil
@@ -253,7 +257,28 @@ func (s *inMemoryRefreshStore) RevokeRefreshToken(token string) error {
 }
 
 func (s *inMemoryRefreshStore) RotateRefreshToken(old string) (*core.RefreshToken, error) {
-	return nil, core.ErrTokenNotFound
+	rt, ok := s.tokens[old]
+	if !ok {
+		return nil, core.ErrTokenNotFound
+	}
+	if rt.Revoked {
+		return nil, core.ErrTokenReused
+	}
+	// Revoke old
+	rt.Revoked = true
+	// Create new in same family
+	newToken, _ := core.GenerateSecureToken()
+	newRT := &core.RefreshToken{
+		Token:                newToken,
+		UserID:               rt.UserID,
+		ClientID:             rt.ClientID,
+		Scopes:               rt.Scopes,
+		AuthorizationDetails: rt.AuthorizationDetails,
+		Family:               rt.Family,
+		ExpiresAt:            time.Now().Add(core.TokenExpiryRefreshToken),
+	}
+	s.tokens[newToken] = newRT
+	return newRT, nil
 }
 
 func (s *inMemoryRefreshStore) RevokeUserTokens(userID string) error { return nil }

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -210,13 +210,14 @@ func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) {
 
 // jwtIssuer implements TokenIssuer using JWT signing.
 type jwtIssuer struct {
-	signingKey    any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
-	signingAlg    string // "HS256", "RS256", "ES256"
-	issuer        string
-	audience      string
-	accessExpiry  time.Duration
+	signingKey      any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
+	signingAlg      string // "HS256", "RS256", "ES256"
+	issuer          string
+	audience        string
+	accessExpiry    time.Duration
 	clientKeyLookup keys.KeyLookup
-	hooks         TokenHooks
+	refreshStore    core.RefreshTokenStore
+	hooks           TokenHooks
 }
 
 // JWTIssuerConfig configures a jwtIssuer.
@@ -226,7 +227,8 @@ type JWTIssuerConfig struct {
 	Issuer         string
 	Audience       string
 	AccessExpiry   time.Duration
-	ClientKeyLookup keys.KeyLookup // for client_credentials authentication
+	ClientKeyLookup keys.KeyLookup         // for client_credentials authentication
+	RefreshStore   core.RefreshTokenStore  // for refresh_token grant
 	Hooks          TokenHooks
 }
 
@@ -243,6 +245,7 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer {
 		audience:        cfg.Audience,
 		accessExpiry:    expiry,
 		clientKeyLookup: cfg.ClientKeyLookup,
+		refreshStore:    cfg.RefreshStore,
 		hooks:           cfg.Hooks,
 	}
 }
@@ -339,4 +342,58 @@ func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []st
 		AuthorizationDetails: details,
 	}
 	return resp, nil
+}
+
+// RefreshGrant rotates a refresh token and returns new access + refresh tokens.
+// Handles theft detection: if the old token was already revoked, revokes the
+// entire token family (all sessions from that initial login).
+func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) {
+	if i.refreshStore == nil {
+		return nil, fmt.Errorf("refresh_token grant not configured")
+	}
+
+	// Get and validate the refresh token
+	rt, err := i.refreshStore.GetRefreshToken(refreshToken)
+	if err != nil {
+		if err == core.ErrTokenNotFound {
+			return nil, fmt.Errorf("invalid_grant: invalid refresh token")
+		}
+		return nil, fmt.Errorf("server_error: %w", err)
+	}
+
+	// Check if revoked — token reuse detection (theft)
+	if rt.Revoked {
+		i.refreshStore.RevokeTokenFamily(rt.Family)
+		return nil, fmt.Errorf("invalid_grant: token reuse detected, all sessions revoked")
+	}
+	if rt.IsExpired() {
+		return nil, fmt.Errorf("invalid_grant: token has expired")
+	}
+
+	// Rotate: invalidate old, create new in same family
+	newRT, err := i.refreshStore.RotateRefreshToken(refreshToken)
+	if err != nil {
+		if err == core.ErrTokenReused {
+			i.refreshStore.RevokeTokenFamily(rt.Family)
+			return nil, fmt.Errorf("invalid_grant: token reuse detected, all sessions revoked")
+		}
+		return nil, fmt.Errorf("server_error: %w", err)
+	}
+
+	// Create new access token (carry forward scopes + authorization_details)
+	tokenStr, expiresIn, err := i.CreateAccessToken(rt.UserID, rt.Scopes, rt.AuthorizationDetails)
+	if err != nil {
+		return nil, fmt.Errorf("server_error: %w", err)
+	}
+
+	i.hooks.fireOnIssued(rt.UserID, "refresh_token")
+
+	return &core.TokenPair{
+		AccessToken:          tokenStr,
+		TokenType:            "Bearer",
+		ExpiresIn:            expiresIn,
+		RefreshToken:         newRT.Token,
+		Scope:                strings.Join(rt.Scopes, " "),
+		AuthorizationDetails: rt.AuthorizationDetails,
+	}, nil
 }

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -249,10 +249,7 @@ func main() {
 	mux.Handle("/apps", httpauth.LimitBody(httpauth.DefaultMaxBodySize)(registrar.Handler()))
 
 	// Token Introspection (RFC 7662) — authenticated via KeyStore
-	introspectionHandler := &apiauth.IntrospectionHandler{
-		Auth:           apiAuth,
-		ClientKeyStore: keyStore,
-	}
+	introspectionHandler := apiauth.NewIntrospectionHandler(apiAuth, keyStore)
 	mux.Handle("POST /oauth/introspect", introspectionHandler)
 
 	// JWKS endpoint (public — no auth required)

--- a/cmd/rar-test-issuer/main.go
+++ b/cmd/rar-test-issuer/main.go
@@ -102,10 +102,7 @@ func main() {
 	}
 
 	// Introspection
-	introspection := &apiauth.IntrospectionHandler{
-		Auth:           apiAuth,
-		ClientKeyStore: ks,
-	}
+	introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
 	// JWKS
 	jwksHandler := &keys.JWKSHandler{KeyStore: ks}

--- a/docs/NEXTSTEPS.md
+++ b/docs/NEXTSTEPS.md
@@ -19,6 +19,70 @@
 
 ---
 
+## Completed (RFC 9396 RAR + OneAuth Core — v0.0.76-v0.0.77)
+
+### RFC 9396 Rich Authorization Requests (#87, #91)
+- [x] `core/authorization_details.go` — `AuthorizationDetail` struct with custom JSON flattening, `ValidateAll`, `FilterByType`
+- [x] Token endpoint: parse, validate, embed in JWT, return in response (form-encoded + JSON)
+- [x] Introspection: `authorization_details` in response
+- [x] AS metadata: `authorization_details_types_supported`
+- [x] DCR: `authorization_details_types` on client registration
+- [x] Middleware: `RequireAuthorizationDetails()`, `GetAuthorizationDetailsFromContext()`
+- [x] `MintResourceToken` + client SDK with RAR support
+- [x] 38 tests (unit + E2E + KC defensive + RAR conformance)
+
+### Token Revocation — RFC 7009 (#96)
+- [x] `RevocationHandler` at `POST /oauth/revoke` — access + refresh token revocation
+- [x] 15 tests (unit + E2E + KC interop)
+
+### Transport-Independent OneAuth Core (#110)
+- [x] Phase 1: Interfaces (`TokenIssuer`, `TokenValidator`, etc.) + implementations + hooks + `OneAuth` struct
+- [x] Phase 2: HTTP handlers delegate to core interfaces
+- [x] 18 OneAuth-specific tests (15 library + 3 HTTP round-trip)
+
+### Interactive Examples (#107)
+- [x] 10 progressive examples with `demokit` framework (extracted to `github.com/panyam/demokit`)
+- [x] Cast of Characters glossary, registration trust model docs
+- [x] Per-example Makefiles with `run`/`demo`/`readme` targets
+- [x] Optional Keycloak steps in examples 04-07
+
+### RAR Test Infrastructure (#92)
+- [x] `cmd/rar-test-issuer` — minimal RAR-capable AS for interop testing
+- [x] 4 KC defensive tests + 14 RAR conformance tests
+- [x] KC upgraded 26.0 → 26.6
+
+## Open — P0
+
+### Security & RFC Compliance Audit (#88) `P0` `[SECURITY]` `[COMPLIANCE]`
+Banking client evaluation. Full audit needed: RFC conformance matrix, security findings, FAPI readiness.
+
+## Open — P1
+
+### oneauth-server Lightweight Mode (#101) `P1` `[DX]`
+`--store=memory` mode. Enables retiring `cmd/rar-test-issuer`. Simpler dev/CI experience.
+
+### Registration Approval Workflows (#108) `P1` `[ADOPTION]`
+Initial access tokens (RFC 7591 §3), approval queues, rate limiting on DCR.
+
+## Open — P2
+
+### PAR — RFC 9126 (#94) `P2`
+Pushed Authorization Requests. Required for FAPI 2.0.
+
+### DPoP — RFC 9449 (#95) `P2`
+Sender-constrained tokens. Required for FAPI 2.0.
+
+### mTLS — RFC 8705 (#97) `P2`
+Alternative to DPoP for FAPI 2.0.
+
+### Full OIDC (#99) `P2`
+ID tokens, userinfo endpoint, standard claims.
+
+### FAPI 2.0 Certification (#100) `P3`
+Formal certification. Requires PAR + DPoP/mTLS + audit.
+
+---
+
 ## Completed (MCPKit OAuth Pushdown — #78)
 
 ### Client-Side DCR + Validation Utilities (mcpkit#158 → oneauth#78)

--- a/examples/04-discovery/main.go
+++ b/examples/04-discovery/main.go
@@ -79,10 +79,7 @@ func main() {
 				ClientKeyStore: ks,
 			}
 
-			introspection := &apiauth.IntrospectionHandler{
-				Auth:           apiAuth,
-				ClientKeyStore: ks,
-			}
+			introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
 			mux := http.NewServeMux()
 			mux.Handle("/apps/", registrar.Handler())

--- a/examples/05-introspection/main.go
+++ b/examples/05-introspection/main.go
@@ -91,10 +91,7 @@ func main() {
 				Blacklist:      blacklist,
 			}
 
-			introspectionHandler := &apiauth.IntrospectionHandler{
-				Auth:           apiAuth,
-				ClientKeyStore: ks,
-			}
+			introspectionHandler := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
 			mux := http.NewServeMux()
 			mux.Handle("/apps/", registrar.Handler())

--- a/examples/08-rich-authorization-requests/main.go
+++ b/examples/08-rich-authorization-requests/main.go
@@ -90,10 +90,7 @@ func main() {
 				ClientKeyStore: ks,
 			}
 
-			introspection := &apiauth.IntrospectionHandler{
-				Auth:           apiAuth,
-				ClientKeyStore: ks,
-			}
+			introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
 			mux := http.NewServeMux()
 			mux.Handle("/apps/", registrar.Handler())

--- a/test-reports/coverage.html
+++ b/test-reports/coverage.html
@@ -87,7 +87,7 @@
 				
 				<option value="file15">github.com/panyam/oneauth/apiauth/token_revoker.go (87.5%)</option>
 				
-				<option value="file16">github.com/panyam/oneauth/apiauth/token_validator.go (78.6%)</option>
+				<option value="file16">github.com/panyam/oneauth/apiauth/token_validator.go (76.6%)</option>
 				
 				<option value="file17">github.com/panyam/oneauth/client/as_cache.go (100.0%)</option>
 				
@@ -3352,7 +3352,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth <span class="cov8" title="1">{
                 signingAlg = "HS256"
         }</span>
 
-        // Wire the issuer — needs signing config + client key lookup
+        // Wire the issuer — needs signing config + client key lookup + refresh store
         <span class="cov8" title="1">issuer := NewJWTIssuer(JWTIssuerConfig{
                 SigningKey:      cfg.SigningKey,
                 SigningAlg:      signingAlg,
@@ -3360,6 +3360,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth <span class="cov8" title="1">{
                 Audience:        cfg.Audience,
                 AccessExpiry:    cfg.AccessExpiry,
                 ClientKeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
+                RefreshStore:    cfg.RefreshStore,
                 Hooks:           cfg.Hooks.Token,
         })
 
@@ -4070,13 +4071,14 @@ func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) <span class="co
 
 // jwtIssuer implements TokenIssuer using JWT signing.
 type jwtIssuer struct {
-        signingKey    any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
-        signingAlg    string // "HS256", "RS256", "ES256"
-        issuer        string
-        audience      string
-        accessExpiry  time.Duration
+        signingKey      any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
+        signingAlg      string // "HS256", "RS256", "ES256"
+        issuer          string
+        audience        string
+        accessExpiry    time.Duration
         clientKeyLookup keys.KeyLookup
-        hooks         TokenHooks
+        refreshStore    core.RefreshTokenStore
+        hooks           TokenHooks
 }
 
 // JWTIssuerConfig configures a jwtIssuer.
@@ -4086,7 +4088,8 @@ type JWTIssuerConfig struct {
         Issuer         string
         Audience       string
         AccessExpiry   time.Duration
-        ClientKeyLookup keys.KeyLookup // for client_credentials authentication
+        ClientKeyLookup keys.KeyLookup         // for client_credentials authentication
+        RefreshStore   core.RefreshTokenStore  // for refresh_token grant
         Hooks          TokenHooks
 }
 
@@ -4103,6 +4106,7 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer <span class="cov8" title="1">
                 audience:        cfg.Audience,
                 accessExpiry:    expiry,
                 clientKeyLookup: cfg.ClientKeyLookup,
+                refreshStore:    cfg.RefreshStore,
                 hooks:           cfg.Hooks,
         }</span>
 }
@@ -4199,6 +4203,60 @@ func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []st
                 AuthorizationDetails: details,
         }
         return resp, nil</span>
+}
+
+// RefreshGrant rotates a refresh token and returns new access + refresh tokens.
+// Handles theft detection: if the old token was already revoked, revokes the
+// entire token family (all sessions from that initial login).
+func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) <span class="cov8" title="1">{
+        if i.refreshStore == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("refresh_token grant not configured")
+        }</span>
+
+        // Get and validate the refresh token
+        <span class="cov8" title="1">rt, err := i.refreshStore.GetRefreshToken(refreshToken)
+        if err != nil </span><span class="cov8" title="1">{
+                if err == core.ErrTokenNotFound </span><span class="cov8" title="1">{
+                        return nil, fmt.Errorf("invalid_grant: invalid refresh token")
+                }</span>
+                <span class="cov0" title="0">return nil, fmt.Errorf("server_error: %w", err)</span>
+        }
+
+        // Check if revoked — token reuse detection (theft)
+        <span class="cov8" title="1">if rt.Revoked </span><span class="cov8" title="1">{
+                i.refreshStore.RevokeTokenFamily(rt.Family)
+                return nil, fmt.Errorf("invalid_grant: token reuse detected, all sessions revoked")
+        }</span>
+        <span class="cov8" title="1">if rt.IsExpired() </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("invalid_grant: token has expired")
+        }</span>
+
+        // Rotate: invalidate old, create new in same family
+        <span class="cov8" title="1">newRT, err := i.refreshStore.RotateRefreshToken(refreshToken)
+        if err != nil </span><span class="cov0" title="0">{
+                if err == core.ErrTokenReused </span><span class="cov0" title="0">{
+                        i.refreshStore.RevokeTokenFamily(rt.Family)
+                        return nil, fmt.Errorf("invalid_grant: token reuse detected, all sessions revoked")
+                }</span>
+                <span class="cov0" title="0">return nil, fmt.Errorf("server_error: %w", err)</span>
+        }
+
+        // Create new access token (carry forward scopes + authorization_details)
+        <span class="cov8" title="1">tokenStr, expiresIn, err := i.CreateAccessToken(rt.UserID, rt.Scopes, rt.AuthorizationDetails)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("server_error: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">i.hooks.fireOnIssued(rt.UserID, "refresh_token")
+
+        return &amp;core.TokenPair{
+                AccessToken:          tokenStr,
+                TokenType:            "Bearer",
+                ExpiresIn:            expiresIn,
+                RefreshToken:         newRT.Token,
+                Scope:                strings.Join(rt.Scopes, " "),
+                AuthorizationDetails: rt.AuthorizationDetails,
+        }, nil</span>
 }
 </pre>
 		

--- a/test-reports/coverage.html
+++ b/test-reports/coverage.html
@@ -67,135 +67,147 @@
 				
 				<option value="file5">github.com/panyam/oneauth/apiauth/as_metadata_proxy.go (91.9%)</option>
 				
-				<option value="file6">github.com/panyam/oneauth/apiauth/auth.go (64.6%)</option>
+				<option value="file6">github.com/panyam/oneauth/apiauth/auth.go (66.0%)</option>
 				
-				<option value="file7">github.com/panyam/oneauth/apiauth/introspection.go (86.2%)</option>
+				<option value="file7">github.com/panyam/oneauth/apiauth/client_authenticator.go (76.9%)</option>
 				
-				<option value="file8">github.com/panyam/oneauth/apiauth/introspection_client.go (85.7%)</option>
+				<option value="file8">github.com/panyam/oneauth/apiauth/hooks.go (80.0%)</option>
 				
-				<option value="file9">github.com/panyam/oneauth/apiauth/protected_resource.go (92.6%)</option>
+				<option value="file9">github.com/panyam/oneauth/apiauth/introspection.go (92.1%)</option>
 				
-				<option value="file10">github.com/panyam/oneauth/client/as_cache.go (100.0%)</option>
+				<option value="file10">github.com/panyam/oneauth/apiauth/introspection_client.go (85.7%)</option>
 				
-				<option value="file11">github.com/panyam/oneauth/client/auth_method.go (93.8%)</option>
+				<option value="file11">github.com/panyam/oneauth/apiauth/oneauth.go (100.0%)</option>
 				
-				<option value="file12">github.com/panyam/oneauth/client/browser_login.go (82.5%)</option>
+				<option value="file12">github.com/panyam/oneauth/apiauth/protected_resource.go (92.6%)</option>
 				
-				<option value="file13">github.com/panyam/oneauth/client/client.go (76.2%)</option>
+				<option value="file13">github.com/panyam/oneauth/apiauth/revocation.go (93.9%)</option>
 				
-				<option value="file14">github.com/panyam/oneauth/client/client_credentials_source.go (90.9%)</option>
+				<option value="file14">github.com/panyam/oneauth/apiauth/token_introspector.go (86.7%)</option>
 				
-				<option value="file15">github.com/panyam/oneauth/client/credentials.go (87.5%)</option>
+				<option value="file15">github.com/panyam/oneauth/apiauth/token_revoker.go (87.5%)</option>
 				
-				<option value="file16">github.com/panyam/oneauth/client/dcr.go (80.0%)</option>
+				<option value="file16">github.com/panyam/oneauth/apiauth/token_validator.go (78.6%)</option>
 				
-				<option value="file17">github.com/panyam/oneauth/client/discovery.go (91.8%)</option>
+				<option value="file17">github.com/panyam/oneauth/client/as_cache.go (100.0%)</option>
 				
-				<option value="file18">github.com/panyam/oneauth/client/stores/fs/credentials.go (77.9%)</option>
+				<option value="file18">github.com/panyam/oneauth/client/auth_method.go (93.8%)</option>
 				
-				<option value="file19">github.com/panyam/oneauth/client/transport.go (0.0%)</option>
+				<option value="file19">github.com/panyam/oneauth/client/browser_login.go (82.5%)</option>
 				
-				<option value="file20">github.com/panyam/oneauth/client/validation.go (100.0%)</option>
+				<option value="file20">github.com/panyam/oneauth/client/client.go (76.2%)</option>
 				
-				<option value="file21">github.com/panyam/oneauth/core/authorization_details.go (93.6%)</option>
+				<option value="file21">github.com/panyam/oneauth/client/client_credentials_source.go (90.9%)</option>
 				
-				<option value="file22">github.com/panyam/oneauth/core/blacklist.go (0.0%)</option>
+				<option value="file22">github.com/panyam/oneauth/client/credentials.go (87.5%)</option>
 				
-				<option value="file23">github.com/panyam/oneauth/core/context.go (0.0%)</option>
+				<option value="file23">github.com/panyam/oneauth/client/dcr.go (80.0%)</option>
 				
-				<option value="file24">github.com/panyam/oneauth/core/credentials.go (0.0%)</option>
+				<option value="file24">github.com/panyam/oneauth/client/discovery.go (91.8%)</option>
 				
-				<option value="file25">github.com/panyam/oneauth/core/email.go (0.0%)</option>
+				<option value="file25">github.com/panyam/oneauth/client/stores/fs/credentials.go (77.9%)</option>
 				
-				<option value="file26">github.com/panyam/oneauth/core/ratelimiter.go (0.0%)</option>
+				<option value="file26">github.com/panyam/oneauth/client/transport.go (0.0%)</option>
 				
-				<option value="file27">github.com/panyam/oneauth/core/scopes.go (14.5%)</option>
+				<option value="file27">github.com/panyam/oneauth/client/validation.go (100.0%)</option>
 				
-				<option value="file28">github.com/panyam/oneauth/core/tokens.go (0.0%)</option>
+				<option value="file28">github.com/panyam/oneauth/core/authorization_details.go (93.6%)</option>
 				
-				<option value="file29">github.com/panyam/oneauth/core/user.go (0.0%)</option>
+				<option value="file29">github.com/panyam/oneauth/core/blacklist.go (0.0%)</option>
 				
-				<option value="file30">github.com/panyam/oneauth/examples/01-client-credentials/main.go (0.0%)</option>
+				<option value="file30">github.com/panyam/oneauth/core/context.go (0.0%)</option>
 				
-				<option value="file31">github.com/panyam/oneauth/examples/02-resource-token-hs256/main.go (0.0%)</option>
+				<option value="file31">github.com/panyam/oneauth/core/credentials.go (0.0%)</option>
 				
-				<option value="file32">github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks/main.go (0.0%)</option>
+				<option value="file32">github.com/panyam/oneauth/core/email.go (0.0%)</option>
 				
-				<option value="file33">github.com/panyam/oneauth/examples/04-discovery/main.go (0.0%)</option>
+				<option value="file33">github.com/panyam/oneauth/core/ratelimiter.go (0.0%)</option>
 				
-				<option value="file34">github.com/panyam/oneauth/examples/05-introspection/main.go (0.0%)</option>
+				<option value="file34">github.com/panyam/oneauth/core/scopes.go (14.5%)</option>
 				
-				<option value="file35">github.com/panyam/oneauth/examples/06-dynamic-client-registration/main.go (0.0%)</option>
+				<option value="file35">github.com/panyam/oneauth/core/tokens.go (0.0%)</option>
 				
-				<option value="file36">github.com/panyam/oneauth/examples/07-client-sdk/main.go (0.0%)</option>
+				<option value="file36">github.com/panyam/oneauth/core/user.go (0.0%)</option>
 				
-				<option value="file37">github.com/panyam/oneauth/examples/08-rich-authorization-requests/main.go (0.0%)</option>
+				<option value="file37">github.com/panyam/oneauth/examples/01-client-credentials/main.go (0.0%)</option>
 				
-				<option value="file38">github.com/panyam/oneauth/examples/09-key-rotation/main.go (0.0%)</option>
+				<option value="file38">github.com/panyam/oneauth/examples/02-resource-token-hs256/main.go (0.0%)</option>
 				
-				<option value="file39">github.com/panyam/oneauth/examples/10-security/main.go (0.0%)</option>
+				<option value="file39">github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks/main.go (0.0%)</option>
 				
-				<option value="file40">github.com/panyam/oneauth/examples/demokit/demokit.go (0.0%)</option>
+				<option value="file40">github.com/panyam/oneauth/examples/04-discovery/main.go (0.0%)</option>
 				
-				<option value="file41">github.com/panyam/oneauth/httpauth/bodylimit.go (50.0%)</option>
+				<option value="file41">github.com/panyam/oneauth/examples/05-introspection/main.go (0.0%)</option>
 				
-				<option value="file42">github.com/panyam/oneauth/httpauth/csrf.go (88.1%)</option>
+				<option value="file42">github.com/panyam/oneauth/examples/06-dynamic-client-registration/main.go (0.0%)</option>
 				
-				<option value="file43">github.com/panyam/oneauth/httpauth/middleware.go (0.0%)</option>
+				<option value="file43">github.com/panyam/oneauth/examples/07-client-sdk/main.go (0.0%)</option>
 				
-				<option value="file44">github.com/panyam/oneauth/httpauth/mux.go (0.0%)</option>
+				<option value="file44">github.com/panyam/oneauth/examples/08-rich-authorization-requests/main.go (0.0%)</option>
 				
-				<option value="file45">github.com/panyam/oneauth/httpauth/securityheaders.go (97.1%)</option>
+				<option value="file45">github.com/panyam/oneauth/examples/09-key-rotation/main.go (0.0%)</option>
 				
-				<option value="file46">github.com/panyam/oneauth/keys/encrypted.go (80.8%)</option>
+				<option value="file46">github.com/panyam/oneauth/examples/10-security/main.go (0.0%)</option>
 				
-				<option value="file47">github.com/panyam/oneauth/keys/jwks_handler.go (52.5%)</option>
+				<option value="file47">github.com/panyam/oneauth/httpauth/bodylimit.go (50.0%)</option>
 				
-				<option value="file48">github.com/panyam/oneauth/keys/jwks_keystore.go (76.7%)</option>
+				<option value="file48">github.com/panyam/oneauth/httpauth/csrf.go (88.1%)</option>
 				
-				<option value="file49">github.com/panyam/oneauth/keys/keystore.go (86.4%)</option>
+				<option value="file49">github.com/panyam/oneauth/httpauth/middleware.go (0.0%)</option>
 				
-				<option value="file50">github.com/panyam/oneauth/keys/kid.go (84.8%)</option>
+				<option value="file50">github.com/panyam/oneauth/httpauth/mux.go (0.0%)</option>
 				
-				<option value="file51">github.com/panyam/oneauth/keystoretest/keystoretest.go (0.0%)</option>
+				<option value="file51">github.com/panyam/oneauth/httpauth/securityheaders.go (97.1%)</option>
 				
-				<option value="file52">github.com/panyam/oneauth/localauth/helpers.go (77.0%)</option>
+				<option value="file52">github.com/panyam/oneauth/keys/encrypted.go (80.8%)</option>
 				
-				<option value="file53">github.com/panyam/oneauth/localauth/local.go (56.1%)</option>
+				<option value="file53">github.com/panyam/oneauth/keys/jwks_handler.go (52.5%)</option>
 				
-				<option value="file54">github.com/panyam/oneauth/localauth/signup.go (60.7%)</option>
+				<option value="file54">github.com/panyam/oneauth/keys/jwks_keystore.go (76.7%)</option>
 				
-				<option value="file55">github.com/panyam/oneauth/stores/fs/fsapikey_store.go (14.3%)</option>
+				<option value="file55">github.com/panyam/oneauth/keys/keystore.go (86.4%)</option>
 				
-				<option value="file56">github.com/panyam/oneauth/stores/fs/fschannel_store.go (21.7%)</option>
+				<option value="file56">github.com/panyam/oneauth/keys/kid.go (84.8%)</option>
 				
-				<option value="file57">github.com/panyam/oneauth/stores/fs/fsidentity_store.go (18.3%)</option>
+				<option value="file57">github.com/panyam/oneauth/keystoretest/keystoretest.go (0.0%)</option>
 				
-				<option value="file58">github.com/panyam/oneauth/stores/fs/fskeystore.go (71.8%)</option>
+				<option value="file58">github.com/panyam/oneauth/localauth/helpers.go (77.0%)</option>
 				
-				<option value="file59">github.com/panyam/oneauth/stores/fs/fsrefreshtoken_store.go (8.8%)</option>
+				<option value="file59">github.com/panyam/oneauth/localauth/local.go (56.1%)</option>
 				
-				<option value="file60">github.com/panyam/oneauth/stores/fs/fstoken_store.go (16.7%)</option>
+				<option value="file60">github.com/panyam/oneauth/localauth/signup.go (60.7%)</option>
 				
-				<option value="file61">github.com/panyam/oneauth/stores/fs/fsuser_store.go (54.1%)</option>
+				<option value="file61">github.com/panyam/oneauth/stores/fs/fsapikey_store.go (14.3%)</option>
 				
-				<option value="file62">github.com/panyam/oneauth/stores/fs/fsusername_store.go (16.5%)</option>
+				<option value="file62">github.com/panyam/oneauth/stores/fs/fschannel_store.go (21.7%)</option>
 				
-				<option value="file63">github.com/panyam/oneauth/stores/fs/utils.go (72.7%)</option>
+				<option value="file63">github.com/panyam/oneauth/stores/fs/fsidentity_store.go (18.3%)</option>
 				
-				<option value="file64">github.com/panyam/oneauth/testutil/helpers.go (71.9%)</option>
+				<option value="file64">github.com/panyam/oneauth/stores/fs/fskeystore.go (71.8%)</option>
 				
-				<option value="file65">github.com/panyam/oneauth/testutil/server.go (82.5%)</option>
+				<option value="file65">github.com/panyam/oneauth/stores/fs/fsrefreshtoken_store.go (8.8%)</option>
 				
-				<option value="file66">github.com/panyam/oneauth/testutil/token.go (90.5%)</option>
+				<option value="file66">github.com/panyam/oneauth/stores/fs/fstoken_store.go (16.7%)</option>
 				
-				<option value="file67">github.com/panyam/oneauth/utils/crypto_helpers.go (78.9%)</option>
+				<option value="file67">github.com/panyam/oneauth/stores/fs/fsuser_store.go (54.1%)</option>
 				
-				<option value="file68">github.com/panyam/oneauth/utils/flask.go (4.9%)</option>
+				<option value="file68">github.com/panyam/oneauth/stores/fs/fsusername_store.go (16.5%)</option>
 				
-				<option value="file69">github.com/panyam/oneauth/utils/jwk.go (83.0%)</option>
+				<option value="file69">github.com/panyam/oneauth/stores/fs/utils.go (72.7%)</option>
 				
-				<option value="file70">github.com/panyam/oneauth/utils/jwk_thumbprint.go (83.9%)</option>
+				<option value="file70">github.com/panyam/oneauth/testutil/helpers.go (71.9%)</option>
+				
+				<option value="file71">github.com/panyam/oneauth/testutil/server.go (82.5%)</option>
+				
+				<option value="file72">github.com/panyam/oneauth/testutil/token.go (90.5%)</option>
+				
+				<option value="file73">github.com/panyam/oneauth/utils/crypto_helpers.go (78.9%)</option>
+				
+				<option value="file74">github.com/panyam/oneauth/utils/flask.go (4.9%)</option>
+				
+				<option value="file75">github.com/panyam/oneauth/utils/jwk.go (83.0%)</option>
+				
+				<option value="file76">github.com/panyam/oneauth/utils/jwk_thumbprint.go (83.9%)</option>
 				
 				</select>
 			</div>
@@ -1201,6 +1213,7 @@ import (
         "log"
         "net/http"
         "strings"
+        "sync"
         "time"
 
         "github.com/golang-jwt/jwt/v5"
@@ -2213,6 +2226,16 @@ type APIMiddleware struct {
         // (no JWTSecretKey, no KeyStore), introspection is the only validation path.
         // If nil, only local validation is used.
         Introspection *IntrospectionValidator
+
+        // Validator is the transport-independent token validator (Phase 2).
+        // When set, validateJWT delegates to it instead of using inline logic.
+        // When nil, a validator is lazily built from the existing fields
+        // (JWTSecretKey, KeyStore, Blacklist, etc.) on first use.
+        Validator TokenValidator
+
+        // validatorOnce ensures the lazy validator is built only once.
+        validatorOnce sync.Once
+        lazyValidator TokenValidator
 }
 
 // GetUserIDFromAPIContext retrieves the user ID from the API middleware context
@@ -2366,14 +2389,61 @@ func (m *APIMiddleware) validateRequest(r *http.Request) (userID string, scopes 
         <span class="cov8" title="1">return "", nil, "", nil, jwtErr</span>
 }
 
-// validateJWT validates a JWT access token
-func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) <span class="cov8" title="1">{
-        token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) </span><span class="cov8" title="1">{
+// getValidator returns the TokenValidator, lazily building one from existing
+// fields if Validator is not explicitly set.
+func (m *APIMiddleware) getValidator() TokenValidator <span class="cov8" title="1">{
+        if m.Validator != nil </span><span class="cov8" title="1">{
+                return m.Validator
+        }</span>
+        <span class="cov8" title="1">m.validatorOnce.Do(func() </span><span class="cov8" title="1">{
                 if m.KeyStore != nil </span><span class="cov8" title="1">{
+                        // Multi-tenant: use KeyStore for kid/client_id-based lookup
+                        m.lazyValidator = NewJWTValidator(JWTValidatorConfig{
+                                KeyLookup: m.KeyStore,
+                                Blacklist: m.Blacklist,
+                                Issuer:    m.JWTIssuer,
+                                Audience:  m.JWTAudience,
+                        })
+                }</span> else<span class="cov8" title="1"> {
+                        // Single-tenant: can't use jwtValidator (it needs kid/client_id lookup).
+                        // Fall back to the original inline validation which handles JWTSecretKey directly.
+                        m.lazyValidator = nil
+                }</span>
+        })
+        <span class="cov8" title="1">return m.lazyValidator</span>
+}
+
+// validateJWT validates a JWT access token using the TokenValidator.
+func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) <span class="cov8" title="1">{
+        if v := m.getValidator(); v != nil </span><span class="cov8" title="1">{
+                info, verr := v.ValidateToken(tokenString)
+                if verr != nil </span><span class="cov8" title="1">{
+                        return "", nil, "", nil, verr
+                }</span>
+                <span class="cov8" title="1">customClaims = info.CustomClaims
+                if customClaims == nil </span><span class="cov0" title="0">{
+                        customClaims = make(map[string]any)
+                }</span>
+                // Store authorization_details in customClaims for context extraction
+                <span class="cov8" title="1">if len(info.AuthorizationDetails) &gt; 0 </span><span class="cov0" title="0">{
+                        customClaims["__authz_details"] = info.AuthorizationDetails
+                }</span>
+                <span class="cov8" title="1">return info.UserID, info.Scopes, info.AuthType, customClaims, nil</span>
+        }
+
+        // Fallback: single-tenant JWTSecretKey validation (no KeyStore configured)
+        <span class="cov8" title="1">return m.validateJWTInline(tokenString)</span>
+}
+
+// validateJWTInline is the original inline JWT validation logic, preserved
+// as fallback. Will be removed in Phase 3.
+func (m *APIMiddleware) validateJWTInline(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) <span class="cov8" title="1">{
+        token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) </span><span class="cov8" title="1">{
+                if m.KeyStore != nil </span><span class="cov0" title="0">{
                         // Try kid-based lookup first (if kid header present)
-                        if kid, ok := token.Header["kid"].(string); ok &amp;&amp; kid != "" </span><span class="cov8" title="1">{
+                        if kid, ok := token.Header["kid"].(string); ok &amp;&amp; kid != "" </span><span class="cov0" title="0">{
                                 rec, err := m.KeyStore.GetKeyByKid(kid)
-                                if err == nil </span><span class="cov8" title="1">{
+                                if err == nil </span><span class="cov0" title="0">{
                                         if token.Header["alg"] != rec.Algorithm </span><span class="cov0" title="0">{
                                                 return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
                                         }</span>
@@ -2381,36 +2451,36 @@ func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes [
                                         // to prevent cross-app token forgery (app A signing with client_id=B).
                                         // Skipped when ClientID is empty (e.g., JWKSKeyStore which doesn't
                                         // carry client_id metadata).
-                                        <span class="cov8" title="1">if rec.ClientID != "" </span><span class="cov8" title="1">{
-                                                if claims, ok := token.Claims.(jwt.MapClaims); ok </span><span class="cov8" title="1">{
+                                        <span class="cov0" title="0">if rec.ClientID != "" </span><span class="cov0" title="0">{
+                                                if claims, ok := token.Claims.(jwt.MapClaims); ok </span><span class="cov0" title="0">{
                                                         if claimClientID, _ := claims["client_id"].(string); claimClientID != "" &amp;&amp; claimClientID != rec.ClientID </span><span class="cov0" title="0">{
                                                                 return nil, fmt.Errorf("kid owner %q does not match client_id claim %q", rec.ClientID, claimClientID)
                                                         }</span>
                                                 }
                                         }
-                                        <span class="cov8" title="1">return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)</span>
+                                        <span class="cov0" title="0">return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)</span>
                                 }
                                 // kid not found — fall through to client_id lookup
                         }
 
                         // Fallback: client_id claim lookup (legacy tokens without kid)
-                        <span class="cov8" title="1">claims, ok := token.Claims.(jwt.MapClaims)
+                        <span class="cov0" title="0">claims, ok := token.Claims.(jwt.MapClaims)
                         if !ok </span><span class="cov0" title="0">{
                                 return nil, fmt.Errorf("invalid claims")
                         }</span>
-                        <span class="cov8" title="1">clientID, _ := claims["client_id"].(string)
+                        <span class="cov0" title="0">clientID, _ := claims["client_id"].(string)
                         if clientID == "" </span><span class="cov0" title="0">{
                                 return nil, fmt.Errorf("missing client_id claim")
                         }</span>
 
-                        <span class="cov8" title="1">rec, err := m.KeyStore.GetKey(clientID)
-                        if err != nil </span><span class="cov8" title="1">{
+                        <span class="cov0" title="0">rec, err := m.KeyStore.GetKey(clientID)
+                        if err != nil </span><span class="cov0" title="0">{
                                 return nil, fmt.Errorf("unknown client: %w", err)
                         }</span>
-                        <span class="cov8" title="1">if token.Header["alg"] != rec.Algorithm </span><span class="cov8" title="1">{
+                        <span class="cov0" title="0">if token.Header["alg"] != rec.Algorithm </span><span class="cov0" title="0">{
                                 return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
                         }</span>
-                        <span class="cov8" title="1">return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)</span>
+                        <span class="cov0" title="0">return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)</span>
                 }
 
                 // Fallback: single-key validation (backwards-compatible)
@@ -2570,14 +2640,14 @@ var standardADFields = map[string]bool{
 
 // parseAuthorizationDetailsFromClaims converts raw JWT claim data ([]any of
 // map[string]any) into typed AuthorizationDetail structs.
-func parseAuthorizationDetailsFromClaims(raw []any) []core.AuthorizationDetail <span class="cov0" title="0">{
+func parseAuthorizationDetailsFromClaims(raw []any) []core.AuthorizationDetail <span class="cov8" title="1">{
         var result []core.AuthorizationDetail
-        for _, item := range raw </span><span class="cov0" title="0">{
+        for _, item := range raw </span><span class="cov8" title="1">{
                 adMap, ok := item.(map[string]any)
                 if !ok </span><span class="cov0" title="0">{
                         continue</span>
                 }
-                <span class="cov0" title="0">ad := core.AuthorizationDetail{
+                <span class="cov8" title="1">ad := core.AuthorizationDetail{
                         Type:       stringFromMap(adMap, "type"),
                         Identifier: stringFromMap(adMap, "identifier"),
                         Locations:  toStringSlice(anySliceFromMap(adMap, "locations")),
@@ -2585,7 +2655,7 @@ func parseAuthorizationDetailsFromClaims(raw []any) []core.AuthorizationDetail <
                         DataTypes:  toStringSlice(anySliceFromMap(adMap, "datatypes")),
                         Privileges: toStringSlice(anySliceFromMap(adMap, "privileges")),
                 }
-                for k, v := range adMap </span><span class="cov0" title="0">{
+                for k, v := range adMap </span><span class="cov8" title="1">{
                         if !standardADFields[k] </span><span class="cov0" title="0">{
                                 if ad.Extra == nil </span><span class="cov0" title="0">{
                                         ad.Extra = make(map[string]any)
@@ -2593,36 +2663,36 @@ func parseAuthorizationDetailsFromClaims(raw []any) []core.AuthorizationDetail <
                                 <span class="cov0" title="0">ad.Extra[k] = v</span>
                         }
                 }
-                <span class="cov0" title="0">result = append(result, ad)</span>
+                <span class="cov8" title="1">result = append(result, ad)</span>
         }
-        <span class="cov0" title="0">return result</span>
+        <span class="cov8" title="1">return result</span>
 }
 
-func stringFromMap(m map[string]any, key string) string <span class="cov0" title="0">{
-        if v, ok := m[key].(string); ok </span><span class="cov0" title="0">{
+func stringFromMap(m map[string]any, key string) string <span class="cov8" title="1">{
+        if v, ok := m[key].(string); ok </span><span class="cov8" title="1">{
                 return v
         }</span>
-        <span class="cov0" title="0">return ""</span>
+        <span class="cov8" title="1">return ""</span>
 }
 
-func anySliceFromMap(m map[string]any, key string) []any <span class="cov0" title="0">{
-        if v, ok := m[key].([]any); ok </span><span class="cov0" title="0">{
+func anySliceFromMap(m map[string]any, key string) []any <span class="cov8" title="1">{
+        if v, ok := m[key].([]any); ok </span><span class="cov8" title="1">{
                 return v
         }</span>
-        <span class="cov0" title="0">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
-func toStringSlice(raw []any) []string <span class="cov0" title="0">{
-        if len(raw) == 0 </span><span class="cov0" title="0">{
+func toStringSlice(raw []any) []string <span class="cov8" title="1">{
+        if len(raw) == 0 </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov0" title="0">result := make([]string, 0, len(raw))
-        for _, v := range raw </span><span class="cov0" title="0">{
-                if s, ok := v.(string); ok </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">result := make([]string, 0, len(raw))
+        for _, v := range raw </span><span class="cov8" title="1">{
+                if s, ok := v.(string); ok </span><span class="cov8" title="1">{
                         result = append(result, s)
                 }</span>
         }
-        <span class="cov0" title="0">return result</span>
+        <span class="cov8" title="1">return result</span>
 }
 
 // setAuthContext sets all standard auth context values on the request context.
@@ -2680,11 +2750,167 @@ func (m *APIMiddleware) RequireAuthorizationDetails(requiredTypes ...string) fun
 		<pre class="file" id="file7" style="display: none">package apiauth
 
 import (
+        "github.com/panyam/oneauth/keys"
+)
+
+var errInvalidClient = &amp;clientError{"invalid_client"}
+
+type clientError struct{ msg string }
+
+func (e *clientError) Error() string <span class="cov0" title="0">{ return e.msg }</span>
+
+// clientAuthenticator implements ClientAuthenticator using a KeyLookup
+// with constant-time secret comparison.
+type clientAuthenticator struct {
+        keyLookup keys.KeyLookup
+}
+
+// NewClientAuthenticator creates a ClientAuthenticator backed by a KeyLookup.
+func NewClientAuthenticator(kl keys.KeyLookup) ClientAuthenticator <span class="cov8" title="1">{
+        return &amp;clientAuthenticator{keyLookup: kl}
+}</span>
+
+// AuthenticateClient verifies client_id + client_secret.
+func (a *clientAuthenticator) AuthenticateClient(clientID, clientSecret string) error <span class="cov8" title="1">{
+        if a.keyLookup == nil </span><span class="cov0" title="0">{
+                return errInvalidClient
+        }</span>
+        <span class="cov8" title="1">rec, err := a.keyLookup.GetKey(clientID)
+        if err != nil || rec == nil </span><span class="cov8" title="1">{
+                return errInvalidClient
+        }</span>
+        <span class="cov8" title="1">storedKey, ok := rec.Key.([]byte)
+        if !ok </span><span class="cov0" title="0">{
+                return errInvalidClient
+        }</span>
+        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), clientSecret) </span><span class="cov8" title="1">{
+                return errInvalidClient
+        }</span>
+        <span class="cov8" title="1">return nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file8" style="display: none">package apiauth
+
+// Hooks provides lifecycle callbacks for OneAuth operations.
+// Grouped by concern — each implementation receives only its relevant group.
+// All callbacks are optional — nil callbacks are no-ops.
+//
+// Configure all hooks in one place on OneAuth.Hooks. Callers set only
+// what they need:
+//
+//        oa := NewOneAuth(OneAuthConfig{
+//            Hooks: Hooks{
+//                Token: TokenHooks{
+//                    OnRevoked: func(token, hint string) { audit.Log("revoked", token) },
+//                },
+//            },
+//        })
+//
+// See: https://github.com/panyam/oneauth/issues/110
+type Hooks struct {
+        Token    TokenHooks
+        Auth     AuthHooks
+        Client   ClientHooks
+        Security SecurityHooks
+}
+
+// TokenHooks fires on token lifecycle events.
+type TokenHooks struct {
+        // OnIssued fires after an access token is successfully created.
+        // subject is the token's sub claim, grantType is the OAuth grant used.
+        OnIssued func(subject, grantType string)
+
+        // OnRefreshed fires after a refresh token is rotated and a new access token issued.
+        OnRefreshed func(subject string)
+
+        // OnRevoked fires after a token is successfully revoked.
+        // hint is the token_type_hint ("access_token", "refresh_token", or "").
+        OnRevoked func(token, hint string)
+}
+
+// AuthHooks fires on authentication events.
+type AuthHooks struct {
+        // OnLoginSuccess fires after a user successfully authenticates
+        // (password grant, auth code exchange).
+        OnLoginSuccess func(userID string)
+
+        // OnLoginFailure fires after a failed authentication attempt.
+        OnLoginFailure func(username string, err error)
+
+        // OnScopeStepUp fires when additional scopes are requested and granted.
+        // from is the original scope set, to is the expanded set.
+        OnScopeStepUp func(subject string, from, to []string)
+}
+
+// ClientHooks fires on client management events.
+type ClientHooks struct {
+        // OnRegistered fires after a new client is registered (DCR or proprietary).
+        // method is "dcr" or "register".
+        OnRegistered func(clientID, method string)
+
+        // OnDeleted fires after a client is deleted.
+        OnDeleted func(clientID string)
+
+        // OnKeyRotated fires after a client's signing key is rotated.
+        OnKeyRotated func(clientID string)
+}
+
+// SecurityHooks fires on security-relevant events.
+// Use these for alerting, audit logging, and intrusion detection.
+type SecurityHooks struct {
+        // OnTokenRejected fires when a token fails validation.
+        // reason describes why (expired, bad signature, revoked, etc.).
+        OnTokenRejected func(reason string)
+
+        // OnBlacklistHit fires when a revoked token is presented.
+        // This indicates token reuse after revocation — potential theft.
+        OnBlacklistHit func(jti string)
+
+        // OnAlgorithmMismatch fires when a token's alg header doesn't match
+        // the stored key's algorithm. This is the CVE-2015-9235 attack vector.
+        OnAlgorithmMismatch func(expected, got string)
+}
+
+// --- Hook helpers (fire if non-nil) ---
+
+func (h *TokenHooks) fireOnIssued(subject, grantType string) <span class="cov8" title="1">{
+        if h != nil &amp;&amp; h.OnIssued != nil </span><span class="cov8" title="1">{
+                h.OnIssued(subject, grantType)
+        }</span>
+}
+
+func (h *TokenHooks) fireOnRevoked(token, hint string) <span class="cov8" title="1">{
+        if h != nil &amp;&amp; h.OnRevoked != nil </span><span class="cov8" title="1">{
+                h.OnRevoked(token, hint)
+        }</span>
+}
+
+func (h *SecurityHooks) fireOnTokenRejected(reason string) <span class="cov8" title="1">{
+        if h != nil &amp;&amp; h.OnTokenRejected != nil </span><span class="cov0" title="0">{
+                h.OnTokenRejected(reason)
+        }</span>
+}
+
+func (h *SecurityHooks) fireOnBlacklistHit(jti string) <span class="cov8" title="1">{
+        if h != nil &amp;&amp; h.OnBlacklistHit != nil </span><span class="cov8" title="1">{
+                h.OnBlacklistHit(jti)
+        }</span>
+}
+
+func (h *SecurityHooks) fireOnAlgorithmMismatch(expected, got string) <span class="cov8" title="1">{
+        if h != nil &amp;&amp; h.OnAlgorithmMismatch != nil </span><span class="cov0" title="0">{
+                h.OnAlgorithmMismatch(expected, got)
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file9" style="display: none">package apiauth
+
+import (
         "encoding/json"
         "net/http"
-        "strings"
 
-        "github.com/golang-jwt/jwt/v5"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -2692,24 +2918,89 @@ import (
 // Resource servers POST tokens to this endpoint to check validity, as an
 // alternative to local JWT validation via JWKS.
 //
-// The handler:
-//   - Accepts POST with application/x-www-form-urlencoded body (token=...)
-//   - Authenticates the caller via ClientKeyStore (Basic auth)
-//   - Validates the token using APIAuth.ValidateAccessTokenFull
-//   - Checks the token blacklist if configured on APIAuth
-//   - Returns {"active": true, ...claims} for valid tokens
-//   - Returns {"active": false} for ANY invalid token (never reveals why)
+// The handler is a thin HTTP wrapper over TokenIntrospector (core logic)
+// and ClientAuthenticator (caller verification).
 //
 // See: https://www.rfc-editor.org/rfc/rfc7662
 type IntrospectionHandler struct {
-        // Auth is the APIAuth instance used to validate tokens.
-        // Must have JWTSecretKey (or JWTVerifyKey) configured.
-        Auth *APIAuth
+        // Introspector performs the actual token introspection (transport-independent).
+        Introspector TokenIntrospector
 
-        // ClientKeyStore authenticates callers of the introspection endpoint.
-        // Resource servers must present valid client_id + client_secret via
-        // HTTP Basic auth. If nil, all callers are rejected.
-        ClientKeyStore keys.KeyLookup
+        // Authenticator verifies the caller's client credentials.
+        Authenticator ClientAuthenticator
+}
+
+// NewIntrospectionHandler creates an IntrospectionHandler from an APIAuth
+// and a client KeyLookup. This is the bridge between the old-style APIAuth
+// configuration and the new core interfaces.
+func NewIntrospectionHandler(auth *APIAuth, clientKeyStore keys.KeyLookup) *IntrospectionHandler <span class="cov8" title="1">{
+        // Build a validator that mirrors APIAuth's validation logic.
+        // APIAuth supports both single-key (JWTSecretKey) and multi-tenant (ClientKeyStore).
+        // We wrap this by using APIAuth.ValidateAccessTokenFull as the validation backend.
+        introspector := &amp;apiauthIntrospector{auth: auth}
+        return &amp;IntrospectionHandler{
+                Introspector:  introspector,
+                Authenticator: NewClientAuthenticator(clientKeyStore),
+        }
+}</span>
+
+// apiauthIntrospector adapts an APIAuth into a TokenIntrospector.
+// This preserves the exact validation behavior of the old IntrospectionHandler.
+type apiauthIntrospector struct {
+        auth *APIAuth
+}
+
+func (ai *apiauthIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) <span class="cov8" title="1">{
+        userID, scopes, _, err := ai.auth.ValidateAccessTokenFull(tokenString)
+        if err != nil </span><span class="cov8" title="1">{
+                return &amp;IntrospectionResult{Active: false}, nil
+        }</span>
+
+        <span class="cov8" title="1">rawClaims := parseRawJWTClaims(tokenString)
+
+        result := &amp;IntrospectionResult{
+                Active:    true,
+                Sub:       userID,
+                TokenType: "access_token",
+        }
+
+        if len(scopes) &gt; 0 </span><span class="cov8" title="1">{
+                result.Scope = joinScopes(scopes)
+        }</span>
+
+        <span class="cov8" title="1">if rawClaims != nil </span><span class="cov8" title="1">{
+                if v, ok := rawClaims["iss"].(string); ok </span><span class="cov8" title="1">{
+                        result.Iss = v
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["exp"].(float64); ok </span><span class="cov8" title="1">{
+                        result.Exp = int64(v)
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["iat"].(float64); ok </span><span class="cov8" title="1">{
+                        result.Iat = int64(v)
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["jti"].(string); ok </span><span class="cov8" title="1">{
+                        result.Jti = v
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["aud"]; ok </span><span class="cov0" title="0">{
+                        result.Aud = v
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["client_id"].(string); ok </span><span class="cov0" title="0">{
+                        result.ClientID = v
+                }</span>
+        }
+
+        <span class="cov8" title="1">return result, nil</span>
+}
+
+func joinScopes(scopes []string) string <span class="cov8" title="1">{
+        s := ""
+        for i, sc := range scopes </span><span class="cov8" title="1">{
+                if i &gt; 0 </span><span class="cov8" title="1">{
+                        s += " "
+                }</span>
+                <span class="cov8" title="1">s += sc</span>
+        }
+        <span class="cov8" title="1">return s</span>
 }
 
 // ServeHTTP handles POST /oauth/introspect per RFC 7662.
@@ -2726,7 +3017,7 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
                 http.Error(w, "Unauthorized", http.StatusUnauthorized)
                 return
         }</span>
-        <span class="cov8" title="1">if err := h.authenticateCaller(clientID, clientSecret); err != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil </span><span class="cov8" title="1">{
                 w.Header().Set("WWW-Authenticate", `Basic realm="introspection"`)
                 http.Error(w, "Unauthorized", http.StatusUnauthorized)
                 return
@@ -2743,86 +3034,50 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
                 return
         }</span>
 
-        // Validate the token using APIAuth (checks signature, expiry, blacklist)
-        <span class="cov8" title="1">userID, scopes, _, err := h.Auth.ValidateAccessTokenFull(token)
-        if err != nil </span><span class="cov8" title="1">{
+        // Delegate to transport-independent introspector
+        <span class="cov8" title="1">result, err := h.Introspector.Introspect(token)
+        if err != nil || !result.Active </span><span class="cov8" title="1">{
                 // RFC 7662: invalid tokens get {"active": false}, never an error
                 h.jsonResponse(w, http.StatusOK, map[string]any{"active": false})
                 return
         }</span>
 
-        // Parse raw claims for the introspection response (ValidateAccessTokenFull
-        // strips standard claims from customClaims, but we need them here)
-        <span class="cov8" title="1">rawClaims := h.parseRawClaims(token)
-
-        // Build the introspection response
-        resp := map[string]any{
+        // Build response from IntrospectionResult
+        <span class="cov8" title="1">resp := map[string]any{
                 "active":     true,
-                "sub":        userID,
-                "token_type": "access_token",
+                "sub":        result.Sub,
+                "token_type": result.TokenType,
         }
-
-        // Add scope as space-separated string (RFC 7662 §2.2)
-        if len(scopes) &gt; 0 </span><span class="cov8" title="1">{
-                resp["scope"] = strings.Join(scopes, " ")
+        if result.Scope != "" </span><span class="cov8" title="1">{
+                resp["scope"] = result.Scope
+        }</span>
+        <span class="cov8" title="1">if result.Iss != "" </span><span class="cov8" title="1">{
+                resp["iss"] = result.Iss
+        }</span>
+        <span class="cov8" title="1">if result.Exp != 0 </span><span class="cov8" title="1">{
+                resp["exp"] = result.Exp
+        }</span>
+        <span class="cov8" title="1">if result.Iat != 0 </span><span class="cov8" title="1">{
+                resp["iat"] = result.Iat
+        }</span>
+        <span class="cov8" title="1">if result.Aud != nil </span><span class="cov0" title="0">{
+                resp["aud"] = result.Aud
+        }</span>
+        <span class="cov8" title="1">if result.Jti != "" </span><span class="cov8" title="1">{
+                resp["jti"] = result.Jti
+        }</span>
+        <span class="cov8" title="1">if result.ClientID != "" </span><span class="cov0" title="0">{
+                resp["client_id"] = result.ClientID
         }</span>
 
-        // Add standard claims from the raw token
-        <span class="cov8" title="1">for _, claim := range []string{"iss", "exp", "iat", "aud", "jti", "client_id"} </span><span class="cov8" title="1">{
-                if v, ok := rawClaims[claim]; ok </span><span class="cov8" title="1">{
-                        resp[claim] = v
-                }</span>
-        }
-
         // Include authorization_details if present (RFC 9396 §9.1)
-        <span class="cov8" title="1">if ad, ok := rawClaims["authorization_details"]; ok </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">rawClaims := parseRawJWTClaims(token)
+        if ad, ok := rawClaims["authorization_details"]; ok </span><span class="cov8" title="1">{
                 resp["authorization_details"] = ad
         }</span>
 
         <span class="cov8" title="1">h.jsonResponse(w, http.StatusOK, resp)</span>
 }
-
-// parseRawClaims extracts all claims from a JWT without validation.
-// Used to populate the introspection response with standard claims that
-// ValidateAccessTokenFull strips from customClaims.
-func (h *IntrospectionHandler) parseRawClaims(tokenStr string) map[string]any <span class="cov8" title="1">{
-        parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-        token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
-        if err != nil </span><span class="cov0" title="0">{
-                return nil
-        }</span>
-        <span class="cov8" title="1">claims, ok := token.Claims.(jwt.MapClaims)
-        if !ok </span><span class="cov0" title="0">{
-                return nil
-        }</span>
-        <span class="cov8" title="1">return claims</span>
-}
-
-// authenticateCaller verifies the caller's client_id + client_secret against
-// the ClientKeyStore using constant-time comparison.
-func (h *IntrospectionHandler) authenticateCaller(clientID, clientSecret string) error <span class="cov8" title="1">{
-        if h.ClientKeyStore == nil </span><span class="cov0" title="0">{
-                return errInvalidClient
-        }</span>
-        <span class="cov8" title="1">rec, err := h.ClientKeyStore.GetKey(clientID)
-        if err != nil || rec == nil </span><span class="cov0" title="0">{
-                return errInvalidClient
-        }</span>
-        <span class="cov8" title="1">storedKey, ok := rec.Key.([]byte)
-        if !ok </span><span class="cov0" title="0">{
-                return errInvalidClient
-        }</span>
-        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), clientSecret) </span><span class="cov8" title="1">{
-                return errInvalidClient
-        }</span>
-        <span class="cov8" title="1">return nil</span>
-}
-
-var errInvalidClient = &amp;clientError{"invalid_client"}
-
-type clientError struct{ msg string }
-
-func (e *clientError) Error() string <span class="cov0" title="0">{ return e.msg }</span>
 
 // jsonResponse writes a JSON response with the given status code.
 func (h *IntrospectionHandler) jsonResponse(w http.ResponseWriter, status int, body any) <span class="cov8" title="1">{
@@ -2834,7 +3089,7 @@ func (h *IntrospectionHandler) jsonResponse(w http.ResponseWriter, status int, b
 }</span>
 </pre>
 		
-		<pre class="file" id="file8" style="display: none">package apiauth
+		<pre class="file" id="file10" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -3024,7 +3279,158 @@ func (v *IntrospectionValidator) putCached(token string, result *IntrospectionRe
 }
 </pre>
 		
-		<pre class="file" id="file9" style="display: none">package apiauth
+		<pre class="file" id="file11" style="display: none">package apiauth
+
+import (
+        "time"
+
+        "github.com/panyam/oneauth/core"
+        "github.com/panyam/oneauth/keys"
+)
+
+// OneAuth is the transport-independent core of the authentication system.
+// It composes focused interfaces (Option A — no god object) and wires
+// hooks for lifecycle callbacks.
+//
+// Use NewOneAuth to create an instance with all dependencies wired.
+// Transport bindings (HTTP handlers, gRPC interceptors, MCP auth) are
+// thin wrappers over these interfaces.
+//
+// Library usage (no HTTP):
+//
+//        oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{...})
+//        token, _, _ := oa.Issuer.CreateAccessToken("alice", []string{"read"}, nil)
+//        info, _ := oa.Validator.ValidateToken(token)
+//        result, _ := oa.Introspector.Introspect(token)
+//        oa.Revoker.Revoke(token, "access_token")
+//
+// See: https://github.com/panyam/oneauth/issues/110
+type OneAuth struct {
+        // Core operation interfaces — each has minimal dependencies.
+        Issuer       TokenIssuer
+        Validator    TokenValidator
+        Introspector TokenIntrospector
+        Revoker      TokenRevoker
+        Authenticator ClientAuthenticator
+
+        // Shared state — available for transport bindings that need direct access.
+        KeyStore     keys.KeyStorage
+        Blacklist    core.TokenBlacklist
+        RefreshStore core.RefreshTokenStore
+
+        // Hooks — lifecycle callbacks grouped by concern.
+        Hooks Hooks
+}
+
+// OneAuthConfig holds the dependencies for creating a OneAuth instance.
+type OneAuthConfig struct {
+        // Key management
+        KeyStore keys.KeyStorage // required — stores client keys
+
+        // Signing configuration
+        SigningKey any    // []byte for HS256, *rsa.PrivateKey for RS256, etc.
+        SigningAlg string // "HS256", "RS256", "ES256" — default "HS256"
+
+        // JWT configuration
+        Issuer       string        // JWT iss claim
+        Audience     string        // JWT aud claim (optional)
+        AccessExpiry time.Duration // default 15 minutes
+
+        // Token lifecycle
+        Blacklist    core.TokenBlacklist    // for access token revocation (optional)
+        RefreshStore core.RefreshTokenStore // for refresh token management (optional)
+
+        // Hooks — lifecycle callbacks
+        Hooks Hooks
+}
+
+// NewOneAuth creates a fully wired OneAuth instance.
+// All implementations receive only the interfaces they need.
+func NewOneAuth(cfg OneAuthConfig) *OneAuth <span class="cov8" title="1">{
+        signingAlg := cfg.SigningAlg
+        if signingAlg == "" </span><span class="cov8" title="1">{
+                signingAlg = "HS256"
+        }</span>
+
+        // Wire the issuer — needs signing config + client key lookup
+        <span class="cov8" title="1">issuer := NewJWTIssuer(JWTIssuerConfig{
+                SigningKey:      cfg.SigningKey,
+                SigningAlg:      signingAlg,
+                Issuer:          cfg.Issuer,
+                Audience:        cfg.Audience,
+                AccessExpiry:    cfg.AccessExpiry,
+                ClientKeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
+                Hooks:           cfg.Hooks.Token,
+        })
+
+        // Wire the validator — needs read-only key lookup + blacklist
+        validator := NewJWTValidator(JWTValidatorConfig{
+                KeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
+                Blacklist: cfg.Blacklist,
+                Issuer:    cfg.Issuer,
+                Audience:  cfg.Audience,
+                Hooks:     cfg.Hooks.Security,
+        })
+
+        // Wire the introspector — needs only the validator
+        introspector := NewTokenIntrospector(validator)
+
+        // Wire the revoker — needs blacklist + refresh store
+        revoker := NewTokenRevoker(TokenRevokerConfig{
+                Blacklist:    cfg.Blacklist,
+                RefreshStore: cfg.RefreshStore,
+                Hooks:        cfg.Hooks.Token,
+        })
+
+        // Wire the client authenticator — needs key lookup
+        authenticator := NewClientAuthenticator(cfg.KeyStore)
+
+        oa := &amp;OneAuth{
+                Issuer:        issuer,
+                Validator:     validator,
+                Introspector:  introspector,
+                Revoker:       revoker,
+                Authenticator: authenticator,
+                KeyStore:      cfg.KeyStore,
+                Blacklist:     cfg.Blacklist,
+                RefreshStore:  cfg.RefreshStore,
+                Hooks:         cfg.Hooks,
+        }
+        return oa</span>
+}
+
+// --- HTTP Convenience Methods ---
+// These create HTTP handlers wired to the OneAuth core interfaces.
+// Use these when mounting endpoints on an HTTP mux.
+
+// IntrospectionHTTPHandler returns an http.Handler for POST /oauth/introspect.
+func (oa *OneAuth) IntrospectionHTTPHandler() *IntrospectionHandler <span class="cov8" title="1">{
+        return &amp;IntrospectionHandler{
+                Introspector:  oa.Introspector,
+                Authenticator: oa.Authenticator,
+        }
+}</span>
+
+// RevocationHTTPHandler returns an http.Handler for POST /oauth/revoke.
+func (oa *OneAuth) RevocationHTTPHandler() *RevocationHandler <span class="cov8" title="1">{
+        return &amp;RevocationHandler{
+                Revoker:       oa.Revoker,
+                Authenticator: oa.Authenticator,
+        }
+}</span>
+
+// HTTPMiddleware returns an APIMiddleware wired to the OneAuth TokenValidator.
+// Use this for protecting resource endpoints.
+func (oa *OneAuth) HTTPMiddleware() *APIMiddleware <span class="cov8" title="1">{
+        return &amp;APIMiddleware{
+                Validator: oa.Validator,
+                Blacklist: oa.Blacklist,
+                KeyStore:  oa.KeyStore,
+        }
+}</span>
+</pre>
+		
+		<pre class="file" id="file12" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -3171,7 +3577,632 @@ func NewProtectedResourceHandler(meta *ProtectedResourceMetadata) http.Handler <
 }
 </pre>
 		
-		<pre class="file" id="file10" style="display: none">package client
+		<pre class="file" id="file13" style="display: none">package apiauth
+
+import (
+        "encoding/json"
+        "net/http"
+
+        "github.com/panyam/oneauth/keys"
+)
+
+// RevocationHandler implements OAuth 2.0 Token Revocation (RFC 7009).
+// It is a thin HTTP wrapper over TokenRevoker (core logic) and
+// ClientAuthenticator (caller verification).
+//
+// See: https://www.rfc-editor.org/rfc/rfc7009
+type RevocationHandler struct {
+        // Revoker performs the actual token revocation (transport-independent).
+        Revoker TokenRevoker
+
+        // Authenticator verifies the caller's client credentials.
+        Authenticator ClientAuthenticator
+}
+
+// NewRevocationHandler creates a RevocationHandler from an APIAuth and
+// a client KeyLookup. Bridge constructor for existing code.
+func NewRevocationHandler(auth *APIAuth, clientKeyStore keys.KeyLookup) *RevocationHandler <span class="cov8" title="1">{
+        revoker := NewTokenRevoker(TokenRevokerConfig{
+                Blacklist:    auth.Blacklist,
+                RefreshStore: auth.RefreshTokenStore,
+        })
+        return &amp;RevocationHandler{
+                Revoker:       revoker,
+                Authenticator: NewClientAuthenticator(clientKeyStore),
+        }
+}</span>
+
+// ServeHTTP handles POST /oauth/revoke per RFC 7009.
+func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
+        if r.Method != http.MethodPost </span><span class="cov8" title="1">{
+                w.Header().Set("Allow", "POST")
+                http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+                return
+        }</span>
+
+        // Parse form body
+        <span class="cov8" title="1">if err := r.ParseForm(); err != nil </span><span class="cov0" title="0">{
+                h.okResponse(w)
+                return
+        }</span>
+
+        // Authenticate the caller — try Basic auth first, then form params
+        <span class="cov8" title="1">clientID, clientSecret, hasBasic := r.BasicAuth()
+        if !hasBasic </span><span class="cov8" title="1">{
+                clientID = r.FormValue("client_id")
+                clientSecret = r.FormValue("client_secret")
+        }</span>
+        <span class="cov8" title="1">if clientID == "" </span><span class="cov8" title="1">{
+                w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
+                h.errorResponse(w, "invalid_client", "Authentication required", http.StatusUnauthorized)
+                return
+        }</span>
+        <span class="cov8" title="1">if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil </span><span class="cov8" title="1">{
+                w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
+                h.errorResponse(w, "invalid_client", "Invalid client credentials", http.StatusUnauthorized)
+                return
+        }</span>
+
+        // Extract token and hint
+        <span class="cov8" title="1">token := r.FormValue("token")
+        if token == "" </span><span class="cov8" title="1">{
+                h.okResponse(w)
+                return
+        }</span>
+        <span class="cov8" title="1">hint := r.FormValue("token_type_hint")
+
+        // Delegate to transport-independent revoker
+        h.Revoker.Revoke(token, hint)
+
+        // RFC 7009 §2.2: always 200 OK
+        h.okResponse(w)</span>
+}
+
+// okResponse sends 200 OK with no body (RFC 7009 §2.2).
+func (h *RevocationHandler) okResponse(w http.ResponseWriter) <span class="cov8" title="1">{
+        w.WriteHeader(http.StatusOK)
+}</span>
+
+// errorResponse sends a JSON error (only for auth failures).
+func (h *RevocationHandler) errorResponse(w http.ResponseWriter, errCode, description string, status int) <span class="cov8" title="1">{
+        w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Cache-Control", "no-store")
+        w.WriteHeader(status)
+        json.NewEncoder(w).Encode(map[string]string{
+                "error":             errCode,
+                "error_description": description,
+        })
+}</span>
+</pre>
+		
+		<pre class="file" id="file14" style="display: none">package apiauth
+
+import (
+        "strings"
+
+        "github.com/golang-jwt/jwt/v5"
+)
+
+// tokenIntrospector implements TokenIntrospector using local JWT validation.
+// Depends only on TokenValidator (for token checking) — no HTTP, no transport.
+type tokenIntrospector struct {
+        validator TokenValidator
+}
+
+// NewTokenIntrospector creates a TokenIntrospector backed by a TokenValidator.
+func NewTokenIntrospector(v TokenValidator) TokenIntrospector <span class="cov8" title="1">{
+        return &amp;tokenIntrospector{validator: v}
+}</span>
+
+// Introspect checks a token and returns the result per RFC 7662.
+// Returns {Active: false} for any invalid token — never reveals why.
+func (ti *tokenIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) <span class="cov8" title="1">{
+        info, err := ti.validator.ValidateToken(tokenString)
+        if err != nil </span><span class="cov8" title="1">{
+                return &amp;IntrospectionResult{Active: false}, nil
+        }</span>
+
+        // Parse raw claims for the full introspection response
+        // (ValidateToken strips standard claims from custom, but introspection
+        // needs them all)
+        <span class="cov8" title="1">rawClaims := parseRawJWTClaims(tokenString)
+
+        result := &amp;IntrospectionResult{
+                Active:    true,
+                Sub:       info.UserID,
+                TokenType: "access_token",
+        }
+
+        // Add scope as space-separated string
+        if len(info.Scopes) &gt; 0 </span><span class="cov8" title="1">{
+                result.Scope = strings.Join(info.Scopes, " ")
+        }</span>
+
+        // Add standard claims from raw token
+        <span class="cov8" title="1">if rawClaims != nil </span><span class="cov8" title="1">{
+                if v, ok := rawClaims["iss"].(string); ok </span><span class="cov8" title="1">{
+                        result.Iss = v
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["exp"].(float64); ok </span><span class="cov8" title="1">{
+                        result.Exp = int64(v)
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["iat"].(float64); ok </span><span class="cov8" title="1">{
+                        result.Iat = int64(v)
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["jti"].(string); ok </span><span class="cov8" title="1">{
+                        result.Jti = v
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["aud"]; ok </span><span class="cov0" title="0">{
+                        result.Aud = v
+                }</span>
+                <span class="cov8" title="1">if v, ok := rawClaims["client_id"].(string); ok </span><span class="cov0" title="0">{
+                        result.ClientID = v
+                }</span>
+        }
+
+        <span class="cov8" title="1">return result, nil</span>
+}
+
+// parseRawJWTClaims extracts all claims from a JWT without validation.
+func parseRawJWTClaims(tokenStr string) map[string]any <span class="cov8" title="1">{
+        parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+        token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+        if err != nil </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        <span class="cov8" title="1">claims, ok := token.Claims.(jwt.MapClaims)
+        if !ok </span><span class="cov0" title="0">{
+                return nil
+        }</span>
+        <span class="cov8" title="1">return claims</span>
+}
+</pre>
+		
+		<pre class="file" id="file15" style="display: none">package apiauth
+
+import (
+        "time"
+
+        "github.com/golang-jwt/jwt/v5"
+        "github.com/panyam/oneauth/core"
+)
+
+// tokenRevoker implements TokenRevoker using a blacklist (for access tokens)
+// and a RefreshTokenStore (for refresh tokens).
+// Depends only on Blacklist + RefreshTokenStore — no HTTP, no transport.
+type tokenRevoker struct {
+        blacklist    core.TokenBlacklist
+        refreshStore core.RefreshTokenStore
+        hooks        TokenHooks
+}
+
+// TokenRevokerConfig configures a tokenRevoker.
+type TokenRevokerConfig struct {
+        Blacklist    core.TokenBlacklist
+        RefreshStore core.RefreshTokenStore
+        Hooks        TokenHooks
+}
+
+// NewTokenRevoker creates a TokenRevoker.
+func NewTokenRevoker(cfg TokenRevokerConfig) TokenRevoker <span class="cov8" title="1">{
+        return &amp;tokenRevoker{
+                blacklist:    cfg.Blacklist,
+                refreshStore: cfg.RefreshStore,
+                hooks:        cfg.Hooks,
+        }
+}</span>
+
+// Revoke invalidates a token. Tries refresh token first if no hint or
+// hint is "refresh_token", then tries access token blacklisting.
+func (r *tokenRevoker) Revoke(token, tokenTypeHint string) error <span class="cov8" title="1">{
+        switch tokenTypeHint </span>{
+        case "refresh_token":<span class="cov8" title="1">
+                r.revokeRefreshToken(token)</span>
+        case "access_token":<span class="cov8" title="1">
+                r.revokeAccessToken(token)</span>
+        default:<span class="cov8" title="1">
+                // No hint — try refresh first (cheaper lookup), then access
+                if !r.revokeRefreshToken(token) </span><span class="cov8" title="1">{
+                        r.revokeAccessToken(token)
+                }</span>
+        }
+
+        <span class="cov8" title="1">r.hooks.fireOnRevoked(token, tokenTypeHint)
+        return nil</span>
+}
+
+// revokeRefreshToken attempts to revoke a refresh token. Returns true if
+// the token was found in the refresh store.
+func (r *tokenRevoker) revokeRefreshToken(token string) bool <span class="cov8" title="1">{
+        if r.refreshStore == nil </span><span class="cov0" title="0">{
+                return false
+        }</span>
+        <span class="cov8" title="1">rt, err := r.refreshStore.GetRefreshToken(token)
+        if err != nil || rt == nil </span><span class="cov8" title="1">{
+                return false
+        }</span>
+        <span class="cov8" title="1">if !rt.Revoked </span><span class="cov8" title="1">{
+                r.refreshStore.RevokeRefreshToken(token)
+        }</span>
+        <span class="cov8" title="1">return true</span>
+}
+
+// revokeAccessToken blacklists a JWT access token by its jti claim.
+func (r *tokenRevoker) revokeAccessToken(token string) <span class="cov8" title="1">{
+        if r.blacklist == nil </span><span class="cov0" title="0">{
+                return
+        }</span>
+
+        <span class="cov8" title="1">parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+        parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+        if err != nil </span><span class="cov8" title="1">{
+                return
+        }</span>
+
+        <span class="cov8" title="1">claims, ok := parsed.Claims.(jwt.MapClaims)
+        if !ok </span><span class="cov0" title="0">{
+                return
+        }</span>
+
+        <span class="cov8" title="1">jti, ok := claims["jti"].(string)
+        if !ok || jti == "" </span><span class="cov0" title="0">{
+                return
+        }</span>
+
+        <span class="cov8" title="1">expiry := time.Now().Add(core.TokenExpiryAccessToken)
+        if exp, err := claims.GetExpirationTime(); err == nil &amp;&amp; exp != nil </span><span class="cov8" title="1">{
+                expiry = exp.Time
+        }</span>
+
+        <span class="cov8" title="1">r.blacklist.Revoke(jti, expiry)</span>
+}
+</pre>
+		
+		<pre class="file" id="file16" style="display: none">package apiauth
+
+import (
+        "fmt"
+        "strings"
+        "time"
+
+        "github.com/golang-jwt/jwt/v5"
+        "github.com/panyam/oneauth/core"
+        "github.com/panyam/oneauth/keys"
+        "github.com/panyam/oneauth/utils"
+)
+
+// jwtValidator implements TokenValidator using local JWT validation.
+// Dependencies are explicit and minimal: KeyLookup (read-only), Blacklist,
+// issuer/audience config, and security hooks.
+type jwtValidator struct {
+        keyLookup keys.KeyLookup
+        blacklist core.TokenBlacklist
+        issuer    string
+        audience  string
+        hooks     SecurityHooks
+}
+
+// JWTValidatorConfig configures a jwtValidator.
+type JWTValidatorConfig struct {
+        KeyLookup keys.KeyLookup
+        Blacklist core.TokenBlacklist
+        Issuer    string
+        Audience  string
+        Hooks     SecurityHooks
+}
+
+// NewJWTValidator creates a TokenValidator that validates JWTs locally.
+func NewJWTValidator(cfg JWTValidatorConfig) TokenValidator <span class="cov8" title="1">{
+        return &amp;jwtValidator{
+                keyLookup: cfg.KeyLookup,
+                blacklist: cfg.Blacklist,
+                issuer:    cfg.Issuer,
+                audience:  cfg.Audience,
+                hooks:     cfg.Hooks,
+        }
+}</span>
+
+// ValidateToken parses and validates a JWT, returning the extracted claims.
+func (v *jwtValidator) ValidateToken(tokenString string) (*TokenInfo, error) <span class="cov8" title="1">{
+        token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) </span><span class="cov8" title="1">{
+                return v.resolveKey(token)
+        }</span>)
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
+                v.hooks.fireOnTokenRejected(fmt.Sprintf("parse error: %v", err))
+                return nil, fmt.Errorf("invalid token: %w", err)
+        }</span>
+        <span class="cov8" title="1">if !token.Valid </span><span class="cov0" title="0">{
+                v.hooks.fireOnTokenRejected("token validation failed")
+                return nil, fmt.Errorf("token validation failed")
+        }</span>
+
+        <span class="cov8" title="1">claims, ok := token.Claims.(jwt.MapClaims)
+        if !ok </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("invalid claims")
+        }</span>
+
+        // Verify token type
+        <span class="cov8" title="1">if tokenType, ok := claims["type"].(string); ok &amp;&amp; tokenType != "access" </span><span class="cov0" title="0">{
+                v.hooks.fireOnTokenRejected("invalid token type")
+                return nil, fmt.Errorf("invalid token type")
+        }</span>
+
+        // Verify issuer
+        <span class="cov8" title="1">if v.issuer != "" </span><span class="cov8" title="1">{
+                if iss, ok := claims["iss"].(string); !ok || iss != v.issuer </span><span class="cov0" title="0">{
+                        v.hooks.fireOnTokenRejected("invalid issuer")
+                        return nil, fmt.Errorf("invalid issuer")
+                }</span>
+        }
+
+        // Verify audience
+        <span class="cov8" title="1">if v.audience != "" </span><span class="cov0" title="0">{
+                if !matchesAudience(claims, v.audience) </span><span class="cov0" title="0">{
+                        v.hooks.fireOnTokenRejected("invalid audience")
+                        return nil, fmt.Errorf("invalid audience")
+                }</span>
+        }
+
+        // Extract subject
+        <span class="cov8" title="1">userID, ok := claims["sub"].(string)
+        if !ok || userID == "" </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("missing subject")
+        }</span>
+
+        // Extract scopes
+        <span class="cov8" title="1">var scopes []string
+        if scopesRaw, ok := claims["scopes"].([]any); ok </span><span class="cov8" title="1">{
+                scopes = make([]string, 0, len(scopesRaw))
+                for _, s := range scopesRaw </span><span class="cov8" title="1">{
+                        if str, ok := s.(string); ok </span><span class="cov8" title="1">{
+                                scopes = append(scopes, str)
+                        }</span>
+                }
+        }
+
+        // Extract authorization_details (RFC 9396)
+        <span class="cov8" title="1">var authzDetails []core.AuthorizationDetail
+        if adRaw, ok := claims["authorization_details"].([]any); ok </span><span class="cov8" title="1">{
+                authzDetails = parseAuthorizationDetailsFromClaims(adRaw)
+        }</span>
+
+        // Extract custom claims
+        <span class="cov8" title="1">customClaims := make(map[string]any)
+        for k, v := range claims </span><span class="cov8" title="1">{
+                if !standardClaims[k] </span><span class="cov8" title="1">{
+                        customClaims[k] = v
+                }</span>
+        }
+
+        // Check blacklist
+        <span class="cov8" title="1">if v.blacklist != nil </span><span class="cov8" title="1">{
+                if jti, ok := claims["jti"].(string); ok &amp;&amp; jti != "" </span><span class="cov8" title="1">{
+                        if v.blacklist.IsRevoked(jti) </span><span class="cov8" title="1">{
+                                v.hooks.fireOnBlacklistHit(jti)
+                                v.hooks.fireOnTokenRejected("token has been revoked")
+                                return nil, fmt.Errorf("token has been revoked")
+                        }</span>
+                }
+        }
+
+        <span class="cov8" title="1">return &amp;TokenInfo{
+                UserID:               userID,
+                Scopes:               scopes,
+                AuthorizationDetails: authzDetails,
+                CustomClaims:         customClaims,
+                AuthType:             "jwt",
+        }, nil</span>
+}
+
+// CheckScopes validates a token and verifies it contains all required scopes.
+func (v *jwtValidator) CheckScopes(token string, required []string) error <span class="cov8" title="1">{
+        info, err := v.ValidateToken(token)
+        if err != nil </span><span class="cov0" title="0">{
+                return err
+        }</span>
+        <span class="cov8" title="1">if !core.ContainsAllScopes(info.Scopes, required) </span><span class="cov8" title="1">{
+                return fmt.Errorf("insufficient scope: requires %v, has %v", required, info.Scopes)
+        }</span>
+        <span class="cov8" title="1">return nil</span>
+}
+
+// CheckAuthorizationDetails validates a token and verifies it contains
+// authorization_details entries for all required types.
+func (v *jwtValidator) CheckAuthorizationDetails(token string, requiredTypes []string) error <span class="cov8" title="1">{
+        info, err := v.ValidateToken(token)
+        if err != nil </span><span class="cov0" title="0">{
+                return err
+        }</span>
+        <span class="cov8" title="1">grantedTypes := make(map[string]bool)
+        for _, ad := range info.AuthorizationDetails </span><span class="cov8" title="1">{
+                grantedTypes[ad.Type] = true
+        }</span>
+        <span class="cov8" title="1">for _, reqType := range requiredTypes </span><span class="cov8" title="1">{
+                if !grantedTypes[reqType] </span><span class="cov8" title="1">{
+                        return fmt.Errorf("missing required authorization_details type: %s", reqType)
+                }</span>
+        }
+        <span class="cov8" title="1">return nil</span>
+}
+
+// resolveKey finds the appropriate signing key for a JWT token.
+func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) <span class="cov8" title="1">{
+        if v.keyLookup == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("no key store configured")
+        }</span>
+
+        // Try kid-based lookup first
+        <span class="cov8" title="1">if kid, ok := token.Header["kid"].(string); ok &amp;&amp; kid != "" </span><span class="cov8" title="1">{
+                rec, err := v.keyLookup.GetKeyByKid(kid)
+                if err == nil &amp;&amp; rec != nil </span><span class="cov8" title="1">{
+                        if token.Header["alg"] != rec.Algorithm </span><span class="cov0" title="0">{
+                                v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
+                                return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
+                        }</span>
+                        // Cross-check kid owner vs client_id claim
+                        <span class="cov8" title="1">if rec.ClientID != "" </span><span class="cov8" title="1">{
+                                if claims, ok := token.Claims.(jwt.MapClaims); ok </span><span class="cov8" title="1">{
+                                        if claimClientID, _ := claims["client_id"].(string); claimClientID != "" &amp;&amp; claimClientID != rec.ClientID </span><span class="cov0" title="0">{
+                                                return nil, fmt.Errorf("kid owner %q does not match client_id claim %q", rec.ClientID, claimClientID)
+                                        }</span>
+                                }
+                        }
+                        <span class="cov8" title="1">return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)</span>
+                }
+        }
+
+        // Fall back to client_id claim
+        <span class="cov8" title="1">if claims, ok := token.Claims.(jwt.MapClaims); ok </span><span class="cov8" title="1">{
+                if clientID, ok := claims["client_id"].(string); ok &amp;&amp; clientID != "" </span><span class="cov8" title="1">{
+                        rec, err := v.keyLookup.GetKey(clientID)
+                        if err == nil &amp;&amp; rec != nil </span><span class="cov8" title="1">{
+                                if token.Header["alg"] != rec.Algorithm </span><span class="cov8" title="1">{
+                                        v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
+                                        return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
+                                }</span>
+                                <span class="cov8" title="1">return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)</span>
+                        }
+                }
+        }
+
+        <span class="cov8" title="1">return nil, fmt.Errorf("no key found for token")</span>
+}
+
+// jwtIssuer implements TokenIssuer using JWT signing.
+type jwtIssuer struct {
+        signingKey    any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
+        signingAlg    string // "HS256", "RS256", "ES256"
+        issuer        string
+        audience      string
+        accessExpiry  time.Duration
+        clientKeyLookup keys.KeyLookup
+        hooks         TokenHooks
+}
+
+// JWTIssuerConfig configures a jwtIssuer.
+type JWTIssuerConfig struct {
+        SigningKey      any
+        SigningAlg      string
+        Issuer         string
+        Audience       string
+        AccessExpiry   time.Duration
+        ClientKeyLookup keys.KeyLookup // for client_credentials authentication
+        Hooks          TokenHooks
+}
+
+// NewJWTIssuer creates a TokenIssuer that signs JWTs.
+func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer <span class="cov8" title="1">{
+        expiry := cfg.AccessExpiry
+        if expiry == 0 </span><span class="cov8" title="1">{
+                expiry = core.TokenExpiryAccessToken
+        }</span>
+        <span class="cov8" title="1">return &amp;jwtIssuer{
+                signingKey:      cfg.SigningKey,
+                signingAlg:      cfg.SigningAlg,
+                issuer:          cfg.Issuer,
+                audience:        cfg.Audience,
+                accessExpiry:    expiry,
+                clientKeyLookup: cfg.ClientKeyLookup,
+                hooks:           cfg.Hooks,
+        }</span>
+}
+
+// CreateAccessToken mints a signed JWT.
+func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details []core.AuthorizationDetail) (string, int64, error) <span class="cov8" title="1">{
+        now := time.Now()
+        expiresAt := now.Add(i.accessExpiry)
+
+        jti, err := core.GenerateSecureToken()
+        if err != nil </span><span class="cov0" title="0">{
+                return "", 0, fmt.Errorf("failed to generate jti: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">claims := jwt.MapClaims{
+                "sub":    subject,
+                "type":   "access",
+                "scopes": scopes,
+                "jti":    jti,
+                "iat":    now.Unix(),
+                "exp":    expiresAt.Unix(),
+        }
+        if len(details) &gt; 0 </span><span class="cov8" title="1">{
+                claims["authorization_details"] = details
+        }</span>
+        <span class="cov8" title="1">if i.issuer != "" </span><span class="cov8" title="1">{
+                claims["iss"] = i.issuer
+        }</span>
+        <span class="cov8" title="1">if i.audience != "" </span><span class="cov0" title="0">{
+                claims["aud"] = i.audience
+        }</span>
+
+        <span class="cov8" title="1">signingMethod, err := utils.SigningMethodForAlg(i.signingAlg)
+        if err != nil </span><span class="cov0" title="0">{
+                // Fall back to HS256 for []byte keys
+                if _, ok := i.signingKey.([]byte); ok </span><span class="cov0" title="0">{
+                        signingMethod = jwt.SigningMethodHS256
+                }</span> else<span class="cov0" title="0"> {
+                        return "", 0, fmt.Errorf("invalid signing algorithm: %w", err)
+                }</span>
+        }
+
+        <span class="cov8" title="1">token := jwt.NewWithClaims(signingMethod, claims)
+        if kid, kidErr := utils.ComputeKid(i.signingKey, signingMethod.Alg()); kidErr == nil </span><span class="cov8" title="1">{
+                token.Header["kid"] = kid
+        }</span>
+
+        <span class="cov8" title="1">tokenString, err := token.SignedString(i.signingKey)
+        if err != nil </span><span class="cov0" title="0">{
+                return "", 0, fmt.Errorf("failed to sign token: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">i.hooks.fireOnIssued(subject, "direct")
+        return tokenString, int64(i.accessExpiry.Seconds()), nil</span>
+}
+
+// ClientCredentials performs the client_credentials grant.
+func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error) <span class="cov8" title="1">{
+        if i.clientKeyLookup == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("client_credentials not configured")
+        }</span>
+
+        // Authenticate client
+        <span class="cov8" title="1">rec, err := i.clientKeyLookup.GetKey(clientID)
+        if err != nil || rec == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("invalid_client: unknown client")
+        }</span>
+        <span class="cov8" title="1">storedKey, ok := rec.Key.([]byte)
+        if !ok </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("invalid_client: client does not support secret authentication")
+        }</span>
+        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), clientSecret) </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("invalid_client: invalid credentials")
+        }</span>
+
+        // Validate authorization_details
+        <span class="cov8" title="1">if err := core.ValidateAll(details); err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        // Create token
+        <span class="cov8" title="1">tokenStr, expiresIn, err := i.CreateAccessToken(clientID, scopes, details)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        <span class="cov8" title="1">i.hooks.fireOnIssued(clientID, "client_credentials")
+
+        resp := &amp;core.TokenPair{
+                AccessToken:          tokenStr,
+                TokenType:            "Bearer",
+                ExpiresIn:            expiresIn,
+                Scope:                strings.Join(scopes, " "),
+                AuthorizationDetails: details,
+        }
+        return resp, nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file17" style="display: none">package client
 
 import (
         "sync"
@@ -3271,7 +4302,7 @@ func (s *MemoryASMetadataStore) Put(issuer string, md *ASMetadata, ttl time.Dura
 var _ ASMetadataStore = (*MemoryASMetadataStore)(nil)
 </pre>
 		
-		<pre class="file" id="file11" style="display: none">package client
+		<pre class="file" id="file18" style="display: none">package client
 
 import "net/url"
 
@@ -3378,7 +4409,7 @@ func applyAuthToForm(method TokenEndpointAuthMethod, clientID, clientSecret stri
 }
 </pre>
 		
-		<pre class="file" id="file12" style="display: none">package client
+		<pre class="file" id="file19" style="display: none">package client
 
 import (
         "context"
@@ -3823,7 +4854,7 @@ func openBrowserDefault(url string) error <span class="cov0" title="0">{
 
 </pre>
 		
-		<pre class="file" id="file13" style="display: none">package client
+		<pre class="file" id="file20" style="display: none">package client
 
 import (
         "bytes"
@@ -4379,7 +5410,7 @@ func parseAuthzDetailsFromRaw(raw []any) []core.AuthorizationDetail <span class=
 }
 </pre>
 		
-		<pre class="file" id="file14" style="display: none">package client
+		<pre class="file" id="file21" style="display: none">package client
 
 import (
         "fmt"
@@ -4638,7 +5669,7 @@ func (s *ClientCredentialsSource) TokenForScopes(scopes []string) (string, error
 }</span>
 </pre>
 		
-		<pre class="file" id="file15" style="display: none">// Package client provides client-side authentication utilities for oneauth.
+		<pre class="file" id="file22" style="display: none">// Package client provides client-side authentication utilities for oneauth.
 // It includes credential storage, automatic token refresh, and HTTP client helpers.
 package client
 
@@ -4709,7 +5740,7 @@ func (noopCredentialStore) ListServers() ([]string, error)                  <spa
 func (noopCredentialStore) Save() error                                     <span class="cov8" title="1">{ return nil }</span>
 </pre>
 		
-		<pre class="file" id="file16" style="display: none">package client
+		<pre class="file" id="file23" style="display: none">package client
 
 import (
         "bytes"
@@ -4784,7 +5815,7 @@ func RegisterClient(endpoint string, meta ClientRegistrationRequest, httpClient 
 }
 </pre>
 		
-		<pre class="file" id="file17" style="display: none">package client
+		<pre class="file" id="file24" style="display: none">package client
 
 import (
         "encoding/json"
@@ -4982,7 +6013,7 @@ func fetchMetadata(client *http.Client, url string) (*ASMetadata, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file18" style="display: none">// Package fs provides a file system-based credential store for oneauth client.
+		<pre class="file" id="file25" style="display: none">// Package fs provides a file system-based credential store for oneauth client.
 package fs
 
 import (
@@ -5173,7 +6204,7 @@ func (s *FSCredentialStore) Path() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file19" style="display: none">package client
+		<pre class="file" id="file26" style="display: none">package client
 
 import (
         "net/http"
@@ -5219,7 +6250,7 @@ func NewAuthTransportWithBase(base http.RoundTripper, token string) *AuthTranspo
 }</span>
 </pre>
 		
-		<pre class="file" id="file20" style="display: none">package client
+		<pre class="file" id="file27" style="display: none">package client
 
 import (
         "fmt"
@@ -5289,7 +6320,7 @@ func ValidateCIMDURL(rawURL string) error <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file21" style="display: none">package core
+		<pre class="file" id="file28" style="display: none">package core
 
 import (
         "encoding/json"
@@ -5444,7 +6475,7 @@ func (ad *AuthorizationDetail) UnmarshalJSON(data []byte) error <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file22" style="display: none">package core
+		<pre class="file" id="file29" style="display: none">package core
 
 import (
         "sync"
@@ -5524,7 +6555,7 @@ func (b *InMemoryBlacklist) Len() int <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file23" style="display: none">package core
+		<pre class="file" id="file30" style="display: none">package core
 
 import "context"
 
@@ -5550,7 +6581,7 @@ func SetUserIDInContext(ctx context.Context, userID string) context.Context <spa
 }</span>
 </pre>
 		
-		<pre class="file" id="file24" style="display: none">package core
+		<pre class="file" id="file31" style="display: none">package core
 
 import (
         "fmt"
@@ -5768,7 +6799,7 @@ func DetectUsernameType(username string) string <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file25" style="display: none">package core
+		<pre class="file" id="file32" style="display: none">package core
 
 import "log"
 
@@ -5800,7 +6831,7 @@ func (c *ConsoleEmailSender) SendPasswordResetEmail(to string, resetLink string)
 }</span>
 </pre>
 		
-		<pre class="file" id="file26" style="display: none">package core
+		<pre class="file" id="file33" style="display: none">package core
 
 import (
         "sync"
@@ -5960,7 +6991,7 @@ func (l *AccountLockout) Reset(key string) <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file27" style="display: none">package core
+		<pre class="file" id="file34" style="display: none">package core
 
 import (
         "sort"
@@ -6124,7 +7155,7 @@ func ScopesEqual(a, b []string) bool <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file28" style="display: none">package core
+		<pre class="file" id="file35" style="display: none">package core
 
 import (
         "crypto/rand"
@@ -6300,7 +7331,7 @@ func GenerateAPIKeySecret() (string, error) <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file29" style="display: none">package core
+		<pre class="file" id="file36" style="display: none">package core
 
 import (
         "net/http"
@@ -6364,7 +7395,7 @@ func IdentityKey(identityType, identityValue string) string <span class="cov0" t
 type HandleUserFunc func(authtype string, provider string, token *oauth2.Token, userInfo map[string]any, w http.ResponseWriter, r *http.Request)
 </pre>
 		
-		<pre class="file" id="file30" style="display: none">// Example 01: OAuth 2.0 Client Credentials Flow
+		<pre class="file" id="file37" style="display: none">// Example 01: OAuth 2.0 Client Credentials Flow
 //
 // The simplest way to get a token from OneAuth. A client authenticates with
 // its client_id and client_secret, and receives a JWT access token.
@@ -6386,7 +7417,8 @@ import (
 
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -6471,7 +7503,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Step 1: Register ---
         demo.Step("Register a client").
-                Ref(demokit.RFC7591).
+                Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST /apps/register {domain, signing_alg}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
                 Note("The client receives credentials it will use to authenticate in the next step.").
@@ -6494,8 +7526,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Step 2: Token ---
         <span class="cov0" title="0">demo.Step("Request an access token").
-                Ref(demokit.RFC6749_ClientCredentials).
-                Ref(demokit.RFC7519).
+                Ref(refs.RFC6749_ClientCredentials).
+                Ref(refs.RFC7519).
                 Arrow("App", "AS", "POST /api/token {grant_type: client_credentials}").
                 DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
                 Note("The AS verifies the client credentials and returns a signed JWT. The token carries sub=client_id (no user context in this flow).").
@@ -6531,8 +7563,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Step 3: Use token ---
         demo.Step("Access a protected resource").
-                Ref(demokit.RFC6750).
-                Ref(demokit.RFC7515).
+                Ref(refs.RFC6750).
+                Ref(refs.RFC7515).
                 Arrow("App", "RS", "GET /resource (Authorization: Bearer token)").
                 Arrow("RS", "RS", "Validate JWT signature + claims").
                 DashedArrow("RS", "App", "200 {data}").
@@ -6553,7 +7585,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Step 4: No token ---
         <span class="cov0" title="0">demo.Step("Access without a token (expect rejection)").
-                Ref(demokit.RFC6750).
+                Ref(refs.RFC6750).
                 Arrow("App", "RS", "GET /resource (no Authorization header)").
                 DashedArrow("RS", "App", "401 Unauthorized").
                 Note("Without a valid Bearer token, the resource server rejects the request.").
@@ -6583,7 +7615,7 @@ func main() <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file31" style="display: none">// Example 02: Resource Token with HS256 (Federated Auth)
+		<pre class="file" id="file38" style="display: none">// Example 02: Resource Token with HS256 (Federated Auth)
 //
 // Building on Example 01, this shows how a registered app can mint
 // resource-scoped tokens for individual users — not just for itself.
@@ -6608,7 +7640,8 @@ import (
 
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -6681,7 +7714,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Register ---
         <span class="cov0" title="0">demo.Step("Register an app with HS256 signing").
-                Ref(demokit.RFC7515).
+                Ref(refs.RFC7515).
                 Arrow("App", "AS", "POST /apps/register {domain: myapp.example.com, signing_alg: HS256}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
                 Note("The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app and resource server can use it for signing/verification.").
@@ -6717,9 +7750,9 @@ func main() <span class="cov0" title="0">{
 
         // --- Mint for Alice ---
         demo.Step("Mint a resource token for user Alice").
-                Ref(demokit.RFC7519).
-                Ref(demokit.RFC7515).
-                Ref(demokit.RFC7638).
+                Ref(refs.RFC7519).
+                Ref(refs.RFC7515).
+                Ref(refs.RFC7638).
                 Arrow("App", "App", "MintResourceToken(alice, scopes=[read,write], max_rooms=10)").
                 Note("The app creates a JWT with sub=alice, signed with its HS256 secret. The token includes quota claims (max_rooms) for resource-level enforcement.").
                 Run(func() </span><span class="cov0" title="0">{
@@ -6738,7 +7771,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Mint for Bob ---
         <span class="cov0" title="0">demo.Step("Mint a resource token for user Bob (different scopes)").
-                Ref(demokit.RFC7519).
+                Ref(refs.RFC7519).
                 Arrow("App", "App", "MintResourceToken(bob, scopes=[read], max_rooms=3)").
                 Note("Same app, different user, different permissions. Bob gets read-only access with a lower room quota.").
                 Run(func() </span><span class="cov0" title="0">{
@@ -6757,8 +7790,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Validate Alice ---
         <span class="cov0" title="0">demo.Step("Resource server validates Alice's token").
-                Ref(demokit.RFC6750).
-                Ref(demokit.RFC7515).
+                Ref(refs.RFC6750).
+                Ref(refs.RFC7515).
                 Arrow("App", "RS", "GET /resource (Bearer: alice's token)").
                 Arrow("RS", "RS", "Validate HS256 signature via KeyStore").
                 DashedArrow("RS", "App", "200 {user: alice, scopes: [read,write], max_rooms: 10}").
@@ -6798,7 +7831,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Wrong secret ---
         <span class="cov0" title="0">demo.Step("Token signed with wrong secret is rejected").
-                Ref(demokit.RFC7515).
+                Ref(refs.RFC7515).
                 Arrow("App", "App", "MintResourceToken(eve, secret=wrong-secret)").
                 Arrow("App", "RS", "GET /resource (Bearer: bad token)").
                 DashedArrow("RS", "App", "401 Unauthorized").
@@ -6833,7 +7866,7 @@ func main() <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file32" style="display: none">// Example 03: Resource Token with RS256 + JWKS Discovery
+		<pre class="file" id="file39" style="display: none">// Example 03: Resource Token with RS256 + JWKS Discovery
 //
 // Building on Example 02 (HS256 shared secret), this shows the asymmetric
 // alternative: the app generates an RSA key pair, registers only the PUBLIC
@@ -6861,7 +7894,8 @@ import (
 
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
 )
@@ -6902,7 +7936,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Start auth server with JWKS endpoint").
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7517).
                 Note("The auth server now serves two endpoints: /apps/ for registration and /.well-known/jwks.json for public key discovery.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -6920,7 +7954,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Generate key pair ---
         <span class="cov0" title="0">demo.Step("App generates an RSA key pair").
-                Ref(demokit.RFC7515).
+                Ref(refs.RFC7515).
                 Note("The app generates a 2048-bit RSA key pair. The private key stays with the app. The public key will be registered with the auth server.").
                 Run(func() </span><span class="cov0" title="0">{
                         privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
@@ -6937,7 +7971,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Register with public key ---
         <span class="cov0" title="0">demo.Step("Register app with RS256 public key").
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7517).
                 Arrow("App", "AS", "POST /apps/register {domain, signing_alg: RS256, public_key}").
                 DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
                 Note("Unlike HS256 registration, no secret is returned. The auth server stores the public key and serves it via JWKS.").
@@ -6961,8 +7995,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Verify JWKS ---
         <span class="cov0" title="0">demo.Step("Verify the public key appears in JWKS").
-                Ref(demokit.RFC7517).
-                Ref(demokit.RFC7638).
+                Ref(refs.RFC7517).
+                Ref(refs.RFC7638).
                 Arrow("App", "AS", "GET /.well-known/jwks.json").
                 DashedArrow("AS", "App", "{keys: [{kty: RSA, alg: RS256, kid: ..., n: ..., e: ...}]}").
                 Note("The JWKS endpoint serves only public keys — HS256 secrets are never exposed. Each key includes a kid (Key ID) computed from the key thumbprint (RFC 7638).").
@@ -7006,7 +8040,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Start resource server with JWKS discovery ---
         demo.Step("Start resource server with JWKS-based key discovery").
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7517).
                 Note("The resource server points its JWKSKeyStore at the auth server's JWKS URL. It automatically fetches and caches the public keys.").
                 Run(func() </span><span class="cov0" title="0">{
                         jwksKS := keys.NewJWKSKeyStore(
@@ -7035,9 +8069,9 @@ func main() <span class="cov0" title="0">{
 
         // --- Mint and validate ---
         <span class="cov0" title="0">demo.Step("Mint a token with the private key and validate via JWKS").
-                Ref(demokit.RFC7519).
-                Ref(demokit.RFC7515).
-                Ref(demokit.RFC7638).
+                Ref(refs.RFC7519).
+                Ref(refs.RFC7515).
+                Ref(refs.RFC7638).
                 Arrow("App", "App", "MintResourceTokenWithKey(alice, privKey)").
                 Arrow("App", "RS", "GET /resource (Bearer: RS256 token)").
                 Arrow("RS", "AS", "GET /.well-known/jwks.json (cached)").
@@ -7066,7 +8100,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Wrong key ---
         <span class="cov0" title="0">demo.Step("Token signed with a different private key is rejected").
-                Ref(demokit.RFC7515).
+                Ref(refs.RFC7515).
                 Arrow("App", "App", "MintResourceTokenWithKey(eve, differentPrivKey)").
                 Arrow("App", "RS", "GET /resource (Bearer: bad token)").
                 DashedArrow("RS", "App", "401 Unauthorized").
@@ -7119,7 +8153,7 @@ func main() <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file33" style="display: none">// Example 04: AS Metadata Discovery (RFC 8414)
+		<pre class="file" id="file40" style="display: none">// Example 04: AS Metadata Discovery (RFC 8414)
 //
 // In Examples 01-03, we hardcoded URLs like authServer.URL+"/api/token".
 // In production, clients discover endpoints automatically from a single
@@ -7144,7 +8178,8 @@ import (
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/oneauth/client"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -7187,7 +8222,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Start auth server with discovery, token, JWKS, and introspection endpoints").
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC8414).
                 Note("This is the most complete auth server we've built so far — it serves discovery, tokens, JWKS, introspection, and registration.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -7199,10 +8234,7 @@ func main() <span class="cov0" title="0">{
                                 ClientKeyStore: ks,
                         }
 
-                        introspection := &amp;apiauth.IntrospectionHandler{
-                                Auth:           apiAuth,
-                                ClientKeyStore: ks,
-                        }
+                        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
                         mux := http.NewServeMux()
                         mux.Handle("/apps/", registrar.Handler())
@@ -7252,7 +8284,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Fetch raw metadata ---
         <span class="cov0" title="0">demo.Step("Fetch the discovery document (raw HTTP)").
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC8414).
                 Arrow("App", "AS", "GET /.well-known/openid-configuration").
                 DashedArrow("AS", "App", "JSON {issuer, token_endpoint, jwks_uri, ...}").
                 Note("The discovery document is a JSON object listing every endpoint the server supports. This is the same format Keycloak, Auth0, and Google use.").
@@ -7285,7 +8317,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Use client.DiscoverAS ---
         demo.Step("Discover using the client SDK (client.DiscoverAS)").
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC8414).
                 Arrow("App", "AS", "client.DiscoverAS(serverURL)").
                 DashedArrow("AS", "App", "typed ASMetadata struct").
                 Note("client.DiscoverAS() fetches and parses the metadata into a typed Go struct. Production code should use this — no manual JSON parsing needed.").
@@ -7330,7 +8362,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Get token using discovered endpoint ---
         <span class="cov0" title="0">demo.Step("Get a token (using discovered token endpoint)").
-                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "POST {discovered_token_endpoint}").
                 DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
                 Note("We use discoveredMeta.TokenEndpoint instead of hardcoding /api/token. This is the key benefit — the same client code works against any compliant AS.").
@@ -7354,7 +8386,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Use the token ---
         <span class="cov0" title="0">demo.Step("Use the token on a resource server").
-                Ref(demokit.RFC6750).
+                Ref(refs.RFC6750).
                 Arrow("App", "RS", "GET /resource (Bearer token)").
                 DashedArrow("RS", "App", "200 {data}").
                 Note("The resource server validates the token as in previous examples. Discovery doesn't change how tokens work — it only changes how the client finds the endpoints.").
@@ -7374,7 +8406,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Optional: Keycloak comparison ---
         <span class="cov0" title="0">demo.Step("Discover Keycloak endpoints (optional)").
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC8414).
                 Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
                 DashedArrow("AS", "App", "{issuer, token_endpoint, jwks_uri, ...}").
                 Note("Same DiscoverAS() call, completely different server. If Keycloak isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
@@ -7446,7 +8478,7 @@ func main() <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file34" style="display: none">// Example 05: Token Introspection (RFC 7662)
+		<pre class="file" id="file41" style="display: none">// Example 05: Token Introspection (RFC 7662)
 //
 // In Examples 01-04, the resource server validated tokens locally by checking
 // the JWT signature. That's fast but has a gap: if a token is revoked, the RS
@@ -7477,7 +8509,8 @@ import (
         "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/oneauth/client"
         "github.com/panyam/oneauth/core"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -7524,7 +8557,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Start auth server with token endpoint, introspection, and blacklist").
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC7662).
                 Note("The auth server now has a blacklist for token revocation. The introspection endpoint checks it before responding.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -7538,10 +8571,7 @@ func main() <span class="cov0" title="0">{
                                 Blacklist:      blacklist,
                         }
 
-                        introspectionHandler := &amp;apiauth.IntrospectionHandler{
-                                Auth:           apiAuth,
-                                ClientKeyStore: ks,
-                        }
+                        introspectionHandler := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
                         mux := http.NewServeMux()
                         mux.Handle("/apps/", registrar.Handler())
@@ -7557,8 +8587,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Register + get token ---
         <span class="cov0" title="0">demo.Step("Register a client and get an access token").
-                Ref(demokit.RFC6749_ClientCredentials).
-                Ref(demokit.RFC7519).
+                Ref(refs.RFC6749_ClientCredentials).
+                Ref(refs.RFC7519).
                 Arrow("App", "AS", "POST /apps/register → POST /api/token").
                 DashedArrow("AS", "App", "{client_id, client_secret, access_token}").
                 Note("Same as Example 01 — register, then client_credentials grant. The token includes a jti (JWT ID) claim used for revocation.").
@@ -7613,7 +8643,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Introspect valid token ---
         demo.Step("Introspect a valid token").
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC7662).
                 Arrow("RS", "AS", "POST /oauth/introspect {token} (Basic auth)").
                 DashedArrow("AS", "RS", "{active: true, sub, scope, exp, iss, jti}").
                 Note("The RS authenticates with its own credentials (same client in this example). The response includes the token's claims — the RS doesn't need to decode the JWT itself.").
@@ -7625,7 +8655,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Introspect garbage ---
         <span class="cov0" title="0">demo.Step("Introspect a garbage token").
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC7662).
                 Arrow("RS", "AS", "POST /oauth/introspect {token: not-a-real-token}").
                 DashedArrow("AS", "RS", "{active: false}").
                 Note("Invalid tokens always return {active: false} — the AS never reveals why. This is a security requirement of RFC 7662.").
@@ -7637,7 +8667,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Revoke and re-introspect ---
         <span class="cov0" title="0">demo.Step("Revoke the token, then introspect again").
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC7662).
                 Arrow("Admin", "AS", "blacklist.Revoke(jti)").
                 Arrow("RS", "AS", "POST /oauth/introspect {same token as step 3}").
                 DashedArrow("AS", "RS", "{active: false}").
@@ -7657,7 +8687,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Unauthenticated caller ---
         <span class="cov0" title="0">demo.Step("Introspect without authentication (rejected)").
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC7662).
                 Arrow("Attacker", "AS", "POST /oauth/introspect {token} (no Basic auth)").
                 DashedArrow("AS", "Attacker", "401 Unauthorized").
                 Note("The introspection endpoint requires the caller to authenticate. An unauthenticated request is rejected — you can't fish for valid tokens.").
@@ -7674,7 +8704,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Optional: Keycloak introspection ---
         <span class="cov0" title="0">demo.Step("Introspect via Keycloak (optional)").
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC7662).
                 Arrow("App", "AS", "POST {KC token_endpoint} → get KC token").
                 Arrow("RS", "AS", "POST {KC introspection_endpoint} {token}").
                 DashedArrow("AS", "RS", "{active: true, sub, scope, ...}").
@@ -7798,7 +8828,7 @@ func parseJWTClaims(tokenStr string) map[string]any <span class="cov0" title="0"
 }
 </pre>
 		
-		<pre class="file" id="file35" style="display: none">// Example 06: Dynamic Client Registration (RFC 7591)
+		<pre class="file" id="file42" style="display: none">// Example 06: Dynamic Client Registration (RFC 7591)
 //
 // In Examples 01-05, we registered apps via OneAuth's proprietary /apps/register
 // endpoint. That works but is OneAuth-specific. RFC 7591 defines a standard way
@@ -7824,7 +8854,8 @@ import (
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/oneauth/client"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
 )
@@ -7865,8 +8896,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Start auth server with DCR endpoint").
-                Ref(demokit.RFC7591).
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC7591).
+                Ref(refs.RFC8414).
                 Note("The auth server serves /apps/dcr (RFC 7591) alongside the proprietary /apps/register. Both create clients in the same KeyStore.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -7925,7 +8956,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Symmetric registration ---
         demo.Step("Register a symmetric client (client_secret_post)").
-                Ref(demokit.RFC7591).
+                Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, auth_method}").
                 DashedArrow("AS", "App", "{client_id, client_secret, client_id_issued_at}").
                 Note("The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.").
@@ -7957,7 +8988,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Use the registered client ---
         <span class="cov0" title="0">demo.Step("Get a token with the DCR-registered client").
-                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "POST /api/token {client_id, client_secret from DCR}").
                 DashedArrow("AS", "App", "{access_token}").
                 Note("The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.").
@@ -7979,8 +9010,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Asymmetric registration ---
         <span class="cov0" title="0">demo.Step("Register an asymmetric client (private_key_jwt with JWKS)").
-                Ref(demokit.RFC7591).
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7591).
+                Ref(refs.RFC7517).
                 Arrow("App", "AS", "POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}").
                 DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
                 Note("For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.").
@@ -8028,7 +9059,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Optional: Keycloak DCR ---
         demo.Step("Register via Keycloak DCR (optional)").
-                Ref(demokit.RFC7591).
+                Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST {KC registration_endpoint} {client_name, grant_types}").
                 DashedArrow("AS", "App", "{client_id, client_secret, registration_access_token}").
                 Note("Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.").
@@ -8090,7 +9121,7 @@ func main() <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file36" style="display: none">// Example 07: Client SDK — Production Patterns
+		<pre class="file" id="file43" style="display: none">// Example 07: Client SDK — Production Patterns
 //
 // Examples 01-06 showed the server side and raw HTTP calls. This example shows
 // how production client code works: discovery-driven configuration, automatic
@@ -8114,7 +9145,8 @@ import (
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/oneauth/client"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -8213,8 +9245,8 @@ func main() <span class="cov0" title="0">{
 
         // --- One-shot token ---
         <span class="cov0" title="0">demo.Step("One-shot token with AuthClient").
-                Ref(demokit.RFC6749_ClientCredentials).
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC6749_ClientCredentials).
+                Ref(refs.RFC8414).
                 Arrow("App", "AS", "client.DiscoverAS(serverURL)").
                 Arrow("App", "AS", "authClient.ClientCredentialsToken(id, secret, scopes)").
                 DashedArrow("AS", "App", "ServerCredential{AccessToken, ExpiresAt, Scope}").
@@ -8249,7 +9281,7 @@ func main() <span class="cov0" title="0">{
 
         // --- TokenSource with caching ---
         demo.Step("Cached token with ClientCredentialsSource").
-                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "App", "tokenSource.Token() → cached or fetched").
                 Arrow("App", "RS", "GET /resource (Bearer: cached token)").
                 DashedArrow("RS", "App", "200 {data}").
@@ -8330,8 +9362,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Optional: Keycloak ---
         demo.Step("Use the SDK against Keycloak (optional)").
-                Ref(demokit.RFC8414).
-                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(refs.RFC8414).
+                Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
                 Arrow("App", "AS", "authClient.ClientCredentialsToken(...)").
                 DashedArrow("AS", "App", "ServerCredential from Keycloak").
@@ -8400,7 +9432,7 @@ func postJSON(url string, body any) map[string]any <span class="cov0" title="0">
 }</span>
 </pre>
 		
-		<pre class="file" id="file37" style="display: none">// Example 08: Rich Authorization Requests (RFC 9396)
+		<pre class="file" id="file44" style="display: none">// Example 08: Rich Authorization Requests (RFC 9396)
 //
 // This is the culmination of Examples 01-07. Flat scopes like "read" and "write"
 // can't express "transfer 45 EUR to Merchant A". RFC 9396 adds structured
@@ -8429,7 +9461,8 @@ import (
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/oneauth/client"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -8479,8 +9512,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Start auth server with RAR support + two resource servers").
-                Ref(demokit.RFC9396).
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC9396).
+                Ref(refs.RFC8414).
                 Note("The auth server advertises authorization_details_types_supported in its discovery document. Two resource servers enforce different authorization types.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -8491,10 +9524,7 @@ func main() <span class="cov0" title="0">{
                                 ClientKeyStore: ks,
                         }
 
-                        introspection := &amp;apiauth.IntrospectionHandler{
-                                Auth:           apiAuth,
-                                ClientKeyStore: ks,
-                        }
+                        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
                         mux := http.NewServeMux()
                         mux.Handle("/apps/", registrar.Handler())
@@ -8556,8 +9586,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Discovery ---
         <span class="cov0" title="0">demo.Step("Discover supported authorization_details types").
-                Ref(demokit.RFC9396).
-                Ref(demokit.RFC8414).
+                Ref(refs.RFC9396).
+                Ref(refs.RFC8414).
                 Arrow("App", "AS", "GET /.well-known/openid-configuration").
                 DashedArrow("AS", "App", "{..., authorization_details_types_supported: [...]}").
                 Note("RFC 9396 §10: the AS advertises which authorization_details types it supports. Clients check this before requesting.").
@@ -8576,7 +9606,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Register via DCR ---
         <span class="cov0" title="0">demo.Step("Register a banking app via DCR (RFC 7591)").
-                Ref(demokit.RFC7591).
+                Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, scope}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
                 Note("Using standards-compliant DCR (Example 06) instead of the proprietary endpoint. A banking app should be fully standards-based.").
@@ -8600,8 +9630,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Payment token ---
         <span class="cov0" title="0">demo.Step("Request a token with payment authorization_details").
-                Ref(demokit.RFC9396).
-                Ref(demokit.RFC6749_ClientCredentials).
+                Ref(refs.RFC9396).
+                Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "POST /api/token {authorization_details: [{type: payment_initiation, ...}]}").
                 DashedArrow("AS", "App", "{access_token, authorization_details: [{type: payment_initiation, ...}]}").
                 Note("The token request includes structured authorization_details — not just 'scope=payments' but the exact payment to initiate. The AS validates, embeds in the JWT, and echoes in the response.").
@@ -8661,7 +9691,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Use on payments RS ---
         demo.Step("Access the Payments API (authorized)").
-                Ref(demokit.RFC9396).
+                Ref(refs.RFC9396).
                 Arrow("App", "Pay", "POST /payments (Bearer: payment token)").
                 Arrow("Pay", "Pay", "RequireAuthorizationDetails(\"payment_initiation\") ✓").
                 DashedArrow("Pay", "App", "200 {status: payment_accepted, details: [...]}").
@@ -8682,7 +9712,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Use on accounts RS (should fail) ---
         <span class="cov0" title="0">demo.Step("Access the Accounts API with a payment token (rejected)").
-                Ref(demokit.RFC9396).
+                Ref(refs.RFC9396).
                 Arrow("App", "Acct", "GET /accounts (Bearer: payment token)").
                 Arrow("Acct", "Acct", "RequireAuthorizationDetails(\"account_information\") ✗").
                 DashedArrow("Acct", "App", "401 Unauthorized").
@@ -8698,8 +9728,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Introspect ---
         <span class="cov0" title="0">demo.Step("Introspect the payment token").
-                Ref(demokit.RFC9396).
-                Ref(demokit.RFC7662).
+                Ref(refs.RFC9396).
+                Ref(refs.RFC7662).
                 Arrow("RS", "AS", "POST /oauth/introspect {token}").
                 DashedArrow("AS", "RS", "{active: true, authorization_details: [...]}").
                 Note("Introspection returns the authorization_details alongside the standard claims. Resource servers that use introspection (instead of local JWT validation) get the same fine-grained information.").
@@ -8721,7 +9751,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Scope coexistence ---
         <span class="cov0" title="0">demo.Step("RAR coexists with scopes").
-                Ref(demokit.RFC9396).
+                Ref(refs.RFC9396).
                 Arrow("App", "AS", "POST /api/token {scope: read, authorization_details: [...]}").
                 DashedArrow("AS", "App", "{scope: read, authorization_details: [...]}").
                 Note("Scopes and authorization_details are independent — you can use both in the same request. Scopes for coarse-grained access, RAR for fine-grained.").
@@ -8750,7 +9780,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Optional: RAR test issuer ---
         <span class="cov0" title="0">demo.Step("Cross-server RAR validation (optional — RAR test issuer)").
-                Ref(demokit.RFC9396).
+                Ref(refs.RFC9396).
                 Arrow("App", "AS", "POST {RAR issuer}/api/token {authorization_details}").
                 Arrow("App", "RS", "Bearer token → validate via JWKS from RAR issuer").
                 Note("No open-source IdP supports RFC 9396 on standard OAuth flows yet. We built a RAR test issuer (cmd/rar-test-issuer) for interop testing. Run 'make uprar' to start it. When Keycloak adds RAR support, this step will migrate to KC.").
@@ -8821,7 +9851,7 @@ func main() <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file38" style="display: none">// Example 09: Key Rotation with Grace Periods
+		<pre class="file" id="file45" style="display: none">// Example 09: Key Rotation with Grace Periods
 //
 // In production, signing keys need to be rotated periodically. But you can't
 // just swap keys — existing tokens signed with the old key would break. OneAuth
@@ -8845,7 +9875,8 @@ import (
         "github.com/golang-jwt/jwt/v5"
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
@@ -8891,8 +9922,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Set up auth server with key rotation support").
-                Ref(demokit.RFC7517).
-                Ref(demokit.RFC7638).
+                Ref(refs.RFC7517).
+                Ref(refs.RFC7638).
                 Note("The auth server uses a KidStore alongside the main KeyStore. On rotation, the old key moves to KidStore with a grace period TTL. The CompositeKeyLookup checks both.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -8916,7 +9947,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Register and mint ---
         <span class="cov0" title="0">demo.Step("Register an app and mint a token with the original key").
-                Ref(demokit.RFC7519).
+                Ref(refs.RFC7519).
                 Arrow("Admin", "AS", "POST /apps/register").
                 DashedArrow("AS", "Admin", "{client_id, client_secret}").
                 Arrow("Admin", "Admin", "MintResourceToken(alice, oldSecret)").
@@ -8947,7 +9978,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Rotate ---
         <span class="cov0" title="0">demo.Step("Rotate the key").
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7517).
                 Arrow("Admin", "AS", "POST /apps/{id}/rotate").
                 DashedArrow("AS", "Admin", "{client_secret: newSecret}").
                 Note("Rotation replaces the key in the main KeyStore and moves the old key to KidStore with a grace period TTL. Both keys are now valid.").
@@ -8974,7 +10005,7 @@ func main() <span class="cov0" title="0">{
 
         // --- During grace period ---
         <span class="cov0" title="0">demo.Step("During grace period — both tokens work").
-                Ref(demokit.RFC7638).
+                Ref(refs.RFC7638).
                 Arrow("RS", "RS", "Validate old token → kid found in KidStore (grace) ✓").
                 Arrow("RS", "RS", "Validate new token → kid found in KeyStore (current) ✓").
                 Note("The CompositeKeyLookup checks the main KeyStore first, then falls back to KidStore. Old tokens find their key in the grace store; new tokens find theirs in the main store.").
@@ -9046,7 +10077,7 @@ func validateToken(handler http.Handler, token string) int <span class="cov0" ti
 }</span>
 </pre>
 		
-		<pre class="file" id="file39" style="display: none">// Example 10: Security — Attack Prevention
+		<pre class="file" id="file46" style="display: none">// Example 10: Security — Attack Prevention
 //
 // This example demonstrates real attacks against JWT-based auth systems and
 // how OneAuth prevents them. Each step shows the attack, why it works against
@@ -9072,7 +10103,8 @@ import (
         "github.com/golang-jwt/jwt/v5"
         "github.com/panyam/oneauth/admin"
         "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/examples/demokit"
+        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
 )
@@ -9105,7 +10137,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Setup ---
         demo.Step("Set up KeyStore with an RS256 app and an HS256 app").
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7517).
                 Note("Two apps coexist: one with an RSA key pair (RS256), one with a shared secret (HS256). The resource server validates tokens from both.").
                 Run(func() </span><span class="cov0" title="0">{
                         ks = keys.NewInMemoryKeyStore()
@@ -9126,8 +10158,8 @@ func main() <span class="cov0" title="0">{
 
         // --- Attack 1: Algorithm confusion ---
         <span class="cov0" title="0">demo.Step("Attack 1: Algorithm confusion (CVE-2015-9235)").
-                Ref(demokit.CVE_2015_9235).
-                Ref(demokit.RFC7515).
+                Ref(refs.CVE_2015_9235).
+                Ref(refs.RFC7515).
                 Arrow("Attacker", "Attacker", "Craft JWT: alg=HS256, sign with RSA public key").
                 Arrow("Attacker", "RS", "Bearer: confused token").
                 DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
@@ -9161,7 +10193,7 @@ func main() <span class="cov0" title="0">{
 
         // --- Attack 2: alg:none ---
         <span class="cov0" title="0">demo.Step("Attack 2: alg:none — no signature at all").
-                Ref(demokit.CVE_2015_9235).
+                Ref(refs.CVE_2015_9235).
                 Arrow("Attacker", "Attacker", "Craft JWT: alg=none, no signature").
                 Arrow("Attacker", "RS", "Bearer: unsigned token").
                 DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
@@ -9224,7 +10256,7 @@ func main() <span class="cov0" title="0">{
 
         // --- JWKS security ---
         <span class="cov0" title="0">demo.Step("JWKS security: only public keys, never secrets").
-                Ref(demokit.RFC7517).
+                Ref(refs.RFC7517).
                 Arrow("Anyone", "AS", "GET /.well-known/jwks.json").
                 DashedArrow("AS", "Anyone", "{keys: [RSA public key only]}").
                 Note("JWKS serves only asymmetric public keys. HS256 secrets are excluded entirely. RSA keys include only public components (n, e) — private fields (d, p, q) are structurally absent from the JWK type.").
@@ -9304,379 +10336,7 @@ func validateToken(handler http.Handler, token string) int <span class="cov0" ti
 }</span>
 </pre>
 		
-		<pre class="file" id="file40" style="display: none">// Package demokit provides an interactive step-through framework for OneAuth
-// examples. Each example defines a sequence of steps (with mermaid diagram
-// arrows) and optional sections (explanatory text). The same definitions
-// drive both the interactive CLI and the generated README.
-//
-// Single source of truth: step titles, arrows, and notes are defined in Go
-// code. The README's mermaid diagram and step documentation are generated
-// from these definitions — never maintained by hand.
-//
-// Usage:
-//
-//        demo := demokit.New("01: Client Credentials Flow").
-//            Description("Non-UI | No infrastructure needed").
-//            Actors(
-//                demokit.Actor("App", "Client App"),
-//                demokit.Actor("AS", "Auth Server"),
-//            )
-//        demo.Step("Register a client").
-//            Arrow("App", "AS", "POST /apps/register").
-//            Arrow("AS", "App", "{client_id, client_secret}").
-//            Note("The client gets credentials for later use.").
-//            Run(func() { fmt.Println("registered!") })
-//        demo.Execute()
-package demokit
-
-import (
-        "bufio"
-        "fmt"
-        "os"
-        "strings"
-)
-
-// ActorDef defines a participant in the sequence diagram.
-type ActorDef struct {
-        ID    string // Short identifier used in arrows (e.g., "AS")
-        Label string // Display label (e.g., "Auth Server")
-}
-
-// Actor creates an ActorDef.
-func Actor(id, label string) ActorDef <span class="cov0" title="0">{
-        return ActorDef{ID: id, Label: label}
-}</span>
-
-// item is a union type for the ordered sequence of steps and sections.
-type item interface {
-        isItem()
-}
-
-// Ref is a named reference (RFC, CVE, blog post, spec section, etc.).
-type Ref struct {
-        Name string // e.g., "RFC 7519 (JWT)" or "CVE-2015-9235"
-        URL  string // e.g., "https://www.rfc-editor.org/rfc/rfc7519"
-}
-
-// StepDef defines one executable step in the demo.
-type StepDef struct {
-        title  string
-        arrows []arrowDef
-        refs   []Ref
-        note   string
-        runFn  func()
-}
-
-type arrowDef struct {
-        from, to, label string
-        dashed          bool // --&gt;&gt; vs -&gt;&gt;
-}
-
-func (s *StepDef) isItem() {<span class="cov0" title="0">}</span>
-
-// Arrow adds a solid arrow (request) to the step's sequence diagram.
-func (s *StepDef) Arrow(from, to, label string) *StepDef <span class="cov0" title="0">{
-        s.arrows = append(s.arrows, arrowDef{from: from, to: to, label: label})
-        return s
-}</span>
-
-// DashedArrow adds a dashed arrow (response) to the step's sequence diagram.
-func (s *StepDef) DashedArrow(from, to, label string) *StepDef <span class="cov0" title="0">{
-        s.arrows = append(s.arrows, arrowDef{from: from, to: to, label: label, dashed: true})
-        return s
-}</span>
-
-// Ref adds a reference (RFC, CVE, spec section, blog post, etc.) to this step.
-// Use pre-defined constants from refs.go: demokit.RFC7519, demokit.CVE_2015_9235, etc.
-func (s *StepDef) Ref(ref Ref) *StepDef <span class="cov0" title="0">{
-        s.refs = append(s.refs, ref)
-        return s
-}</span>
-
-// Note adds explanatory text shown in both CLI and README.
-func (s *StepDef) Note(text string) *StepDef <span class="cov0" title="0">{
-        s.note = text
-        return s
-}</span>
-
-// Run sets the function to execute for this step.
-func (s *StepDef) Run(fn func()) *StepDef <span class="cov0" title="0">{
-        s.runFn = fn
-        return s
-}</span>
-
-// SectionDef is a non-executable block of explanatory content.
-type SectionDef struct {
-        title string
-        body  string
-}
-
-func (s *SectionDef) isItem() {<span class="cov0" title="0">}</span>
-
-// Demo is the top-level container for an interactive example.
-type Demo struct {
-        title       string
-        description string
-        dir         string // directory name for run commands in generated README
-        actors      []ActorDef
-        items       []item
-        stepCount   int
-}
-
-// New creates a new Demo with the given title.
-func New(title string) *Demo <span class="cov0" title="0">{
-        return &amp;Demo{title: title}
-}</span>
-
-// Description sets the one-line description shown in the CLI header.
-func (d *Demo) Description(desc string) *Demo <span class="cov0" title="0">{
-        d.description = desc
-        return d
-}</span>
-
-// Dir sets the directory name used in generated README run commands.
-// e.g., Dir("01-client-credentials") produces "go run ./examples/01-client-credentials/"
-func (d *Demo) Dir(name string) *Demo <span class="cov0" title="0">{
-        d.dir = name
-        return d
-}</span>
-
-// Actors sets the sequence diagram participants.
-func (d *Demo) Actors(actors ...ActorDef) *Demo <span class="cov0" title="0">{
-        d.actors = actors
-        return d
-}</span>
-
-// Step adds an executable step to the demo. Returns the StepDef for chaining.
-func (d *Demo) Step(title string) *StepDef <span class="cov0" title="0">{
-        s := &amp;StepDef{title: title}
-        d.items = append(d.items, s)
-        d.stepCount++
-        return s
-}</span>
-
-// Section adds a non-executable explanatory block. Lines are joined with
-// newlines, so you can write multi-paragraph markdown naturally:
-//
-//        demo.Section("How it works",
-//            "The auth server signs tokens with HS256.",
-//            "",
-//            "**Key insight:** Both servers share the same KeyStore.",
-//        )
-func (d *Demo) Section(title string, lines ...string) *Demo <span class="cov0" title="0">{
-        d.items = append(d.items, &amp;SectionDef{title: title, body: strings.Join(lines, "\n")})
-        return d
-}</span>
-
-// Execute runs the demo interactively — pausing between steps for Enter.
-// If --non-interactive is passed (or stdin is not a terminal), runs without pausing.
-func (d *Demo) Execute() <span class="cov0" title="0">{
-        interactive := isTerminal()
-        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
-                if arg == "--non-interactive" </span><span class="cov0" title="0">{
-                        interactive = false
-                }</span>
-                <span class="cov0" title="0">if arg == "--readme" </span><span class="cov0" title="0">{
-                        fmt.Print(d.Markdown())
-                        return
-                }</span>
-        }
-
-        // Header
-        <span class="cov0" title="0">fmt.Printf("=== %s ===\n", d.title)
-        if d.description != "" </span><span class="cov0" title="0">{
-                fmt.Printf("    %s\n", d.description)
-        }</span>
-        <span class="cov0" title="0">fmt.Printf("    %d steps\n", d.stepCount)
-        fmt.Println()
-
-        reader := bufio.NewReader(os.Stdin)
-        stepNum := 0
-
-        for _, it := range d.items </span><span class="cov0" title="0">{
-                switch v := it.(type) </span>{
-                case *StepDef:<span class="cov0" title="0">
-                        stepNum++
-                        // Step header
-                        fmt.Printf("  Step %d/%d: %s", stepNum, d.stepCount, v.title)
-                        fmt.Printf("  [README → Step %d]\n", stepNum)
-
-                        // References
-                        if len(v.refs) &gt; 0 </span><span class="cov0" title="0">{
-                                fmt.Print("    Refs: ")
-                                for i, ref := range v.refs </span><span class="cov0" title="0">{
-                                        if i &gt; 0 </span><span class="cov0" title="0">{
-                                                fmt.Print(", ")
-                                        }</span>
-                                        <span class="cov0" title="0">fmt.Print(ref.Name)</span>
-                                }
-                                <span class="cov0" title="0">fmt.Println()</span>
-                        }
-
-                        // Diagram arrows
-                        <span class="cov0" title="0">for _, a := range v.arrows </span><span class="cov0" title="0">{
-                                arrow := "-&gt;&gt;"
-                                if a.dashed </span><span class="cov0" title="0">{
-                                        arrow = "--&gt;&gt;"
-                                }</span>
-                                <span class="cov0" title="0">fmt.Printf("    %s %s %s: %s\n", a.from, arrow, a.to, a.label)</span>
-                        }
-
-                        // Note
-                        <span class="cov0" title="0">if v.note != "" </span><span class="cov0" title="0">{
-                                fmt.Printf("\n    %s\n", v.note)
-                        }</span>
-
-                        // Pause
-                        <span class="cov0" title="0">if interactive </span><span class="cov0" title="0">{
-                                fmt.Print("\n    Press Enter to run this step...")
-                                reader.ReadString('\n')
-                        }</span>
-                        <span class="cov0" title="0">fmt.Println()
-
-                        // Execute
-                        if v.runFn != nil </span><span class="cov0" title="0">{
-                                v.runFn()
-                        }</span>
-                        <span class="cov0" title="0">fmt.Println()</span>
-
-                case *SectionDef:<span class="cov0" title="0">
-                        fmt.Printf("  --- %s ---\n", v.title)
-                        for _, line := range strings.Split(v.body, "\n") </span><span class="cov0" title="0">{
-                                fmt.Printf("    %s\n", line)
-                        }</span>
-                        <span class="cov0" title="0">fmt.Println()</span>
-                }
-        }
-
-        <span class="cov0" title="0">fmt.Println("=== Done ===")</span>
-}
-
-// Markdown generates the full README content from the demo definition.
-// This is the single source of truth — run with --readme to regenerate.
-func (d *Demo) Markdown() string <span class="cov0" title="0">{
-        var b strings.Builder
-
-        // Title and description
-        fmt.Fprintf(&amp;b, "# %s\n\n", d.title)
-        if d.description != "" </span><span class="cov0" title="0">{
-                fmt.Fprintf(&amp;b, "%s\n\n", d.description)
-        }</span>
-
-        // Collect steps for the summary
-        <span class="cov0" title="0">var steps []*StepDef
-        for _, it := range d.items </span><span class="cov0" title="0">{
-                if s, ok := it.(*StepDef); ok </span><span class="cov0" title="0">{
-                        steps = append(steps, s)
-                }</span>
-        }
-
-        // What you'll learn (from step notes)
-        <span class="cov0" title="0">hasNotes := false
-        for _, s := range steps </span><span class="cov0" title="0">{
-                if s.note != "" </span><span class="cov0" title="0">{
-                        hasNotes = true
-                        break</span>
-                }
-        }
-        <span class="cov0" title="0">if hasNotes </span><span class="cov0" title="0">{
-                b.WriteString("## What you'll learn\n\n")
-                for _, s := range steps </span><span class="cov0" title="0">{
-                        if s.note != "" </span><span class="cov0" title="0">{
-                                fmt.Fprintf(&amp;b, "- **%s** — %s\n", s.title, s.note)
-                        }</span>
-                }
-                <span class="cov0" title="0">b.WriteString("\n")</span>
-        }
-
-        // Sequence diagram
-        <span class="cov0" title="0">b.WriteString("## Flow\n\n```mermaid\nsequenceDiagram\n")
-        for _, a := range d.actors </span><span class="cov0" title="0">{
-                if a.ID != a.Label </span><span class="cov0" title="0">{
-                        fmt.Fprintf(&amp;b, "    participant %s as %s\n", a.ID, a.Label)
-                }</span> else<span class="cov0" title="0"> {
-                        fmt.Fprintf(&amp;b, "    participant %s\n", a.ID)
-                }</span>
-        }
-        <span class="cov0" title="0">stepNum := 0
-        for _, it := range d.items </span><span class="cov0" title="0">{
-                switch v := it.(type) </span>{
-                case *StepDef:<span class="cov0" title="0">
-                        stepNum++
-                        fmt.Fprintf(&amp;b, "\n    Note over %s,%s: Step %d: %s\n",
-                                d.actors[0].ID, d.actors[len(d.actors)-1].ID, stepNum, v.title)
-                        for _, a := range v.arrows </span><span class="cov0" title="0">{
-                                if a.dashed </span><span class="cov0" title="0">{
-                                        fmt.Fprintf(&amp;b, "    %s--&gt;&gt;%s: %s\n", a.from, a.to, a.label)
-                                }</span> else<span class="cov0" title="0"> {
-                                        fmt.Fprintf(&amp;b, "    %s-&gt;&gt;%s: %s\n", a.from, a.to, a.label)
-                                }</span>
-                        }
-                }
-        }
-        <span class="cov0" title="0">b.WriteString("```\n\n")
-
-        // Steps detail
-        b.WriteString("## Steps\n\n")
-        stepNum = 0
-        allRefs := make(map[string]Ref) // dedup by URL
-        for _, it := range d.items </span><span class="cov0" title="0">{
-                switch v := it.(type) </span>{
-                case *StepDef:<span class="cov0" title="0">
-                        stepNum++
-                        fmt.Fprintf(&amp;b, "### Step %d: %s\n\n", stepNum, v.title)
-                        if len(v.refs) &gt; 0 </span><span class="cov0" title="0">{
-                                b.WriteString("&gt; **References:** ")
-                                for i, ref := range v.refs </span><span class="cov0" title="0">{
-                                        if i &gt; 0 </span><span class="cov0" title="0">{
-                                                b.WriteString(", ")
-                                        }</span>
-                                        <span class="cov0" title="0">fmt.Fprintf(&amp;b, "[%s](%s)", ref.Name, ref.URL)
-                                        allRefs[ref.URL] = ref</span>
-                                }
-                                <span class="cov0" title="0">b.WriteString("\n\n")</span>
-                        }
-                        <span class="cov0" title="0">if v.note != "" </span><span class="cov0" title="0">{
-                                fmt.Fprintf(&amp;b, "%s\n\n", v.note)
-                        }</span>
-                case *SectionDef:<span class="cov0" title="0">
-                        fmt.Fprintf(&amp;b, "### %s\n\n%s\n\n", v.title, v.body)</span>
-                }
-        }
-
-        // Collected references (deduped)
-        <span class="cov0" title="0">if len(allRefs) &gt; 0 </span><span class="cov0" title="0">{
-                b.WriteString("## References\n\n")
-                for _, ref := range allRefs </span><span class="cov0" title="0">{
-                        fmt.Fprintf(&amp;b, "- [%s](%s)\n", ref.Name, ref.URL)
-                }</span>
-                <span class="cov0" title="0">b.WriteString("\n")</span>
-        }
-
-        // Run command
-        <span class="cov0" title="0">dir := d.dir
-        if dir == "" </span><span class="cov0" title="0">{
-                dir = "&lt;this-directory&gt;"
-        }</span>
-        <span class="cov0" title="0">b.WriteString("## Run it\n\n")
-        fmt.Fprintf(&amp;b, "```bash\ngo run ./examples/%s/\n```\n\n", dir)
-        b.WriteString("Pass `--non-interactive` to skip pauses:\n\n")
-        fmt.Fprintf(&amp;b, "```bash\ngo run ./examples/%s/ --non-interactive\n```\n", dir)
-
-        return b.String()</span>
-}
-
-// isTerminal returns true if stdin appears to be an interactive terminal.
-func isTerminal() bool <span class="cov0" title="0">{
-        fi, err := os.Stdin.Stat()
-        if err != nil </span><span class="cov0" title="0">{
-                return false
-        }</span>
-        <span class="cov0" title="0">return fi.Mode()&amp;os.ModeCharDevice != 0</span>
-}
-</pre>
-		
-		<pre class="file" id="file41" style="display: none">package httpauth
+		<pre class="file" id="file47" style="display: none">package httpauth
 
 import (
         "io"
@@ -9736,7 +10396,7 @@ func IsBodyTooLargeError(err error) bool <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file42" style="display: none">package httpauth
+		<pre class="file" id="file48" style="display: none">package httpauth
 
 import (
         "context"
@@ -9943,7 +10603,7 @@ func CSRFTemplateField(r *http.Request) template.HTML <span class="cov8" title="
 }</span>
 </pre>
 		
-		<pre class="file" id="file43" style="display: none">package httpauth
+		<pre class="file" id="file49" style="display: none">package httpauth
 
 import (
         "context"
@@ -10103,7 +10763,7 @@ func (a *Middleware) setLoggedInUserId(userId string, r *http.Request) *http.Req
 }</span>
 </pre>
 		
-		<pre class="file" id="file44" style="display: none">package httpauth
+		<pre class="file" id="file50" style="display: none">package httpauth
 
 import (
         "fmt"
@@ -10642,7 +11302,7 @@ func (a *OneAuth) GetLinkingUserID(r *http.Request) string <span class="cov0" ti
 }</span>
 </pre>
 		
-		<pre class="file" id="file45" style="display: none">package httpauth
+		<pre class="file" id="file51" style="display: none">package httpauth
 
 import "net/http"
 
@@ -10766,7 +11426,7 @@ func itoa(n int) string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file46" style="display: none">package keys
+		<pre class="file" id="file52" style="display: none">package keys
 
 import (
         "crypto/aes"
@@ -10975,7 +11635,7 @@ func isHMACAlgorithm(alg string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file47" style="display: none">package keys
+		<pre class="file" id="file53" style="display: none">package keys
 
 import (
         "crypto/sha256"
@@ -11090,7 +11750,7 @@ func (h *JWKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span cl
 }
 </pre>
 		
-		<pre class="file" id="file48" style="display: none">package keys
+		<pre class="file" id="file54" style="display: none">package keys
 
 import (
         "crypto"
@@ -11311,7 +11971,7 @@ func (s *JWKSKeyStore) GetExpectedAlg(clientID string) (string, error) <span cla
 }
 </pre>
 		
-		<pre class="file" id="file49" style="display: none">package keys
+		<pre class="file" id="file55" style="display: none">package keys
 
 import (
         "fmt"
@@ -11527,7 +12187,7 @@ func (s *InMemoryKeyStore) GetCurrentKid(clientID string) (string, error) <span 
 }
 </pre>
 		
-		<pre class="file" id="file50" style="display: none">package keys
+		<pre class="file" id="file56" style="display: none">package keys
 
 import (
         "sync"
@@ -11657,7 +12317,7 @@ func (c *CompositeKeyLookup) GetKeyByKid(kid string) (*KeyRecord, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file51" style="display: none">// Package keystoretest provides shared test suites for all KeyStore implementations.
+		<pre class="file" id="file57" style="display: none">// Package keystoretest provides shared test suites for all KeyStore implementations.
 // Each backend (inmem, gorm, fs, gae) calls these tests with its own factory function.
 package keystoretest
 
@@ -12027,7 +12687,7 @@ func TestRegisterAndGetAsymmetricKey(t *testing.T, factory Factory) <span class=
 }
 </pre>
 		
-		<pre class="file" id="file52" style="display: none">package localauth
+		<pre class="file" id="file58" style="display: none">package localauth
 
 import (
         "crypto/rand"
@@ -12717,7 +13377,7 @@ func parseIdentityKey(key string) []string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file53" style="display: none">package localauth
+		<pre class="file" id="file59" style="display: none">package localauth
 
 import (
         "encoding/json"
@@ -13404,7 +14064,7 @@ func (a *LocalAuth) HandleLinkCredentials(config LinkCredentialsConfig, getUser 
 }
 </pre>
 		
-		<pre class="file" id="file54" style="display: none">package localauth
+		<pre class="file" id="file60" style="display: none">package localauth
 
 import (
         "encoding/json"
@@ -13664,7 +14324,7 @@ func (a *LocalAuth) parseSignupForm(r *http.Request) (*core.Credentials, *core.A
 }
 </pre>
 		
-		<pre class="file" id="file55" style="display: none">package fs
+		<pre class="file" id="file61" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -13914,7 +14574,7 @@ func (s *FSAPIKeyStore) UpdateAPIKeyLastUsed(keyID string) error <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file56" style="display: none">package fs
+		<pre class="file" id="file62" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14045,7 +14705,7 @@ func (s *FSChannelStore) GetChannelsByIdentity(identityKey string) ([]*core.Chan
 }
 </pre>
 		
-		<pre class="file" id="file57" style="display: none">package fs
+		<pre class="file" id="file63" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14180,7 +14840,7 @@ func (s *FSIdentityStore) GetUserIdentities(userId string) ([]*core.Identity, er
 }
 </pre>
 		
-		<pre class="file" id="file58" style="display: none">package fs
+		<pre class="file" id="file64" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14413,7 +15073,7 @@ func (s *FSKeyStore) GetCurrentKid(clientID string) (string, error) <span class=
 }
 </pre>
 		
-		<pre class="file" id="file59" style="display: none">package fs
+		<pre class="file" id="file65" style="display: none">package fs
 
 import (
         "crypto/sha256"
@@ -14752,7 +15412,7 @@ func (s *FSRefreshTokenStore) forEachToken(fn func(token *core.RefreshToken, pat
 }
 </pre>
 		
-		<pre class="file" id="file60" style="display: none">package fs
+		<pre class="file" id="file66" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14890,7 +15550,7 @@ func (s *FSTokenStore) DeleteUserTokens(userID string, tokenType core.TokenType)
 }
 </pre>
 		
-		<pre class="file" id="file61" style="display: none">package fs
+		<pre class="file" id="file67" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14998,7 +15658,7 @@ func (s *FSUserStore) SaveUser(user core.User) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file62" style="display: none">package fs
+		<pre class="file" id="file68" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -15290,7 +15950,7 @@ func (s *FSUsernameStore) ChangeUsername(oldUsername, newUsername, userID string
 }
 </pre>
 		
-		<pre class="file" id="file63" style="display: none">package fs
+		<pre class="file" id="file69" style="display: none">package fs
 
 import (
         "fmt"
@@ -15377,7 +16037,7 @@ func writeAtomicFile(path string, data []byte) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file64" style="display: none">// Package testutil provides reusable test infrastructure for oneauth
+		<pre class="file" id="file70" style="display: none">// Package testutil provides reusable test infrastructure for oneauth
 // integration tests. It is intended to be imported by downstream projects
 // (mcpkit, relay, etc.) as well as oneauth's own test suites.
 //
@@ -15569,7 +16229,7 @@ func ParseJWTHeader(t *testing.T, tokenStr string) map[string]any <span class="c
 }
 </pre>
 		
-		<pre class="file" id="file65" style="display: none">package testutil
+		<pre class="file" id="file71" style="display: none">package testutil
 
 import (
         "crypto/rand"
@@ -15717,10 +16377,7 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) <span class="cov8" t
                 ClientKeyStore: ks,
         }
 
-        introspection := &amp;apiauth.IntrospectionHandler{
-                Auth:           apiAuth,
-                ClientKeyStore: ks,
-        }
+        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
         jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
 
@@ -15832,7 +16489,7 @@ func (s *TestAuthServer) MintTokenForSubject(subject string, scopes []string) (s
 }
 </pre>
 		
-		<pre class="file" id="file66" style="display: none">package testutil
+		<pre class="file" id="file72" style="display: none">package testutil
 
 import (
         "time"
@@ -15911,7 +16568,7 @@ func (s *TestAuthServer) signToken(claims jwt.MapClaims) (string, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file67" style="display: none">package utils
+		<pre class="file" id="file73" style="display: none">package utils
 
 import (
         "crypto"
@@ -16093,7 +16750,7 @@ func SigningMethodForAlg(alg string) (jwt.SigningMethod, error) <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file68" style="display: none">package utils
+		<pre class="file" id="file74" style="display: none">package utils
 
 import (
         "bytes"
@@ -16261,7 +16918,7 @@ func excelDecode(encoded string, alpha string, revmap map[rune]uint) uint64 <spa
 }
 </pre>
 		
-		<pre class="file" id="file69" style="display: none">package utils
+		<pre class="file" id="file75" style="display: none">package utils
 
 import (
         "crypto"
@@ -16406,7 +17063,7 @@ func ecJWKToPublicKey(jwk JWK) (crypto.PublicKey, string, error) <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file70" style="display: none">package utils
+		<pre class="file" id="file76" style="display: none">package utils
 
 import (
         "crypto/ecdsa"

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>feat/oneauth-core-phase2</strong> | Commit: <code>8d67444</code> | Date: 2026-04-27 14:02:19</div>
+<div class='meta'>Branch: <strong>feat/oneauth-core-phase2</strong> | Commit: <code>a3434a4</code> | Date: 2026-04-27 14:24:01</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
@@ -31,11 +31,11 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 14:01:04 PDT 2026
+Started: Mon Apr 27 14:22:39 PDT 2026
 Starting PostgreSQL...
-0287f0aaa02574d157b6660a07e1ad2ae446c70091642b369c681d14cd0d2645
+e6abec8e9975401276a1ab980d002b7c49c2c91c99accfd54f340a29f2ad8ef5
 Starting Keycloak...
-d422c7d0ea517c1968326cd235226110a01e3927ed7a8de39e016ed2502b6dae
+f7a42a8d278d592812c3915dd5cf9ff96b60f73f2c7f87c435fdbb1b0bf39925
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -44,12 +44,12 @@ d422c7d0ea517c1968326cd235226110a01e3927ed7a8de39e016ed2502b6dae
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.530s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	3.078s	coverage: 75.3% of statements
-ok  	github.com/panyam/oneauth/client	5.446s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.389s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	0.939s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	1.442s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	0.651s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	3.378s	coverage: 75.1% of statements
+ok  	github.com/panyam/oneauth/client	5.502s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.228s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	0.996s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	1.138s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -61,26 +61,26 @@ ok  	github.com/panyam/oneauth/examples	1.442s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
 ?   	github.com/panyam/oneauth/examples/refs	[no test files]
-ok  	github.com/panyam/oneauth/httpauth	1.100s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	1.983s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/httpauth	0.552s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	1.917s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	6.113s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	1.870s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	4.080s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	2.471s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	3.385s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	6.145s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	1.350s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	3.832s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	2.249s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	3.507s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	14.463s
+ok  	github.com/panyam/oneauth/tests/e2e	16.318s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.736s
+ok  	github.com/panyam/oneauth/stores/gorm	0.810s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -91,7 +91,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.038s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.435s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -103,10 +103,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.038s
     ○ ░
     ░    gitleaks
 
-[90m2:01PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m2:01PM[0m [32mINF[0m [1m199 commits scanned.[0m
-[90m2:01PM[0m [32mINF[0m [1mscanned ~3510729 bytes (3.51 MB) in 559ms[0m
-[90m2:01PM[0m [32mINF[0m [1mno leaks found[0m
+[90m2:23PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m2:23PM[0m [32mINF[0m [1m201 commits scanned.[0m
+[90m2:23PM[0m [32mINF[0m [1mscanned ~3593358 bytes (3.59 MB) in 656ms[0m
+[90m2:23PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -117,16 +117,16 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 14:01:39 Using in-memory KeyStore (not persistent)
-2026/04/27 14:01:39 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 14:01:39 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 14:01:39 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 14:02:10 
+2026/04/27 14:23:19 Using in-memory KeyStore (not persistent)
+2026/04/27 14:23:19 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 14:23:19 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 14:23:19 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 14:23:50 
 === EMAIL: Password Reset ===
-2026/04/27 14:02:10 To: zaproxy@example.com
-2026/04/27 14:02:10 Subject: Reset your password
-2026/04/27 14:02:10 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=4e9a15294a762b880521e7ff4905c7c5ccab72bf83d736b82463e664df97dd51
-2026/04/27 14:02:10 ==============================
+2026/04/27 14:23:50 To: zaproxy@example.com
+2026/04/27 14:23:50 Subject: Reset your password
+2026/04/27 14:23:50 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=c8ae885178e7648c3853a250f04f5903a641a24e983c98aa287f9e277a19ca67
+2026/04/27 14:23:50 ==============================
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -194,24 +194,22 @@ IGNORE: Cookie No HttpOnly Flag [10010] x 2
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 7 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
 	http://host.docker.internal:19876/auth/login (403 Forbidden)
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: CSP: style-src unsafe-inline [10055] x 5 
-	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/robots.txt (404 Not Found)
+IGNORE: CSP: style-src unsafe-inline [10055] x 3 
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (403 Forbidden)
@@ -220,23 +218,23 @@ IGNORE: Session Management Response Identified [10112] x 3
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 16 
+	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 14:02:19 PDT 2026
-Error response from daemon: No such container: oneauth-test-pg
-Error response from daemon: No such container: oneauth-test-keycloak
+Finished: Mon Apr 27 14:24:00 PDT 2026
+oneauth-test-pg
+oneauth-test-keycloak
 </pre>
 </body></html>

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>feat/rar-phase1</strong> | Commit: <code>b554d82</code> | Date: 2026-04-27 01:13:54</div>
+<div class='meta'>Branch: <strong>feat/oneauth-core-phase2</strong> | Commit: <code>8d67444</code> | Date: 2026-04-27 14:02:19</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
@@ -31,28 +31,11 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 01:12:00 PDT 2026
+Started: Mon Apr 27 14:01:04 PDT 2026
 Starting PostgreSQL...
-16839d43f60a3781432ec61d3cce21b23385fe6ae80ff7cce23ae5b9e2c07079
+0287f0aaa02574d157b6660a07e1ad2ae446c70091642b369c681d14cd0d2645
 Starting Keycloak...
-Unable to find image 'quay.io/keycloak/keycloak:26.6' locally
-26.6: Pulling from keycloak/keycloak
-aa06a88f8d3d: Pulling fs layer
-b45b14b2d95c: Pulling fs layer
-7c001a69653d: Pulling fs layer
-7f89c20ca4d5: Pulling fs layer
-12b9e5d4c972: Download complete
-aa06a88f8d3d: Download complete
-b45b14b2d95c: Download complete
-b45b14b2d95c: Pull complete
-7c001a69653d: Download complete
-7f89c20ca4d5: Download complete
-7c001a69653d: Pull complete
-aa06a88f8d3d: Pull complete
-7f89c20ca4d5: Pull complete
-Digest: sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
-Status: Downloaded newer image for quay.io/keycloak/keycloak:26.6
-a8e7e7d9fd525b97fefcd0d3211021f616e50c58d806efd789b49129d2572325
+d422c7d0ea517c1968326cd235226110a01e3927ed7a8de39e016ed2502b6dae
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -61,12 +44,12 @@ a8e7e7d9fd525b97fefcd0d3211021f616e50c58d806efd789b49129d2572325
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.997s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	6.243s	coverage: 71.1% of statements
-ok  	github.com/panyam/oneauth/client	5.701s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.202s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	1.931s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	2.125s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	0.530s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	3.078s	coverage: 75.3% of statements
+ok  	github.com/panyam/oneauth/client	5.446s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.389s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	0.939s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	1.442s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -77,27 +60,27 @@ ok  	github.com/panyam/oneauth/examples	2.125s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/08-rich-authorization-requests		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
-	github.com/panyam/oneauth/examples/demokit		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/httpauth	1.079s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	3.655s	coverage: 75.6% of statements
+?   	github.com/panyam/oneauth/examples/refs	[no test files]
+ok  	github.com/panyam/oneauth/httpauth	1.100s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	1.983s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	8.879s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	2.355s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	5.181s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	3.950s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	4.311s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	6.113s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	1.870s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	4.080s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	2.471s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	3.385s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	19.684s
+ok  	github.com/panyam/oneauth/tests/e2e	14.463s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	1.226s
+ok  	github.com/panyam/oneauth/stores/gorm	0.736s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -108,7 +91,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.532s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.038s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -120,10 +103,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.532s
     ○ ░
     ░    gitleaks
 
-[90m1:13AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m1:13AM[0m [32mINF[0m [1m187 commits scanned.[0m
-[90m1:13AM[0m [32mINF[0m [1mscanned ~3195271 bytes (3.20 MB) in 791ms[0m
-[90m1:13AM[0m [32mINF[0m [1mno leaks found[0m
+[90m2:01PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m2:01PM[0m [32mINF[0m [1m199 commits scanned.[0m
+[90m2:01PM[0m [32mINF[0m [1mscanned ~3510729 bytes (3.51 MB) in 559ms[0m
+[90m2:01PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -134,17 +117,16 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 01:13:16 Using in-memory KeyStore (not persistent)
-2026/04/27 01:13:16 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 01:13:16 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 01:13:16 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 01:13:43 
+2026/04/27 14:01:39 Using in-memory KeyStore (not persistent)
+2026/04/27 14:01:39 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 14:01:39 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 14:01:39 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 14:02:10 
 === EMAIL: Password Reset ===
-2026/04/27 01:13:43 To: zaproxy@example.com
-2026/04/27 01:13:43 Subject: Reset your password
-2026/04/27 01:13:43 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=b2152c5919fd480729ad04fa13631008b08c6249f99b50cf55198ec2aaeccec8
-2026/04/27 01:13:43 ==============================
-2026/04/27 01:13:43 error validating user:  invalid credentials
+2026/04/27 14:02:10 To: zaproxy@example.com
+2026/04/27 14:02:10 Subject: Reset your password
+2026/04/27 14:02:10 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=4e9a15294a762b880521e7ff4905c7c5ccab72bf83d736b82463e664df97dd51
+2026/04/27 14:02:10 ==============================
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -208,23 +190,23 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-IGNORE: Cookie No HttpOnly Flag [10010] x 1 
+IGNORE: Cookie No HttpOnly Flag [10010] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
-	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Non-Storable Content [10049] x 6 
+IGNORE: Non-Storable Content [10049] x 7 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
+	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
@@ -232,28 +214,29 @@ IGNORE: CSP: style-src unsafe-inline [10055] x 5
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
+	http://host.docker.internal:19876/auth/login (403 Forbidden)
+IGNORE: Session Management Response Identified [10112] x 3 
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: Session Management Response Identified [10112] x 2 
-	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 16 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
+	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
-	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 01:13:52 PDT 2026
-oneauth-test-pg
-oneauth-test-keycloak
+Finished: Mon Apr 27 14:02:19 PDT 2026
+Error response from daemon: No such container: oneauth-test-pg
+Error response from daemon: No such container: oneauth-test-keycloak
 </pre>
 </body></html>

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,9 +1,9 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 14:01:04 PDT 2026
+Started: Mon Apr 27 14:22:39 PDT 2026
 Starting PostgreSQL...
-0287f0aaa02574d157b6660a07e1ad2ae446c70091642b369c681d14cd0d2645
+e6abec8e9975401276a1ab980d002b7c49c2c91c99accfd54f340a29f2ad8ef5
 Starting Keycloak...
-d422c7d0ea517c1968326cd235226110a01e3927ed7a8de39e016ed2502b6dae
+f7a42a8d278d592812c3915dd5cf9ff96b60f73f2c7f87c435fdbb1b0bf39925
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -12,12 +12,12 @@ d422c7d0ea517c1968326cd235226110a01e3927ed7a8de39e016ed2502b6dae
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.530s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	3.078s	coverage: 75.3% of statements
-ok  	github.com/panyam/oneauth/client	5.446s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.389s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	0.939s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	1.442s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	0.651s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	3.378s	coverage: 75.1% of statements
+ok  	github.com/panyam/oneauth/client	5.502s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.228s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	0.996s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	1.138s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -29,26 +29,26 @@ ok  	github.com/panyam/oneauth/examples	1.442s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
 ?   	github.com/panyam/oneauth/examples/refs	[no test files]
-ok  	github.com/panyam/oneauth/httpauth	1.100s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	1.983s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/httpauth	0.552s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	1.917s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	6.113s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	1.870s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	4.080s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	2.471s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	3.385s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	6.145s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	1.350s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	3.832s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	2.249s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	3.507s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	14.463s
+ok  	github.com/panyam/oneauth/tests/e2e	16.318s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.736s
+ok  	github.com/panyam/oneauth/stores/gorm	0.810s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -59,7 +59,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.038s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.435s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -71,10 +71,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.038s
     ○ ░
     ░    gitleaks
 
-[90m2:01PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m2:01PM[0m [32mINF[0m [1m199 commits scanned.[0m
-[90m2:01PM[0m [32mINF[0m [1mscanned ~3510729 bytes (3.51 MB) in 559ms[0m
-[90m2:01PM[0m [32mINF[0m [1mno leaks found[0m
+[90m2:23PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m2:23PM[0m [32mINF[0m [1m201 commits scanned.[0m
+[90m2:23PM[0m [32mINF[0m [1mscanned ~3593358 bytes (3.59 MB) in 656ms[0m
+[90m2:23PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -85,16 +85,16 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 14:01:39 Using in-memory KeyStore (not persistent)
-2026/04/27 14:01:39 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 14:01:39 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 14:01:39 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 14:02:10 
+2026/04/27 14:23:19 Using in-memory KeyStore (not persistent)
+2026/04/27 14:23:19 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 14:23:19 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 14:23:19 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 14:23:50 
 === EMAIL: Password Reset ===
-2026/04/27 14:02:10 To: zaproxy@example.com
-2026/04/27 14:02:10 Subject: Reset your password
-2026/04/27 14:02:10 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=4e9a15294a762b880521e7ff4905c7c5ccab72bf83d736b82463e664df97dd51
-2026/04/27 14:02:10 ==============================
+2026/04/27 14:23:50 To: zaproxy@example.com
+2026/04/27 14:23:50 Subject: Reset your password
+2026/04/27 14:23:50 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=c8ae885178e7648c3853a250f04f5903a641a24e983c98aa287f9e277a19ca67
+2026/04/27 14:23:50 ==============================
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -162,24 +162,22 @@ IGNORE: Cookie No HttpOnly Flag [10010] x 2
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 7 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
 	http://host.docker.internal:19876/auth/login (403 Forbidden)
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: CSP: style-src unsafe-inline [10055] x 5 
-	http://host.docker.internal:19876 (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/robots.txt (404 Not Found)
+IGNORE: CSP: style-src unsafe-inline [10055] x 3 
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (403 Forbidden)
@@ -188,21 +186,21 @@ IGNORE: Session Management Response Identified [10112] x 3
 	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 16 
+	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 14:02:19 PDT 2026
-Error response from daemon: No such container: oneauth-test-pg
-Error response from daemon: No such container: oneauth-test-keycloak
+Finished: Mon Apr 27 14:24:00 PDT 2026
+oneauth-test-pg
+oneauth-test-keycloak

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,26 +1,9 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 01:12:00 PDT 2026
+Started: Mon Apr 27 14:01:04 PDT 2026
 Starting PostgreSQL...
-16839d43f60a3781432ec61d3cce21b23385fe6ae80ff7cce23ae5b9e2c07079
+0287f0aaa02574d157b6660a07e1ad2ae446c70091642b369c681d14cd0d2645
 Starting Keycloak...
-Unable to find image 'quay.io/keycloak/keycloak:26.6' locally
-26.6: Pulling from keycloak/keycloak
-aa06a88f8d3d: Pulling fs layer
-b45b14b2d95c: Pulling fs layer
-7c001a69653d: Pulling fs layer
-7f89c20ca4d5: Pulling fs layer
-12b9e5d4c972: Download complete
-aa06a88f8d3d: Download complete
-b45b14b2d95c: Download complete
-b45b14b2d95c: Pull complete
-7c001a69653d: Download complete
-7f89c20ca4d5: Download complete
-7c001a69653d: Pull complete
-aa06a88f8d3d: Pull complete
-7f89c20ca4d5: Pull complete
-Digest: sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
-Status: Downloaded newer image for quay.io/keycloak/keycloak:26.6
-a8e7e7d9fd525b97fefcd0d3211021f616e50c58d806efd789b49129d2572325
+d422c7d0ea517c1968326cd235226110a01e3927ed7a8de39e016ed2502b6dae
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -29,12 +12,12 @@ a8e7e7d9fd525b97fefcd0d3211021f616e50c58d806efd789b49129d2572325
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.997s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	6.243s	coverage: 71.1% of statements
-ok  	github.com/panyam/oneauth/client	5.701s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.202s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	1.931s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	2.125s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	0.530s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	3.078s	coverage: 75.3% of statements
+ok  	github.com/panyam/oneauth/client	5.446s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.389s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	0.939s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	1.442s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -45,27 +28,27 @@ ok  	github.com/panyam/oneauth/examples	2.125s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/08-rich-authorization-requests		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
-	github.com/panyam/oneauth/examples/demokit		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/httpauth	1.079s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	3.655s	coverage: 75.6% of statements
+?   	github.com/panyam/oneauth/examples/refs	[no test files]
+ok  	github.com/panyam/oneauth/httpauth	1.100s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	1.983s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	8.879s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	2.355s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	5.181s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	3.950s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	4.311s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	6.113s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	1.870s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	4.080s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	2.471s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	3.385s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	19.684s
+ok  	github.com/panyam/oneauth/tests/e2e	14.463s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	1.226s
+ok  	github.com/panyam/oneauth/stores/gorm	0.736s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -76,7 +59,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.532s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.038s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -88,10 +71,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.532s
     ○ ░
     ░    gitleaks
 
-[90m1:13AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m1:13AM[0m [32mINF[0m [1m187 commits scanned.[0m
-[90m1:13AM[0m [32mINF[0m [1mscanned ~3195271 bytes (3.20 MB) in 791ms[0m
-[90m1:13AM[0m [32mINF[0m [1mno leaks found[0m
+[90m2:01PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m2:01PM[0m [32mINF[0m [1m199 commits scanned.[0m
+[90m2:01PM[0m [32mINF[0m [1mscanned ~3510729 bytes (3.51 MB) in 559ms[0m
+[90m2:01PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -102,17 +85,16 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 01:13:16 Using in-memory KeyStore (not persistent)
-2026/04/27 01:13:16 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 01:13:16 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 01:13:16 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 01:13:43 
+2026/04/27 14:01:39 Using in-memory KeyStore (not persistent)
+2026/04/27 14:01:39 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 14:01:39 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 14:01:39 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 14:02:10 
 === EMAIL: Password Reset ===
-2026/04/27 01:13:43 To: zaproxy@example.com
-2026/04/27 01:13:43 Subject: Reset your password
-2026/04/27 01:13:43 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=b2152c5919fd480729ad04fa13631008b08c6249f99b50cf55198ec2aaeccec8
-2026/04/27 01:13:43 ==============================
-2026/04/27 01:13:43 error validating user:  invalid credentials
+2026/04/27 14:02:10 To: zaproxy@example.com
+2026/04/27 14:02:10 Subject: Reset your password
+2026/04/27 14:02:10 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=4e9a15294a762b880521e7ff4905c7c5ccab72bf83d736b82463e664df97dd51
+2026/04/27 14:02:10 ==============================
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -176,23 +158,23 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-IGNORE: Cookie No HttpOnly Flag [10010] x 1 
+IGNORE: Cookie No HttpOnly Flag [10010] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
-	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Non-Storable Content [10049] x 6 
+IGNORE: Non-Storable Content [10049] x 7 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
+	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
@@ -200,26 +182,27 @@ IGNORE: CSP: style-src unsafe-inline [10055] x 5
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
+	http://host.docker.internal:19876/auth/login (403 Forbidden)
+IGNORE: Session Management Response Identified [10112] x 3 
 	http://host.docker.internal:19876/auth/login (200 OK)
-IGNORE: Session Management Response Identified [10112] x 2 
-	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
 	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
+IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 16 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
+	http://host.docker.internal:19876/auth/login (403 Forbidden)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
-	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 01:13:52 PDT 2026
-oneauth-test-pg
-oneauth-test-keycloak
+Finished: Mon Apr 27 14:02:19 PDT 2026
+Error response from daemon: No such container: oneauth-test-pg
+Error response from daemon: No such container: oneauth-test-keycloak

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -239,10 +239,7 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 	mux.Handle("/apps", httpauth.LimitBody(httpauth.DefaultMaxBodySize)(e.registrar.Handler()))
 
 	// Token Introspection (RFC 7662)
-	introspectionHandler := &apiauth.IntrospectionHandler{
-		Auth:           e.apiAuth,
-		ClientKeyStore: e.KeyStore,
-	}
+	introspectionHandler := apiauth.NewIntrospectionHandler(e.apiAuth, e.KeyStore)
 	mux.Handle("POST /oauth/introspect", introspectionHandler)
 
 	// Token Revocation (RFC 7009)

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -243,10 +243,7 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 	mux.Handle("POST /oauth/introspect", introspectionHandler)
 
 	// Token Revocation (RFC 7009)
-	revocationHandler := &apiauth.RevocationHandler{
-		Auth:           e.apiAuth,
-		ClientKeyStore: e.KeyStore,
-	}
+	revocationHandler := apiauth.NewRevocationHandler(e.apiAuth, e.KeyStore)
 	mux.Handle("POST /oauth/revoke", revocationHandler)
 
 	// JWKS

--- a/tests/keycloak/go.mod
+++ b/tests/keycloak/go.mod
@@ -1,6 +1,6 @@
 module github.com/panyam/oneauth/tests/keycloak
 
-go 1.26.1
+go 1.26.2
 
 replace github.com/panyam/oneauth => ../..
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -146,10 +146,7 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		ClientKeyStore: ks,
 	}
 
-	introspection := &apiauth.IntrospectionHandler{
-		Auth:           apiAuth,
-		ClientKeyStore: ks,
-	}
+	introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
 
 	jwksHandler := &keys.JWKSHandler{KeyStore: ks}
 


### PR DESCRIPTION
## Summary

Phase 2 of #110: HTTP handlers now delegate to the transport-independent core interfaces from Phase 1. All three handlers refactored:

**IntrospectionHandler** → `TokenIntrospector` + `ClientAuthenticator`
**RevocationHandler** → `TokenRevoker` + `ClientAuthenticator`
**APIMiddleware** → `TokenValidator` (multi-tenant KeyStore mode)

Bridge constructors (`NewIntrospectionHandler(auth, ks)`, `NewRevocationHandler(auth, ks)`) preserve existing patterns for code that constructs handlers from `*APIAuth`.

OneAuth HTTP convenience methods:
```go
oa := apiauth.NewOneAuth(cfg)
mux.Handle("POST /oauth/introspect", oa.IntrospectionHTTPHandler())
mux.Handle("POST /oauth/revoke", oa.RevocationHTTPHandler())
mux.Handle("/resource", oa.HTTPMiddleware().ValidateToken(handler))
```

## Test plan
- [x] All 19 introspection tests pass unchanged
- [x] All 9 revocation tests pass unchanged
- [x] All middleware tests pass (single-tenant + multi-tenant)
- [x] All E2E tests pass unchanged
- [x] 3 new HTTP round-trip tests for OneAuth convenience methods
- [x] Total: 18 OneAuth-specific tests (15 library + 3 HTTP)
- [x] Zero relaxed assertions

Refs #110

## Done
- [x] IntrospectionHandler delegates to core
- [x] RevocationHandler delegates to core
- [x] APIMiddleware delegates to TokenValidator
- [x] OneAuth HTTP convenience methods