### PR TITLE
feat(admin): RFC 7592 PUT + ctx/req/resp convention

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -16,7 +16,7 @@
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
 - pluggable-app-registry: AppRegistrationStore interface for persisting registered apps; in-memory backend ships now, FS / GORM backends pending (issues 166, 167)
-- dcr-management-rfc7592: GET /apps/dcr/{client_id} for RFC 7592 read; clients get registration_access_token + registration_client_uri at registration time (issue 168). PUT/DELETE arrive in 169/170. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go).
+- dcr-management-rfc7592: GET (issue 168) + PUT (issue 169) at /apps/dcr/{client_id}, with token rotation on PUT per RFC 7592 §2.2. Clients receive registration_access_token + registration_client_uri at registration time. DELETE arrives in 170. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go) following the (ctx, *Req) → (*Resp, error) convention adopted across the library.
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model
 - client-credentials-grant: Machine-to-machine auth (RFC 6749 §4.4)

--- a/admin/SUMMARY.md
+++ b/admin/SUMMARY.md
@@ -7,8 +7,8 @@ Admin authentication, app registration API, and resource token minting for the f
 - **registrar.go** — `AppRegistrar` HTTP handler (register/list/delete/rotate apps), `AppRegistration`, `SaveRegistration`
 - **appstore.go** — `AppRegistrationStore` interface + `InMemoryAppStore` (issue 165). `ErrAppNotFound`. Persistent backends in `stores/fs/` and `stores/gorm/` (issues 166, 167).
 - **dcr.go** — `DCRHandler` for RFC 7591 Dynamic Client Registration at `POST /apps/dcr`. Now issues RFC 7592 §3 management credentials (`registration_access_token`, `registration_client_uri`) on every successful registration.
-- **client_management.go** — `ClientRegistrationManager` interface + `ErrUnauthorized` (issue 168). Transport-agnostic core for the RFC 7592 management surface — handlers in `dcr_management.go` are thin wrappers. Blueprint for the wider admin/ refactor tracked under issue 172.
-- **dcr_management.go** — `DCRManagementHandler` for RFC 7592 reads at `GET /apps/dcr/{client_id}` (issue 168). PUT / DELETE arrive in 169 / 170.
+- **client_management.go** — `ClientRegistrationManager` interface + `ErrUnauthorized` + `ErrInvalidClientMetadata`. Transport-agnostic core for the RFC 7592 management surface; methods follow the `(ctx context.Context, *XRequest) → (*XResponse, error)` convention so future gRPC stubs drop in cleanly. Blueprint for the wider admin/ refactor tracked under issue 172 and the apiauth port under issue 175.
+- **dcr_management.go** — `DCRManagementHandler` HTTP wrapper for `GET /apps/dcr/{client_id}` (issue 168) and `PUT /apps/dcr/{client_id}` (issue 169). DELETE arrives in 170.
 - **mint.go** — `MintResourceToken()`, `MintResourceTokenWithKey()`, `AppQuota`
 
 ## Dependencies

--- a/admin/client_management.go
+++ b/admin/client_management.go
@@ -1,6 +1,9 @@
 package admin
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 // ClientRegistrationManager is the transport-agnostic core of OAuth 2.0
 // Dynamic Client Registration Management (RFC 7592). HTTP handlers in admin/
@@ -9,14 +12,84 @@ import "errors"
 // response. Mirrors the apiauth/ pattern (TokenIssuer / TokenValidator /
 // TokenIntrospector / TokenRevoker — see issue #110).
 //
-// Issue #168 ships GetRegistration. UpdateRegistration / DeleteRegistration
-// arrive in #169 / #170.
+// Method shape — every method follows the convention:
+//
+//	MethodName(ctx context.Context, req *XRequest) (*XResponse, error)
+//
+// Two-arg / two-return signatures map cleanly to gRPC codegen if we ever
+// generate stubs from these interfaces. The first parameter is plain
+// context.Context for now; a typed library context (carrying stores,
+// loggers, request-scoped deps) can replace it later without changing the
+// shape — that's the point of standardizing on a single ctx parameter
+// rather than expanding the parameter list ad hoc.
+//
+// #168 ships GetRegistration. #169 ships UpdateRegistration. DeleteRegistration
+// arrives in #170.
 type ClientRegistrationManager interface {
-	// GetRegistration returns the registration for clientID iff accessToken
-	// matches its stored registration_access_token. Returns ErrUnauthorized
-	// for any failure mode — wrong token, missing token, unknown client_id —
-	// so callers (and attackers) cannot distinguish them.
-	GetRegistration(clientID, accessToken string) (*DCRResponse, error)
+	// GetRegistration returns the registration for req.ClientID iff
+	// req.AccessToken matches its stored registration_access_token. Any
+	// auth failure — wrong token, missing token, unknown client_id — yields
+	// ErrUnauthorized so callers (and attackers) cannot distinguish them.
+	GetRegistration(ctx context.Context, req *GetRegistrationRequest) (*GetRegistrationResponse, error)
+
+	// UpdateRegistration replaces the metadata for req.ClientID per RFC 7592
+	// §2.2 (full replacement, not PATCH-style merge). The request's body-level
+	// client_id (req.Metadata.ClientID) MUST equal req.ClientID — mismatch
+	// returns ErrInvalidClientMetadata, mapped to HTTP 400 by the wrapper.
+	// Auth failures return ErrUnauthorized as with GetRegistration.
+	//
+	// On success the registration_access_token is rotated (RFC 7592 §2.2
+	// recommended) and the new token is returned in the response; the old
+	// token is invalid for any subsequent management request.
+	//
+	// Out of scope for #169: changing token_endpoint_auth_method (which would
+	// require re-keying / new secret). Such requests return
+	// ErrInvalidClientMetadata. Clients that need to change auth method
+	// DELETE and re-register.
+	UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*UpdateRegistrationResponse, error)
+}
+
+// GetRegistrationRequest is the input to ClientRegistrationManager.GetRegistration.
+type GetRegistrationRequest struct {
+	// ClientID identifies the registration to read.
+	ClientID string
+
+	// AccessToken is the registration_access_token issued at registration time
+	// (RFC 7592 §3). Must match the value stored on the registration.
+	AccessToken string
+}
+
+// GetRegistrationResponse wraps the registration metadata. Wrapped (rather than
+// returning *DCRResponse directly) so that future forward-compat fields can be
+// added without changing the method signature — same reason gRPC requires
+// dedicated response messages per method.
+type GetRegistrationResponse struct {
+	Registration *DCRResponse
+}
+
+// UpdateRegistrationRequest is the input to ClientRegistrationManager.UpdateRegistration.
+type UpdateRegistrationRequest struct {
+	// ClientID identifies the registration to update. The wrapper guarantees
+	// this matches Metadata.ClientID before invoking the manager.
+	ClientID string
+
+	// AccessToken is the registration_access_token issued at registration time
+	// (or the rotated value from a previous UpdateRegistration). Must match
+	// the value currently stored on the registration.
+	AccessToken string
+
+	// Metadata is the RFC 7591 / 7592 client metadata to replace the existing
+	// registration with. Treated as a full-replacement payload per
+	// RFC 7592 §2.2 — fields omitted from Metadata are cleared on the server.
+	Metadata *DCRRequest
+}
+
+// UpdateRegistrationResponse wraps the post-update registration. Registration
+// includes the rotated registration_access_token, which supersedes the one
+// passed in via the request. Callers MUST persist the new token before
+// discarding the old one.
+type UpdateRegistrationResponse struct {
+	Registration *DCRResponse
 }
 
 // ErrUnauthorized is the single failure mode returned by ClientRegistrationManager
@@ -24,3 +97,11 @@ type ClientRegistrationManager interface {
 // is intentional: distinguishing "unknown client_id" from "wrong token" would
 // turn /apps/dcr/{client_id} into a probe for valid identifiers.
 var ErrUnauthorized = errors.New("unauthorized registration management request")
+
+// ErrInvalidClientMetadata signals that a management request was authenticated
+// successfully but the request body fails RFC 7591 / 7592 client-metadata
+// validation. HTTP wrappers map this to 400 Bad Request. Distinct from
+// ErrUnauthorized because, by the time we get here, the caller has already
+// proven possession of the registration access token — refusing to distinguish
+// would be needlessly cryptic.
+var ErrInvalidClientMetadata = errors.New("invalid client metadata")

--- a/admin/dcr.go
+++ b/admin/dcr.go
@@ -48,15 +48,26 @@ type DCRHandler struct {
 	IssuerBaseURL string
 }
 
-// DCRRequest is the RFC 7591 client registration request.
+// DCRRequest is the RFC 7591 client registration request, also reused as the
+// RFC 7592 §2.2 update request body.
+//
+// On RFC 7591 registration the ClientID field is unused — the server assigns
+// the value. On RFC 7592 PUT the client MUST include its existing client_id;
+// the HTTP wrapper validates that it matches the URL path before invoking
+// ClientRegistrationManager.UpdateRegistration.
+//
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-2
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
 type DCRRequest struct {
+	// ClientID is required for PUT (RFC 7592 §2.2), ignored for register.
+	ClientID string `json:"client_id,omitempty"`
+
 	// Client metadata
-	ClientName  string   `json:"client_name,omitempty"`
-	ClientURI   string   `json:"client_uri,omitempty"`
-	RedirectURIs []string `json:"redirect_uris,omitempty"`
-	GrantTypes  []string `json:"grant_types,omitempty"`
-	Scope       string   `json:"scope,omitempty"`
+	ClientName              string   `json:"client_name,omitempty"`
+	ClientURI               string   `json:"client_uri,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
 
 	// Authentication method
 	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`

--- a/admin/dcr_management.go
+++ b/admin/dcr_management.go
@@ -13,14 +13,18 @@ import (
 // authorization decisions live behind the interface so the same logic is
 // usable from gRPC, in-process callers, and tests without HTTP machinery.
 //
-// Issue #168 ships GET; #169 / #170 add PUT / DELETE. Until those land
-// non-GET methods return 405 with an Allow header.
+// #168 ships GET; #169 ships PUT; #170 adds DELETE. Until DELETE lands
+// it returns 405 with an Allow header advertising the supported methods.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7592
 type DCRManagementHandler struct {
 	// Manager is the transport-agnostic core. Required.
 	Manager ClientRegistrationManager
 }
+
+// allowedMethods is the value of the Allow header on 405 responses. Updated
+// when new verbs come online so a single string captures the supported set.
+const allowedMethods = "GET, PUT"
 
 // ServeHTTP routes /apps/dcr/{client_id} requests by HTTP method.
 func (h *DCRManagementHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -33,17 +37,67 @@ func (h *DCRManagementHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	switch r.Method {
 	case http.MethodGet:
 		h.handleGet(w, r, clientID)
+	case http.MethodPut:
+		h.handlePut(w, r, clientID)
 	default:
 		// 405 does not depend on client_id or auth, so it leaks no per-client
 		// information. The Allow header advertises what's currently supported.
-		w.Header().Set("Allow", "GET")
+		w.Header().Set("Allow", allowedMethods)
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 	}
 }
 
+func (h *DCRManagementHandler) handlePut(w http.ResponseWriter, r *http.Request, clientID string) {
+	token := bearerToken(r.Header.Get("Authorization"))
+
+	// Limit body size to prevent unbounded JSON payloads from exhausting memory.
+	// 64 KiB is generous for client metadata; tighten if it ever feels too loose.
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+
+	var body DCRRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		dcrBadRequest(w, "invalid_client_metadata", "Invalid JSON body")
+		return
+	}
+
+	// RFC 7592 §2.2: the client MUST include the client_id and it MUST match
+	// the registered identifier. We enforce here so the manager only sees
+	// validated requests.
+	if body.ClientID == "" || body.ClientID != clientID {
+		dcrBadRequest(w, "invalid_client_metadata", "client_id in body must match URL path")
+		return
+	}
+
+	resp, err := h.Manager.UpdateRegistration(r.Context(), &UpdateRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: token,
+		Metadata:    &body,
+	})
+	switch {
+	case errors.Is(err, ErrUnauthorized):
+		dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
+		return
+	case errors.Is(err, ErrInvalidClientMetadata):
+		dcrBadRequest(w, "invalid_client_metadata", "Update rejected: "+err.Error())
+		return
+	case err != nil:
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp.Registration)
+}
+
 func (h *DCRManagementHandler) handleGet(w http.ResponseWriter, r *http.Request, clientID string) {
 	token := bearerToken(r.Header.Get("Authorization"))
-	resp, err := h.Manager.GetRegistration(clientID, token)
+	resp, err := h.Manager.GetRegistration(r.Context(), &GetRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: token,
+	})
 	if errors.Is(err, ErrUnauthorized) {
 		dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
 		return
@@ -56,7 +110,7 @@ func (h *DCRManagementHandler) handleGet(w http.ResponseWriter, r *http.Request,
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp.Registration)
 }
 
 // extractClientID parses the trailing segment of /apps/dcr/{client_id}.
@@ -97,6 +151,20 @@ func dcrUnauthorized(w http.ResponseWriter, errCode, description string) {
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
 	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             errCode,
+		"error_description": description,
+	})
+}
+
+// dcrBadRequest writes an RFC 7591/7592 client-metadata error (HTTP 400).
+// Used when the request is well-authenticated but the body fails validation
+// (malformed JSON, missing/mismatched client_id, locked-field change, etc.).
+func dcrBadRequest(w http.ResponseWriter, errCode, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"error":             errCode,
 		"error_description": description,

--- a/admin/dcr_management_test.go
+++ b/admin/dcr_management_test.go
@@ -11,6 +11,7 @@ package admin_test
 //   - Blueprint for transport-agnostic admin/ refactor: issue 172.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -54,13 +55,18 @@ func TestGetRegistration_ValidTokenReturnsResponse(t *testing.T) {
 	clientID := registered["client_id"].(string)
 	token := registered["registration_access_token"].(string)
 
-	resp, err := registrar.GetRegistration(clientID, token)
+	resp, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: token,
+	})
 	require.NoError(t, err)
-	assert.Equal(t, clientID, resp.ClientID)
-	assert.Equal(t, "Read Me", resp.ClientName)
-	assert.Equal(t, []string{"https://app.example/cb"}, resp.RedirectURIs)
-	assert.Equal(t, token, resp.RegistrationAccessToken)
-	assert.Empty(t, resp.ClientSecret, "client_secret must NOT be echoed on read")
+	require.NotNil(t, resp.Registration)
+	got := resp.Registration
+	assert.Equal(t, clientID, got.ClientID)
+	assert.Equal(t, "Read Me", got.ClientName)
+	assert.Equal(t, []string{"https://app.example/cb"}, got.RedirectURIs)
+	assert.Equal(t, token, got.RegistrationAccessToken)
+	assert.Empty(t, got.ClientSecret, "client_secret must NOT be echoed on read")
 }
 
 // TestGetRegistration_WrongTokenReturnsUnauthorized verifies that a caller
@@ -71,7 +77,10 @@ func TestGetRegistration_WrongTokenReturnsUnauthorized(t *testing.T) {
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	registered := registerDCRClient(t, registrar, `{"client_name":"Wrong Token"}`)
 
-	_, err := registrar.GetRegistration(registered["client_id"].(string), "definitely-not-the-token")
+	_, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID:    registered["client_id"].(string),
+		AccessToken: "definitely-not-the-token",
+	})
 	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
 }
 
@@ -83,7 +92,10 @@ func TestGetRegistration_UnknownClientReturnsUnauthorized(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 
-	_, err := registrar.GetRegistration("app_does_not_exist", "any-token")
+	_, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID:    "app_does_not_exist",
+		AccessToken: "any-token",
+	})
 	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
 }
 
@@ -104,7 +116,10 @@ func TestGetRegistration_LegacyRegistrationCannotBeRead(t *testing.T) {
 	var legacy map[string]any
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &legacy))
 
-	_, err := registrar.GetRegistration(legacy["client_id"].(string), "any-token")
+	_, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID:    legacy["client_id"].(string),
+		AccessToken: "any-token",
+	})
 	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "legacy app must not be readable via mgmt endpoint")
 }
 
@@ -123,7 +138,10 @@ func TestGetRegistration_EmptyInputsReturnUnauthorized(t *testing.T) {
 		{"both empty", "", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := registrar.GetRegistration(tc.clientID, tc.token)
+			_, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+				ClientID:    tc.clientID,
+				AccessToken: tc.token,
+			})
 			assert.True(t, errors.Is(err, admin.ErrUnauthorized), "expected ErrUnauthorized for %s", tc.name)
 		})
 	}
@@ -205,15 +223,16 @@ func TestDCRManagement_GET_UnknownClient_Returns401NotFound(t *testing.T) {
 	assert.NotEqual(t, http.StatusNotFound, rr.Code)
 }
 
-// TestDCRManagement_NonGETMethodReturns405 verifies that PUT / DELETE / POST
-// against /apps/dcr/{client_id} return 405 with an Allow: GET header until
-// #169 / #170 land.
-func TestDCRManagement_NonGETMethodReturns405(t *testing.T) {
+// TestDCRManagement_UnsupportedMethodReturns405 verifies that methods we
+// don't yet support (DELETE — pending #170 — and arbitrary verbs like POST)
+// return 405 with an Allow header advertising the currently supported set.
+// This list shrinks as #170 lands.
+func TestDCRManagement_UnsupportedMethodReturns405(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	registered := registerDCRClient(t, registrar, `{"client_name":"405 Test"}`)
 
-	for _, method := range []string{http.MethodPut, http.MethodDelete, http.MethodPost} {
+	for _, method := range []string{http.MethodDelete, http.MethodPost} {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/apps/dcr/"+registered["client_id"].(string), nil)
 			req.Header.Set("Authorization", "Bearer "+registered["registration_access_token"].(string))
@@ -221,9 +240,216 @@ func TestDCRManagement_NonGETMethodReturns405(t *testing.T) {
 			registrar.Handler().ServeHTTP(rr, req)
 
 			assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
-			assert.Equal(t, "GET", rr.Header().Get("Allow"))
+			assert.Equal(t, "GET, PUT", rr.Header().Get("Allow"))
 		})
 	}
+}
+
+// --- PUT — RFC 7592 §2.2 update tests ---
+//
+// Issue #169 ships full-replace semantics, registration_access_token rotation,
+// and rejection of token_endpoint_auth_method changes (out of scope here;
+// clients change auth method via DELETE + re-register).
+
+// TestUpdateRegistration_HappyPath_RotatesToken verifies that a successful PUT
+// replaces editable metadata and rotates the registration_access_token. The
+// old token MUST stop working after rotation — that's the security guarantee.
+func TestUpdateRegistration_HappyPath_RotatesToken(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar,
+		`{"client_name":"Pre Update","scope":"read"}`)
+	clientID := registered["client_id"].(string)
+	oldToken := registered["registration_access_token"].(string)
+
+	updated, err := registrar.UpdateRegistration(context.Background(), &admin.UpdateRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: oldToken,
+		Metadata: &admin.DCRRequest{
+			ClientID:   clientID,
+			ClientName: "Post Update",
+			Scope:      "read write",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.Registration)
+	assert.Equal(t, "Post Update", updated.Registration.ClientName)
+	assert.Equal(t, "read write", updated.Registration.Scope)
+
+	newToken := updated.Registration.RegistrationAccessToken
+	require.NotEmpty(t, newToken, "PUT must return a registration_access_token")
+	assert.NotEqual(t, oldToken, newToken, "token must rotate on PUT (RFC 7592 §2.2)")
+
+	// Old token is now invalid.
+	_, err = registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID: clientID, AccessToken: oldToken,
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "old token must not survive rotation")
+	// New token works.
+	gotAfter, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID: clientID, AccessToken: newToken,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Post Update", gotAfter.Registration.ClientName)
+}
+
+// TestUpdateRegistration_WrongTokenReturnsUnauthorized verifies that a caller
+// presenting a non-matching token cannot update the registration.
+func TestUpdateRegistration_WrongTokenReturnsUnauthorized(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Wrong Token PUT"}`)
+	clientID := registered["client_id"].(string)
+
+	_, err := registrar.UpdateRegistration(context.Background(), &admin.UpdateRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: "definitely-wrong",
+		Metadata: &admin.DCRRequest{
+			ClientID:   clientID,
+			ClientName: "Hacked",
+		},
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized))
+}
+
+// TestUpdateRegistration_UnknownClientReturnsUnauthorized verifies that
+// unknown client_ids look the same as wrong-token failures (no enumeration).
+func TestUpdateRegistration_UnknownClientReturnsUnauthorized(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	_, err := registrar.UpdateRegistration(context.Background(), &admin.UpdateRegistrationRequest{
+		ClientID:    "app_phantom",
+		AccessToken: "any",
+		Metadata: &admin.DCRRequest{
+			ClientID:   "app_phantom",
+			ClientName: "x",
+		},
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized))
+}
+
+// TestUpdateRegistration_AuthMethodChangeRejected verifies that PUT cannot
+// switch token_endpoint_auth_method (e.g., HS256 client_secret_post →
+// private_key_jwt). Such a change requires re-keying and is out of scope for
+// #169; clients DELETE + re-register instead.
+func TestUpdateRegistration_AuthMethodChangeRejected(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Auth Method Lock"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	_, err := registrar.UpdateRegistration(context.Background(), &admin.UpdateRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: token,
+		Metadata: &admin.DCRRequest{
+			ClientID:                clientID,
+			ClientName:              "Auth Method Lock",
+			TokenEndpointAuthMethod: "private_key_jwt", // was client_secret_post
+		},
+	})
+	assert.True(t, errors.Is(err, admin.ErrInvalidClientMetadata))
+}
+
+// TestDCRManagement_PUT_HappyPath drives the full HTTP wrapper: success
+// returns 200 + the no-store cache headers + the rotated token in the body.
+func TestDCRManagement_PUT_HappyPath(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"PUT HP","scope":"read"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	body := `{"client_id":"` + clientID + `","client_name":"PUT HP Updated","scope":"read write"}`
+	req := httptest.NewRequest(http.MethodPut, "/apps/dcr/"+clientID, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal(t, "no-store", rr.Header().Get("Cache-Control"))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Equal(t, "PUT HP Updated", got["client_name"])
+	assert.Equal(t, "read write", got["scope"])
+	newTok, _ := got["registration_access_token"].(string)
+	require.NotEmpty(t, newTok)
+	assert.NotEqual(t, token, newTok, "PUT response must include rotated token")
+}
+
+// TestDCRManagement_PUT_MissingBodyClientID verifies the RFC 7592 §2.2
+// requirement that the body MUST include client_id matching the URL. Wrapper
+// returns 400 before the manager is invoked.
+func TestDCRManagement_PUT_MissingBodyClientID(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Missing CID"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	body := `{"client_name":"No client_id field"}` // intentionally no client_id
+	req := httptest.NewRequest(http.MethodPut, "/apps/dcr/"+clientID, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestDCRManagement_PUT_BodyClientIDMismatch verifies that a body with the
+// wrong client_id is rejected with 400, even when the auth token is valid.
+func TestDCRManagement_PUT_BodyClientIDMismatch(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Mismatch"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	body := `{"client_id":"app_other","client_name":"Mismatched"}`
+	req := httptest.NewRequest(http.MethodPut, "/apps/dcr/"+clientID, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestDCRManagement_PUT_MalformedJSONReturns400 ensures unparsable bodies are
+// surfaced as 400, not 500.
+func TestDCRManagement_PUT_MalformedJSONReturns400(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Malformed"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	req := httptest.NewRequest(http.MethodPut, "/apps/dcr/"+clientID, strings.NewReader("{not-json"))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestDCRManagement_PUT_WrongTokenReturns401 mirrors the GET wrong-token
+// behavior at the wire level — uniform 401 envelope, no leakage.
+func TestDCRManagement_PUT_WrongTokenReturns401(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"PUT Wrong Token"}`)
+	clientID := registered["client_id"].(string)
+
+	body := `{"client_id":"` + clientID + `","client_name":"Should fail"}`
+	req := httptest.NewRequest(http.MethodPut, "/apps/dcr/"+clientID, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer not-the-real-token")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Header().Get("WWW-Authenticate"), "Bearer")
 }
 
 // TestDCRManagement_GET_DoesNotShadowDCRRegister verifies the routing

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
@@ -124,44 +125,138 @@ func (h *AppRegistrar) SaveRegistration(reg *AppRegistration) error {
 }
 
 // GetRegistration implements ClientRegistrationManager. It returns the
-// RFC 7591 registration for clientID iff accessToken matches the stored
-// registration_access_token. Returns ErrUnauthorized for every failure mode
-// — wrong/missing token, unknown client_id, or a registration that lacks a
-// management token (e.g., a legacy /apps/register entry) — so the management
-// endpoint cannot be used to probe for valid client_ids.
+// RFC 7591 registration for req.ClientID iff req.AccessToken matches the
+// stored registration_access_token. Returns ErrUnauthorized for every
+// failure mode — wrong/missing token, unknown client_id, or a registration
+// that lacks a management token (e.g., a legacy /apps/register entry) — so
+// the management endpoint cannot be used to probe for valid client_ids.
 //
 // The returned DCRResponse intentionally omits client_secret. RFC 7592 §3
 // permits but does not require echoing the secret on read; re-emitting
 // symmetric credentials on every read enlarges the disclosure window if the
 // registration access token is ever logged or proxied. Clients that lose
 // the secret can rotate via PUT (#169).
-func (h *AppRegistrar) GetRegistration(clientID, accessToken string) (*DCRResponse, error) {
-	if clientID == "" || accessToken == "" {
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops, and for parity with the rest of
+// the manager interface.
+func (h *AppRegistrar) GetRegistration(ctx context.Context, req *GetRegistrationRequest) (*GetRegistrationResponse, error) {
+	if req == nil || req.ClientID == "" || req.AccessToken == "" {
 		return nil, ErrUnauthorized
 	}
-	reg, err := h.Store.GetApp(clientID)
+	reg, err := h.Store.GetApp(req.ClientID)
 	if err != nil || reg == nil {
 		return nil, ErrUnauthorized
 	}
 	if reg.RegistrationAccessToken == "" {
 		return nil, ErrUnauthorized
 	}
-	if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(accessToken)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(req.AccessToken)) != 1 {
 		return nil, ErrUnauthorized
 	}
-	return &DCRResponse{
-		ClientID:                  reg.ClientID,
-		ClientIDIssuedAt:          reg.CreatedAt.Unix(),
-		ClientSecretExpiresAt:     0,
-		ClientName:                reg.ClientName,
-		ClientURI:                 reg.ClientURI,
-		RedirectURIs:              reg.RedirectURIs,
-		GrantTypes:                reg.GrantTypes,
-		TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
-		Scope:                     reg.Scope,
-		AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
-		RegistrationAccessToken:   reg.RegistrationAccessToken,
-		RegistrationClientURI:     reg.RegistrationClientURI,
+	return &GetRegistrationResponse{
+		Registration: &DCRResponse{
+			ClientID:                  reg.ClientID,
+			ClientIDIssuedAt:          reg.CreatedAt.Unix(),
+			ClientSecretExpiresAt:     0,
+			ClientName:                reg.ClientName,
+			ClientURI:                 reg.ClientURI,
+			RedirectURIs:              reg.RedirectURIs,
+			GrantTypes:                reg.GrantTypes,
+			TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
+			Scope:                     reg.Scope,
+			AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
+			RegistrationAccessToken:   reg.RegistrationAccessToken,
+			RegistrationClientURI:     reg.RegistrationClientURI,
+		},
+	}, nil
+}
+
+// UpdateRegistration implements ClientRegistrationManager (RFC 7592 §2.2).
+// It performs a full replacement of the editable metadata fields and rotates
+// the registration_access_token; the new token is returned in the response.
+// The old token becomes invalid as soon as SaveRegistration succeeds.
+//
+// Editable fields (overwritten from req.Metadata on success): ClientName,
+// ClientURI, RedirectURIs, GrantTypes, Scope, AuthorizationDetailsTypes,
+// ClientDomain (derived from ClientURI / ClientName, mirroring DCRHandler's
+// logic).
+//
+// Locked fields (return ErrInvalidClientMetadata on attempted change):
+//   - TokenEndpointAuthMethod — would require re-keying; out of scope for #169.
+// Locked fields (silently retained):
+//   - SigningAlg, ClientID, CreatedAt, RegistrationClientURI, the key material
+//     in KeyStore.
+//
+// req.Metadata is treated as RFC 7591 client metadata; req.Metadata.JWKS is
+// currently ignored (auth-method changes are rejected, so the JWKS cannot
+// usefully change either).
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops, and for parity with the rest of
+// the manager interface.
+func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*UpdateRegistrationResponse, error) {
+	if req == nil || req.ClientID == "" || req.AccessToken == "" || req.Metadata == nil {
+		return nil, ErrUnauthorized
+	}
+	reg, err := h.Store.GetApp(req.ClientID)
+	if err != nil || reg == nil {
+		return nil, ErrUnauthorized
+	}
+	if reg.RegistrationAccessToken == "" {
+		return nil, ErrUnauthorized
+	}
+	if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(req.AccessToken)) != 1 {
+		return nil, ErrUnauthorized
+	}
+
+	// Authenticated — past this point, validation errors return
+	// ErrInvalidClientMetadata so the wrapper can map to 400 instead of 401.
+	// Auth method changes are out of scope for #169 (would require re-keying).
+	md := req.Metadata
+	if md.TokenEndpointAuthMethod != "" && md.TokenEndpointAuthMethod != reg.TokenEndpointAuthMethod {
+		return nil, ErrInvalidClientMetadata
+	}
+
+	newToken, err := generateRegistrationAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace the editable metadata fields. ClientDomain mirrors the derivation
+	// in DCRHandler.ServeHTTP so callers see consistent behavior on register
+	// and update.
+	domain := md.ClientURI
+	if domain == "" {
+		domain = md.ClientName
+	}
+	reg.ClientName = md.ClientName
+	reg.ClientURI = md.ClientURI
+	reg.RedirectURIs = md.RedirectURIs
+	reg.GrantTypes = md.GrantTypes
+	reg.Scope = md.Scope
+	reg.AuthorizationDetailsTypes = md.AuthorizationDetailsTypes
+	reg.ClientDomain = domain
+	reg.RegistrationAccessToken = newToken
+
+	if err := h.SaveRegistration(reg); err != nil {
+		return nil, err
+	}
+	return &UpdateRegistrationResponse{
+		Registration: &DCRResponse{
+			ClientID:                  reg.ClientID,
+			ClientIDIssuedAt:          reg.CreatedAt.Unix(),
+			ClientSecretExpiresAt:     0,
+			ClientName:                reg.ClientName,
+			ClientURI:                 reg.ClientURI,
+			RedirectURIs:              reg.RedirectURIs,
+			GrantTypes:                reg.GrantTypes,
+			TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
+			Scope:                     reg.Scope,
+			AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
+			RegistrationAccessToken:   reg.RegistrationAccessToken,
+			RegistrationClientURI:     reg.RegistrationClientURI,
+		},
 	}, nil
 }
 

--- a/client/dcr.go
+++ b/client/dcr.go
@@ -2,23 +2,40 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 )
 
+// Method-shape convention (issue 169): every transport-agnostic SDK call
+// follows MethodName(ctx context.Context, req *XRequest) (*XResponse, error).
+// Two-arg / two-return signatures map cleanly to gRPC stub generation should
+// we ever need it. Helpers that only make HTTP calls (RegisterClient — the
+// pre-convention shape) are kept as-is for now; converting them lives under
+// issue 175.
+
 // ClientRegistrationRequest is the payload for RFC 7591 Dynamic Client
-// Registration. This represents a client requesting registration at an
-// authorization server's registration endpoint.
+// Registration and the RFC 7592 §2.2 update body. This represents a client
+// requesting registration (or replacing its registration) at an authorization
+// server's endpoint.
+//
+// On register the ClientID field is unused (the server assigns the value).
+// On update the ClientID MUST equal the client's existing identifier — the
+// server returns 400 otherwise. UpdateRegistration auto-fills it for callers.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-2
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
 type ClientRegistrationRequest struct {
+	ClientID                string   `json:"client_id,omitempty"`
 	ClientName              string   `json:"client_name"`
+	ClientURI               string   `json:"client_uri,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris"`
 	GrantTypes              []string `json:"grant_types,omitempty"`
 	ResponseTypes           []string `json:"response_types,omitempty"`
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
 }
 
 // ClientRegistrationResponse is the parsed response from a DCR endpoint,
@@ -96,38 +113,61 @@ func RegisterClient(endpoint string, meta ClientRegistrationRequest, httpClient 
 // cannot use this error to distinguish those cases.
 var ErrRegistrationUnauthorized = fmt.Errorf("registration management: unauthorized")
 
+// GetRegistrationRequest is the input to GetRegistration.
+type GetRegistrationRequest struct {
+	// RegistrationClientURI is the management endpoint returned at
+	// registration time (RFC 7592 §3 registration_client_uri).
+	RegistrationClientURI string
+	// RegistrationAccessToken authorizes calls to RegistrationClientURI
+	// (RFC 7592 §3).
+	RegistrationAccessToken string
+	// HTTPClient is used to make the request. nil → http.DefaultClient.
+	// Conceptually this is a transport option (analog of gRPC CallOption);
+	// it lives on the request struct so the method retains a strict
+	// (ctx, req) → (resp, err) signature.
+	HTTPClient *http.Client
+}
+
+// GetRegistrationResponse wraps the parsed registration metadata. Wrapped
+// (rather than returning *ClientRegistrationResponse directly) for symmetry
+// with the server-side ClientRegistrationManager interface and so future
+// fields can be added without changing the method signature.
+type GetRegistrationResponse struct {
+	Registration *ClientRegistrationResponse
+}
+
 // GetRegistration performs an RFC 7592 §2.1 read of a previously-registered
-// client. The caller supplies the registration_client_uri and
-// registration_access_token returned at registration time (see
-// ClientRegistrationResponse), and gets back the current registration metadata.
+// client.
 //
 // The server is required to return 401 for any authentication failure; this
 // function maps that case to ErrRegistrationUnauthorized so callers can branch
 // on errors.Is. Other non-2xx responses surface as a generic error including
 // status code and body for diagnostics.
 //
-// If httpClient is nil, http.DefaultClient is used.
-//
 // See: https://www.rfc-editor.org/rfc/rfc7592#section-2.1
-func GetRegistration(registrationClientURI, registrationAccessToken string, httpClient *http.Client) (*ClientRegistrationResponse, error) {
-	if registrationClientURI == "" {
+func GetRegistration(ctx context.Context, req *GetRegistrationRequest) (*GetRegistrationResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	if req.RegistrationClientURI == "" {
 		return nil, fmt.Errorf("registration_client_uri is required")
 	}
-	if registrationAccessToken == "" {
+	if req.RegistrationAccessToken == "" {
 		return nil, fmt.Errorf("registration_access_token is required")
 	}
+	httpClient := req.HTTPClient
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
-	req, err := http.NewRequest(http.MethodGet, registrationClientURI, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.RegistrationClientURI, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build GetRegistration request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+registrationAccessToken)
-	req.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+req.RegistrationAccessToken)
+	httpReq.Header.Set("Accept", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("GetRegistration GET: %w", err)
 	}
@@ -152,5 +192,109 @@ func GetRegistration(registrationClientURI, registrationAccessToken string, http
 	if result.ClientID == "" {
 		return nil, fmt.Errorf("GetRegistration returned empty client_id: %s", string(body))
 	}
-	return &result, nil
+	return &GetRegistrationResponse{Registration: &result}, nil
+}
+
+// UpdateRegistrationRequest is the input to UpdateRegistration.
+type UpdateRegistrationRequest struct {
+	RegistrationClientURI   string
+	RegistrationAccessToken string
+	// ClientID is the client's existing client_id. Required by RFC 7592 §2.2;
+	// auto-filled into Metadata.ClientID by the SDK before sending if the
+	// caller hasn't already set it.
+	ClientID string
+	// Metadata is the full RFC 7591/7592 client metadata that will replace
+	// the existing registration. Treated as a full replacement (not PATCH).
+	Metadata ClientRegistrationRequest
+	// HTTPClient — see GetRegistrationRequest for rationale.
+	HTTPClient *http.Client
+}
+
+// UpdateRegistrationResponse wraps the post-update registration. Registration
+// includes the rotated registration_access_token, which supersedes the one in
+// the request. Callers MUST persist the new token before discarding the old
+// one.
+type UpdateRegistrationResponse struct {
+	Registration *ClientRegistrationResponse
+}
+
+// UpdateRegistration performs an RFC 7592 §2.2 full-replace update.
+//
+// On success the AS rotates the registration_access_token; the new token
+// surfaces on the response.
+//
+// Maps server responses:
+//   - 200 OK → returns the parsed response (with the rotated token)
+//   - 401 → ErrRegistrationUnauthorized
+//   - 400 → returns a generic error including the AS's error_description
+//   - others → generic error including status + body
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
+func UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*UpdateRegistrationResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	if req.RegistrationClientURI == "" {
+		return nil, fmt.Errorf("registration_client_uri is required")
+	}
+	if req.RegistrationAccessToken == "" {
+		return nil, fmt.Errorf("registration_access_token is required")
+	}
+	if req.ClientID == "" {
+		return nil, fmt.Errorf("clientID is required (RFC 7592 §2.2)")
+	}
+	httpClient := req.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	// RFC 7592 §2.2 requires the body's client_id to match the registered
+	// identifier; auto-fill if the caller hasn't set it explicitly.
+	md := req.Metadata
+	if md.ClientID == "" {
+		md.ClientID = req.ClientID
+	}
+
+	body, err := json.Marshal(md)
+	if err != nil {
+		return nil, fmt.Errorf("marshal UpdateRegistration request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, req.RegistrationClientURI, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build UpdateRegistration request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+req.RegistrationAccessToken)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateRegistration PUT: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read UpdateRegistration response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrRegistrationUnauthorized
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("UpdateRegistration returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result ClientRegistrationResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse UpdateRegistration response: %w (body: %s)", err, string(respBody))
+	}
+	if result.ClientID == "" {
+		return nil, fmt.Errorf("UpdateRegistration returned empty client_id: %s", string(respBody))
+	}
+	if result.RegistrationAccessToken == "" {
+		return nil, fmt.Errorf("UpdateRegistration response missing registration_access_token")
+	}
+	return &UpdateRegistrationResponse{Registration: &result}, nil
 }

--- a/client/dcr_test.go
+++ b/client/dcr_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -136,11 +137,16 @@ func TestGetRegistration_Success(t *testing.T) {
 	defer server.Close()
 	serverURL = server.URL
 
-	resp, err := GetRegistration(server.URL, "rat-good", nil)
+	resp, err := GetRegistration(context.Background(), &GetRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat-good",
+	})
 	require.NoError(t, err)
-	assert.Equal(t, "client-1", resp.ClientID)
-	assert.Equal(t, "Example Client", resp.ClientName)
-	assert.Equal(t, []string{"https://app.example/cb"}, resp.RedirectURIs)
+	require.NotNil(t, resp.Registration)
+	got := resp.Registration
+	assert.Equal(t, "client-1", got.ClientID)
+	assert.Equal(t, "Example Client", got.ClientName)
+	assert.Equal(t, []string{"https://app.example/cb"}, got.RedirectURIs)
 }
 
 // TestGetRegistration_Unauthorized verifies that a 401 from the AS surfaces as
@@ -154,7 +160,10 @@ func TestGetRegistration_Unauthorized(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := GetRegistration(server.URL, "rat-bad", nil)
+	_, err := GetRegistration(context.Background(), &GetRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat-bad",
+	})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrRegistrationUnauthorized), "expected ErrRegistrationUnauthorized, got %v", err)
 }
@@ -167,7 +176,10 @@ func TestGetRegistration_OtherErrors(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := GetRegistration(server.URL, "rat", nil)
+	_, err := GetRegistration(context.Background(), &GetRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat",
+	})
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, ErrRegistrationUnauthorized))
 	assert.Contains(t, err.Error(), "500")
@@ -177,11 +189,177 @@ func TestGetRegistration_OtherErrors(t *testing.T) {
 // or empty registration_access_token return validation errors before any network
 // I/O, so misuse fails fast.
 func TestGetRegistration_ValidatesArguments(t *testing.T) {
-	_, err := GetRegistration("", "rat", nil)
+	_, err := GetRegistration(context.Background(), &GetRegistrationRequest{
+		RegistrationAccessToken: "rat",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registration_client_uri")
 
-	_, err = GetRegistration("https://x", "", nil)
+	_, err = GetRegistration(context.Background(), &GetRegistrationRequest{
+		RegistrationClientURI: "https://x",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registration_access_token")
+}
+
+// --- UpdateRegistration tests (RFC 7592 §2.2) ---
+
+// TestUpdateRegistration_Success verifies the happy-path PUT round trip:
+// SDK auto-fills body client_id, server returns rotated token, SDK parses it.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
+func TestUpdateRegistration_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "Bearer old-rat", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var got ClientRegistrationRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "client-1", got.ClientID, "SDK must inline client_id in body")
+		assert.Equal(t, "Updated Name", got.ClientName)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ClientRegistrationResponse{
+			ClientID:                "client-1",
+			ClientName:              "Updated Name",
+			Scope:                   "read write",
+			RegistrationAccessToken: "new-rat", // rotated
+		})
+	}))
+	defer server.Close()
+
+	resp, err := UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "old-rat",
+		ClientID:                "client-1",
+		Metadata: ClientRegistrationRequest{
+			ClientName: "Updated Name",
+			Scope:      "read write",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Registration)
+	assert.Equal(t, "Updated Name", resp.Registration.ClientName)
+	assert.Equal(t, "new-rat", resp.Registration.RegistrationAccessToken, "response must surface the rotated token")
+	assert.NotEqual(t, "old-rat", resp.Registration.RegistrationAccessToken)
+}
+
+// TestUpdateRegistration_PreservesExplicitClientID verifies that when the
+// caller already set req.ClientID the SDK does not overwrite it.
+func TestUpdateRegistration_PreservesExplicitClientID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got ClientRegistrationRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "explicit-id", got.ClientID, "explicit ClientID must be preserved")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ClientRegistrationResponse{
+			ClientID:                "explicit-id",
+			RegistrationAccessToken: "rotated",
+		})
+	}))
+	defer server.Close()
+
+	_, err := UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat",
+		ClientID:                "explicit-id",
+		Metadata: ClientRegistrationRequest{
+			ClientID:   "explicit-id",
+			ClientName: "x",
+		},
+	})
+	require.NoError(t, err)
+}
+
+// TestUpdateRegistration_Unauthorized verifies that 401 from the AS surfaces
+// as ErrRegistrationUnauthorized for branching on errors.Is. Reuses the same
+// sentinel as GetRegistration since the wire-level meaning is identical.
+func TestUpdateRegistration_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "bad-rat",
+		ClientID:                "client-1",
+		Metadata:                ClientRegistrationRequest{ClientName: "x"},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRegistrationUnauthorized))
+}
+
+// TestUpdateRegistration_BadRequest verifies that 400 from the AS surfaces
+// with the body for diagnostics (so callers can show RFC 7591 error_description).
+func TestUpdateRegistration_BadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"invalid_client_metadata","error_description":"client_id mismatch"}`))
+	}))
+	defer server.Close()
+
+	_, err := UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat",
+		ClientID:                "client-1",
+		Metadata:                ClientRegistrationRequest{ClientName: "x"},
+	})
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrRegistrationUnauthorized))
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "client_id mismatch")
+}
+
+// TestUpdateRegistration_MissingTokenInResponse verifies that the SDK rejects
+// responses that omit a rotated token — RFC 7592 §2.2 says the AS SHOULD
+// rotate, and our sever does, so a missing token is a server bug worth
+// flagging rather than silently leaving the caller with the old token.
+func TestUpdateRegistration_MissingTokenInResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"client_id":   "client-1",
+			"client_name": "no rotated token",
+		})
+	}))
+	defer server.Close()
+
+	_, err := UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat",
+		ClientID:                "client-1",
+		Metadata:                ClientRegistrationRequest{ClientName: "x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_access_token")
+}
+
+// TestUpdateRegistration_ValidatesArguments verifies that empty inputs fail
+// fast without making a network call.
+func TestUpdateRegistration_ValidatesArguments(t *testing.T) {
+	_, err := UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationAccessToken: "rat",
+		ClientID:                "id",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_client_uri")
+
+	_, err = UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI: "https://x",
+		ClientID:              "id",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_access_token")
+
+	_, err = UpdateRegistration(context.Background(), &UpdateRegistrationRequest{
+		RegistrationClientURI:   "https://x",
+		RegistrationAccessToken: "rat",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clientID")
 }

--- a/docs/CLIENT_SDK.md
+++ b/docs/CLIENT_SDK.md
@@ -312,19 +312,51 @@ resp, err := client.RegisterClient(asMetadata.RegistrationEndpoint, client.Clien
 
 Once registered, the client holds two extra fields — `RegistrationAccessToken` and `RegistrationClientURI`. They are the management credentials for *that specific registration*.
 
+The SDK follows the library-wide `(ctx, *Request) → (*Response, error)` convention so calls thread cancellation/deadlines through and stay shaped for future gRPC stubs.
+
 ```go
-got, err := client.GetRegistration(resp.RegistrationClientURI, resp.RegistrationAccessToken, nil)
+got, err := client.GetRegistration(ctx, &client.GetRegistrationRequest{
+    RegistrationClientURI:   resp.RegistrationClientURI,
+    RegistrationAccessToken: resp.RegistrationAccessToken,
+})
 if errors.Is(err, client.ErrRegistrationUnauthorized) {
     // Token rejected — the AS returned 401. The token may have been rotated
-    // (RFC 7592 §2.2 allows re-issue on PUT) or the client unregistered.
+    // (RFC 7592 §2.2 re-issues on PUT) or the client unregistered.
 }
+metadata := got.Registration // *ClientRegistrationResponse
 ```
 
-`GetRegistration` returns the current registration metadata. The response intentionally **does not** echo `client_secret`; clients that lose the secret rotate via PUT (issue 169, pending).
+`GetRegistration` returns the current registration metadata wrapped in a response struct. The metadata intentionally **does not** echo `client_secret`; clients that lose the secret rotate via PUT (below).
 
-### Update / Delete (planned)
+### Update your own registration (RFC 7592 §2.2)
 
-`UpdateRegistration` (PUT) and `DeleteRegistration` (DELETE) ship in issues 169 and 170. The shape will mirror `GetRegistration`.
+`UpdateRegistration` performs a **full replacement** of the registration metadata (not a PATCH-style merge — fields omitted from `Metadata` are cleared on the server). On success the AS rotates the `registration_access_token`; the new token surfaces on the response and the old one is invalid for any subsequent management call.
+
+```go
+resp, err := client.UpdateRegistration(ctx, &client.UpdateRegistrationRequest{
+    RegistrationClientURI:   regURI,
+    RegistrationAccessToken: oldToken,
+    ClientID:                clientID, // RFC 7592 §2.2 requires it; SDK auto-fills body
+    Metadata: client.ClientRegistrationRequest{
+        ClientName: "My Renamed Bot",
+        Scope:      "read write admin",
+        // ... other fields you want to KEEP must also be set; replacement is total
+    },
+})
+if err != nil {
+    if errors.Is(err, client.ErrRegistrationUnauthorized) {
+        // Old token already rotated, or the AS unregistered the client.
+    }
+    return err
+}
+newToken := resp.Registration.RegistrationAccessToken // persist before discarding oldToken
+```
+
+OneAuth rejects updates that change `token_endpoint_auth_method` (would require re-keying); clients that need to switch auth method DELETE and re-register.
+
+### Delete (planned)
+
+`DeleteRegistration` ships in issue 170 with the same shape.
 
 ## AuthTransport (Static Token)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -194,8 +194,8 @@ Splits issue 157 (parent) into vertical verb-by-verb slices. Each ticket ships a
 
 | # | Slice | Status |
 |---|-------|--------|
-| 168 | Foundation + GET — registration_access_token + registration_client_uri issuance, `ClientRegistrationManager` interface, `DCRManagementHandler`, `client.GetRegistration`, walkthrough step | In progress |
-| 169 | PUT — full-replace update + token re-issuance + `client.UpdateRegistration` + walkthrough step | Pending |
+| 168 | Foundation + GET — registration_access_token + registration_client_uri issuance, `ClientRegistrationManager` interface, `DCRManagementHandler`, `client.GetRegistration`, walkthrough step | Merged |
+| 169 | PUT — full-replace update + token re-issuance + `client.UpdateRegistration` + walkthrough steps; **manager interface and client SDK adopt the `(ctx, *Req) → (*Resp, error)` convention** (blueprint for 172 / 175) | In progress |
 | 170 | DELETE — registration removal + `client.DeleteRegistration` + walkthrough step | Pending |
 | 171 | Keycloak interop — full lifecycle test against Keycloak's RFC 7592 endpoints | Pending |
 

--- a/examples/06-dynamic-client-registration/WALKTHROUGH.md
+++ b/examples/06-dynamic-client-registration/WALKTHROUGH.md
@@ -6,6 +6,8 @@ Non-UI | No infrastructure needed | Builds on Example 04
 
 - **Register a symmetric client (client_secret_post)** — The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.
 - **Fetch your own registration (RFC 7592 §2.1)** — client.GetRegistration is a thin SDK wrapper. Note the response intentionally omits client_secret on read — re-emitting symmetric credentials on every fetch enlarges disclosure if the access token leaks. Clients that lose the secret will rotate via PUT (#169).
+- **Update your scope (RFC 7592 §2.2)** — PUT is a full replacement (not PATCH-style merge): any field omitted from the body is cleared. The AS rotates the registration_access_token on success — the response includes a NEW token that supersedes the one passed in. The OneAuth server also rejects token_endpoint_auth_method changes (those require re-keying; clients DELETE + re-register instead).
+- **Old token is rejected after rotation** — After PUT rotates the token, attempting to reuse the *previous* registration_access_token must fail with 401 — even though the client_id is still valid. This is the security guarantee of rotation: a leaked-then-rotated token cannot be replayed.
 - **Get a token with the DCR-registered client** — The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.
 - **Register an asymmetric client (private_key_jwt with JWKS)** — For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.
 - **Register via Keycloak DCR (optional)** — Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.
@@ -25,15 +27,23 @@ sequenceDiagram
     App->>AS: GET {registration_client_uri}  Authorization: Bearer {registration_access_token}
     AS-->>App: {registration metadata — without client_secret}
 
-    Note over App,AS: Step 3: Get a token with the DCR-registered client
+    Note over App,AS: Step 3: Update your scope (RFC 7592 §2.2)
+    App->>AS: PUT {registration_client_uri}  Authorization: Bearer {registration_access_token}
+    AS-->>App: {registration metadata + NEW registration_access_token}
+
+    Note over App,AS: Step 4: Old token is rejected after rotation
+    App->>AS: GET {registration_client_uri}  Authorization: Bearer {OLD token}
+    AS-->>App: 401 Unauthorized
+
+    Note over App,AS: Step 5: Get a token with the DCR-registered client
     App->>AS: POST /api/token {client_id, client_secret from DCR}
     AS-->>App: {access_token}
 
-    Note over App,AS: Step 4: Register an asymmetric client (private_key_jwt with JWKS)
+    Note over App,AS: Step 6: Register an asymmetric client (private_key_jwt with JWKS)
     App->>AS: POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}
     AS-->>App: {client_id} (no client_secret — asymmetric!)
 
-    Note over App,AS: Step 5: Register via Keycloak DCR (optional)
+    Note over App,AS: Step 7: Register via Keycloak DCR (optional)
     App->>AS: POST {KC registration_endpoint} {client_name, grant_types}
     AS-->>App: {client_id, client_secret, registration_access_token}
 ```
@@ -127,7 +137,35 @@ curl -s -X GET '<registration_client_uri>' \
   -H 'Authorization: Bearer <registration_access_token>' | jq
 ```
 
-### Step 3: Get a token with the DCR-registered client
+### Step 3: Update your scope (RFC 7592 §2.2)
+
+> **References:** [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
+
+PUT is a full replacement (not PATCH-style merge): any field omitted from the body is cleared. The AS rotates the registration_access_token on success — the response includes a NEW token that supersedes the one passed in. The OneAuth server also rejects token_endpoint_auth_method changes (those require re-keying; clients DELETE + re-register instead).
+
+#### Reproduce on the wire
+
+```bash
+curl -s -X PUT '<registration_client_uri>' \
+  -H 'Authorization: Bearer <registration_access_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_id":"<from registration>",
+    "client_name":"My Example Bot",
+    "client_uri":"https://bot.example.com",
+    "grant_types":["client_credentials"],
+    "token_endpoint_auth_method":"client_secret_post",
+    "scope":"read write admin"
+  }' | jq
+```
+
+### Step 4: Old token is rejected after rotation
+
+> **References:** [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
+
+After PUT rotates the token, attempting to reuse the *previous* registration_access_token must fail with 401 — even though the client_id is still valid. This is the security guarantee of rotation: a leaked-then-rotated token cannot be replayed.
+
+### Step 5: Get a token with the DCR-registered client
 
 > **References:** [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 
@@ -143,7 +181,7 @@ curl -s -X POST http://localhost:8081/api/token \
   -d 'scope=read' | jq
 ```
 
-### Step 4: Register an asymmetric client (private_key_jwt with JWKS)
+### Step 6: Register an asymmetric client (private_key_jwt with JWKS)
 
 > **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591), [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
 
@@ -174,7 +212,7 @@ curl -s -X POST http://localhost:8081/apps/dcr \
 | **Key in JWKS** | Not in JWKS (secret) | Public key served in JWKS |
 | **Best for** | Simple integrations | High-security, multi-service |
 
-### Step 5: Register via Keycloak DCR (optional)
+### Step 7: Register via Keycloak DCR (optional)
 
 > **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
 
@@ -188,10 +226,10 @@ configuration — all wrapped in a simple `TokenSource` interface.
 
 ## References
 
-- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
-- [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
 - [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
+- [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
+- [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
 
 ## Run it
 

--- a/examples/06-dynamic-client-registration/walkthrough.go
+++ b/examples/06-dynamic-client-registration/walkthrough.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +34,7 @@ func runDemo() {
 
 	var symClientID, symClientSecret string
 	var symRegToken, symRegURI string
+	var symRegTokenPrevious string // captured before PUT rotation so the next step can demo rejection
 	var asymClientID string
 
 	demo := demokit.New("06: Dynamic Client Registration").
@@ -153,16 +156,92 @@ func runDemo() {
 			if symRegToken == "" || symRegURI == "" {
 				return demokit.Errf("symmetric registration didn't issue management credentials")
 			}
-			got, err := client.GetRegistration(symRegURI, symRegToken, nil)
+			resp, err := client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+				RegistrationClientURI:   symRegURI,
+				RegistrationAccessToken: symRegToken,
+			})
 			if err != nil {
 				return demokit.Errf("GetRegistration: %v", err)
 			}
+			got := resp.Registration
 			fmt.Printf("    client_id:                 %s\n", got.ClientID)
 			fmt.Printf("    client_name:               %s\n", got.ClientName)
 			fmt.Printf("    scope:                     %s\n", got.Scope)
 			fmt.Printf("    grant_types:               %v\n", got.GrantTypes)
 			fmt.Printf("    registration_client_uri:   %s\n", got.RegistrationClientURI)
 			fmt.Printf("    client_secret in response: %v (intentionally omitted)\n", got.ClientSecret != "")
+			return nil
+		})
+
+	demo.Step("Update your scope (RFC 7592 §2.2)").
+		Ref(refs.RFC7592).
+		Arrow("App", "AS", "PUT {registration_client_uri}  Authorization: Bearer {registration_access_token}").
+		DashedArrow("AS", "App", "{registration metadata + NEW registration_access_token}").
+		Note("PUT is a full replacement (not PATCH-style merge): any field omitted from the body is cleared. The AS rotates the registration_access_token on success — the response includes a NEW token that supersedes the one passed in. The OneAuth server also rejects token_endpoint_auth_method changes (those require re-keying; clients DELETE + re-register instead).").
+		VerbatimLang("Reproduce on the wire", "bash", `curl -s -X PUT '<registration_client_uri>' \
+  -H 'Authorization: Bearer <registration_access_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_id":"<from registration>",
+    "client_name":"My Example Bot",
+    "client_uri":"https://bot.example.com",
+    "grant_types":["client_credentials"],
+    "token_endpoint_auth_method":"client_secret_post",
+    "scope":"read write admin"
+  }' | jq`).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if symRegToken == "" || symRegURI == "" {
+				return demokit.Errf("symmetric registration didn't issue management credentials")
+			}
+			resp, err := client.UpdateRegistration(context.Background(), &client.UpdateRegistrationRequest{
+				RegistrationClientURI:   symRegURI,
+				RegistrationAccessToken: symRegToken,
+				ClientID:                symClientID,
+				Metadata: client.ClientRegistrationRequest{
+					ClientName:              "My Example Bot",
+					ClientURI:               "https://bot.example.com",
+					GrantTypes:              []string{"client_credentials"},
+					TokenEndpointAuthMethod: "client_secret_post",
+					Scope:                   "read write admin",
+				},
+			})
+			if err != nil {
+				return demokit.Errf("UpdateRegistration: %v", err)
+			}
+			updated := resp.Registration
+			fmt.Printf("    client_id:        %s\n", updated.ClientID)
+			fmt.Printf("    new scope:        %s\n", updated.Scope)
+			fmt.Printf("    token rotated:    %v (old != new)\n", updated.RegistrationAccessToken != symRegToken)
+			fmt.Printf("    new token (4):    %s...\n", updated.RegistrationAccessToken[:4])
+
+			// Persist the rotated token; remember the old one so the next step
+			// can demonstrate that it is now rejected.
+			symRegTokenPrevious = symRegToken
+			symRegToken = updated.RegistrationAccessToken
+			return nil
+		})
+
+	demo.Step("Old token is rejected after rotation").
+		Ref(refs.RFC7592).
+		Arrow("App", "AS", "GET {registration_client_uri}  Authorization: Bearer {OLD token}").
+		DashedArrow("AS", "App", "401 Unauthorized").
+		Note("After PUT rotates the token, attempting to reuse the *previous* registration_access_token must fail with 401 — even though the client_id is still valid. This is the security guarantee of rotation: a leaked-then-rotated token cannot be replayed.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if symRegTokenPrevious == "" {
+				return demokit.Errf("previous step didn't capture the old token")
+			}
+			_, err := client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+				RegistrationClientURI:   symRegURI,
+				RegistrationAccessToken: symRegTokenPrevious,
+			})
+			if err == nil {
+				return demokit.Errf("expected old token to be rejected; it succeeded instead")
+			}
+			fmt.Printf("    old token (4): %s...\n", symRegTokenPrevious[:4])
+			fmt.Printf("    new token (4): %s...\n", symRegToken[:4])
+			fmt.Printf("    error from AS: %v\n", err)
+			fmt.Printf("    is ErrRegistrationUnauthorized: %v\n",
+				errors.Is(err, client.ErrRegistrationUnauthorized))
 			return nil
 		})
 

--- a/tests/e2e/dcr_management_test.go
+++ b/tests/e2e/dcr_management_test.go
@@ -11,6 +11,7 @@ package e2e_test
 //   - https://github.com/panyam/oneauth/issues/168
 
 import (
+	"context"
 	"testing"
 
 	"github.com/panyam/oneauth/client"
@@ -51,8 +52,13 @@ func TestE2E_DCRManagement_GetRegistration(t *testing.T) {
 	require.NotEmpty(t, regURI, "DCR must issue registration_client_uri (RFC 7592 §3)")
 
 	// Drive the SDK against the live management endpoint.
-	got, err := client.GetRegistration(regURI, regToken, nil)
+	resp2, err := client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: regToken,
+	})
 	require.NoError(t, err)
+	require.NotNil(t, resp2.Registration)
+	got := resp2.Registration
 
 	assert.Equal(t, clientID, got.ClientID, "GET must echo the registered client_id")
 	assert.Equal(t, "E2E Mgmt Client", got.ClientName)
@@ -83,9 +89,101 @@ func TestE2E_DCRManagement_WrongTokenReturns401(t *testing.T) {
 	clientID, _ := dcr["client_id"].(string)
 	regURI, _ := dcr["registration_client_uri"].(string)
 
-	_, err := client.GetRegistration(regURI, "this-is-not-the-token", nil)
+	_, err := client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: "this-is-not-the-token",
+	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, client.ErrRegistrationUnauthorized)
+
+	c.Delete("/apps/" + clientID)
+}
+
+// TestE2E_DCRManagement_UpdateRegistration drives the full RFC 7592 §2.2 PUT
+// round trip against the real auth server: register → update scope → verify
+// the GET reflects the new metadata using the *rotated* token. The original
+// token must stop working after rotation — that's the security guarantee for
+// post-update token leakage.
+func TestE2E_DCRManagement_UpdateRegistration(t *testing.T) {
+	env := NewTestEnv(t)
+	c := NewTestClient(env)
+
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name": "PUT E2E",
+		"scope":       "read",
+	})
+	require.Equal(t, 201, resp.StatusCode)
+	dcr := ReadJSON(resp)
+	clientID, _ := dcr["client_id"].(string)
+	oldToken, _ := dcr["registration_access_token"].(string)
+	regURI, _ := dcr["registration_client_uri"].(string)
+
+	// PUT — change scope.
+	updateResp, err := client.UpdateRegistration(context.Background(), &client.UpdateRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: oldToken,
+		ClientID:                clientID,
+		Metadata: client.ClientRegistrationRequest{
+			ClientName: "PUT E2E Updated",
+			Scope:      "read write",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updateResp.Registration)
+	updated := updateResp.Registration
+	assert.Equal(t, "PUT E2E Updated", updated.ClientName)
+	assert.Equal(t, "read write", updated.Scope)
+
+	newToken := updated.RegistrationAccessToken
+	require.NotEmpty(t, newToken)
+	assert.NotEqual(t, oldToken, newToken, "AS must rotate the registration_access_token on PUT")
+
+	// New token works for GET; old token is now rejected with 401.
+	getResp, err := client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: newToken,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PUT E2E Updated", getResp.Registration.ClientName)
+
+	_, err = client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: oldToken,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, client.ErrRegistrationUnauthorized,
+		"old token must be invalid after rotation")
+
+	c.Delete("/apps/" + clientID)
+}
+
+// TestE2E_DCRManagement_PUT_BodyMismatchReturns400 verifies that the AS
+// rejects a body whose client_id does not match the URL with HTTP 400
+// (RFC 7592 §2.2 MUST). The SDK auto-fills the body so an explicit override
+// to a wrong value is the realistic failure mode.
+func TestE2E_DCRManagement_PUT_BodyMismatchReturns400(t *testing.T) {
+	env := NewTestEnv(t)
+	c := NewTestClient(env)
+
+	resp := c.PostJSON("/apps/dcr", map[string]any{"client_name": "Body Mismatch"})
+	require.Equal(t, 201, resp.StatusCode)
+	dcr := ReadJSON(resp)
+	clientID, _ := dcr["client_id"].(string)
+	token, _ := dcr["registration_access_token"].(string)
+	regURI, _ := dcr["registration_client_uri"].(string)
+
+	// Send a body whose client_id is wrong on purpose.
+	_, err := client.UpdateRegistration(context.Background(), &client.UpdateRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: token,
+		ClientID:                clientID,
+		Metadata: client.ClientRegistrationRequest{
+			ClientID:   "app_other_id",
+			ClientName: "Should Fail",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
 
 	c.Delete("/apps/" + clientID)
 }


### PR DESCRIPTION
## Summary
- Ships RFC 7592 §2.2 PUT — clients update their own metadata; the AS rotates the `registration_access_token` on success and rejects subsequent calls with the old one.
- Adopts a uniform `MethodName(ctx context.Context, *XRequest) (*XResponse, error)` convention on `ClientRegistrationManager` and the matching `client/dcr.go` SDK helpers — sets the blueprint for future gRPC stubs and for the parallel apiauth port (issue 175).
- Auth-method changes are rejected (out of scope; would require re-keying). Locked-field changes return `ErrInvalidClientMetadata`, mapped to HTTP 400 by the wrapper. `client_id`-in-body must match the URL — the SDK auto-fills it for callers.
- Two new walkthrough steps in `examples/06-dynamic-client-registration/` ("Update your scope" and "Old token rejected after rotation") demonstrate the rotation security guarantee. `WALKTHROUGH.md` regenerated.

Closes 169. Built on 168. Followups 170 (DELETE), 171 (Keycloak interop), 172 (legacy admin/ refactor to same convention), 175 (apiauth port — filed as part of this PR's discussion).

## Test plan
- [x] `make test` — 5 interface tests + 5 HTTP wrapper tests + 6 SDK tests covering: rotation happy path, wrong/unknown/legacy token, auth-method-change rejected, malformed JSON, body client_id mismatch, missing rotated token in response, argument validation.
- [x] `make e2e` — register → PUT → GET-with-new-token; body-mismatch returns 400; full 21s in-process run including the new tests.
- [x] Manually ran `make demo` in example 06 — Steps 3 and 4 confirm `token rotated: true` and `is ErrRegistrationUnauthorized: true` for the old token.
- [x] Existing `GetRegistration` tests refactored to new shape with 0 weakened assertions; legacy `/apps/register` tests untouched.