### PR TITLE
feat(admin): RFC 7592 foundation + GET /apps/dcr/{client_id}

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -16,6 +16,7 @@
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
 - pluggable-app-registry: AppRegistrationStore interface for persisting registered apps; in-memory backend ships now, FS / GORM backends pending (issues 166, 167)
+- dcr-management-rfc7592: GET /apps/dcr/{client_id} for RFC 7592 read; clients get registration_access_token + registration_client_uri at registration time (issue 168). PUT/DELETE arrive in 169/170. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go).
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model
 - client-credentials-grant: Machine-to-machine auth (RFC 6749 §4.4)

--- a/admin/SUMMARY.md
+++ b/admin/SUMMARY.md
@@ -6,7 +6,9 @@ Admin authentication, app registration API, and resource token minting for the f
 - **auth.go** — `AdminAuth` interface, `NoAuth`, `APIKeyAuth` (X-Admin-Key header)
 - **registrar.go** — `AppRegistrar` HTTP handler (register/list/delete/rotate apps), `AppRegistration`, `SaveRegistration`
 - **appstore.go** — `AppRegistrationStore` interface + `InMemoryAppStore` (issue 165). `ErrAppNotFound`. Persistent backends in `stores/fs/` and `stores/gorm/` (issues 166, 167).
-- **dcr.go** — `DCRHandler` for RFC 7591 Dynamic Client Registration at `POST /apps/dcr`
+- **dcr.go** — `DCRHandler` for RFC 7591 Dynamic Client Registration at `POST /apps/dcr`. Now issues RFC 7592 §3 management credentials (`registration_access_token`, `registration_client_uri`) on every successful registration.
+- **client_management.go** — `ClientRegistrationManager` interface + `ErrUnauthorized` (issue 168). Transport-agnostic core for the RFC 7592 management surface — handlers in `dcr_management.go` are thin wrappers. Blueprint for the wider admin/ refactor tracked under issue 172.
+- **dcr_management.go** — `DCRManagementHandler` for RFC 7592 reads at `GET /apps/dcr/{client_id}` (issue 168). PUT / DELETE arrive in 169 / 170.
 - **mint.go** — `MintResourceToken()`, `MintResourceTokenWithKey()`, `AppQuota`
 
 ## Dependencies

--- a/admin/client_management.go
+++ b/admin/client_management.go
@@ -1,0 +1,26 @@
+package admin
+
+import "errors"
+
+// ClientRegistrationManager is the transport-agnostic core of OAuth 2.0
+// Dynamic Client Registration Management (RFC 7592). HTTP handlers in admin/
+// (and any future gRPC / in-process callers) are thin wrappers around this
+// interface — they parse the request, call into the manager, then format the
+// response. Mirrors the apiauth/ pattern (TokenIssuer / TokenValidator /
+// TokenIntrospector / TokenRevoker — see issue #110).
+//
+// Issue #168 ships GetRegistration. UpdateRegistration / DeleteRegistration
+// arrive in #169 / #170.
+type ClientRegistrationManager interface {
+	// GetRegistration returns the registration for clientID iff accessToken
+	// matches its stored registration_access_token. Returns ErrUnauthorized
+	// for any failure mode — wrong token, missing token, unknown client_id —
+	// so callers (and attackers) cannot distinguish them.
+	GetRegistration(clientID, accessToken string) (*DCRResponse, error)
+}
+
+// ErrUnauthorized is the single failure mode returned by ClientRegistrationManager
+// for any authentication problem on the management protocol. The uniform error
+// is intentional: distinguishing "unknown client_id" from "wrong token" would
+// turn /apps/dcr/{client_id} into a probe for valid identifiers.
+var ErrUnauthorized = errors.New("unauthorized registration management request")

--- a/admin/dcr.go
+++ b/admin/dcr.go
@@ -19,7 +19,12 @@ import (
 // Automatically mounted by AppRegistrar.Handler() at POST /apps/dcr.
 // Existing /apps/* endpoints continue working unchanged.
 //
+// On successful registration the response includes a registration access
+// token + management URI (RFC 7592 §3) which the client uses to read,
+// update, or delete its own registration via /apps/dcr/{client_id}.
+//
 // See: https://www.rfc-editor.org/rfc/rfc7591
+// See: https://www.rfc-editor.org/rfc/rfc7592
 type DCRHandler struct {
 	// KeyStore stores client credentials (same KeyStore as AppRegistrar).
 	KeyStore keys.KeyStorage
@@ -33,6 +38,14 @@ type DCRHandler struct {
 	// Registrar is the underlying AppRegistrar for metadata storage.
 	// If nil, client metadata is not persisted (only KeyStore is used).
 	Registrar *AppRegistrar
+
+	// IssuerBaseURL is the public base URL used to construct
+	// registration_client_uri values returned in DCR responses
+	// (e.g. "https://auth.example.com"). When empty, the URI is
+	// built from the incoming request's scheme + Host header — fine
+	// for tests but unreliable behind proxies, so production
+	// deployments should set this explicitly.
+	IssuerBaseURL string
 }
 
 // DCRRequest is the RFC 7591 client registration request.
@@ -55,20 +68,28 @@ type DCRRequest struct {
 	JWKS *utils.JWKSet `json:"jwks,omitempty"`
 }
 
-// DCRResponse is the RFC 7591 client registration response.
+// DCRResponse is the RFC 7591 client registration response, extended with the
+// RFC 7592 §3 management credentials (registration_access_token +
+// registration_client_uri) so that registered clients can subsequently call
+// /apps/dcr/{client_id} to read, update, or delete their own registration.
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-3
 type DCRResponse struct {
-	ClientID                string   `json:"client_id"`
-	ClientSecret            string   `json:"client_secret,omitempty"`
-	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
-	ClientSecretExpiresAt   int64    `json:"client_secret_expires_at"`
-	ClientName              string   `json:"client_name,omitempty"`
-	ClientURI               string   `json:"client_uri,omitempty"`
-	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	ClientID                  string   `json:"client_id"`
+	ClientSecret              string   `json:"client_secret,omitempty"`
+	ClientIDIssuedAt          int64    `json:"client_id_issued_at"`
+	ClientSecretExpiresAt     int64    `json:"client_secret_expires_at"`
+	ClientName                string   `json:"client_name,omitempty"`
+	ClientURI                 string   `json:"client_uri,omitempty"`
+	RedirectURIs              []string `json:"redirect_uris,omitempty"`
 	GrantTypes                []string `json:"grant_types,omitempty"`
 	TokenEndpointAuthMethod   string   `json:"token_endpoint_auth_method,omitempty"`
 	Scope                     string   `json:"scope,omitempty"`
 	AuthorizationDetailsTypes []string `json:"authorization_details_types,omitempty"` // RFC 9396
+
+	// RFC 7592 §3 — management credentials.
+	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 }
 
 // ServeHTTP handles POST /register per RFC 7591.
@@ -116,6 +137,17 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Generate the RFC 7592 §3 management credentials. These are returned
+	// in the registration response and persisted on AppRegistration so the
+	// management endpoints (GET / PUT / DELETE /apps/dcr/{client_id}) can
+	// authenticate subsequent requests from this client.
+	regAccessToken, err := generateRegistrationAccessToken()
+	if err != nil {
+		h.jsonError(w, "server_error", "Failed to generate registration access token", http.StatusInternalServerError)
+		return
+	}
+	regClientURI := h.buildRegistrationClientURI(r, clientID)
+
 	resp := DCRResponse{
 		ClientID:                  clientID,
 		ClientIDIssuedAt:          time.Now().Unix(),
@@ -127,6 +159,8 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		TokenEndpointAuthMethod:   req.TokenEndpointAuthMethod,
 		Scope:                     req.Scope,
 		AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
+		RegistrationAccessToken:   regAccessToken,
+		RegistrationClientURI:     regClientURI,
 	}
 
 	if utils.IsAsymmetricAlg(signingAlg) {
@@ -181,6 +215,8 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			GrantTypes:                req.GrantTypes,
 			Scope:                     req.Scope,
 			TokenEndpointAuthMethod:   req.TokenEndpointAuthMethod,
+			RegistrationAccessToken:   regAccessToken,
+			RegistrationClientURI:     regClientURI,
 		}
 		if err := h.Registrar.SaveRegistration(reg); err != nil {
 			h.jsonError(w, "server_error", "Failed to persist registration", http.StatusInternalServerError)
@@ -216,4 +252,32 @@ func generateDCRSecret() (string, error) {
 		return "", fmt.Errorf("failed to generate secret: %w", err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// generateRegistrationAccessToken returns a 32-byte (256-bit) hex-encoded random
+// token used as the RFC 7592 management credential for a DCR-registered client.
+// The token is stored on AppRegistration.RegistrationAccessToken and validated
+// on every /apps/dcr/{client_id} request via DCRManagementHandler.
+func generateRegistrationAccessToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate registration access token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// buildRegistrationClientURI constructs the RFC 7592 §3 management URI for a
+// freshly registered client. It prefers the configured IssuerBaseURL (correct
+// behind reverse proxies); when that's empty, it falls back to scheme+Host
+// from the incoming request — fine for tests, unreliable in production.
+func (h *DCRHandler) buildRegistrationClientURI(r *http.Request, clientID string) string {
+	base := h.IssuerBaseURL
+	if base == "" {
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		base = scheme + "://" + r.Host
+	}
+	return base + "/apps/dcr/" + clientID
 }

--- a/admin/dcr_management.go
+++ b/admin/dcr_management.go
@@ -1,0 +1,104 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// DCRManagementHandler is the HTTP transport adapter for the RFC 7592
+// management protocol — it parses the request, hands off to a
+// ClientRegistrationManager, then formats the response. All protocol /
+// authorization decisions live behind the interface so the same logic is
+// usable from gRPC, in-process callers, and tests without HTTP machinery.
+//
+// Issue #168 ships GET; #169 / #170 add PUT / DELETE. Until those land
+// non-GET methods return 405 with an Allow header.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592
+type DCRManagementHandler struct {
+	// Manager is the transport-agnostic core. Required.
+	Manager ClientRegistrationManager
+}
+
+// ServeHTTP routes /apps/dcr/{client_id} requests by HTTP method.
+func (h *DCRManagementHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	clientID := extractClientID(r.URL.Path)
+	if clientID == "" {
+		dcrUnauthorized(w, "invalid_token", "Missing client identifier")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGet(w, r, clientID)
+	default:
+		// 405 does not depend on client_id or auth, so it leaks no per-client
+		// information. The Allow header advertises what's currently supported.
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *DCRManagementHandler) handleGet(w http.ResponseWriter, r *http.Request, clientID string) {
+	token := bearerToken(r.Header.Get("Authorization"))
+	resp, err := h.Manager.GetRegistration(clientID, token)
+	if errors.Is(err, ErrUnauthorized) {
+		dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
+		return
+	}
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// extractClientID parses the trailing segment of /apps/dcr/{client_id}.
+// Returns "" if the path doesn't match. Trailing slashes are tolerated;
+// nested paths (which #169 / #170 might add for sub-resources) are not.
+func extractClientID(path string) string {
+	const prefix = "/apps/dcr/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	rest = strings.TrimSuffix(rest, "/")
+	if rest == "" || strings.Contains(rest, "/") {
+		return ""
+	}
+	return rest
+}
+
+// bearerToken extracts the token from an "Authorization: Bearer <token>"
+// header. Returns "" when the header is missing, malformed, or uses a
+// different scheme (Basic, etc.).
+func bearerToken(header string) string {
+	const scheme = "Bearer "
+	if len(header) < len(scheme) {
+		return ""
+	}
+	if !strings.EqualFold(header[:len(scheme)], scheme) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(scheme):])
+}
+
+// dcrUnauthorized writes an RFC 6750-shaped error response with the standard
+// no-store cache headers required for token-bearing endpoints.
+func dcrUnauthorized(w http.ResponseWriter, errCode, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             errCode,
+		"error_description": description,
+	})
+}

--- a/admin/dcr_management_test.go
+++ b/admin/dcr_management_test.go
@@ -1,0 +1,244 @@
+package admin_test
+
+// Tests for the RFC 7592 Dynamic Client Registration Management protocol —
+// both the transport-agnostic ClientRegistrationManager interface and the
+// HTTP wrapper DCRManagementHandler that exposes it at /apps/dcr/{client_id}.
+//
+// References:
+//   - RFC 7592 (https://www.rfc-editor.org/rfc/rfc7592):
+//     "OAuth 2.0 Dynamic Client Registration Management Protocol"
+//   - See: https://github.com/panyam/oneauth/issues/168
+//   - Blueprint for transport-agnostic admin/ refactor: issue 172.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerDCRClient is a test helper: drives a DCR registration through the
+// HTTP handler and returns the raw response map (so tests can assert on
+// whichever fields they care about).
+func registerDCRClient(t *testing.T, registrar *admin.AppRegistrar, body string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "auth.example.com"
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	return resp
+}
+
+// --- Interface-level tests (exercise ClientRegistrationManager directly) ---
+
+// TestGetRegistration_ValidTokenReturnsResponse verifies the happy-path: a
+// caller holding the registration_access_token issued at registration time
+// can fetch the registration as RFC 7591/7592 JSON.
+func TestGetRegistration_ValidTokenReturnsResponse(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar,
+		`{"client_name":"Read Me","redirect_uris":["https://app.example/cb"]}`)
+
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	resp, err := registrar.GetRegistration(clientID, token)
+	require.NoError(t, err)
+	assert.Equal(t, clientID, resp.ClientID)
+	assert.Equal(t, "Read Me", resp.ClientName)
+	assert.Equal(t, []string{"https://app.example/cb"}, resp.RedirectURIs)
+	assert.Equal(t, token, resp.RegistrationAccessToken)
+	assert.Empty(t, resp.ClientSecret, "client_secret must NOT be echoed on read")
+}
+
+// TestGetRegistration_WrongTokenReturnsUnauthorized verifies that a caller
+// presenting a token that does not match the stored registration_access_token
+// is rejected with ErrUnauthorized — even though the client_id exists.
+func TestGetRegistration_WrongTokenReturnsUnauthorized(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Wrong Token"}`)
+
+	_, err := registrar.GetRegistration(registered["client_id"].(string), "definitely-not-the-token")
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
+}
+
+// TestGetRegistration_UnknownClientReturnsUnauthorized verifies that asking
+// for a client_id that doesn't exist returns ErrUnauthorized — NOT a "not
+// found" error. Distinguishing them would let the management endpoint be
+// used to enumerate valid client_ids.
+func TestGetRegistration_UnknownClientReturnsUnauthorized(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	_, err := registrar.GetRegistration("app_does_not_exist", "any-token")
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
+}
+
+// TestGetRegistration_LegacyRegistrationCannotBeRead verifies that apps
+// registered via the non-DCR endpoint (/apps/register), which do NOT receive
+// a registration_access_token, are not readable through the management
+// interface. Only DCR-registered clients participate in RFC 7592.
+func TestGetRegistration_LegacyRegistrationCannotBeRead(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	// Register through the legacy endpoint — no management token issued.
+	body := `{"client_domain":"legacy.example","signing_alg":"HS256"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/register", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var legacy map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &legacy))
+
+	_, err := registrar.GetRegistration(legacy["client_id"].(string), "any-token")
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "legacy app must not be readable via mgmt endpoint")
+}
+
+// TestGetRegistration_EmptyInputsReturnUnauthorized covers the boundary cases
+// — empty client_id, empty token — to ensure they short-circuit to
+// ErrUnauthorized rather than reaching the store.
+func TestGetRegistration_EmptyInputsReturnUnauthorized(t *testing.T) {
+	registrar := admin.NewAppRegistrar(keys.NewInMemoryKeyStore(), admin.NewNoAuth())
+
+	for _, tc := range []struct {
+		name              string
+		clientID, token   string
+	}{
+		{"empty clientID", "", "some-token"},
+		{"empty token", "app_x", ""},
+		{"both empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := registrar.GetRegistration(tc.clientID, tc.token)
+			assert.True(t, errors.Is(err, admin.ErrUnauthorized), "expected ErrUnauthorized for %s", tc.name)
+		})
+	}
+}
+
+// --- HTTP-layer tests (exercise DCRManagementHandler) ---
+
+// TestDCRManagement_GET_HappyPath verifies the wire-level GET behavior: status
+// 200, JSON body that matches the registered client, and the no-store cache
+// headers required for token-bearing endpoints.
+func TestDCRManagement_GET_HappyPath(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar,
+		`{"client_name":"GET Test","redirect_uris":["https://app.example/cb"]}`)
+
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/dcr/"+clientID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal(t, "no-store", rr.Header().Get("Cache-Control"))
+	assert.Equal(t, "no-cache", rr.Header().Get("Pragma"))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Equal(t, clientID, got["client_id"])
+	assert.Equal(t, "GET Test", got["client_name"])
+	_, hasSecret := got["client_secret"]
+	assert.False(t, hasSecret, "GET response must NOT include client_secret")
+}
+
+// TestDCRManagement_GET_WrongToken returns 401 + WWW-Authenticate when the
+// Bearer value does not match the stored registration_access_token.
+func TestDCRManagement_GET_WrongToken(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Wrong Token HTTP"}`)
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/dcr/"+registered["client_id"].(string), nil)
+	req.Header.Set("Authorization", "Bearer not-the-real-token")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Header().Get("WWW-Authenticate"), "Bearer")
+}
+
+// TestDCRManagement_GET_MissingAuthHeader returns 401 with no auth header at all.
+func TestDCRManagement_GET_MissingAuthHeader(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"No Auth Header"}`)
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/dcr/"+registered["client_id"].(string), nil)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestDCRManagement_GET_UnknownClient_Returns401NotFound verifies the
+// information-disclosure guard: an unknown client_id must look identical to a
+// wrong-token response. 401, not 404.
+func TestDCRManagement_GET_UnknownClient_Returns401NotFound(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/dcr/app_phantom", nil)
+	req.Header.Set("Authorization", "Bearer something")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code, "must not reveal that the client_id does not exist")
+	assert.NotEqual(t, http.StatusNotFound, rr.Code)
+}
+
+// TestDCRManagement_NonGETMethodReturns405 verifies that PUT / DELETE / POST
+// against /apps/dcr/{client_id} return 405 with an Allow: GET header until
+// #169 / #170 land.
+func TestDCRManagement_NonGETMethodReturns405(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"405 Test"}`)
+
+	for _, method := range []string{http.MethodPut, http.MethodDelete, http.MethodPost} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/apps/dcr/"+registered["client_id"].(string), nil)
+			req.Header.Set("Authorization", "Bearer "+registered["registration_access_token"].(string))
+			rr := httptest.NewRecorder()
+			registrar.Handler().ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+			assert.Equal(t, "GET", rr.Header().Get("Allow"))
+		})
+	}
+}
+
+// TestDCRManagement_GET_DoesNotShadowDCRRegister verifies the routing
+// precedence: POST /apps/dcr (no trailing slash) still hits the RFC 7591
+// registration handler, even after we mount the /apps/dcr/ prefix for
+// management. Regression guard for go ServeMux longest-prefix-match behavior.
+func TestDCRManagement_GET_DoesNotShadowDCRRegister(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	body := `{"client_name":"Routing Guard"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusCreated, rr.Code, "POST /apps/dcr must still register; got %s", rr.Body.String())
+}

--- a/admin/dcr_test.go
+++ b/admin/dcr_test.go
@@ -56,6 +56,39 @@ func TestDCR_SymmetricRegistration(t *testing.T) {
 	assert.Equal(t, "HS256", rec.Algorithm)
 }
 
+// TestDCR_RegistrationResponseIncludesManagementCredentials verifies that every
+// successful DCR registration returns a registration_access_token and a
+// registration_client_uri (RFC 7592 §3). These are the credentials the client
+// will use to read / update / delete its own registration via /apps/dcr/{client_id}.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-3
+// See: https://github.com/panyam/oneauth/issues/168
+func TestDCR_RegistrationResponseIncludesManagementCredentials(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	handler := registrar.Handler()
+
+	body := `{"client_name":"Mgmt App","redirect_uris":["https://app.example/cb"]}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "auth.example.com"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	tok, _ := resp["registration_access_token"].(string)
+	require.NotEmpty(t, tok, "registration_access_token must be set per RFC 7592 §3")
+	assert.GreaterOrEqual(t, len(tok), 32, "registration_access_token must have meaningful entropy")
+
+	uri, _ := resp["registration_client_uri"].(string)
+	require.NotEmpty(t, uri, "registration_client_uri must be set per RFC 7592 §3")
+	clientID := resp["client_id"].(string)
+	assert.Contains(t, uri, "/apps/dcr/"+clientID, "URI must point at the client's management endpoint")
+}
+
 // TestDCR_AsymmetricRegistration verifies that a client can register with
 // a JWK public key (private_key_jwt auth method). No client_secret should
 // be returned — the client keeps its private key.

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -122,6 +123,48 @@ func (h *AppRegistrar) SaveRegistration(reg *AppRegistration) error {
 	return nil
 }
 
+// GetRegistration implements ClientRegistrationManager. It returns the
+// RFC 7591 registration for clientID iff accessToken matches the stored
+// registration_access_token. Returns ErrUnauthorized for every failure mode
+// — wrong/missing token, unknown client_id, or a registration that lacks a
+// management token (e.g., a legacy /apps/register entry) — so the management
+// endpoint cannot be used to probe for valid client_ids.
+//
+// The returned DCRResponse intentionally omits client_secret. RFC 7592 §3
+// permits but does not require echoing the secret on read; re-emitting
+// symmetric credentials on every read enlarges the disclosure window if the
+// registration access token is ever logged or proxied. Clients that lose
+// the secret can rotate via PUT (#169).
+func (h *AppRegistrar) GetRegistration(clientID, accessToken string) (*DCRResponse, error) {
+	if clientID == "" || accessToken == "" {
+		return nil, ErrUnauthorized
+	}
+	reg, err := h.Store.GetApp(clientID)
+	if err != nil || reg == nil {
+		return nil, ErrUnauthorized
+	}
+	if reg.RegistrationAccessToken == "" {
+		return nil, ErrUnauthorized
+	}
+	if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(accessToken)) != 1 {
+		return nil, ErrUnauthorized
+	}
+	return &DCRResponse{
+		ClientID:                  reg.ClientID,
+		ClientIDIssuedAt:          reg.CreatedAt.Unix(),
+		ClientSecretExpiresAt:     0,
+		ClientName:                reg.ClientName,
+		ClientURI:                 reg.ClientURI,
+		RedirectURIs:              reg.RedirectURIs,
+		GrantTypes:                reg.GrantTypes,
+		TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
+		Scope:                     reg.Scope,
+		AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
+		RegistrationAccessToken:   reg.RegistrationAccessToken,
+		RegistrationClientURI:     reg.RegistrationClientURI,
+	}, nil
+}
+
 // RLockApps calls fn with a read-locked view of all registered apps.
 func (h *AppRegistrar) RLockApps(fn func(map[string]*AppRegistration)) {
 	h.mu.RLock()
@@ -130,23 +173,31 @@ func (h *AppRegistrar) RLockApps(fn func(map[string]*AppRegistration)) {
 }
 
 // Handler returns an http.Handler for app registration endpoints.
-// Includes both custom OneAuth API and RFC 7591 DCR endpoint:
+// Includes both custom OneAuth API, RFC 7591 DCR, and RFC 7592 DCR Management:
 //
-//	POST /apps/register  — OneAuth custom registration
-//	POST /apps/dcr       — RFC 7591 Dynamic Client Registration
-//	GET  /apps           — List all apps
-//	GET  /apps/{id}      — Get app metadata
-//	DELETE /apps/{id}    — Delete app
-//	POST /apps/{id}/rotate — Rotate secret/key
+//	POST   /apps/register         — OneAuth custom registration
+//	POST   /apps/dcr              — RFC 7591 Dynamic Client Registration
+//	GET    /apps/dcr/{client_id}  — RFC 7592 DCR Management read (issue #168)
+//	GET    /apps                  — List all apps
+//	GET    /apps/{id}             — Get app metadata
+//	DELETE /apps/{id}             — Delete app
+//	POST   /apps/{id}/rotate      — Rotate secret/key
+//
+// Routing precedence note: Go's ServeMux uses longest-prefix matching, so the
+// "/apps/dcr/" prefix below wins over the "/apps/" catch-all without further
+// fiddling. The exact-match "/apps/dcr" route handles RFC 7591 registration.
 func (h *AppRegistrar) Handler() http.Handler {
 	dcr := &DCRHandler{
 		KeyStore:  h.KeyStore,
 		Auth:      h.Auth,
 		Registrar: h,
 	}
+	dcrMgmt := &DCRManagementHandler{Manager: h}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/apps/register", h.withAuth(h.handleRegister))
 	mux.Handle("/apps/dcr", http.HandlerFunc(dcr.ServeHTTP))
+	mux.Handle("/apps/dcr/", http.HandlerFunc(dcrMgmt.ServeHTTP))
 	mux.HandleFunc("/apps/", h.withAuth(h.handleAppByID))
 	mux.HandleFunc("/apps", h.withAuth(h.handleListApps))
 	return mux

--- a/client/dcr.go
+++ b/client/dcr.go
@@ -22,12 +22,29 @@ type ClientRegistrationRequest struct {
 }
 
 // ClientRegistrationResponse is the parsed response from a DCR endpoint,
-// containing the assigned client_id and optional client_secret.
+// extended with the RFC 7592 §3 management credentials so callers can
+// subsequently use GetRegistration / UpdateRegistration / DeleteRegistration
+// against the issuer's management endpoint.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-3
 type ClientRegistrationResponse struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret,omitempty"`
+	ClientID                string   `json:"client_id"`
+	ClientSecret            string   `json:"client_secret,omitempty"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at,omitempty"`
+	ClientSecretExpiresAt   int64    `json:"client_secret_expires_at,omitempty"`
+	ClientName              string   `json:"client_name,omitempty"`
+	ClientURI               string   `json:"client_uri,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
+
+	// RFC 7592 §3 — management credentials. RegistrationClientURI is the
+	// management endpoint for this specific registration; RegistrationAccessToken
+	// is the Bearer token that authorizes calls against it.
+	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 }
 
 // RegisterClient performs RFC 7591 Dynamic Client Registration against the
@@ -69,5 +86,71 @@ func RegisterClient(endpoint string, meta ClientRegistrationRequest, httpClient 
 		return nil, fmt.Errorf("DCR returned empty client_id: %s", string(respBody))
 	}
 
+	return &result, nil
+}
+
+// ErrRegistrationUnauthorized is returned by GetRegistration (and, in #169 / #170,
+// UpdateRegistration / DeleteRegistration) when the authorization server rejects
+// the registration access token. Per RFC 7592 the server returns 401 for any
+// auth failure — wrong token, missing token, or unknown client_id — so callers
+// cannot use this error to distinguish those cases.
+var ErrRegistrationUnauthorized = fmt.Errorf("registration management: unauthorized")
+
+// GetRegistration performs an RFC 7592 §2.1 read of a previously-registered
+// client. The caller supplies the registration_client_uri and
+// registration_access_token returned at registration time (see
+// ClientRegistrationResponse), and gets back the current registration metadata.
+//
+// The server is required to return 401 for any authentication failure; this
+// function maps that case to ErrRegistrationUnauthorized so callers can branch
+// on errors.Is. Other non-2xx responses surface as a generic error including
+// status code and body for diagnostics.
+//
+// If httpClient is nil, http.DefaultClient is used.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.1
+func GetRegistration(registrationClientURI, registrationAccessToken string, httpClient *http.Client) (*ClientRegistrationResponse, error) {
+	if registrationClientURI == "" {
+		return nil, fmt.Errorf("registration_client_uri is required")
+	}
+	if registrationAccessToken == "" {
+		return nil, fmt.Errorf("registration_access_token is required")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	req, err := http.NewRequest(http.MethodGet, registrationClientURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build GetRegistration request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+registrationAccessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetRegistration GET: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read GetRegistration response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrRegistrationUnauthorized
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GetRegistration returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result ClientRegistrationResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse GetRegistration response: %w (body: %s)", err, string(body))
+	}
+	if result.ClientID == "" {
+		return nil, fmt.Errorf("GetRegistration returned empty client_id: %s", string(body))
+	}
 	return &result, nil
 }

--- a/client/dcr_test.go
+++ b/client/dcr_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -83,4 +84,104 @@ func TestRegisterClient_EmptyClientID(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty client_id")
+}
+
+// TestRegisterClient_ParsesManagementCredentials verifies that registration_access_token
+// and registration_client_uri (RFC 7592 §3) are deserialized into the response when the
+// AS includes them, so callers can subsequently invoke GetRegistration / Update / Delete.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-3
+// See: https://github.com/panyam/oneauth/issues/168
+func TestRegisterClient_ParsesManagementCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"client_id":                 "client-mgmt-1",
+			"client_secret":             "s",
+			"registration_access_token": "rat-token-xyz",
+			"registration_client_uri":   "https://issuer.example/apps/dcr/client-mgmt-1",
+		})
+	}))
+	defer server.Close()
+
+	resp, err := RegisterClient(server.URL, ClientRegistrationRequest{ClientName: "x"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "rat-token-xyz", resp.RegistrationAccessToken)
+	assert.Equal(t, "https://issuer.example/apps/dcr/client-mgmt-1", resp.RegistrationClientURI)
+}
+
+// TestGetRegistration_Success verifies the happy-path RFC 7592 GET round trip:
+// the client sends Authorization: Bearer <registration_access_token> to the
+// registration_client_uri and receives the parsed registration metadata.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.1
+func TestGetRegistration_Success(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "Bearer rat-good", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		json.NewEncoder(w).Encode(ClientRegistrationResponse{
+			ClientID:                "client-1",
+			ClientName:              "Example Client",
+			RedirectURIs:            []string{"https://app.example/cb"},
+			RegistrationAccessToken: "rat-good",
+			RegistrationClientURI:   serverURL,
+		})
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	resp, err := GetRegistration(server.URL, "rat-good", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "client-1", resp.ClientID)
+	assert.Equal(t, "Example Client", resp.ClientName)
+	assert.Equal(t, []string{"https://app.example/cb"}, resp.RedirectURIs)
+}
+
+// TestGetRegistration_Unauthorized verifies that a 401 from the AS surfaces as
+// ErrRegistrationUnauthorized so callers can branch on errors.Is. Per RFC 7592,
+// the AS returns 401 for any auth failure (wrong token, missing token, unknown
+// client_id), so this single error covers all of them.
+func TestGetRegistration_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := GetRegistration(server.URL, "rat-bad", nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRegistrationUnauthorized), "expected ErrRegistrationUnauthorized, got %v", err)
+}
+
+// TestGetRegistration_OtherErrors verifies that non-401 server errors include
+// the status code and body in the returned error for diagnostics.
+func TestGetRegistration_OtherErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := GetRegistration(server.URL, "rat", nil)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrRegistrationUnauthorized))
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestGetRegistration_ValidatesArguments verifies that empty registration_client_uri
+// or empty registration_access_token return validation errors before any network
+// I/O, so misuse fails fast.
+func TestGetRegistration_ValidatesArguments(t *testing.T) {
+	_, err := GetRegistration("", "rat", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_client_uri")
+
+	_, err = GetRegistration("https://x", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_access_token")
 }

--- a/docs/CLIENT_SDK.md
+++ b/docs/CLIENT_SDK.md
@@ -292,6 +292,40 @@ refreshTransport.RoundTrip()
 
 The refresh uses a `grant_type=refresh_token` request to the token endpoint. The base transport is used for refresh requests to avoid infinite loops.
 
+## Dynamic Client Registration & Management (RFC 7591 / 7592)
+
+The `client/dcr.go` helpers let an application register itself at an authorization server and subsequently manage that registration without going through an admin UI.
+
+### Register
+
+```go
+resp, err := client.RegisterClient(asMetadata.RegistrationEndpoint, client.ClientRegistrationRequest{
+    ClientName:   "My Bot",
+    RedirectURIs: []string{"https://bot.example/cb"},
+    GrantTypes:   []string{"client_credentials"},
+}, nil)
+// resp.ClientID, resp.ClientSecret — the credentials
+// resp.RegistrationAccessToken, resp.RegistrationClientURI — RFC 7592 management credentials
+```
+
+### Read your own registration (RFC 7592 §2.1)
+
+Once registered, the client holds two extra fields — `RegistrationAccessToken` and `RegistrationClientURI`. They are the management credentials for *that specific registration*.
+
+```go
+got, err := client.GetRegistration(resp.RegistrationClientURI, resp.RegistrationAccessToken, nil)
+if errors.Is(err, client.ErrRegistrationUnauthorized) {
+    // Token rejected — the AS returned 401. The token may have been rotated
+    // (RFC 7592 §2.2 allows re-issue on PUT) or the client unregistered.
+}
+```
+
+`GetRegistration` returns the current registration metadata. The response intentionally **does not** echo `client_secret`; clients that lose the secret rotate via PUT (issue 169, pending).
+
+### Update / Delete (planned)
+
+`UpdateRegistration` (PUT) and `DeleteRegistration` (DELETE) ship in issues 169 and 170. The shape will mirror `GetRegistration`.
+
 ## AuthTransport (Static Token)
 
 For simpler cases where you have a static token and don't need refresh:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -188,6 +188,17 @@ Splits issue 20 (Persist AppRegistrar state) into shippable backend chunks. The 
 
 After 167 lands, parent issue 20 can close. The chain unblocks the entire RFC 7592 track (issues 168 / 169 / 170 / 171) tracked under issue 157.
 
+## RFC 7592 — DCR Management
+
+Splits issue 157 (parent) into vertical verb-by-verb slices. Each ticket ships a server handler, a client SDK helper, tests, and a walkthrough step in `examples/06-dynamic-client-registration/`. The `ClientRegistrationManager` interface introduced in 168 is also the blueprint for issue 172 (transport-agnostic refactor of legacy admin/ surface).
+
+| # | Slice | Status |
+|---|-------|--------|
+| 168 | Foundation + GET — registration_access_token + registration_client_uri issuance, `ClientRegistrationManager` interface, `DCRManagementHandler`, `client.GetRegistration`, walkthrough step | In progress |
+| 169 | PUT — full-replace update + token re-issuance + `client.UpdateRegistration` + walkthrough step | Pending |
+| 170 | DELETE — registration removal + `client.DeleteRegistration` + walkthrough step | Pending |
+| 171 | Keycloak interop — full lifecycle test against Keycloak's RFC 7592 endpoints | Pending |
+
 ---
 
 ## Relationship to Existing Work

--- a/examples/06-dynamic-client-registration/WALKTHROUGH.md
+++ b/examples/06-dynamic-client-registration/WALKTHROUGH.md
@@ -5,6 +5,7 @@ Non-UI | No infrastructure needed | Builds on Example 04
 ## What you'll learn
 
 - **Register a symmetric client (client_secret_post)** — The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.
+- **Fetch your own registration (RFC 7592 §2.1)** — client.GetRegistration is a thin SDK wrapper. Note the response intentionally omits client_secret on read — re-emitting symmetric credentials on every fetch enlarges disclosure if the access token leaks. Clients that lose the secret will rotate via PUT (#169).
 - **Get a token with the DCR-registered client** — The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.
 - **Register an asymmetric client (private_key_jwt with JWKS)** — For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.
 - **Register via Keycloak DCR (optional)** — Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.
@@ -20,15 +21,19 @@ sequenceDiagram
     App->>AS: POST /apps/dcr {client_name, grant_types, auth_method}
     AS-->>App: {client_id, client_secret, client_id_issued_at}
 
-    Note over App,AS: Step 2: Get a token with the DCR-registered client
+    Note over App,AS: Step 2: Fetch your own registration (RFC 7592 §2.1)
+    App->>AS: GET {registration_client_uri}  Authorization: Bearer {registration_access_token}
+    AS-->>App: {registration metadata — without client_secret}
+
+    Note over App,AS: Step 3: Get a token with the DCR-registered client
     App->>AS: POST /api/token {client_id, client_secret from DCR}
     AS-->>App: {access_token}
 
-    Note over App,AS: Step 3: Register an asymmetric client (private_key_jwt with JWKS)
+    Note over App,AS: Step 4: Register an asymmetric client (private_key_jwt with JWKS)
     App->>AS: POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}
     AS-->>App: {client_id} (no client_secret — asymmetric!)
 
-    Note over App,AS: Step 4: Register via Keycloak DCR (optional)
+    Note over App,AS: Step 5: Register via Keycloak DCR (optional)
     App->>AS: POST {KC registration_endpoint} {client_name, grant_types}
     AS-->>App: {client_id, client_secret, registration_access_token}
 ```
@@ -96,7 +101,33 @@ curl -s -X POST http://localhost:8081/apps/dcr \
   }' | jq
 ```
 
-### Step 2: Get a token with the DCR-registered client
+### RFC 7592: managing your own registration
+
+Notice the response above includes two extra fields:
+
+- `registration_access_token` — a Bearer token tied to **this specific client_id**
+- `registration_client_uri` — the management endpoint for this registration
+
+These come from RFC 7592 (Dynamic Client Registration *Management*). Once a client
+is registered, holding the access token lets the client read, update, or delete
+its own registration without going through an admin — a self-service lifecycle.
+
+OneAuth issue 168 ships GET (read); 169 / 170 will add PUT (update) and DELETE.
+
+### Step 2: Fetch your own registration (RFC 7592 §2.1)
+
+> **References:** [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
+
+client.GetRegistration is a thin SDK wrapper. Note the response intentionally omits client_secret on read — re-emitting symmetric credentials on every fetch enlarges disclosure if the access token leaks. Clients that lose the secret will rotate via PUT (#169).
+
+#### Reproduce on the wire
+
+```bash
+curl -s -X GET '<registration_client_uri>' \
+  -H 'Authorization: Bearer <registration_access_token>' | jq
+```
+
+### Step 3: Get a token with the DCR-registered client
 
 > **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 
@@ -112,7 +143,7 @@ curl -s -X POST http://localhost:8081/api/token \
   -d 'scope=read' | jq
 ```
 
-### Step 3: Register an asymmetric client (private_key_jwt with JWKS)
+### Step 4: Register an asymmetric client (private_key_jwt with JWKS)
 
 > **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591), [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
 
@@ -143,7 +174,7 @@ curl -s -X POST http://localhost:8081/apps/dcr \
 | **Key in JWKS** | Not in JWKS (secret) | Public key served in JWKS |
 | **Best for** | Simple integrations | High-security, multi-service |
 
-### Step 4: Register via Keycloak DCR (optional)
+### Step 5: Register via Keycloak DCR (optional)
 
 > **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
 
@@ -158,6 +189,7 @@ configuration — all wrapped in a simple `TokenSource` interface.
 ## References
 
 - [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+- [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
 - [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
 

--- a/examples/06-dynamic-client-registration/walkthrough.go
+++ b/examples/06-dynamic-client-registration/walkthrough.go
@@ -31,6 +31,7 @@ func runDemo() {
 	authServer.Config.Handler = newAuthServer(ks, authServer.URL)
 
 	var symClientID, symClientSecret string
+	var symRegToken, symRegURI string
 	var asymClientID string
 
 	demo := demokit.New("06: Dynamic Client Registration").
@@ -123,6 +124,45 @@ func runDemo() {
 
 			symClientID = dcrResp["client_id"].(string)
 			symClientSecret = dcrResp["client_secret"].(string)
+			symRegToken, _ = dcrResp["registration_access_token"].(string)
+			symRegURI, _ = dcrResp["registration_client_uri"].(string)
+			return nil
+		})
+
+	demo.Section("RFC 7592: managing your own registration",
+		"Notice the response above includes two extra fields:",
+		"",
+		"- `registration_access_token` — a Bearer token tied to **this specific client_id**",
+		"- `registration_client_uri` — the management endpoint for this registration",
+		"",
+		"These come from RFC 7592 (Dynamic Client Registration *Management*). Once a client",
+		"is registered, holding the access token lets the client read, update, or delete",
+		"its own registration without going through an admin — a self-service lifecycle.",
+		"",
+		"OneAuth issue 168 ships GET (read); 169 / 170 will add PUT (update) and DELETE.",
+	)
+
+	demo.Step("Fetch your own registration (RFC 7592 §2.1)").
+		Ref(refs.RFC7592).
+		Arrow("App", "AS", "GET {registration_client_uri}  Authorization: Bearer {registration_access_token}").
+		DashedArrow("AS", "App", "{registration metadata — without client_secret}").
+		Note("client.GetRegistration is a thin SDK wrapper. Note the response intentionally omits client_secret on read — re-emitting symmetric credentials on every fetch enlarges disclosure if the access token leaks. Clients that lose the secret will rotate via PUT (#169).").
+		VerbatimLang("Reproduce on the wire", "bash", `curl -s -X GET '<registration_client_uri>' \
+  -H 'Authorization: Bearer <registration_access_token>' | jq`).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if symRegToken == "" || symRegURI == "" {
+				return demokit.Errf("symmetric registration didn't issue management credentials")
+			}
+			got, err := client.GetRegistration(symRegURI, symRegToken, nil)
+			if err != nil {
+				return demokit.Errf("GetRegistration: %v", err)
+			}
+			fmt.Printf("    client_id:                 %s\n", got.ClientID)
+			fmt.Printf("    client_name:               %s\n", got.ClientName)
+			fmt.Printf("    scope:                     %s\n", got.Scope)
+			fmt.Printf("    grant_types:               %v\n", got.GrantTypes)
+			fmt.Printf("    registration_client_uri:   %s\n", got.RegistrationClientURI)
+			fmt.Printf("    client_secret in response: %v (intentionally omitted)\n", got.ClientSecret != "")
 			return nil
 		})
 

--- a/examples/refs/refs.go
+++ b/examples/refs/refs.go
@@ -24,6 +24,7 @@ var (
 // Token management
 var (
 	RFC7591 = demokit.Ref{Name: "RFC 7591 — Dynamic Client Registration", URL: "https://www.rfc-editor.org/rfc/rfc7591"}
+	RFC7592 = demokit.Ref{Name: "RFC 7592 — Dynamic Client Registration Management", URL: "https://www.rfc-editor.org/rfc/rfc7592"}
 	RFC7636 = demokit.Ref{Name: "RFC 7636 — PKCE", URL: "https://www.rfc-editor.org/rfc/rfc7636"}
 	RFC7662 = demokit.Ref{Name: "RFC 7662 — Token Introspection", URL: "https://www.rfc-editor.org/rfc/rfc7662"}
 	RFC8414 = demokit.Ref{Name: "RFC 8414 — AS Metadata Discovery", URL: "https://www.rfc-editor.org/rfc/rfc8414"}

--- a/tests/e2e/dcr_management_test.go
+++ b/tests/e2e/dcr_management_test.go
@@ -1,0 +1,91 @@
+package e2e_test
+
+// E2E for the RFC 7592 management protocol — proves that a client registered
+// via DCR can subsequently fetch its own registration using the management
+// credentials returned at registration time, end to end through the real auth
+// server. The client SDK helper (client.GetRegistration) is exercised here so
+// regressions in the wire format on either side are caught immediately.
+//
+// References:
+//   - RFC 7592 §2.1 — Read Client Registration
+//   - https://github.com/panyam/oneauth/issues/168
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2E_DCRManagement_GetRegistration registers a client via DCR against
+// the real auth server, then uses the issued registration_access_token +
+// registration_client_uri to call the management GET endpoint. It verifies
+// the round-trip preserves all the metadata the client supplied at
+// registration, and that the management response intentionally omits
+// client_secret.
+func TestE2E_DCRManagement_GetRegistration(t *testing.T) {
+	env := NewTestEnv(t)
+	c := NewTestClient(env)
+
+	// Register a client via DCR with rich metadata so we can verify the
+	// management response echoes it back correctly.
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name":   "E2E Mgmt Client",
+		"client_uri":    "https://e2e.example",
+		"redirect_uris": []string{"https://e2e.example/cb"},
+		"grant_types":   []string{"client_credentials"},
+		"scope":         "read write",
+	})
+	require.Equal(t, 201, resp.StatusCode)
+	dcr := ReadJSON(resp)
+
+	clientID, _ := dcr["client_id"].(string)
+	clientSecret, _ := dcr["client_secret"].(string)
+	regToken, _ := dcr["registration_access_token"].(string)
+	regURI, _ := dcr["registration_client_uri"].(string)
+
+	require.NotEmpty(t, clientID, "DCR must issue client_id")
+	require.NotEmpty(t, clientSecret, "DCR must issue client_secret for symmetric")
+	require.NotEmpty(t, regToken, "DCR must issue registration_access_token (RFC 7592 §3)")
+	require.NotEmpty(t, regURI, "DCR must issue registration_client_uri (RFC 7592 §3)")
+
+	// Drive the SDK against the live management endpoint.
+	got, err := client.GetRegistration(regURI, regToken, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, clientID, got.ClientID, "GET must echo the registered client_id")
+	assert.Equal(t, "E2E Mgmt Client", got.ClientName)
+	assert.Equal(t, "https://e2e.example", got.ClientURI)
+	assert.Equal(t, []string{"https://e2e.example/cb"}, got.RedirectURIs)
+	assert.Equal(t, []string{"client_credentials"}, got.GrantTypes)
+	assert.Equal(t, "read write", got.Scope)
+	assert.Equal(t, regToken, got.RegistrationAccessToken)
+
+	// Per security note in DCRManagementHandler.handleGet, client_secret must
+	// NOT be echoed on read.
+	assert.Empty(t, got.ClientSecret, "GET response must NOT include client_secret")
+
+	// Cleanup so the test environment doesn't accumulate state across runs.
+	c.Delete("/apps/" + clientID)
+}
+
+// TestE2E_DCRManagement_WrongTokenReturns401 verifies the wire-level rejection
+// path: hitting the live management endpoint with a wrong token yields 401
+// (mapped to ErrRegistrationUnauthorized by the SDK).
+func TestE2E_DCRManagement_WrongTokenReturns401(t *testing.T) {
+	env := NewTestEnv(t)
+	c := NewTestClient(env)
+
+	resp := c.PostJSON("/apps/dcr", map[string]any{"client_name": "Wrong Token E2E"})
+	require.Equal(t, 201, resp.StatusCode)
+	dcr := ReadJSON(resp)
+	clientID, _ := dcr["client_id"].(string)
+	regURI, _ := dcr["registration_client_uri"].(string)
+
+	_, err := client.GetRegistration(regURI, "this-is-not-the-token", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, client.ErrRegistrationUnauthorized)
+
+	c.Delete("/apps/" + clientID)
+}


### PR DESCRIPTION
## Summary
- DCR registration response now issues RFC 7592 §3 management credentials (registration_access_token + registration_client_uri); clients use them to fetch their own registration via `GET /apps/dcr/{client_id}`.
- New `ClientRegistrationManager` interface in admin/ — protocol logic lives behind the interface, `DCRManagementHandler` is a thin HTTP wrapper. Mirrors the apiauth/ pattern (TokenIssuer / Validator / Introspector / Revoker) and is the blueprint for the legacy admin/ refactor tracked in issue 172.
- New `client.GetRegistration` SDK helper + `ErrRegistrationUnauthorized` sentinel; example 06 walkthrough gains a "Fetch your own registration" step demonstrating the full round trip.
- Security choices documented in code: GET response omits client_secret; uniform 401 for any auth failure to prevent client_id enumeration; constant-time token comparison; legacy /apps/register clients (no management token issued) cannot be read via this endpoint.

Closes 168. Built on the foundation in PR 173 (issue 165). Lays the auth + interface for 169 (PUT) and 170 (DELETE).

> **Stacked review note**: this PR's base is `feat/issue-165-app-registration-store`, so the diff shows only the 168 changes. After 173 merges, GitHub will rebase this onto main automatically.

## Test plan
- [x] `make test` — added 5 interface tests (GetRegistration valid / wrong token / unknown client / legacy registration / empty inputs), 6 HTTP tests (happy path, wrong token, missing header, unknown client returns 401 not 404, 405 with Allow: GET, routing precedence guard), and 5 client SDK tests (mgmt fields parsing, GetRegistration round trip, 401 → ErrRegistrationUnauthorized, other errors, argument validation).
- [x] `make e2e` — `tests/e2e/dcr_management_test.go` exercises the full DCR-register → SDK GetRegistration round trip against the real auth server, plus the wrong-token 401 path.
- [x] Manually ran `make demo` for example 06 — the new "Fetch your own registration" step prints the registration metadata and confirms `client_secret in response: false (intentionally omitted)`.
- [x] All existing tests continue to pass; `WALKTHROUGH.md` regenerated via `make walkthrough`.