### PR TITLE
feat: PasswordGrant — transport-independent, no device info coupling

### DIFF
--- a/apiauth/interfaces.go
+++ b/apiauth/interfaces.go
@@ -27,6 +27,31 @@ type TokenIssuer interface {
 	// RefreshGrant rotates a refresh token and returns a new access + refresh token pair.
 	// Handles theft detection (revoked token → revoke entire family).
 	RefreshGrant(refreshToken string) (*core.TokenPair, error)
+
+	// PasswordGrant authenticates a user with username/password and returns
+	// an access token. Does NOT create a refresh token — that's the caller's
+	// responsibility (via RefreshTokenStore.CreateRefreshToken), since refresh
+	// tokens may carry transport-specific metadata (device info, IP, etc.).
+	PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResult, error)
+}
+
+// PasswordGrantRequest holds the inputs for a password grant.
+type PasswordGrantRequest struct {
+	Username             string
+	Password             string
+	Scopes               []string                  // requested (intersected with allowed)
+	AuthorizationDetails []core.AuthorizationDetail // RFC 9396
+	ClientID             string                     // optional — associated client
+}
+
+// PasswordGrantResult holds the output of a successful password grant.
+// The caller uses UserID + GrantedScopes to create a refresh token if needed.
+type PasswordGrantResult struct {
+	UserID               string
+	AccessToken          string
+	ExpiresIn            int64
+	GrantedScopes        []string
+	AuthorizationDetails []core.AuthorizationDetail
 }
 
 // TokenValidator validates tokens and checks authorization.

--- a/apiauth/oneauth.go
+++ b/apiauth/oneauth.go
@@ -59,6 +59,10 @@ type OneAuthConfig struct {
 	Blacklist    core.TokenBlacklist    // for access token revocation (optional)
 	RefreshStore core.RefreshTokenStore // for refresh token management (optional)
 
+	// Password grant callbacks (optional — only needed if password grant is used)
+	ValidateCredentials core.CredentialsValidator // validates username/password
+	GetUserScopes       core.GetUserScopesFunc   // returns allowed scopes for a user
+
 	// Hooks — lifecycle callbacks
 	Hooks Hooks
 }
@@ -78,9 +82,11 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 		Issuer:          cfg.Issuer,
 		Audience:        cfg.Audience,
 		AccessExpiry:    cfg.AccessExpiry,
-		ClientKeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
-		RefreshStore:    cfg.RefreshStore,
-		Hooks:           cfg.Hooks.Token,
+		ClientKeyLookup:     cfg.KeyStore, // KeyStorage implements KeyLookup
+		RefreshStore:        cfg.RefreshStore,
+		ValidateCredentials: cfg.ValidateCredentials,
+		GetUserScopes:       cfg.GetUserScopes,
+		Hooks:               cfg.Hooks.Token,
 	})
 
 	// Wire the validator — needs read-only key lookup + blacklist

--- a/apiauth/oneauth_grants_test.go
+++ b/apiauth/oneauth_grants_test.go
@@ -1,0 +1,193 @@
+package apiauth_test
+
+// Tests for OAuth grant types via the transport-independent OneAuth core.
+// These tests prove that password, refresh, and client_credentials grants
+// work as library calls without any HTTP endpoint.
+//
+// See: https://github.com/panyam/oneauth/issues/110
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Refresh Token Grant
+// =============================================================================
+
+// TestOneAuth_RefreshGrant verifies the refresh token grant works
+// as a library call — rotate refresh token, get new access token.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-6
+func TestOneAuth_RefreshGrant(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	rt, err := oa.RefreshStore.CreateRefreshToken("refresh-user", "test-client", nil, []string{"read", "write"})
+	require.NoError(t, err)
+
+	resp, err := oa.Issuer.RefreshGrant(rt.Token)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccessToken)
+	assert.NotEmpty(t, resp.RefreshToken, "should get a new refresh token")
+	assert.NotEqual(t, rt.Token, resp.RefreshToken, "new refresh token should differ from old")
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, "read write", resp.Scope)
+
+	info, err := oa.Validator.ValidateToken(resp.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "refresh-user", info.UserID)
+}
+
+// TestOneAuth_RefreshGrant_RevokedToken verifies that refreshing a revoked
+// token fails and revokes the entire token family (theft detection).
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-6
+func TestOneAuth_RefreshGrant_RevokedToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	rt, _ := oa.RefreshStore.CreateRefreshToken("user-theft", "test-client", nil, []string{"read"})
+	oa.RefreshStore.RevokeRefreshToken(rt.Token)
+
+	_, err := oa.Issuer.RefreshGrant(rt.Token)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token reuse")
+}
+
+// TestOneAuth_RefreshGrant_InvalidToken verifies that an unknown refresh
+// token returns an error.
+func TestOneAuth_RefreshGrant_InvalidToken(t *testing.T) {
+	oa := newTestOneAuth(t)
+
+	_, err := oa.Issuer.RefreshGrant("not-a-real-refresh-token")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_grant")
+}
+
+// =============================================================================
+// Password Grant
+// =============================================================================
+
+// newTestOneAuthWithPasswordGrant creates a OneAuth with password grant support.
+func newTestOneAuthWithPasswordGrant(t *testing.T) *apiauth.OneAuth {
+	t.Helper()
+	signingSecret := []byte("test-signing-secret-32chars-min!")
+	ks := keys.NewInMemoryKeyStore()
+	ks.PutKey(&keys.KeyRecord{ClientID: "test-issuer", Key: signingSecret, Algorithm: "HS256"})
+
+	return apiauth.NewOneAuth(apiauth.OneAuthConfig{
+		KeyStore:     ks,
+		SigningKey:   signingSecret,
+		Issuer:       "test-issuer",
+		Blacklist:    core.NewInMemoryBlacklist(),
+		RefreshStore: newInMemoryRefreshStore(),
+		ValidateCredentials: func(username, password, usernameType string) (core.User, error) {
+			if username == "alice@example.com" && password == "correct-password" {
+				return &core.BasicUser{ID: "user-alice", ProfileData: map[string]any{"email": username}}, nil
+			}
+			return nil, fmt.Errorf("invalid credentials")
+		},
+		GetUserScopes: func(userID string) ([]string, error) {
+			return []string{"read", "write", "profile"}, nil
+		},
+	})
+}
+
+// TestOneAuth_PasswordGrant verifies the password grant works as a
+// library call — authenticate user, get access token, validate it.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.3
+func TestOneAuth_PasswordGrant(t *testing.T) {
+	oa := newTestOneAuthWithPasswordGrant(t)
+
+	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+		Username: "alice@example.com",
+		Password: "correct-password",
+		Scopes:   []string{"read"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "user-alice", result.UserID)
+	assert.NotEmpty(t, result.AccessToken)
+	assert.True(t, result.ExpiresIn > 0)
+	assert.Equal(t, []string{"read"}, result.GrantedScopes)
+
+	info, err := oa.Validator.ValidateToken(result.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "user-alice", info.UserID)
+}
+
+// TestOneAuth_PasswordGrant_BadPassword verifies that wrong credentials
+// are rejected.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6749#section-4.3
+func TestOneAuth_PasswordGrant_BadPassword(t *testing.T) {
+	oa := newTestOneAuthWithPasswordGrant(t)
+
+	_, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+		Username: "alice@example.com",
+		Password: "wrong-password",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_grant")
+}
+
+// TestOneAuth_PasswordGrant_ScopeIntersection verifies that requested
+// scopes are intersected with allowed scopes.
+func TestOneAuth_PasswordGrant_ScopeIntersection(t *testing.T) {
+	oa := newTestOneAuthWithPasswordGrant(t)
+
+	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+		Username: "alice@example.com",
+		Password: "correct-password",
+		Scopes:   []string{"read", "admin"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"read"}, result.GrantedScopes, "admin should be filtered out")
+}
+
+// TestOneAuth_PasswordGrant_DefaultScopes verifies that when no scopes
+// are requested, all allowed scopes are granted.
+func TestOneAuth_PasswordGrant_DefaultScopes(t *testing.T) {
+	oa := newTestOneAuthWithPasswordGrant(t)
+
+	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+		Username: "alice@example.com",
+		Password: "correct-password",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"read", "write", "profile"}, result.GrantedScopes)
+}
+
+// TestOneAuth_PasswordGrant_CallerCreatesRefreshToken verifies the
+// intended usage pattern: grant returns access token, caller creates
+// refresh token separately with transport-specific metadata.
+func TestOneAuth_PasswordGrant_CallerCreatesRefreshToken(t *testing.T) {
+	oa := newTestOneAuthWithPasswordGrant(t)
+
+	// Step 1: Password grant (core — no device info)
+	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+		Username: "alice@example.com",
+		Password: "correct-password",
+		Scopes:   []string{"read", "write"},
+	})
+	require.NoError(t, err)
+
+	// Step 2: Caller creates refresh token with transport metadata
+	rt, err := oa.RefreshStore.CreateRefreshToken(
+		result.UserID, "my-app",
+		map[string]any{"user_agent": "TestBot/1.0", "ip": "127.0.0.1"},
+		result.GrantedScopes,
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rt.Token)
+
+	// Step 3: Later, refresh the token via core
+	refreshResult, err := oa.Issuer.RefreshGrant(rt.Token)
+	require.NoError(t, err)
+	assert.NotEmpty(t, refreshResult.AccessToken)
+}

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -313,64 +313,6 @@ func TestOneAuth_Hooks_OnBlacklistHit(t *testing.T) {
 }
 
 // =============================================================================
-// Refresh Token Grant — library call, no HTTP
-// =============================================================================
-
-// TestOneAuth_RefreshGrant verifies the refresh token grant works
-// as a library call — rotate refresh token, get new access token.
-//
-// See: https://www.rfc-editor.org/rfc/rfc6749#section-6
-func TestOneAuth_RefreshGrant(t *testing.T) {
-	oa := newTestOneAuth(t)
-
-	// Create a refresh token
-	rt, err := oa.RefreshStore.CreateRefreshToken("refresh-user", "test-client", nil, []string{"read", "write"})
-	require.NoError(t, err)
-
-	// Refresh it via library call
-	resp, err := oa.Issuer.RefreshGrant(rt.Token)
-	require.NoError(t, err)
-	assert.NotEmpty(t, resp.AccessToken)
-	assert.NotEmpty(t, resp.RefreshToken, "should get a new refresh token")
-	assert.NotEqual(t, rt.Token, resp.RefreshToken, "new refresh token should differ from old")
-	assert.Equal(t, "Bearer", resp.TokenType)
-	assert.Equal(t, "read write", resp.Scope)
-
-	// New access token should validate
-	info, err := oa.Validator.ValidateToken(resp.AccessToken)
-	require.NoError(t, err)
-	assert.Equal(t, "refresh-user", info.UserID)
-}
-
-// TestOneAuth_RefreshGrant_RevokedToken verifies that refreshing a revoked
-// token fails and revokes the entire token family (theft detection).
-//
-// See: https://www.rfc-editor.org/rfc/rfc6749#section-6
-func TestOneAuth_RefreshGrant_RevokedToken(t *testing.T) {
-	oa := newTestOneAuth(t)
-
-	rt, _ := oa.RefreshStore.CreateRefreshToken("user-theft", "test-client", nil, []string{"read"})
-
-	// Revoke the refresh token (simulating theft detection)
-	oa.RefreshStore.RevokeRefreshToken(rt.Token)
-
-	// Attempt to refresh — should fail
-	_, err := oa.Issuer.RefreshGrant(rt.Token)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "token reuse")
-}
-
-// TestOneAuth_RefreshGrant_InvalidToken verifies that an unknown refresh
-// token returns an error.
-func TestOneAuth_RefreshGrant_InvalidToken(t *testing.T) {
-	oa := newTestOneAuth(t)
-
-	_, err := oa.Issuer.RefreshGrant("not-a-real-refresh-token")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid_grant")
-}
-
-// =============================================================================
 // HTTP Convenience Methods — prove the OneAuth→HTTP bridge works
 // =============================================================================
 

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -210,26 +210,30 @@ func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) {
 
 // jwtIssuer implements TokenIssuer using JWT signing.
 type jwtIssuer struct {
-	signingKey      any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
-	signingAlg      string // "HS256", "RS256", "ES256"
-	issuer          string
-	audience        string
-	accessExpiry    time.Duration
-	clientKeyLookup keys.KeyLookup
-	refreshStore    core.RefreshTokenStore
-	hooks           TokenHooks
+	signingKey          any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
+	signingAlg          string // "HS256", "RS256", "ES256"
+	issuer              string
+	audience            string
+	accessExpiry        time.Duration
+	clientKeyLookup     keys.KeyLookup
+	refreshStore        core.RefreshTokenStore
+	validateCredentials core.CredentialsValidator
+	getUserScopes       core.GetUserScopesFunc
+	hooks               TokenHooks
 }
 
 // JWTIssuerConfig configures a jwtIssuer.
 type JWTIssuerConfig struct {
-	SigningKey      any
-	SigningAlg      string
-	Issuer         string
-	Audience       string
-	AccessExpiry   time.Duration
-	ClientKeyLookup keys.KeyLookup         // for client_credentials authentication
-	RefreshStore   core.RefreshTokenStore  // for refresh_token grant
-	Hooks          TokenHooks
+	SigningKey           any
+	SigningAlg           string
+	Issuer              string
+	Audience            string
+	AccessExpiry        time.Duration
+	ClientKeyLookup     keys.KeyLookup         // for client_credentials authentication
+	RefreshStore        core.RefreshTokenStore  // for refresh_token grant
+	ValidateCredentials core.CredentialsValidator // for password grant
+	GetUserScopes       core.GetUserScopesFunc   // for password grant (optional)
+	Hooks               TokenHooks
 }
 
 // NewJWTIssuer creates a TokenIssuer that signs JWTs.
@@ -239,14 +243,16 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer {
 		expiry = core.TokenExpiryAccessToken
 	}
 	return &jwtIssuer{
-		signingKey:      cfg.SigningKey,
-		signingAlg:      cfg.SigningAlg,
-		issuer:          cfg.Issuer,
-		audience:        cfg.Audience,
-		accessExpiry:    expiry,
-		clientKeyLookup: cfg.ClientKeyLookup,
-		refreshStore:    cfg.RefreshStore,
-		hooks:           cfg.Hooks,
+		signingKey:          cfg.SigningKey,
+		signingAlg:          cfg.SigningAlg,
+		issuer:              cfg.Issuer,
+		audience:            cfg.Audience,
+		accessExpiry:        expiry,
+		clientKeyLookup:     cfg.ClientKeyLookup,
+		refreshStore:        cfg.RefreshStore,
+		validateCredentials: cfg.ValidateCredentials,
+		getUserScopes:       cfg.GetUserScopes,
+		hooks:               cfg.Hooks,
 	}
 }
 
@@ -395,5 +401,59 @@ func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) {
 		RefreshToken:         newRT.Token,
 		Scope:                strings.Join(rt.Scopes, " "),
 		AuthorizationDetails: rt.AuthorizationDetails,
+	}, nil
+}
+
+// PasswordGrant authenticates a user and returns an access token.
+// Does NOT create a refresh token — the caller handles that with
+// transport-specific metadata (device info, IP, etc.).
+func (i *jwtIssuer) PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResult, error) {
+	if i.validateCredentials == nil {
+		return nil, fmt.Errorf("server_error: password grant not configured")
+	}
+
+	// Validate credentials
+	usernameType := core.DetectUsernameType(req.Username)
+	user, err := i.validateCredentials(req.Username, req.Password, usernameType)
+	if err != nil || user == nil {
+		return nil, fmt.Errorf("invalid_grant: invalid credentials")
+	}
+
+	// Get allowed scopes
+	allowedScopes := []string{core.ScopeRead, core.ScopeWrite, core.ScopeProfile, core.ScopeOffline}
+	if i.getUserScopes != nil {
+		var err error
+		allowedScopes, err = i.getUserScopes(user.Id())
+		if err != nil {
+			return nil, fmt.Errorf("server_error: failed to get user scopes: %w", err)
+		}
+	}
+
+	// Intersect requested with allowed
+	requestedScopes := req.Scopes
+	if len(requestedScopes) == 0 {
+		requestedScopes = allowedScopes
+	}
+	grantedScopes := core.IntersectScopes(requestedScopes, allowedScopes)
+
+	// Validate authorization_details (RFC 9396)
+	if err := core.ValidateAll(req.AuthorizationDetails); err != nil {
+		return nil, err
+	}
+
+	// Create access token
+	tokenStr, expiresIn, err := i.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
+	if err != nil {
+		return nil, fmt.Errorf("server_error: %w", err)
+	}
+
+	i.hooks.fireOnIssued(user.Id(), "password")
+
+	return &PasswordGrantResult{
+		UserID:               user.Id(),
+		AccessToken:          tokenStr,
+		ExpiresIn:            expiresIn,
+		GrantedScopes:        grantedScopes,
+		AuthorizationDetails: req.AuthorizationDetails,
 	}, nil
 }

--- a/test-reports/coverage.html
+++ b/test-reports/coverage.html
@@ -87,7 +87,7 @@
 				
 				<option value="file15">github.com/panyam/oneauth/apiauth/token_revoker.go (87.5%)</option>
 				
-				<option value="file16">github.com/panyam/oneauth/apiauth/token_validator.go (76.6%)</option>
+				<option value="file16">github.com/panyam/oneauth/apiauth/token_validator.go (77.4%)</option>
 				
 				<option value="file17">github.com/panyam/oneauth/client/as_cache.go (100.0%)</option>
 				
@@ -3340,6 +3340,10 @@ type OneAuthConfig struct {
         Blacklist    core.TokenBlacklist    // for access token revocation (optional)
         RefreshStore core.RefreshTokenStore // for refresh token management (optional)
 
+        // Password grant callbacks (optional — only needed if password grant is used)
+        ValidateCredentials core.CredentialsValidator // validates username/password
+        GetUserScopes       core.GetUserScopesFunc   // returns allowed scopes for a user
+
         // Hooks — lifecycle callbacks
         Hooks Hooks
 }
@@ -3359,9 +3363,11 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth <span class="cov8" title="1">{
                 Issuer:          cfg.Issuer,
                 Audience:        cfg.Audience,
                 AccessExpiry:    cfg.AccessExpiry,
-                ClientKeyLookup: cfg.KeyStore, // KeyStorage implements KeyLookup
-                RefreshStore:    cfg.RefreshStore,
-                Hooks:           cfg.Hooks.Token,
+                ClientKeyLookup:     cfg.KeyStore, // KeyStorage implements KeyLookup
+                RefreshStore:        cfg.RefreshStore,
+                ValidateCredentials: cfg.ValidateCredentials,
+                GetUserScopes:       cfg.GetUserScopes,
+                Hooks:               cfg.Hooks.Token,
         })
 
         // Wire the validator — needs read-only key lookup + blacklist
@@ -4071,26 +4077,30 @@ func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) <span class="co
 
 // jwtIssuer implements TokenIssuer using JWT signing.
 type jwtIssuer struct {
-        signingKey      any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
-        signingAlg      string // "HS256", "RS256", "ES256"
-        issuer          string
-        audience        string
-        accessExpiry    time.Duration
-        clientKeyLookup keys.KeyLookup
-        refreshStore    core.RefreshTokenStore
-        hooks           TokenHooks
+        signingKey          any    // []byte for HS256, *rsa.PrivateKey for RS256, *ecdsa.PrivateKey for ES256
+        signingAlg          string // "HS256", "RS256", "ES256"
+        issuer              string
+        audience            string
+        accessExpiry        time.Duration
+        clientKeyLookup     keys.KeyLookup
+        refreshStore        core.RefreshTokenStore
+        validateCredentials core.CredentialsValidator
+        getUserScopes       core.GetUserScopesFunc
+        hooks               TokenHooks
 }
 
 // JWTIssuerConfig configures a jwtIssuer.
 type JWTIssuerConfig struct {
-        SigningKey      any
-        SigningAlg      string
-        Issuer         string
-        Audience       string
-        AccessExpiry   time.Duration
-        ClientKeyLookup keys.KeyLookup         // for client_credentials authentication
-        RefreshStore   core.RefreshTokenStore  // for refresh_token grant
-        Hooks          TokenHooks
+        SigningKey           any
+        SigningAlg           string
+        Issuer              string
+        Audience            string
+        AccessExpiry        time.Duration
+        ClientKeyLookup     keys.KeyLookup         // for client_credentials authentication
+        RefreshStore        core.RefreshTokenStore  // for refresh_token grant
+        ValidateCredentials core.CredentialsValidator // for password grant
+        GetUserScopes       core.GetUserScopesFunc   // for password grant (optional)
+        Hooks               TokenHooks
 }
 
 // NewJWTIssuer creates a TokenIssuer that signs JWTs.
@@ -4100,14 +4110,16 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer <span class="cov8" title="1">
                 expiry = core.TokenExpiryAccessToken
         }</span>
         <span class="cov8" title="1">return &amp;jwtIssuer{
-                signingKey:      cfg.SigningKey,
-                signingAlg:      cfg.SigningAlg,
-                issuer:          cfg.Issuer,
-                audience:        cfg.Audience,
-                accessExpiry:    expiry,
-                clientKeyLookup: cfg.ClientKeyLookup,
-                refreshStore:    cfg.RefreshStore,
-                hooks:           cfg.Hooks,
+                signingKey:          cfg.SigningKey,
+                signingAlg:          cfg.SigningAlg,
+                issuer:              cfg.Issuer,
+                audience:            cfg.Audience,
+                accessExpiry:        expiry,
+                clientKeyLookup:     cfg.ClientKeyLookup,
+                refreshStore:        cfg.RefreshStore,
+                validateCredentials: cfg.ValidateCredentials,
+                getUserScopes:       cfg.GetUserScopes,
+                hooks:               cfg.Hooks,
         }</span>
 }
 
@@ -4256,6 +4268,60 @@ func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) <
                 RefreshToken:         newRT.Token,
                 Scope:                strings.Join(rt.Scopes, " "),
                 AuthorizationDetails: rt.AuthorizationDetails,
+        }, nil</span>
+}
+
+// PasswordGrant authenticates a user and returns an access token.
+// Does NOT create a refresh token — the caller handles that with
+// transport-specific metadata (device info, IP, etc.).
+func (i *jwtIssuer) PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResult, error) <span class="cov8" title="1">{
+        if i.validateCredentials == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("server_error: password grant not configured")
+        }</span>
+
+        // Validate credentials
+        <span class="cov8" title="1">usernameType := core.DetectUsernameType(req.Username)
+        user, err := i.validateCredentials(req.Username, req.Password, usernameType)
+        if err != nil || user == nil </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("invalid_grant: invalid credentials")
+        }</span>
+
+        // Get allowed scopes
+        <span class="cov8" title="1">allowedScopes := []string{core.ScopeRead, core.ScopeWrite, core.ScopeProfile, core.ScopeOffline}
+        if i.getUserScopes != nil </span><span class="cov8" title="1">{
+                var err error
+                allowedScopes, err = i.getUserScopes(user.Id())
+                if err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("server_error: failed to get user scopes: %w", err)
+                }</span>
+        }
+
+        // Intersect requested with allowed
+        <span class="cov8" title="1">requestedScopes := req.Scopes
+        if len(requestedScopes) == 0 </span><span class="cov8" title="1">{
+                requestedScopes = allowedScopes
+        }</span>
+        <span class="cov8" title="1">grantedScopes := core.IntersectScopes(requestedScopes, allowedScopes)
+
+        // Validate authorization_details (RFC 9396)
+        if err := core.ValidateAll(req.AuthorizationDetails); err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        // Create access token
+        <span class="cov8" title="1">tokenStr, expiresIn, err := i.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("server_error: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">i.hooks.fireOnIssued(user.Id(), "password")
+
+        return &amp;PasswordGrantResult{
+                UserID:               user.Id(),
+                AccessToken:          tokenStr,
+                ExpiresIn:            expiresIn,
+                GrantedScopes:        grantedScopes,
+                AuthorizationDetails: req.AuthorizationDetails,
         }, nil</span>
 }
 </pre>

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>feat/oneauth-core-phase2</strong> | Commit: <code>a3434a4</code> | Date: 2026-04-27 14:24:01</div>
+<div class='meta'>Branch: <strong>feat/password-grant-core</strong> | Commit: <code>0db5b4e</code> | Date: 2026-04-27 14:49:00</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
@@ -31,11 +31,11 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 14:22:39 PDT 2026
+Started: Mon Apr 27 14:47:38 PDT 2026
 Starting PostgreSQL...
-e6abec8e9975401276a1ab980d002b7c49c2c91c99accfd54f340a29f2ad8ef5
+b6cffe2f23f8fa65ba0983524be6f2b52e01d776e1b98143ed497a08ee3a7bed
 Starting Keycloak...
-f7a42a8d278d592812c3915dd5cf9ff96b60f73f2c7f87c435fdbb1b0bf39925
+6d8c242536bdac8db5d96021e383410605051af554eedb775e7f9904041d4567
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -44,12 +44,12 @@ f7a42a8d278d592812c3915dd5cf9ff96b60f73f2c7f87c435fdbb1b0bf39925
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.651s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	3.378s	coverage: 75.1% of statements
-ok  	github.com/panyam/oneauth/client	5.502s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.228s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	0.996s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	1.138s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	0.483s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	3.270s	coverage: 75.2% of statements
+ok  	github.com/panyam/oneauth/client	4.990s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	0.731s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	0.938s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	1.591s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -61,26 +61,26 @@ ok  	github.com/panyam/oneauth/examples	1.138s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
 ?   	github.com/panyam/oneauth/examples/refs	[no test files]
-ok  	github.com/panyam/oneauth/httpauth	0.552s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	1.917s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/httpauth	1.164s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	2.316s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	6.145s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	1.350s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	3.832s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	2.249s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	3.507s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	6.295s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	1.950s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	4.071s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	3.202s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	4.117s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	16.318s
+ok  	github.com/panyam/oneauth/tests/e2e	14.980s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.810s
+ok  	github.com/panyam/oneauth/stores/gorm	0.881s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -91,7 +91,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.435s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.298s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -103,10 +103,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.435s
     ○ ░
     ░    gitleaks
 
-[90m2:23PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m2:23PM[0m [32mINF[0m [1m201 commits scanned.[0m
-[90m2:23PM[0m [32mINF[0m [1mscanned ~3593358 bytes (3.59 MB) in 656ms[0m
-[90m2:23PM[0m [32mINF[0m [1mno leaks found[0m
+[90m2:48PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m2:48PM[0m [32mINF[0m [1m203 commits scanned.[0m
+[90m2:48PM[0m [32mINF[0m [1mscanned ~3614492 bytes (3.61 MB) in 615ms[0m
+[90m2:48PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -117,16 +117,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 14:23:19 Using in-memory KeyStore (not persistent)
-2026/04/27 14:23:19 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 14:23:19 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 14:23:19 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 14:23:50 
+2026/04/27 14:48:18 Using in-memory KeyStore (not persistent)
+2026/04/27 14:48:18 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 14:48:18 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 14:48:18 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 14:48:49 
 === EMAIL: Password Reset ===
-2026/04/27 14:23:50 To: zaproxy@example.com
-2026/04/27 14:23:50 Subject: Reset your password
-2026/04/27 14:23:50 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=c8ae885178e7648c3853a250f04f5903a641a24e983c98aa287f9e277a19ca67
-2026/04/27 14:23:50 ==============================
+2026/04/27 14:48:49 To: zaproxy@example.com
+2026/04/27 14:48:49 Subject: Reset your password
+2026/04/27 14:48:49 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=5ac266021ce2f3910bb42b8ab49b835f050d06e055dd1f53c72770a5a8ef5c9b
+2026/04/27 14:48:49 ==============================
+2026/04/27 14:48:49 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -190,39 +191,40 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-IGNORE: Cookie No HttpOnly Flag [10010] x 2 
+IGNORE: Cookie No HttpOnly Flag [10010] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Non-Storable Content [10049] x 7 
+IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
-IGNORE: CSP: style-src unsafe-inline [10055] x 3 
-	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Authentication Request Identified [10111] x 1 
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
-IGNORE: Session Management Response Identified [10112] x 3 
-	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
+IGNORE: CSP: style-src unsafe-inline [10055] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Authentication Request Identified [10111] x 1 
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: Session Management Response Identified [10112] x 2 
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
@@ -233,7 +235,7 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 14:24:00 PDT 2026
+Finished: Mon Apr 27 14:48:59 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak
 </pre>

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,9 +1,9 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 14:22:39 PDT 2026
+Started: Mon Apr 27 14:47:38 PDT 2026
 Starting PostgreSQL...
-e6abec8e9975401276a1ab980d002b7c49c2c91c99accfd54f340a29f2ad8ef5
+b6cffe2f23f8fa65ba0983524be6f2b52e01d776e1b98143ed497a08ee3a7bed
 Starting Keycloak...
-f7a42a8d278d592812c3915dd5cf9ff96b60f73f2c7f87c435fdbb1b0bf39925
+6d8c242536bdac8db5d96021e383410605051af554eedb775e7f9904041d4567
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -12,12 +12,12 @@ f7a42a8d278d592812c3915dd5cf9ff96b60f73f2c7f87c435fdbb1b0bf39925
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.651s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	3.378s	coverage: 75.1% of statements
-ok  	github.com/panyam/oneauth/client	5.502s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.228s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	0.996s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	1.138s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	0.483s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/apiauth	3.270s	coverage: 75.2% of statements
+ok  	github.com/panyam/oneauth/client	4.990s	coverage: 82.4% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	0.731s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	0.938s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	1.591s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -29,26 +29,26 @@ ok  	github.com/panyam/oneauth/examples	1.138s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
 ?   	github.com/panyam/oneauth/examples/refs	[no test files]
-ok  	github.com/panyam/oneauth/httpauth	0.552s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	1.917s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/httpauth	1.164s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	2.316s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	6.145s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	1.350s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	3.832s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	2.249s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	3.507s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	6.295s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	1.950s	coverage: 27.9% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	4.071s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	3.202s	coverage: 79.1% of statements
+ok  	github.com/panyam/oneauth/utils	4.117s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	16.318s
+ok  	github.com/panyam/oneauth/tests/e2e	14.980s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	0.810s
+ok  	github.com/panyam/oneauth/stores/gorm	0.881s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -59,7 +59,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.435s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.298s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -71,10 +71,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.435s
     ○ ░
     ░    gitleaks
 
-[90m2:23PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m2:23PM[0m [32mINF[0m [1m201 commits scanned.[0m
-[90m2:23PM[0m [32mINF[0m [1mscanned ~3593358 bytes (3.59 MB) in 656ms[0m
-[90m2:23PM[0m [32mINF[0m [1mno leaks found[0m
+[90m2:48PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m2:48PM[0m [32mINF[0m [1m203 commits scanned.[0m
+[90m2:48PM[0m [32mINF[0m [1mscanned ~3614492 bytes (3.61 MB) in 615ms[0m
+[90m2:48PM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -85,16 +85,17 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 14:23:19 Using in-memory KeyStore (not persistent)
-2026/04/27 14:23:19 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 14:23:19 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 14:23:19 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 14:23:50 
+2026/04/27 14:48:18 Using in-memory KeyStore (not persistent)
+2026/04/27 14:48:18 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/04/27 14:48:18 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/04/27 14:48:18 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/04/27 14:48:49 
 === EMAIL: Password Reset ===
-2026/04/27 14:23:50 To: zaproxy@example.com
-2026/04/27 14:23:50 Subject: Reset your password
-2026/04/27 14:23:50 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=c8ae885178e7648c3853a250f04f5903a641a24e983c98aa287f9e277a19ca67
-2026/04/27 14:23:50 ==============================
+2026/04/27 14:48:49 To: zaproxy@example.com
+2026/04/27 14:48:49 Subject: Reset your password
+2026/04/27 14:48:49 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=5ac266021ce2f3910bb42b8ab49b835f050d06e055dd1f53c72770a5a8ef5c9b
+2026/04/27 14:48:49 ==============================
+2026/04/27 14:48:49 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -158,39 +159,40 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-IGNORE: Cookie No HttpOnly Flag [10010] x 2 
+IGNORE: Cookie No HttpOnly Flag [10010] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 1 
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Non-Storable Content [10049] x 7 
+IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
-	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
-IGNORE: CSP: style-src unsafe-inline [10055] x 3 
-	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Authentication Request Identified [10111] x 1 
-	http://host.docker.internal:19876/auth/login (403 Forbidden)
-IGNORE: Session Management Response Identified [10112] x 3 
-	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
+IGNORE: CSP: style-src unsafe-inline [10055] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/signup (200 OK)
+IGNORE: Authentication Request Identified [10111] x 1 
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: Session Management Response Identified [10112] x 2 
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
+	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
+	http://host.docker.internal:19876/auth/forgot-password (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
@@ -201,6 +203,6 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 14:24:00 PDT 2026
+Finished: Mon Apr 27 14:48:59 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak


### PR DESCRIPTION
## Summary

Completes #110 Phase 3: all three OAuth grants are now library calls.

**PasswordGrant** authenticates users and returns an access token only. Refresh token creation is the caller's responsibility — transport layers attach their own metadata.

### The 3-step pattern (HTTP handler example):
```go
// 1. Core: authenticate + access token
result, _ := oa.Issuer.PasswordGrant(req)

// 2. Transport: create refresh token with device info
rt, _ := oa.RefreshStore.CreateRefreshToken(
    result.UserID, clientID,
    map[string]any{"user_agent": r.UserAgent(), "ip": getClientIP(r)},
    result.GrantedScopes,
)

// 3. Transport: build HTTP response
writeTokenResponse(w, result.AccessToken, rt.Token, result.GrantedScopes)
```

### Why not include device info in the grant?
Device info is transport-specific metadata (HTTP user agent, gRPC peer, MCP session). The auth core shouldn't know about it. The 3-step pattern keeps the core transport-independent while letting each transport attach its own metadata.

## Test plan
- [x] 8 grant tests in `oneauth_grants_test.go` (password + refresh)
- [x] 18 core/HTTP tests in `oneauth_test.go` (unchanged)
- [x] All existing tests pass
- [x] Test file split to stay under 500 lines

Refs #110