### PR TITLE
feat(admin): AppRegistrationStore + InMemoryAppStore foundation

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -15,6 +15,7 @@
 - refresh-token-rotation: Refresh tokens with theft detection (family-based revocation)
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
+- pluggable-app-registry: AppRegistrationStore interface for persisting registered apps; in-memory backend ships now, FS / GORM backends pending (issues 166, 167)
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model
 - client-credentials-grant: Machine-to-machine auth (RFC 6749 §4.4)

--- a/admin/SUMMARY.md
+++ b/admin/SUMMARY.md
@@ -4,7 +4,8 @@ Admin authentication, app registration API, and resource token minting for the f
 
 ## Contents
 - **auth.go** — `AdminAuth` interface, `NoAuth`, `APIKeyAuth` (X-Admin-Key header)
-- **registrar.go** — `AppRegistrar` HTTP handler (register/list/delete/rotate apps), `AppRegistration`
+- **registrar.go** — `AppRegistrar` HTTP handler (register/list/delete/rotate apps), `AppRegistration`, `SaveRegistration`
+- **appstore.go** — `AppRegistrationStore` interface + `InMemoryAppStore` (issue 165). `ErrAppNotFound`. Persistent backends in `stores/fs/` and `stores/gorm/` (issues 166, 167).
 - **dcr.go** — `DCRHandler` for RFC 7591 Dynamic Client Registration at `POST /apps/dcr`
 - **mint.go** — `MintResourceToken()`, `MintResourceTokenWithKey()`, `AppQuota`
 

--- a/admin/appstore.go
+++ b/admin/appstore.go
@@ -1,0 +1,89 @@
+package admin
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrAppNotFound is returned by AppRegistrationStore.GetApp and DeleteApp
+// when the requested client_id does not exist.
+var ErrAppNotFound = errors.New("app registration not found")
+
+// AppRegistrationStore persists app registration metadata.
+//
+// It is the source of truth for registered apps; AppRegistrar holds a
+// hot-path in-memory cache that is hydrated from the store on construction
+// and updated on every write.
+//
+// Backends: InMemoryAppStore (admin/), FSAppStore (stores/fs/, see issue #166),
+// GORMAppStore (stores/gorm/, see issue #167).
+type AppRegistrationStore interface {
+	// SaveApp inserts or replaces the registration for app.ClientID.
+	SaveApp(app *AppRegistration) error
+
+	// GetApp returns the registration for clientID, or ErrAppNotFound.
+	GetApp(clientID string) (*AppRegistration, error)
+
+	// ListApps returns every registration in the store. Order is unspecified.
+	ListApps() ([]*AppRegistration, error)
+
+	// DeleteApp removes the registration for clientID. Returns ErrAppNotFound
+	// if no such registration exists.
+	DeleteApp(clientID string) error
+}
+
+// InMemoryAppStore is a process-local AppRegistrationStore. State is lost on
+// restart — suitable for tests and dev. Production deployments should use a
+// persistent backend (FS, GORM).
+type InMemoryAppStore struct {
+	mu   sync.RWMutex
+	apps map[string]*AppRegistration
+}
+
+// NewInMemoryAppStore returns an empty InMemoryAppStore.
+func NewInMemoryAppStore() *InMemoryAppStore {
+	return &InMemoryAppStore{apps: make(map[string]*AppRegistration)}
+}
+
+func (s *InMemoryAppStore) SaveApp(app *AppRegistration) error {
+	if app == nil || app.ClientID == "" {
+		return errors.New("AppRegistration.ClientID required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := *app
+	s.apps[app.ClientID] = &clone
+	return nil
+}
+
+func (s *InMemoryAppStore) GetApp(clientID string) (*AppRegistration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	app, ok := s.apps[clientID]
+	if !ok {
+		return nil, ErrAppNotFound
+	}
+	clone := *app
+	return &clone, nil
+}
+
+func (s *InMemoryAppStore) ListApps() ([]*AppRegistration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*AppRegistration, 0, len(s.apps))
+	for _, app := range s.apps {
+		clone := *app
+		out = append(out, &clone)
+	}
+	return out, nil
+}
+
+func (s *InMemoryAppStore) DeleteApp(clientID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.apps[clientID]; !ok {
+		return ErrAppNotFound
+	}
+	delete(s.apps, clientID)
+	return nil
+}

--- a/admin/appstore_test.go
+++ b/admin/appstore_test.go
@@ -1,0 +1,19 @@
+// Tests the in-memory AppRegistrationStore against the shared appstoretest
+// contract suite. Persistent backends (FS in #166, GORM in #167) reuse the
+// same suite from their own packages.
+package admin_test
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/appstoretest"
+)
+
+// TestInMemoryAppStore verifies that admin.NewInMemoryAppStore satisfies the
+// AppRegistrationStore contract.
+func TestInMemoryAppStore(t *testing.T) {
+	appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
+		return admin.NewInMemoryAppStore()
+	})
+}

--- a/admin/dcr.go
+++ b/admin/dcr.go
@@ -163,7 +163,7 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Store metadata in AppRegistrar if available
+	// Store metadata in AppRegistrar if available (persists to Store + updates cache).
 	if h.Registrar != nil {
 		domain := req.ClientURI
 		if domain == "" {
@@ -175,10 +175,17 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			SigningAlg:                signingAlg,
 			AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
 			CreatedAt:                 time.Now(),
+			ClientName:                req.ClientName,
+			ClientURI:                 req.ClientURI,
+			RedirectURIs:              req.RedirectURIs,
+			GrantTypes:                req.GrantTypes,
+			Scope:                     req.Scope,
+			TokenEndpointAuthMethod:   req.TokenEndpointAuthMethod,
 		}
-		h.Registrar.mu.Lock()
-		h.Registrar.apps[clientID] = reg
-		h.Registrar.mu.Unlock()
+		if err := h.Registrar.SaveRegistration(reg); err != nil {
+			h.jsonError(w, "server_error", "Failed to persist registration", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -15,6 +15,13 @@ import (
 )
 
 // AppRegistration holds metadata about a registered App.
+//
+// The DCR / RFC 7592 fields below (ClientName, ClientURI, RedirectURIs,
+// GrantTypes, Scope, TokenEndpointAuthMethod, RegistrationAccessToken,
+// RegistrationClientURI) are persisted starting in issue #165 so that
+// the schema is stable when issue #157 (RFC 7592 Management) populates
+// them. They may be empty for apps registered via the legacy
+// /apps/register endpoint.
 type AppRegistration struct {
 	ClientID                  string    `json:"client_id"`
 	ClientDomain              string    `json:"client_domain"`
@@ -24,11 +31,24 @@ type AppRegistration struct {
 	AuthorizationDetailsTypes []string  `json:"authorization_details_types,omitempty"` // RFC 9396
 	CreatedAt                 time.Time `json:"created_at"`
 	Revoked                   bool      `json:"revoked"`
+
+	// RFC 7591 / 7592 client metadata (populated by DCR; see #157).
+	ClientName              string   `json:"client_name,omitempty"`
+	ClientURI               string   `json:"client_uri,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+
+	// RFC 7592 management credentials. Issued when the management protocol
+	// is implemented (#168); empty for legacy registrations.
+	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 }
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.
 // Mount it on any admin service's mux to let apps register and obtain signing credentials.
-// Create with NewAppRegistrar().
+// Create with NewAppRegistrar() (in-memory store) or NewAppRegistrarWithStore.
 type AppRegistrar struct {
 	KeyStore keys.KeyStorage
 	Auth     AdminAuth
@@ -42,17 +62,64 @@ type AppRegistrar struct {
 	// when not specified in the request. Defaults to 24h.
 	DefaultGracePeriod time.Duration
 
+	// Store persists app registration metadata. It is the source of truth;
+	// the apps map below is a hot-path cache hydrated on construction and
+	// updated synchronously on every write.
+	Store AppRegistrationStore
+
 	mu   sync.RWMutex
 	apps map[string]*AppRegistration
 }
 
-// NewAppRegistrar creates an AppRegistrar with initialized internal state.
+// NewAppRegistrar creates an AppRegistrar backed by an in-memory store.
+// Equivalent to NewAppRegistrarWithStore(keyStore, auth, NewInMemoryAppStore()).
+//
+// For deployments that need registrations to survive restart, use
+// NewAppRegistrarWithStore with a persistent backend (FSAppStore, GORMAppStore).
 func NewAppRegistrar(keyStore keys.KeyStorage, auth AdminAuth) *AppRegistrar {
-	return &AppRegistrar{
+	return NewAppRegistrarWithStore(keyStore, auth, NewInMemoryAppStore())
+}
+
+// NewAppRegistrarWithStore creates an AppRegistrar backed by the given store.
+// Existing registrations in the store are loaded into the in-memory cache so
+// that subsequent reads (RLockApps, GET /apps) reflect the persisted state
+// immediately after construction.
+//
+// If store.ListApps returns an error during hydration, the AppRegistrar is
+// returned with an empty cache; subsequent writes proceed normally. (We do
+// not panic — a transient store error at startup should not crash the host
+// process. The error is intentionally swallowed here since there is no
+// caller-visible context to report it through; callers wanting strict
+// startup semantics should call store.ListApps themselves first.)
+func NewAppRegistrarWithStore(keyStore keys.KeyStorage, auth AdminAuth, store AppRegistrationStore) *AppRegistrar {
+	r := &AppRegistrar{
 		KeyStore: keyStore,
 		Auth:     auth,
+		Store:    store,
 		apps:     make(map[string]*AppRegistration),
 	}
+	if existing, err := store.ListApps(); err == nil {
+		for _, app := range existing {
+			clone := *app
+			r.apps[app.ClientID] = &clone
+		}
+	}
+	return r
+}
+
+// SaveRegistration persists the registration to the store and updates the
+// in-memory cache. Used by handleRegister, DCRHandler, and (in #157) the
+// RFC 7592 management endpoints. If the store write fails, the cache is
+// not updated and the error is returned.
+func (h *AppRegistrar) SaveRegistration(reg *AppRegistration) error {
+	if err := h.Store.SaveApp(reg); err != nil {
+		return err
+	}
+	h.mu.Lock()
+	clone := *reg
+	h.apps[reg.ClientID] = &clone
+	h.mu.Unlock()
+	return nil
 }
 
 // RLockApps calls fn with a read-locked view of all registered apps.
@@ -169,7 +236,7 @@ func (h *AppRegistrar) handleRegister(w http.ResponseWriter, r *http.Request) {
 		resp["client_secret"] = secret
 	}
 
-	// Store registration metadata
+	// Store registration metadata (persists to Store + updates cache).
 	reg := &AppRegistration{
 		ClientID:     clientID,
 		ClientDomain: req.ClientDomain,
@@ -178,9 +245,10 @@ func (h *AppRegistrar) handleRegister(w http.ResponseWriter, r *http.Request) {
 		MaxMsgRate:   req.MaxMsgRate,
 		CreatedAt:    time.Now(),
 	}
-	h.mu.Lock()
-	h.apps[clientID] = reg
-	h.mu.Unlock()
+	if err := h.SaveRegistration(reg); err != nil {
+		h.jsonError(w, "server_error", "Failed to persist registration", http.StatusInternalServerError)
+		return
+	}
 
 	resp["created_at"] = reg.CreatedAt
 
@@ -249,13 +317,24 @@ func (h *AppRegistrar) handleGetApp(w http.ResponseWriter, _ *http.Request, clie
 }
 
 func (h *AppRegistrar) handleDeleteApp(w http.ResponseWriter, _ *http.Request, clientID string) {
-	h.mu.Lock()
+	h.mu.RLock()
 	_, ok := h.apps[clientID]
+	h.mu.RUnlock()
 	if !ok {
-		h.mu.Unlock()
 		h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
 		return
 	}
+
+	// Persist deletion first; if the store fails we must not invalidate the
+	// in-memory cache or the KeyStore — that would leave the app un-revokable
+	// on subsequent restarts (the registration would still hydrate from the
+	// store, but the key would be gone).
+	if err := h.Store.DeleteApp(clientID); err != nil && err != ErrAppNotFound {
+		h.jsonError(w, "server_error", "Failed to delete registration", http.StatusInternalServerError)
+		return
+	}
+
+	h.mu.Lock()
 	delete(h.apps, clientID)
 	h.mu.Unlock()
 

--- a/admin/registrar_store_test.go
+++ b/admin/registrar_store_test.go
@@ -1,0 +1,194 @@
+package admin_test
+
+// Tests covering the AppRegistrar + AppRegistrationStore integration added in
+// issue #165: cache hydration on construction, SaveRegistration write-through,
+// handleRegister persistence, handleDeleteApp persistence, and the DCR handler
+// routing through the store.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/keys"
+)
+
+// TestAppRegistrar_HydratesFromStore verifies that a freshly constructed
+// AppRegistrar exposes registrations that were already in the store. This
+// guards the "registrations survive restart" property: dropping and rebuilding
+// the registrar over the same store is the in-process simulation of restart.
+func TestAppRegistrar_HydratesFromStore(t *testing.T) {
+	store := admin.NewInMemoryAppStore()
+	store.SaveApp(&admin.AppRegistration{
+		ClientID:     "app_pre_existing",
+		ClientDomain: "example.com",
+		SigningAlg:   "HS256",
+		CreatedAt:    time.Now(),
+	})
+	store.SaveApp(&admin.AppRegistration{
+		ClientID:   "app_revoked",
+		SigningAlg: "RS256",
+		Revoked:    true,
+		CreatedAt:  time.Now(),
+	})
+
+	ks := keys.NewInMemoryKeyStore()
+	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+
+	req := httptest.NewRequest(http.MethodGet, "/apps", nil)
+	rr := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /apps: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Apps []*admin.AppRegistration `json:"apps"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Apps) != 2 {
+		t.Fatalf("expected 2 hydrated apps, got %d: %s", len(resp.Apps), rr.Body.String())
+	}
+}
+
+// TestAppRegistrar_SaveRegistration_PersistsToStore verifies that SaveRegistration
+// writes through to the underlying store, not just the in-memory cache. Without
+// this, registrations would be lost on restart even with a persistent backend.
+func TestAppRegistrar_SaveRegistration_PersistsToStore(t *testing.T) {
+	store := admin.NewInMemoryAppStore()
+	ks := keys.NewInMemoryKeyStore()
+	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+
+	app := &admin.AppRegistration{
+		ClientID:     "app_via_save",
+		ClientDomain: "save.example",
+		SigningAlg:   "HS256",
+		CreatedAt:    time.Now(),
+	}
+	if err := reg.SaveRegistration(app); err != nil {
+		t.Fatalf("SaveRegistration: %v", err)
+	}
+
+	got, err := store.GetApp("app_via_save")
+	if err != nil {
+		t.Fatalf("store.GetApp: %v", err)
+	}
+	if got.ClientDomain != "save.example" {
+		t.Errorf("ClientDomain=%q, want save.example", got.ClientDomain)
+	}
+}
+
+// TestAppRegistrar_HandleRegister_PersistsToStore verifies that POST /apps/register
+// persists the new registration to the store, not only to the in-memory cache.
+func TestAppRegistrar_HandleRegister_PersistsToStore(t *testing.T) {
+	store := admin.NewInMemoryAppStore()
+	ks := keys.NewInMemoryKeyStore()
+	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+
+	body, _ := json.Marshal(map[string]any{"client_domain": "register.example", "signing_alg": "HS256"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := store.GetApp(resp.ClientID)
+	if err != nil {
+		t.Fatalf("store.GetApp(%s): %v", resp.ClientID, err)
+	}
+	if got.ClientDomain != "register.example" {
+		t.Errorf("ClientDomain=%q, want register.example", got.ClientDomain)
+	}
+}
+
+// TestAppRegistrar_HandleDeleteApp_PersistsDeletion verifies that DELETE /apps/{id}
+// removes the registration from the store. Without this, a deleted (revoked) app
+// would be resurrected on restart from stale store contents.
+func TestAppRegistrar_HandleDeleteApp_PersistsDeletion(t *testing.T) {
+	store := admin.NewInMemoryAppStore()
+	ks := keys.NewInMemoryKeyStore()
+	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+
+	// Register, then delete, both via HTTP.
+	body, _ := json.Marshal(map[string]any{"client_domain": "delete.example", "signing_alg": "HS256"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var registered struct {
+		ClientID string `json:"client_id"`
+	}
+	json.Unmarshal(rr.Body.Bytes(), &registered)
+
+	delReq := httptest.NewRequest(http.MethodDelete, "/apps/"+registered.ClientID, nil)
+	delRR := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(delRR, delReq)
+	if delRR.Code != http.StatusOK {
+		t.Fatalf("delete: status=%d body=%s", delRR.Code, delRR.Body.String())
+	}
+
+	if _, err := store.GetApp(registered.ClientID); err != admin.ErrAppNotFound {
+		t.Errorf("store should not contain deleted app, got err=%v", err)
+	}
+}
+
+// TestDCR_PersistsViaRegistrar verifies that POST /apps/dcr (RFC 7591) writes
+// through the AppRegistrar.SaveRegistration path so the registration lands in
+// the store. Without this, DCR-registered clients would be lost on restart.
+func TestDCR_PersistsViaRegistrar(t *testing.T) {
+	store := admin.NewInMemoryAppStore()
+	ks := keys.NewInMemoryKeyStore()
+	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+
+	body, _ := json.Marshal(map[string]any{
+		"client_name":  "DCR Test App",
+		"client_uri":   "https://dcr.example",
+		"redirect_uris": []string{"https://dcr.example/cb"},
+		"grant_types":  []string{"authorization_code"},
+		"scope":        "read",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("dcr: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ClientID string `json:"client_id"`
+	}
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	got, err := store.GetApp(resp.ClientID)
+	if err != nil {
+		t.Fatalf("store.GetApp(%s): %v", resp.ClientID, err)
+	}
+	if got.ClientName != "DCR Test App" {
+		t.Errorf("ClientName=%q, want DCR Test App", got.ClientName)
+	}
+	if got.ClientURI != "https://dcr.example" {
+		t.Errorf("ClientURI=%q, want https://dcr.example", got.ClientURI)
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "https://dcr.example/cb" {
+		t.Errorf("RedirectURIs=%v", got.RedirectURIs)
+	}
+	if got.Scope != "read" {
+		t.Errorf("Scope=%q, want read", got.Scope)
+	}
+}

--- a/appstoretest/appstoretest.go
+++ b/appstoretest/appstoretest.go
@@ -1,0 +1,260 @@
+// Package appstoretest provides a shared contract test suite for all
+// AppRegistrationStore implementations. Each backend (inmem, fs, gorm)
+// calls these tests with its own factory function. Mirrors keystoretest.
+package appstoretest
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+)
+
+// Factory creates a fresh AppRegistrationStore for each test.
+type Factory func(t *testing.T) admin.AppRegistrationStore
+
+// RunAll runs the complete AppRegistrationStore test suite against the provided factory.
+func RunAll(t *testing.T, factory Factory) {
+	t.Run("SaveAndGet", func(t *testing.T) { TestSaveAndGet(t, factory) })
+	t.Run("NotFound", func(t *testing.T) { TestNotFound(t, factory) })
+	t.Run("DeleteApp", func(t *testing.T) { TestDeleteApp(t, factory) })
+	t.Run("DeleteNonexistent", func(t *testing.T) { TestDeleteNonexistent(t, factory) })
+	t.Run("OverwriteApp", func(t *testing.T) { TestOverwriteApp(t, factory) })
+	t.Run("ListApps", func(t *testing.T) { TestListApps(t, factory) })
+	t.Run("ListAppsEmpty", func(t *testing.T) { TestListAppsEmpty(t, factory) })
+	t.Run("Persistence", func(t *testing.T) { TestPersistence(t, factory) })
+	t.Run("AllFieldsRoundTrip", func(t *testing.T) { TestAllFieldsRoundTrip(t, factory) })
+}
+
+// TestSaveAndGet verifies that SaveApp followed by GetApp returns the saved registration.
+func TestSaveAndGet(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	app := &admin.AppRegistration{
+		ClientID:     "app_abc",
+		ClientDomain: "example.com",
+		SigningAlg:   "HS256",
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+
+	if err := s.SaveApp(app); err != nil {
+		t.Fatalf("SaveApp failed: %v", err)
+	}
+
+	got, err := s.GetApp("app_abc")
+	if err != nil {
+		t.Fatalf("GetApp failed: %v", err)
+	}
+	if got.ClientID != "app_abc" {
+		t.Errorf("ClientID=%q, want app_abc", got.ClientID)
+	}
+	if got.ClientDomain != "example.com" {
+		t.Errorf("ClientDomain=%q, want example.com", got.ClientDomain)
+	}
+	if got.SigningAlg != "HS256" {
+		t.Errorf("SigningAlg=%q, want HS256", got.SigningAlg)
+	}
+}
+
+// TestNotFound verifies that GetApp on a missing client_id returns ErrAppNotFound.
+func TestNotFound(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	_, err := s.GetApp("does-not-exist")
+	if err != admin.ErrAppNotFound {
+		t.Errorf("expected ErrAppNotFound, got %v", err)
+	}
+}
+
+// TestDeleteApp verifies that DeleteApp removes the registration and subsequent
+// GetApp returns ErrAppNotFound.
+func TestDeleteApp(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	app := &admin.AppRegistration{ClientID: "app_del", SigningAlg: "HS256", CreatedAt: time.Now()}
+	if err := s.SaveApp(app); err != nil {
+		t.Fatalf("SaveApp failed: %v", err)
+	}
+
+	if err := s.DeleteApp("app_del"); err != nil {
+		t.Fatalf("DeleteApp failed: %v", err)
+	}
+
+	if _, err := s.GetApp("app_del"); err != admin.ErrAppNotFound {
+		t.Errorf("expected ErrAppNotFound after delete, got %v", err)
+	}
+}
+
+// TestDeleteNonexistent verifies that deleting a missing client_id returns ErrAppNotFound,
+// matching KeyStorage.DeleteKey semantics.
+func TestDeleteNonexistent(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	err := s.DeleteApp("never-existed")
+	if err != admin.ErrAppNotFound {
+		t.Errorf("expected ErrAppNotFound, got %v", err)
+	}
+}
+
+// TestOverwriteApp verifies that SaveApp on an existing client_id replaces the
+// stored registration with the new metadata.
+func TestOverwriteApp(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	original := &admin.AppRegistration{ClientID: "app_ow", ClientDomain: "old.example", SigningAlg: "HS256", CreatedAt: time.Now()}
+	updated := &admin.AppRegistration{ClientID: "app_ow", ClientDomain: "new.example", SigningAlg: "RS256", CreatedAt: time.Now()}
+
+	if err := s.SaveApp(original); err != nil {
+		t.Fatalf("SaveApp original failed: %v", err)
+	}
+	if err := s.SaveApp(updated); err != nil {
+		t.Fatalf("SaveApp updated failed: %v", err)
+	}
+
+	got, err := s.GetApp("app_ow")
+	if err != nil {
+		t.Fatalf("GetApp failed: %v", err)
+	}
+	if got.ClientDomain != "new.example" {
+		t.Errorf("ClientDomain=%q, want new.example (overwrite)", got.ClientDomain)
+	}
+	if got.SigningAlg != "RS256" {
+		t.Errorf("SigningAlg=%q, want RS256 (overwrite)", got.SigningAlg)
+	}
+}
+
+// TestListApps verifies that ListApps returns every saved registration.
+func TestListApps(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	for _, id := range []string{"app_alpha", "app_beta", "app_gamma"} {
+		if err := s.SaveApp(&admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("SaveApp %s failed: %v", id, err)
+		}
+	}
+
+	apps, err := s.ListApps()
+	if err != nil {
+		t.Fatalf("ListApps failed: %v", err)
+	}
+	if len(apps) != 3 {
+		t.Fatalf("expected 3 apps, got %d", len(apps))
+	}
+
+	gotIDs := make([]string, 0, len(apps))
+	for _, a := range apps {
+		gotIDs = append(gotIDs, a.ClientID)
+	}
+	sort.Strings(gotIDs)
+	want := []string{"app_alpha", "app_beta", "app_gamma"}
+	for i, id := range want {
+		if gotIDs[i] != id {
+			t.Errorf("apps[%d]=%s, want %s", i, gotIDs[i], id)
+		}
+	}
+}
+
+// TestListAppsEmpty verifies that ListApps on a fresh store returns an empty slice
+// (not an error).
+func TestListAppsEmpty(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	apps, err := s.ListApps()
+	if err != nil {
+		t.Fatalf("ListApps failed: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("expected 0 apps, got %d", len(apps))
+	}
+}
+
+// TestPersistence verifies that a saved registration is visible to subsequent reads
+// from the same store handle. For persistent backends (FS, GORM) this catches
+// write-buffering bugs; for InMem it is trivially true.
+func TestPersistence(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	app := &admin.AppRegistration{ClientID: "app_persist", ClientDomain: "p.example", SigningAlg: "HS256", CreatedAt: time.Now()}
+	if err := s.SaveApp(app); err != nil {
+		t.Fatalf("SaveApp failed: %v", err)
+	}
+
+	got, err := s.GetApp("app_persist")
+	if err != nil {
+		t.Fatalf("GetApp after save failed: %v", err)
+	}
+	if got.ClientDomain != "p.example" {
+		t.Errorf("ClientDomain=%q, want p.example", got.ClientDomain)
+	}
+}
+
+// TestAllFieldsRoundTrip verifies that every field on AppRegistration survives a
+// SaveApp/GetApp round-trip. Catches backend serialization bugs (e.g., GORM
+// forgetting to JSON-encode slice fields).
+func TestAllFieldsRoundTrip(t *testing.T, factory Factory) {
+	s := factory(t)
+
+	created := time.Now().UTC().Truncate(time.Second)
+	app := &admin.AppRegistration{
+		ClientID:                  "app_full",
+		ClientDomain:              "full.example",
+		SigningAlg:                "RS256",
+		MaxRooms:                  42,
+		MaxMsgRate:                3.14,
+		AuthorizationDetailsTypes: []string{"payment_initiation", "account_information"},
+		CreatedAt:                 created,
+		Revoked:                   false,
+		ClientName:                "Full App",
+		ClientURI:                 "https://full.example",
+		RedirectURIs:              []string{"https://full.example/cb", "http://localhost/cb"},
+		GrantTypes:                []string{"authorization_code", "refresh_token"},
+		Scope:                     "read write",
+		TokenEndpointAuthMethod:   "private_key_jwt",
+		RegistrationAccessToken:   "reg-tok-abc",
+		RegistrationClientURI:     "https://issuer.example/apps/dcr/app_full",
+	}
+
+	if err := s.SaveApp(app); err != nil {
+		t.Fatalf("SaveApp failed: %v", err)
+	}
+
+	got, err := s.GetApp("app_full")
+	if err != nil {
+		t.Fatalf("GetApp failed: %v", err)
+	}
+
+	if got.ClientName != "Full App" {
+		t.Errorf("ClientName=%q, want %q", got.ClientName, "Full App")
+	}
+	if got.ClientURI != "https://full.example" {
+		t.Errorf("ClientURI=%q", got.ClientURI)
+	}
+	if len(got.RedirectURIs) != 2 || got.RedirectURIs[0] != "https://full.example/cb" {
+		t.Errorf("RedirectURIs=%v", got.RedirectURIs)
+	}
+	if len(got.GrantTypes) != 2 || got.GrantTypes[0] != "authorization_code" {
+		t.Errorf("GrantTypes=%v", got.GrantTypes)
+	}
+	if got.Scope != "read write" {
+		t.Errorf("Scope=%q", got.Scope)
+	}
+	if got.TokenEndpointAuthMethod != "private_key_jwt" {
+		t.Errorf("TokenEndpointAuthMethod=%q", got.TokenEndpointAuthMethod)
+	}
+	if got.RegistrationAccessToken != "reg-tok-abc" {
+		t.Errorf("RegistrationAccessToken=%q", got.RegistrationAccessToken)
+	}
+	if got.RegistrationClientURI != "https://issuer.example/apps/dcr/app_full" {
+		t.Errorf("RegistrationClientURI=%q", got.RegistrationClientURI)
+	}
+	if len(got.AuthorizationDetailsTypes) != 2 || got.AuthorizationDetailsTypes[0] != "payment_initiation" {
+		t.Errorf("AuthorizationDetailsTypes=%v", got.AuthorizationDetailsTypes)
+	}
+	if got.MaxRooms != 42 {
+		t.Errorf("MaxRooms=%d", got.MaxRooms)
+	}
+	if got.MaxMsgRate != 3.14 {
+		t.Errorf("MaxMsgRate=%f", got.MaxMsgRate)
+	}
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -176,6 +176,20 @@ Pure-OAuth code pushed down from mcpkit/ext/auth (mcpkit#158) into oneauth for b
 
 ---
 
+## App Registrar Persistence
+
+Splits issue 20 (Persist AppRegistrar state) into shippable backend chunks. The schema additions for issue 157 (RFC 7592 management) are baked in upfront so subsequent tickets do not churn the table layout.
+
+| # | Scope | Status |
+|---|-------|--------|
+| 165 | `AppRegistrationStore` interface + `InMemoryAppStore` + AppRegistrar refactor (cache + write-through) + `appstoretest` contract suite + e2e simulated-restart test | In progress |
+| 166 | `FSAppStore` (filesystem backend) | Pending |
+| 167 | `GORMAppStore` + reference-server config wiring | Pending |
+
+After 167 lands, parent issue 20 can close. The chain unblocks the entire RFC 7592 track (issues 168 / 169 / 170 / 171) tracked under issue 157.
+
+---
+
 ## Relationship to Existing Work
 
 ### What this track does NOT change

--- a/docs/STORES.md
+++ b/docs/STORES.md
@@ -260,3 +260,44 @@ func TestMyKeyStore(t *testing.T) {
 All three built-in KeyStore implementations (FS, GORM, GAE) use this shared test suite. When implementing a custom KeyStorage, run these tests to verify compatibility.
 
 For how KeyLookup/KeyStorage is used in multi-tenant JWT validation, see [API_AUTH.md](API_AUTH.md#multi-tenant-jwt-validation-keystore).
+
+## AppRegistrationStore
+
+Persists app registration metadata for `AppRegistrar` and the DCR handler. Registrations are the source of truth for which `client_id`s exist and their RFC 7591/7592 metadata; without persistence, revoked apps come back on restart.
+
+```go
+type AppRegistrationStore interface {
+    SaveApp(app *AppRegistration) error
+    GetApp(clientID string) (*AppRegistration, error)
+    ListApps() ([]*AppRegistration, error)
+    DeleteApp(clientID string) error
+}
+```
+
+`AppRegistrar` keeps an in-memory cache hydrated from the store on construction; reads hit the cache, writes go through `SaveRegistration` which writes the store first and updates the cache.
+
+### Implementations
+
+| Backend | Status | Use case |
+|---------|--------|----------|
+| `admin.InMemoryAppStore` | Available | Tests, dev (registrations lost on restart) |
+| `stores/fs.FSAppStore` | Pending — issue 166 | Single-node, dev-friendly persistence |
+| `stores/gorm.GORMAppStore` | Pending — issue 167 | Production, multi-node (Postgres / MySQL / SQLite) |
+
+Construct with `admin.NewAppRegistrar(keyStore, auth)` for the default in-memory store, or `admin.NewAppRegistrarWithStore(keyStore, auth, store)` to plug in a persistent backend.
+
+### appstoretest Shared Test Suite
+
+The `appstoretest` package mirrors `keystoretest`: any `AppRegistrationStore` implementation can run the contract tests to verify correctness.
+
+```go
+import "github.com/panyam/oneauth/appstoretest"
+
+func TestMyAppStore(t *testing.T) {
+    appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
+        return NewMyAppStore(...)
+    })
+}
+```
+
+The suite covers Save/Get/List/Delete contracts, overwrite, persistence (read-after-write), and a full-fields round-trip (catches serialization bugs in slice-typed columns like `RedirectURIs` and `GrantTypes`).

--- a/tests/e2e/app_persistence_test.go
+++ b/tests/e2e/app_persistence_test.go
@@ -1,0 +1,107 @@
+package e2e_test
+
+// End-to-end "simulated restart" test for AppRegistrationStore (issue #165).
+// Builds a self-contained AppRegistrar over a shared store + KeyStore, exercises
+// register/list/delete via HTTP, then drops the registrar and builds a fresh one
+// over the SAME backing stores to verify persistence survives a process restart.
+//
+// We deliberately do NOT use TestEnv here: TestEnv constructs the full auth
+// server with its own default in-memory stores, and this test specifically
+// needs to reuse the same Store/KeyStore across two AppRegistrar instances.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppRegistrar_PersistsAcrossRestart verifies that registrations created
+// against one AppRegistrar are visible to a fresh AppRegistrar instance backed
+// by the same store, and that deletions made through the first instance are
+// also persisted (i.e., a revoked app does NOT come back after restart). This
+// is the canonical regression test for the bug behind issue #20.
+func TestAppRegistrar_PersistsAcrossRestart(t *testing.T) {
+	store := admin.NewInMemoryAppStore()
+	ks := keys.NewInMemoryKeyStore()
+
+	// --- Phase 1: first AppRegistrar instance (the "before-restart" world).
+	reg1 := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+	srv1 := httptest.NewServer(reg1.Handler())
+	defer srv1.Close()
+
+	// Register two apps; we'll delete one and verify the other survives.
+	keepID := registerApp(t, srv1.URL, "keep.example")
+	revokeID := registerApp(t, srv1.URL, "revoke.example")
+
+	// Sanity: both visible via the first instance.
+	apps := listApps(t, srv1.URL)
+	require.Len(t, apps, 2)
+
+	// Revoke (delete) one app via the first instance.
+	resp, err := http.NewRequest(http.MethodDelete, srv1.URL+"/apps/"+revokeID, nil)
+	require.NoError(t, err)
+	delResp, err := http.DefaultClient.Do(resp)
+	require.NoError(t, err)
+	delResp.Body.Close()
+	require.Equal(t, http.StatusOK, delResp.StatusCode)
+
+	srv1.Close()
+	// reg1 is now garbage; cache is gone. Persistence must come from `store`.
+
+	// --- Phase 2: fresh AppRegistrar instance over the same backing stores.
+	reg2 := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
+	srv2 := httptest.NewServer(reg2.Handler())
+	defer srv2.Close()
+
+	apps2 := listApps(t, srv2.URL)
+	if assert.Len(t, apps2, 1, "exactly the un-revoked app should survive restart") {
+		assert.Equal(t, keepID, apps2[0]["client_id"], "kept app survived")
+	}
+
+	// The revoked app must NOT resurrect: GET /apps/{revokedID} returns 404.
+	getResp, err := http.Get(srv2.URL + "/apps/" + revokeID)
+	require.NoError(t, err)
+	getResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, getResp.StatusCode, "revoked app must not be resurrected on restart")
+
+	// And the revoked app's signing key must be gone from the KeyStore too.
+	if _, err := ks.GetKey(revokeID); err != keys.ErrKeyNotFound {
+		t.Errorf("expected ErrKeyNotFound for revoked app's signing key, got %v", err)
+	}
+}
+
+func registerApp(t *testing.T, baseURL, domain string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"client_domain": domain, "signing_alg": "HS256"})
+	resp, err := http.Post(baseURL+"/apps/register", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	raw, _ := io.ReadAll(resp.Body)
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(raw, &data))
+	return data["client_id"].(string)
+}
+
+func listApps(t *testing.T, baseURL string) []map[string]any {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/apps")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var data struct {
+		Apps []map[string]any `json:"apps"`
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(raw, &data))
+	return data.Apps
+}


### PR DESCRIPTION
## Summary
- Defines `AppRegistrationStore` interface (Save / Get / List / Delete + `ErrAppNotFound`) and ships `InMemoryAppStore` as the default backend, mirroring the `keys.KeyStorage` pattern.
- Refactors `AppRegistrar` so reads still hit a hot in-memory cache but writes go through `Store` (cache hydrated from store on construction). DCR handler now writes via `SaveRegistration` instead of poking `.apps` directly.
- `AppRegistration` schema bakes in the RFC 7592 fields needed by issue 157 upfront (registration_access_token, registration_client_uri, plus DCR metadata) so subsequent tickets do not churn the table.

Closes 165. Foundation for 166 (FS backend), 167 (GORM backend), and the entire RFC 7592 chain (168 / 169 / 170 / 171).

## Test plan
- [x] `make test` — 9 contract tests in `appstoretest/` + 5 admin integration tests (cache hydration, SaveRegistration, register/delete persistence, DCR routing).
- [x] `make e2e` — including new simulated-restart test (`tests/e2e/app_persistence_test.go`) that proves a deleted app stays deleted across two `AppRegistrar` instances over the same store. This is the canonical regression test for issue 20.
- [x] Existing `admin/registrar_test.go` and `admin/dcr_test.go` continue to pass unchanged (backward-compat: `NewAppRegistrar(keyStore, auth)` keeps its signature).