### PR TITLE
feat(admin): RFC 7592 DELETE — closes the DCR management verb trio

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -16,7 +16,7 @@
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
 - pluggable-app-registry: AppRegistrationStore interface for persisting registered apps; in-memory backend ships now, FS / GORM backends pending (issues 166, 167)
-- dcr-management-rfc7592: GET (issue 168) + PUT (issue 169) at /apps/dcr/{client_id}, with token rotation on PUT per RFC 7592 §2.2. Clients receive registration_access_token + registration_client_uri at registration time. DELETE arrives in 170. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go) following the (ctx, *Req) → (*Resp, error) convention adopted across the library.
+- dcr-management-rfc7592: Full RFC 7592 verb trio at /apps/dcr/{client_id} — GET (issue 168), PUT with registration_access_token rotation (issue 169), DELETE with credential invalidation (issue 170). Clients receive registration_access_token + registration_client_uri at registration time. Keycloak interop test pending in 171. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go) following the (ctx, *Req) → (*Resp, error) convention adopted across the library.
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model
 - client-credentials-grant: Machine-to-machine auth (RFC 6749 §4.4)

--- a/admin/SUMMARY.md
+++ b/admin/SUMMARY.md
@@ -8,7 +8,7 @@ Admin authentication, app registration API, and resource token minting for the f
 - **appstore.go** — `AppRegistrationStore` interface + `InMemoryAppStore` (issue 165). `ErrAppNotFound`. Persistent backends in `stores/fs/` and `stores/gorm/` (issues 166, 167).
 - **dcr.go** — `DCRHandler` for RFC 7591 Dynamic Client Registration at `POST /apps/dcr`. Now issues RFC 7592 §3 management credentials (`registration_access_token`, `registration_client_uri`) on every successful registration.
 - **client_management.go** — `ClientRegistrationManager` interface + `ErrUnauthorized` + `ErrInvalidClientMetadata`. Transport-agnostic core for the RFC 7592 management surface; methods follow the `(ctx context.Context, *XRequest) → (*XResponse, error)` convention so future gRPC stubs drop in cleanly. Blueprint for the wider admin/ refactor tracked under issue 172 and the apiauth port under issue 175.
-- **dcr_management.go** — `DCRManagementHandler` HTTP wrapper for `GET /apps/dcr/{client_id}` (issue 168) and `PUT /apps/dcr/{client_id}` (issue 169). DELETE arrives in 170.
+- **dcr_management.go** — `DCRManagementHandler` HTTP wrapper for the full RFC 7592 verb trio at `/apps/dcr/{client_id}`: `GET` (issue 168), `PUT` (issue 169), `DELETE` (issue 170). 405 on any other verb with `Allow: GET, PUT, DELETE`.
 - **mint.go** — `MintResourceToken()`, `MintResourceTokenWithKey()`, `AppQuota`
 
 ## Dependencies

--- a/admin/client_management.go
+++ b/admin/client_management.go
@@ -23,8 +23,8 @@ import (
 // shape — that's the point of standardizing on a single ctx parameter
 // rather than expanding the parameter list ad hoc.
 //
-// #168 ships GetRegistration. #169 ships UpdateRegistration. DeleteRegistration
-// arrives in #170.
+// #168 ships GetRegistration. #169 ships UpdateRegistration. #170 ships
+// DeleteRegistration — completing the verb trio.
 type ClientRegistrationManager interface {
 	// GetRegistration returns the registration for req.ClientID iff
 	// req.AccessToken matches its stored registration_access_token. Any
@@ -47,6 +47,19 @@ type ClientRegistrationManager interface {
 	// ErrInvalidClientMetadata. Clients that need to change auth method
 	// DELETE and re-register.
 	UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*UpdateRegistrationResponse, error)
+
+	// DeleteRegistration removes the registration for req.ClientID iff
+	// req.AccessToken matches the stored registration_access_token, and
+	// invalidates the client's signing credentials so already-issued tokens
+	// fail subsequent validation (RFC 7592 §2.3 — "the authorization server
+	// MUST invalidate" all tokens for the deleted client). The same uniform
+	// ErrUnauthorized envelope as the other methods covers every auth failure.
+	//
+	// Idempotency is intentional but limited: a second DELETE on the same
+	// client_id returns ErrUnauthorized (the registration is gone, so the
+	// token check fails at lookup) rather than a special "already deleted"
+	// error — preserves the no-enumeration guard.
+	DeleteRegistration(ctx context.Context, req *DeleteRegistrationRequest) (*DeleteRegistrationResponse, error)
 }
 
 // GetRegistrationRequest is the input to ClientRegistrationManager.GetRegistration.
@@ -91,6 +104,23 @@ type UpdateRegistrationRequest struct {
 type UpdateRegistrationResponse struct {
 	Registration *DCRResponse
 }
+
+// DeleteRegistrationRequest is the input to ClientRegistrationManager.DeleteRegistration.
+type DeleteRegistrationRequest struct {
+	// ClientID identifies the registration to remove.
+	ClientID string
+
+	// AccessToken is the registration_access_token currently on the
+	// registration — must match for the deletion to be authorized.
+	AccessToken string
+}
+
+// DeleteRegistrationResponse is intentionally empty today: RFC 7592 §2.3
+// returns 204 No Content with no body. The struct exists so future
+// forward-compat fields (e.g., a deletion confirmation token) can be added
+// without changing the method signature — same rationale as the other
+// response types.
+type DeleteRegistrationResponse struct{}
 
 // ErrUnauthorized is the single failure mode returned by ClientRegistrationManager
 // for any authentication problem on the management protocol. The uniform error

--- a/admin/dcr_management.go
+++ b/admin/dcr_management.go
@@ -13,8 +13,9 @@ import (
 // authorization decisions live behind the interface so the same logic is
 // usable from gRPC, in-process callers, and tests without HTTP machinery.
 //
-// #168 ships GET; #169 ships PUT; #170 adds DELETE. Until DELETE lands
-// it returns 405 with an Allow header advertising the supported methods.
+// #168 ships GET; #169 ships PUT; #170 ships DELETE — completing the verb
+// trio. Other HTTP methods return 405 with an Allow header advertising the
+// supported set.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7592
 type DCRManagementHandler struct {
@@ -24,7 +25,7 @@ type DCRManagementHandler struct {
 
 // allowedMethods is the value of the Allow header on 405 responses. Updated
 // when new verbs come online so a single string captures the supported set.
-const allowedMethods = "GET, PUT"
+const allowedMethods = "GET, PUT, DELETE"
 
 // ServeHTTP routes /apps/dcr/{client_id} requests by HTTP method.
 func (h *DCRManagementHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,12 +40,34 @@ func (h *DCRManagementHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		h.handleGet(w, r, clientID)
 	case http.MethodPut:
 		h.handlePut(w, r, clientID)
+	case http.MethodDelete:
+		h.handleDelete(w, r, clientID)
 	default:
 		// 405 does not depend on client_id or auth, so it leaks no per-client
 		// information. The Allow header advertises what's currently supported.
 		w.Header().Set("Allow", allowedMethods)
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func (h *DCRManagementHandler) handleDelete(w http.ResponseWriter, r *http.Request, clientID string) {
+	token := bearerToken(r.Header.Get("Authorization"))
+	_, err := h.Manager.DeleteRegistration(r.Context(), &DeleteRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: token,
+	})
+	if errors.Is(err, ErrUnauthorized) {
+		dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
+		return
+	}
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	// RFC 7592 §2.3: 204 No Content with no body.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *DCRManagementHandler) handlePut(w http.ResponseWriter, r *http.Request, clientID string) {

--- a/admin/dcr_management_test.go
+++ b/admin/dcr_management_test.go
@@ -223,16 +223,15 @@ func TestDCRManagement_GET_UnknownClient_Returns401NotFound(t *testing.T) {
 	assert.NotEqual(t, http.StatusNotFound, rr.Code)
 }
 
-// TestDCRManagement_UnsupportedMethodReturns405 verifies that methods we
-// don't yet support (DELETE — pending #170 — and arbitrary verbs like POST)
-// return 405 with an Allow header advertising the currently supported set.
-// This list shrinks as #170 lands.
+// TestDCRManagement_UnsupportedMethodReturns405 verifies that arbitrary verbs
+// (POST, PATCH, etc.) return 405 with an Allow header advertising the supported
+// set. After #170 the supported set is {GET, PUT, DELETE}.
 func TestDCRManagement_UnsupportedMethodReturns405(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	registered := registerDCRClient(t, registrar, `{"client_name":"405 Test"}`)
 
-	for _, method := range []string{http.MethodDelete, http.MethodPost} {
+	for _, method := range []string{http.MethodPost, http.MethodPatch} {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/apps/dcr/"+registered["client_id"].(string), nil)
 			req.Header.Set("Authorization", "Bearer "+registered["registration_access_token"].(string))
@@ -240,7 +239,7 @@ func TestDCRManagement_UnsupportedMethodReturns405(t *testing.T) {
 			registrar.Handler().ServeHTTP(rr, req)
 
 			assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
-			assert.Equal(t, "GET, PUT", rr.Header().Get("Allow"))
+			assert.Equal(t, "GET, PUT, DELETE", rr.Header().Get("Allow"))
 		})
 	}
 }
@@ -450,6 +449,165 @@ func TestDCRManagement_PUT_WrongTokenReturns401(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	assert.Contains(t, rr.Header().Get("WWW-Authenticate"), "Bearer")
+}
+
+// --- DELETE — RFC 7592 §2.3 tests ---
+//
+// Issue #170 ships full deletion semantics: registration removed, signing
+// credentials invalidated so already-issued tokens fail subsequent validation.
+
+// TestDeleteRegistration_HappyPath verifies the canonical delete flow: the
+// registration is gone from the store, the signing key is gone from KeyStore,
+// and any subsequent management call (with the same token) returns
+// ErrUnauthorized — there is no special "already deleted" signal, by design.
+func TestDeleteRegistration_HappyPath(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Delete Me"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	resp, err := registrar.DeleteRegistration(context.Background(), &admin.DeleteRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: token,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	// Registration is gone — subsequent GETs cannot tell you anything.
+	_, err = registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID: clientID, AccessToken: token,
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized), "post-delete GET must return ErrUnauthorized")
+
+	// Signing key is gone — tokens issued under this client_id can no longer
+	// be re-validated against the AS.
+	if _, err := ks.GetKey(clientID); err != keys.ErrKeyNotFound {
+		t.Errorf("expected ErrKeyNotFound after delete, got %v", err)
+	}
+}
+
+// TestDeleteRegistration_WrongTokenReturnsUnauthorized verifies that a caller
+// presenting a non-matching token cannot delete the registration. The
+// registration must remain intact afterwards.
+func TestDeleteRegistration_WrongTokenReturnsUnauthorized(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"Wrong Token DELETE"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	_, err := registrar.DeleteRegistration(context.Background(), &admin.DeleteRegistrationRequest{
+		ClientID:    clientID,
+		AccessToken: "definitely-not-the-token",
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized))
+
+	// Registration must still be readable with the legitimate token.
+	resp, err := registrar.GetRegistration(context.Background(), &admin.GetRegistrationRequest{
+		ClientID: clientID, AccessToken: token,
+	})
+	require.NoError(t, err, "registration must survive a failed delete")
+	assert.Equal(t, clientID, resp.Registration.ClientID)
+}
+
+// TestDeleteRegistration_UnknownClientReturnsUnauthorized verifies the
+// no-enumeration property: deleting an unknown client_id returns
+// ErrUnauthorized, not a "not found" signal.
+func TestDeleteRegistration_UnknownClientReturnsUnauthorized(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	_, err := registrar.DeleteRegistration(context.Background(), &admin.DeleteRegistrationRequest{
+		ClientID:    "app_does_not_exist",
+		AccessToken: "any",
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized))
+}
+
+// TestDeleteRegistration_LegacyRegistrationCannotBeDeleted verifies that
+// apps registered through the legacy /apps/register endpoint (no
+// registration_access_token issued) are not deletable through the management
+// interface — only DCR-registered clients participate in RFC 7592.
+func TestDeleteRegistration_LegacyRegistrationCannotBeDeleted(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	body := `{"client_domain":"legacy.example","signing_alg":"HS256"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/register", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var legacy map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &legacy))
+
+	_, err := registrar.DeleteRegistration(context.Background(), &admin.DeleteRegistrationRequest{
+		ClientID:    legacy["client_id"].(string),
+		AccessToken: "any-token",
+	})
+	assert.True(t, errors.Is(err, admin.ErrUnauthorized))
+}
+
+// TestDCRManagement_DELETE_HappyPath verifies the wire-level behavior: 204
+// No Content with the no-store cache headers required for token-bearing
+// endpoints, and an empty response body.
+func TestDCRManagement_DELETE_HappyPath(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"DELETE HP"}`)
+	clientID := registered["client_id"].(string)
+	token := registered["registration_access_token"].(string)
+
+	req := httptest.NewRequest(http.MethodDelete, "/apps/dcr/"+clientID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Equal(t, "no-store", rr.Header().Get("Cache-Control"))
+	assert.Empty(t, rr.Body.String(), "204 response must have an empty body")
+}
+
+// TestDCRManagement_DELETE_WrongToken returns 401 when the Bearer value does
+// not match the stored registration_access_token.
+func TestDCRManagement_DELETE_WrongToken(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"DELETE Wrong Token"}`)
+
+	req := httptest.NewRequest(http.MethodDelete, "/apps/dcr/"+registered["client_id"].(string), nil)
+	req.Header.Set("Authorization", "Bearer not-the-real-token")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestDCRManagement_DELETE_MissingAuthHeader returns 401 with no auth header.
+func TestDCRManagement_DELETE_MissingAuthHeader(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registered := registerDCRClient(t, registrar, `{"client_name":"DELETE No Auth"}`)
+
+	req := httptest.NewRequest(http.MethodDelete, "/apps/dcr/"+registered["client_id"].(string), nil)
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestDCRManagement_DELETE_UnknownClient returns 401 (not 404) — same
+// no-enumeration guard as GET / PUT.
+func TestDCRManagement_DELETE_UnknownClient(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+
+	req := httptest.NewRequest(http.MethodDelete, "/apps/dcr/app_phantom", nil)
+	req.Header.Set("Authorization", "Bearer something")
+	rr := httptest.NewRecorder()
+	registrar.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
 // TestDCRManagement_GET_DoesNotShadowDCRRegister verifies the routing

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -260,6 +260,57 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	}, nil
 }
 
+// DeleteRegistration implements ClientRegistrationManager (RFC 7592 §2.3).
+// On success it removes the registration from the AppRegistrationStore (and
+// the in-memory cache), and deletes the client's signing key from KeyStore
+// so any tokens already issued under this client_id fail subsequent
+// signature-validation — satisfying the spec requirement that "the
+// authorization server MUST invalidate" all tokens for a deleted client.
+//
+// Failure ordering mirrors handleDeleteApp: we persist the deletion in the
+// store first; only on success do we drop the cache entry and the KeyStore
+// key. If the store write fails we return early without touching the
+// in-memory cache or the credentials, so the registration remains
+// authoritatively present (deletion can be retried).
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops.
+func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegistrationRequest) (*DeleteRegistrationResponse, error) {
+	if req == nil || req.ClientID == "" || req.AccessToken == "" {
+		return nil, ErrUnauthorized
+	}
+	reg, err := h.Store.GetApp(req.ClientID)
+	if err != nil || reg == nil {
+		return nil, ErrUnauthorized
+	}
+	if reg.RegistrationAccessToken == "" {
+		return nil, ErrUnauthorized
+	}
+	if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(req.AccessToken)) != 1 {
+		return nil, ErrUnauthorized
+	}
+
+	// Persist deletion first. If the store write fails we leave the cache
+	// and KeyStore intact so the client retains a known-consistent state
+	// and the caller can retry; otherwise we'd leave dangling key material
+	// without a registration to bind it.
+	if err := h.Store.DeleteApp(req.ClientID); err != nil && err != ErrAppNotFound {
+		return nil, err
+	}
+
+	h.mu.Lock()
+	delete(h.apps, req.ClientID)
+	h.mu.Unlock()
+
+	// Invalidate the signing credentials. Errors here are non-fatal — the
+	// registration is gone, which is the user-visible deletion contract;
+	// a stranded key is at worst an internal cleanup concern (the KeyStore
+	// entry is unreachable without an AppRegistration to point at it).
+	_ = h.KeyStore.DeleteKey(req.ClientID)
+
+	return &DeleteRegistrationResponse{}, nil
+}
+
 // RLockApps calls fn with a read-locked view of all registered apps.
 func (h *AppRegistrar) RLockApps(fn func(map[string]*AppRegistration)) {
 	h.mu.RLock()

--- a/client/dcr.go
+++ b/client/dcr.go
@@ -218,6 +218,19 @@ type UpdateRegistrationResponse struct {
 	Registration *ClientRegistrationResponse
 }
 
+// DeleteRegistrationRequest is the input to DeleteRegistration.
+type DeleteRegistrationRequest struct {
+	RegistrationClientURI   string
+	RegistrationAccessToken string
+	// HTTPClient — see GetRegistrationRequest for rationale.
+	HTTPClient *http.Client
+}
+
+// DeleteRegistrationResponse is intentionally empty today: the AS returns
+// 204 No Content with no body. Wrapped struct preserves the convention's
+// (ctx, *Req) → (*Resp, error) shape and gives forward-compat headroom.
+type DeleteRegistrationResponse struct{}
+
 // UpdateRegistration performs an RFC 7592 §2.2 full-replace update.
 //
 // On success the AS rotates the registration_access_token; the new token
@@ -297,4 +310,52 @@ func UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*U
 		return nil, fmt.Errorf("UpdateRegistration response missing registration_access_token")
 	}
 	return &UpdateRegistrationResponse{Registration: &result}, nil
+}
+
+// DeleteRegistration performs an RFC 7592 §2.3 deletion. After it returns
+// successfully the AS has removed the registration and invalidated the
+// signing credentials, so any tokens already issued under this client_id
+// will fail subsequent validation.
+//
+// Maps server responses:
+//   - 204 No Content → nil error + empty response struct
+//   - 401 → ErrRegistrationUnauthorized
+//   - others → generic error including status + body
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.3
+func DeleteRegistration(ctx context.Context, req *DeleteRegistrationRequest) (*DeleteRegistrationResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	if req.RegistrationClientURI == "" {
+		return nil, fmt.Errorf("registration_client_uri is required")
+	}
+	if req.RegistrationAccessToken == "" {
+		return nil, fmt.Errorf("registration_access_token is required")
+	}
+	httpClient := req.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, req.RegistrationClientURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build DeleteRegistration request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+req.RegistrationAccessToken)
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteRegistration DELETE: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return &DeleteRegistrationResponse{}, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrRegistrationUnauthorized
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return nil, fmt.Errorf("DeleteRegistration returned %d: %s", resp.StatusCode, string(body))
 }

--- a/client/dcr_test.go
+++ b/client/dcr_test.go
@@ -339,6 +339,77 @@ func TestUpdateRegistration_MissingTokenInResponse(t *testing.T) {
 	assert.Contains(t, err.Error(), "registration_access_token")
 }
 
+// --- DeleteRegistration tests (RFC 7592 §2.3) ---
+
+// TestDeleteRegistration_Success verifies the happy-path 204 round trip:
+// SDK sends DELETE with Bearer auth, AS replies 204, SDK returns an empty
+// response struct.
+func TestDeleteRegistration_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "Bearer rat-good", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	resp, err := DeleteRegistration(context.Background(), &DeleteRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat-good",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+// TestDeleteRegistration_Unauthorized verifies that 401 surfaces as
+// ErrRegistrationUnauthorized — same sentinel as Get/Update since the
+// wire-level meaning (server rejected the access token) is identical.
+func TestDeleteRegistration_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := DeleteRegistration(context.Background(), &DeleteRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat-bad",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRegistrationUnauthorized))
+}
+
+// TestDeleteRegistration_OtherErrors verifies that non-204/401 responses
+// surface the status + body for diagnostics.
+func TestDeleteRegistration_OtherErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := DeleteRegistration(context.Background(), &DeleteRegistrationRequest{
+		RegistrationClientURI:   server.URL,
+		RegistrationAccessToken: "rat",
+	})
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrRegistrationUnauthorized))
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestDeleteRegistration_ValidatesArguments verifies that empty inputs fail
+// fast without making a network call.
+func TestDeleteRegistration_ValidatesArguments(t *testing.T) {
+	_, err := DeleteRegistration(context.Background(), &DeleteRegistrationRequest{
+		RegistrationAccessToken: "rat",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_client_uri")
+
+	_, err = DeleteRegistration(context.Background(), &DeleteRegistrationRequest{
+		RegistrationClientURI: "https://x",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration_access_token")
+}
+
 // TestUpdateRegistration_ValidatesArguments verifies that empty inputs fail
 // fast without making a network call.
 func TestUpdateRegistration_ValidatesArguments(t *testing.T) {

--- a/docs/CLIENT_SDK.md
+++ b/docs/CLIENT_SDK.md
@@ -354,9 +354,25 @@ newToken := resp.Registration.RegistrationAccessToken // persist before discardi
 
 OneAuth rejects updates that change `token_endpoint_auth_method` (would require re-keying); clients that need to switch auth method DELETE and re-register.
 
-### Delete (planned)
+### Delete your registration (RFC 7592 §2.3)
 
-`DeleteRegistration` ships in issue 170 with the same shape.
+`DeleteRegistration` removes the registration AND invalidates the signing credentials. After it returns successfully, the `client_secret` (or asymmetric key) captured at registration can no longer mint access tokens.
+
+```go
+_, err := client.DeleteRegistration(ctx, &client.DeleteRegistrationRequest{
+    RegistrationClientURI:   regURI,
+    RegistrationAccessToken: regToken,
+})
+if err != nil {
+    if errors.Is(err, client.ErrRegistrationUnauthorized) {
+        // Token rejected — already deleted, or never had management rights
+    }
+    return err
+}
+// 204 No Content. Empty response struct; nothing to inspect.
+```
+
+The response struct is intentionally empty today (the wire response is 204 No Content); it exists to keep the `(ctx, *Req) → (*Resp, error)` shape and gives forward-compat headroom.
 
 ## AuthTransport (Static Token)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -195,8 +195,8 @@ Splits issue 157 (parent) into vertical verb-by-verb slices. Each ticket ships a
 | # | Slice | Status |
 |---|-------|--------|
 | 168 | Foundation + GET — registration_access_token + registration_client_uri issuance, `ClientRegistrationManager` interface, `DCRManagementHandler`, `client.GetRegistration`, walkthrough step | Merged |
-| 169 | PUT — full-replace update + token re-issuance + `client.UpdateRegistration` + walkthrough steps; **manager interface and client SDK adopt the `(ctx, *Req) → (*Resp, error)` convention** (blueprint for 172 / 175) | In progress |
-| 170 | DELETE — registration removal + `client.DeleteRegistration` + walkthrough step | Pending |
+| 169 | PUT — full-replace update + token re-issuance + `client.UpdateRegistration` + walkthrough steps; **manager interface and client SDK adopt the `(ctx, *Req) → (*Resp, error)` convention** (blueprint for 172 / 175) | Merged |
+| 170 | DELETE — registration removal + KeyStore credential invalidation + `client.DeleteRegistration` + walkthrough step. Closes the verb trio. | In progress |
 | 171 | Keycloak interop — full lifecycle test against Keycloak's RFC 7592 endpoints | Pending |
 
 ---

--- a/examples/06-dynamic-client-registration/WALKTHROUGH.md
+++ b/examples/06-dynamic-client-registration/WALKTHROUGH.md
@@ -9,6 +9,7 @@ Non-UI | No infrastructure needed | Builds on Example 04
 - **Update your scope (RFC 7592 §2.2)** — PUT is a full replacement (not PATCH-style merge): any field omitted from the body is cleared. The AS rotates the registration_access_token on success — the response includes a NEW token that supersedes the one passed in. The OneAuth server also rejects token_endpoint_auth_method changes (those require re-keying; clients DELETE + re-register instead).
 - **Old token is rejected after rotation** — After PUT rotates the token, attempting to reuse the *previous* registration_access_token must fail with 401 — even though the client_id is still valid. This is the security guarantee of rotation: a leaked-then-rotated token cannot be replayed.
 - **Get a token with the DCR-registered client** — The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.
+- **Delete the registration (RFC 7592 §2.3)** — DELETE removes the registration AND invalidates the signing credentials. After this, the client_secret captured at registration can no longer mint access tokens — the AS has dropped the signing key. RFC 7592 §2.3 requires the AS to MUST invalidate already-issued tokens; OneAuth does this by deleting the KeyStore entry so the JWT signature check fails.
 - **Register an asymmetric client (private_key_jwt with JWKS)** — For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.
 - **Register via Keycloak DCR (optional)** — Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.
 
@@ -39,11 +40,15 @@ sequenceDiagram
     App->>AS: POST /api/token {client_id, client_secret from DCR}
     AS-->>App: {access_token}
 
-    Note over App,AS: Step 6: Register an asymmetric client (private_key_jwt with JWKS)
+    Note over App,AS: Step 6: Delete the registration (RFC 7592 §2.3)
+    App->>AS: DELETE {registration_client_uri}  Authorization: Bearer {registration_access_token}
+    AS-->>App: 204 No Content
+
+    Note over App,AS: Step 7: Register an asymmetric client (private_key_jwt with JWKS)
     App->>AS: POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}
     AS-->>App: {client_id} (no client_secret — asymmetric!)
 
-    Note over App,AS: Step 7: Register via Keycloak DCR (optional)
+    Note over App,AS: Step 8: Register via Keycloak DCR (optional)
     App->>AS: POST {KC registration_endpoint} {client_name, grant_types}
     AS-->>App: {client_id, client_secret, registration_access_token}
 ```
@@ -181,7 +186,20 @@ curl -s -X POST http://localhost:8081/api/token \
   -d 'scope=read' | jq
 ```
 
-### Step 6: Register an asymmetric client (private_key_jwt with JWKS)
+### Step 6: Delete the registration (RFC 7592 §2.3)
+
+> **References:** [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
+
+DELETE removes the registration AND invalidates the signing credentials. After this, the client_secret captured at registration can no longer mint access tokens — the AS has dropped the signing key. RFC 7592 §2.3 requires the AS to MUST invalidate already-issued tokens; OneAuth does this by deleting the KeyStore entry so the JWT signature check fails.
+
+#### Reproduce on the wire
+
+```bash
+curl -s -X DELETE '<registration_client_uri>' \
+  -H 'Authorization: Bearer <registration_access_token>' -i
+```
+
+### Step 7: Register an asymmetric client (private_key_jwt with JWKS)
 
 > **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591), [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
 
@@ -212,7 +230,7 @@ curl -s -X POST http://localhost:8081/apps/dcr \
 | **Key in JWKS** | Not in JWKS (secret) | Public key served in JWKS |
 | **Best for** | Simple integrations | High-security, multi-service |
 
-### Step 7: Register via Keycloak DCR (optional)
+### Step 8: Register via Keycloak DCR (optional)
 
 > **References:** [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
 
@@ -226,10 +244,10 @@ configuration — all wrapped in a simple `TokenSource` interface.
 
 ## References
 
-- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [RFC 7517 — JSON Web Key (JWK)](https://www.rfc-editor.org/rfc/rfc7517)
 - [RFC 7591 — Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591)
 - [RFC 7592 — Dynamic Client Registration Management](https://www.rfc-editor.org/rfc/rfc7592)
+- [RFC 6749 §4.4 — Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 
 ## Run it
 

--- a/examples/06-dynamic-client-registration/walkthrough.go
+++ b/examples/06-dynamic-client-registration/walkthrough.go
@@ -275,6 +275,42 @@ func runDemo() {
 			return nil
 		})
 
+	demo.Step("Delete the registration (RFC 7592 §2.3)").
+		Ref(refs.RFC7592).
+		Arrow("App", "AS", "DELETE {registration_client_uri}  Authorization: Bearer {registration_access_token}").
+		DashedArrow("AS", "App", "204 No Content").
+		Note("DELETE removes the registration AND invalidates the signing credentials. After this, the client_secret captured at registration can no longer mint access tokens — the AS has dropped the signing key. RFC 7592 §2.3 requires the AS to MUST invalidate already-issued tokens; OneAuth does this by deleting the KeyStore entry so the JWT signature check fails.").
+		VerbatimLang("Reproduce on the wire", "bash", `curl -s -X DELETE '<registration_client_uri>' \
+  -H 'Authorization: Bearer <registration_access_token>' -i`).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if symRegToken == "" || symRegURI == "" {
+				return demokit.Errf("symmetric registration didn't issue management credentials")
+			}
+			_, err := client.DeleteRegistration(context.Background(), &client.DeleteRegistrationRequest{
+				RegistrationClientURI:   symRegURI,
+				RegistrationAccessToken: symRegToken,
+			})
+			if err != nil {
+				return demokit.Errf("DeleteRegistration: %v", err)
+			}
+			fmt.Printf("    DELETE: 204 No Content (registration removed)\n\n")
+
+			// Demonstrate that the credentials are dead — client_credentials
+			// with the now-invalidated secret fails.
+			tokenResp, err := http.PostForm(authServer.URL+"/api/token", url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {symClientID},
+				"client_secret": {symClientSecret},
+				"scope":         {"read"},
+			})
+			if err != nil {
+				return demokit.Errf("token check: %v", err)
+			}
+			tokenResp.Body.Close()
+			fmt.Printf("    POST /api/token with old secret → HTTP %d (deleted client cannot mint tokens)\n", tokenResp.StatusCode)
+			return nil
+		})
+
 	demo.Step("Register an asymmetric client (private_key_jwt with JWKS)").
 		Ref(refs.RFC7591).
 		Ref(refs.RFC7517).

--- a/tests/e2e/dcr_management_test.go
+++ b/tests/e2e/dcr_management_test.go
@@ -12,6 +12,8 @@ package e2e_test
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/panyam/oneauth/client"
@@ -186,4 +188,70 @@ func TestE2E_DCRManagement_PUT_BodyMismatchReturns400(t *testing.T) {
 	assert.Contains(t, err.Error(), "400")
 
 	c.Delete("/apps/" + clientID)
+}
+
+// TestE2E_DCRManagement_DeleteRegistration drives the full RFC 7592 §2.3
+// lifecycle against the real auth server: register → DELETE → verify the
+// management endpoint stops returning the registration AND the deleted
+// client's secret can no longer mint access tokens. Together these prove
+// that "the authorization server MUST invalidate" the deleted client end
+// to end.
+func TestE2E_DCRManagement_DeleteRegistration(t *testing.T) {
+	env := NewTestEnv(t)
+	c := NewTestClient(env)
+
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name": "DELETE E2E",
+		"grant_types": []string{"client_credentials"},
+	})
+	require.Equal(t, 201, resp.StatusCode)
+	dcr := ReadJSON(resp)
+	clientID, _ := dcr["client_id"].(string)
+	clientSecret, _ := dcr["client_secret"].(string)
+	regToken, _ := dcr["registration_access_token"].(string)
+	regURI, _ := dcr["registration_client_uri"].(string)
+
+	require.NotEmpty(t, clientSecret, "DCR must issue a client_secret for symmetric registrations")
+
+	tokenURL := env.BaseURL() + "/api/token"
+	credForm := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"scope":         {"read"},
+	}
+
+	// Sanity: the freshly-registered client can mint an access token via
+	// client_credentials. Confirms the precondition for the post-delete
+	// invalidation check below.
+	tokResp, err := http.PostForm(tokenURL, credForm)
+	require.NoError(t, err)
+	require.Equal(t, 200, tokResp.StatusCode, "client_credentials must succeed BEFORE delete")
+	tokResp.Body.Close()
+
+	// DELETE the registration via the SDK.
+	delResp, err := client.DeleteRegistration(context.Background(), &client.DeleteRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: regToken,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, delResp)
+
+	// Management calls with the same token now return 401 (the registration
+	// is gone — uniform unauthorized envelope, no enumeration leakage).
+	_, err = client.GetRegistration(context.Background(), &client.GetRegistrationRequest{
+		RegistrationClientURI:   regURI,
+		RegistrationAccessToken: regToken,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, client.ErrRegistrationUnauthorized)
+
+	// And the credentials are dead: client_credentials with the previously
+	// valid client_id+secret pair must now fail (the signing key is gone
+	// from KeyStore — RFC 7592 §2.3 invalidation).
+	tokResp2, err := http.PostForm(tokenURL, credForm)
+	require.NoError(t, err)
+	defer tokResp2.Body.Close()
+	assert.NotEqual(t, 200, tokResp2.StatusCode,
+		"deleted client must not be able to mint access tokens (RFC 7592 §2.3)")
 }


### PR DESCRIPTION
## Summary
- Ships RFC 7592 §2.3 DELETE — clients can self-deregister; the AS drops the registration and invalidates signing credentials so already-issued tokens fail subsequent validation.
- 204 No Content with no body, standard no-store cache headers. `allowedMethods` extended to `GET, PUT, DELETE`; 405 set narrows to anything else.
- New `client.DeleteRegistration` SDK helper following the established `(ctx, *Req) → (*Resp, error)` convention. 204 → empty response; 401 → `ErrRegistrationUnauthorized`; others → diagnostic error.
- Walkthrough in `examples/06-dynamic-client-registration/` gains a final "Delete the registration" step proving the invalidation contract: post-DELETE, the previously-valid `client_secret` returns 401 from `/api/token`. Closes the RFC 7592 management chain (#157) on the verb side; only Keycloak interop (171) remains.

## Test plan
- [x] `make test` — 4 interface tests + 4 HTTP wrapper tests + 4 SDK tests covering happy path, uniform-401 enumeration guards, legacy-registration rejection, wire-format compliance.
- [x] `make e2e` — full lifecycle: register → mint token → DELETE → confirm 401 on management AND `client_secret` can no longer mint tokens. Proves RFC 7592 §2.3 "MUST invalidate" end to end.
- [x] Manually ran example 06 — Step 6 prints `DELETE: 204 No Content` and `POST /api/token with old secret → HTTP 401 (deleted client cannot mint tokens)`.
- [x] Existing 405 test updated for narrower unsupported set; no weakened assertions elsewhere.