### PR TITLE
feat(apiauth): MountASMetadata — serve AS metadata at both RFC 8414 and OIDC paths

### DIFF
--- a/apiauth/as_metadata.go
+++ b/apiauth/as_metadata.go
@@ -7,9 +7,10 @@ import (
 )
 
 // ASServerMetadata describes an OAuth 2.0 Authorization Server per RFC 8414
-// and OpenID Connect Discovery 1.0 §4. The auth server serves this at
-// GET /.well-known/openid-configuration so OIDC-aware clients can
-// auto-discover endpoints.
+// and OpenID Connect Discovery 1.0 §4. RFC 8414 §3 mandates this metadata
+// be served at /.well-known/oauth-authorization-server; OIDC Discovery
+// places the same document at /.well-known/openid-configuration. Use
+// MountASMetadata to register both paths in one call.
 //
 // This is metadata-only — serving this does NOT make the server a full OIDC
 // provider. It simply advertises what endpoints exist (token, JWKS,
@@ -45,8 +46,10 @@ type ASServerMetadata struct {
 	CacheMaxAge int `json:"-"`
 }
 
-// NewASMetadataHandler returns an http.Handler that serves Authorization Server
-// metadata JSON at GET /.well-known/openid-configuration.
+// NewASMetadataHandler returns an http.Handler that serves Authorization
+// Server metadata JSON. The handler is path-agnostic — register it at
+// whichever well-known path you need, or use MountASMetadata to register
+// at both required paths at once.
 //
 // The handler:
 //   - Responds to GET only (405 for other methods)
@@ -77,4 +80,27 @@ func NewASMetadataHandler(meta *ASServerMetadata) http.Handler {
 		w.Header().Set("Cache-Control", cacheHeader)
 		w.Write(body)
 	})
+}
+
+// MountASMetadata registers AS metadata at both well-known paths required
+// by the OAuth/OIDC ecosystem:
+//
+//   - /.well-known/oauth-authorization-server (RFC 8414 §3, MUST)
+//   - /.well-known/openid-configuration       (OIDC Discovery 1.0 §4)
+//
+// Both paths serve the same handler, so the documents are byte-identical.
+// OAuth-only clients (which know about RFC 8414 but not OIDC Discovery)
+// and OIDC clients (which look up openid-configuration) can both
+// auto-discover the AS without falling back.
+//
+// Callers that want only one path can register NewASMetadataHandler
+// directly. This helper is the recommended default.
+//
+// See:
+//   - RFC 8414 §3 (https://www.rfc-editor.org/rfc/rfc8414#section-3)
+//   - OIDC Discovery 1.0 §4
+func MountASMetadata(mux *http.ServeMux, meta *ASServerMetadata) {
+	h := NewASMetadataHandler(meta)
+	mux.Handle("GET /.well-known/oauth-authorization-server", h)
+	mux.Handle("GET /.well-known/openid-configuration", h)
 }

--- a/apiauth/as_metadata_test.go
+++ b/apiauth/as_metadata_test.go
@@ -16,6 +16,7 @@ package apiauth_test
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -148,6 +149,74 @@ func TestASMetadata_MethodNotAllowed(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusMethodNotAllowed, rr.Code, "Method %s should be rejected", method)
+	}
+}
+
+// TestMountASMetadata_DualPath verifies that MountASMetadata registers
+// the same handler at both well-known paths and that the documents
+// returned at the two paths are byte-identical. RFC 8414 §3 requires
+// the AS metadata be available at /.well-known/oauth-authorization-server;
+// OIDC Discovery 1.0 §4 places the same document at
+// /.well-known/openid-configuration. Clients that only know one of the
+// two specs must be able to discover us at their preferred path.
+//
+// See:
+//   - RFC 8414 §3 (https://www.rfc-editor.org/rfc/rfc8414#section-3)
+func TestMountASMetadata_DualPath(t *testing.T) {
+	meta := &apiauth.ASServerMetadata{
+		Issuer:        "https://auth.example.com",
+		TokenEndpoint: "https://auth.example.com/api/token",
+		JWKSURI:       "https://auth.example.com/.well-known/jwks.json",
+	}
+
+	mux := http.NewServeMux()
+	apiauth.MountASMetadata(mux, meta)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	paths := []string{
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/openid-configuration",
+	}
+
+	bodies := map[string][]byte{}
+	for _, p := range paths {
+		resp, err := http.Get(srv.URL + p)
+		require.NoError(t, err, "GET %s", p)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s", p)
+		require.Equal(t, "application/json", resp.Header.Get("Content-Type"), "GET %s", p)
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.NoError(t, err)
+		bodies[p] = body
+	}
+
+	assert.Equal(t,
+		string(bodies["/.well-known/oauth-authorization-server"]),
+		string(bodies["/.well-known/openid-configuration"]),
+		"both well-known paths must serve byte-identical metadata")
+}
+
+// TestMountASMetadata_MethodNotAllowed verifies that non-GET requests
+// are rejected at both paths.
+func TestMountASMetadata_MethodNotAllowed(t *testing.T) {
+	mux := http.NewServeMux()
+	apiauth.MountASMetadata(mux, &apiauth.ASServerMetadata{
+		Issuer:        "https://auth.example.com",
+		TokenEndpoint: "https://auth.example.com/api/token",
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, p := range []string{
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/openid-configuration",
+	} {
+		req, _ := http.NewRequest(http.MethodPost, srv.URL+p, nil)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "POST %s", p)
 	}
 }
 

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -262,7 +262,7 @@ func main() {
 	if cfg.TLS.Enabled {
 		baseURL = fmt.Sprintf("https://%s:%s", cfg.Server.Host, cfg.Server.Port)
 	}
-	asMetaHandler := apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+	apiauth.MountASMetadata(mux, &apiauth.ASServerMetadata{
 		Issuer:                             baseURL,
 		TokenEndpoint:                      baseURL + "/api/token",
 		JWKSURI:                            baseURL + "/.well-known/jwks.json",
@@ -276,7 +276,6 @@ func main() {
 		SubjectTypesSupported:              []string{"public"},
 		AuthorizationDetailsTypesSupported: cfg.JWT.AuthorizationDetailsTypes,
 	})
-	mux.Handle("GET /.well-known/openid-configuration", asMetaHandler)
 
 	addr := cfg.Server.Host + ":" + cfg.Server.Port
 	log.Printf("oneauth-server listening on %s (keystore=%s, user_stores=%s, auth=%s)",

--- a/memories/MEMORY.md
+++ b/memories/MEMORY.md
@@ -4,3 +4,4 @@
 - [feedback_subpackage_refactor.md](feedback_subpackage_refactor.md) — Lessons from large subpackage reorganization: regex scripts unreliable for Go type prefixing, use git mv for history, work in chunks, export struct fields when moving cross-package.
 - [feedback_pr_docs.md](feedback_pr_docs.md) — Always update docs as part of every PR commit, not as afterthought. Close GitHub issue, update SUMMARY, ROADMAP, guide docs, subpackage SUMMARYs.
 - [feedback_test_file_organization.md](feedback_test_file_organization.md) — Keep new test groups in separate _test.go files to prevent bloat in existing test files.
+- [feedback_review_cadences.md](feedback_review_cadences.md) — Prefer ad-hoc `make X-report` targets over cron/calendar review cadences; advisory metadata (e.g., `expires:`) shouldn't gate.

--- a/memories/feedback_review_cadences.md
+++ b/memories/feedback_review_cadences.md
@@ -1,0 +1,18 @@
+---
+name: feedback_review_cadences
+description: For recurring audits/reviews, prefer ad-hoc reports + checked-in artifacts over cron-based or calendar-based cadences.
+type: feedback
+---
+
+When designing a periodic review mechanism (suppression review, gap audit, dependency check, anything "we should look at this every N days"), default to **ad-hoc with a checked-in report**, not a cron or calendar trigger.
+
+Pattern: a `make <something>-report` target writes a Markdown summary to `test-reports/`. Run when a human wants to look. The report itself is the artifact.
+
+**Why:** Validated during the conformance-testing PR. I initially proposed quarterly suppression review (per the strategy doc); user pushed back: "i dont need a quarterly review yet — it should be weekly i think given our cadence — or even better just adhoc (like our `make testall` in mcpkit which runs *everything* and creates reports — wdyt?)". The reasoning that landed: time-based cadences degenerate into mechanical "bump expires by 90 days" PRs with no real review; ad-hoc means the review happens when there's a question to answer, and the strongest staleness signal is usually the gating mechanism itself (e.g., the ratchet catches "gap silently shipped" without any review).
+
+**How to apply:**
+- Default to `make X-report` over GH Actions cron or scheduled jobs.
+- Keep advisory metadata (e.g., `expires:` dates) as report-sort hints, not as enforced gates — enforcement creates fire drills.
+- The `test-reports/` directory in this repo is checked-in-explicitly territory; reports go there.
+- If the gating mechanism (CI ratchet, lint, etc.) already catches the most important staleness case, say so explicitly when proposing the review — it's often enough on its own.
+- This is a decision point worth surfacing rather than picking silently. The user wants to weigh in on cadence questions.

--- a/tests/conformance/known-gaps.yaml
+++ b/tests/conformance/known-gaps.yaml
@@ -17,18 +17,4 @@
 #   reason    — multi-line; what is missing and why this is filed instead of fixed
 #   expires   — ISO date; advisory only (consumed by the report, not the ratchet)
 
-- suite: as_metadata
-  id: TestDualPathParity/rfc8414_path_parity
-  status: expected-fail
-  issue: 187
-  owner: panyam
-  reason: |
-    OneAuth's AS only registers /.well-known/openid-configuration
-    (cmd/oneauth-server/main.go:279, testutil/server.go:183). RFC 8414 §3
-    requires the same metadata be served at /.well-known/oauth-authorization-server
-    so OAuth-only clients can discover it. Fix is a second mux registration
-    pointing at the same handler.
-
-    NOTE: issue number 187 is a placeholder; replace with the real tracking
-    issue when the seed PR lands.
-  expires: 2026-08-07
+[]

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -168,7 +168,7 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		issuer = baseURL
 		apiAuth.JWTIssuer = issuer
 	}
-	asMetaHandler := apiauth.NewASMetadataHandler(&apiauth.ASServerMetadata{
+	apiauth.MountASMetadata(mux, &apiauth.ASServerMetadata{
 		Issuer:                        issuer,
 		TokenEndpoint:                 baseURL + "/api/token",
 		JWKSURI:                       baseURL + "/.well-known/jwks.json",
@@ -180,7 +180,6 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
 		CodeChallengeMethodsSupported: []string{"S256"},
 	})
-	mux.Handle("GET /.well-known/openid-configuration", asMetaHandler)
 
 	return &TestAuthServer{
 		Server:     server,


### PR DESCRIPTION
## Summary

Closes the gap surfaced by yesterday's conformance ratchet seed PR (177): OneAuth's AS only registered metadata at `/.well-known/openid-configuration`, not at `/.well-known/oauth-authorization-server`. RFC 8414 §3 mandates the latter, and OAuth-only clients (no OIDC fallback) get a 404 trying to discover us.

The fix is small. The handler in `apiauth/as_metadata.go` was already path-agnostic; only the doc comments claimed otherwise. Two callers (`cmd/oneauth-server/main.go`, `testutil/server.go`) registered at one path each. Adds a `MountASMetadata(mux, meta)` helper that registers both paths, mirroring the existing `MountProtectedResource` pattern (apiauth/protected_resource.go:81), and switches both callers to use it.

This is also the first **ratchet-up** since the conformance system landed in PR 177 — the seed test `TestDualPathParity/rfc8414_path_parity` now passes, so its entry was removed from `tests/conformance/known-gaps.yaml`. Verified mid-PR that leaving the entry in produced the expected `ratchet-up` CI failure (transcript in commit history).

## Changes

- `apiauth/as_metadata.go` — new `MountASMetadata(mux, meta)`. Doc comments on `ASServerMetadata` and `NewASMetadataHandler` updated to drop the misleading "openid-configuration only" claim.
- `apiauth/as_metadata_test.go` — `TestMountASMetadata_DualPath` (both paths return byte-identical metadata), `TestMountASMetadata_MethodNotAllowed` (405 at both paths).
- `cmd/oneauth-server/main.go`, `testutil/server.go` — switch from manual `mux.Handle` to `apiauth.MountASMetadata`.
- `tests/conformance/known-gaps.yaml` — entry for `rfc8414_path_parity` removed.
- One stray commit (`1cd5713`) capturing a memory file from yesterday's session — independent of the fix; piggybacking to keep the worktree clean.

## Test plan

- [x] `go test ./apiauth/... ./testutil/...` — green, including the two new tests
- [x] `make testconformance` — exits 0 (ratchet clean after the manifest entry was removed)
- [x] `cd tests/conformance && go test -v ./as_metadata/...` — both subtests now pass
- [x] `go test -short ./...` (root module) — green
- [x] `go vet` and `staticcheck` clean
- [x] Manually verified ratchet-up CI failure shape by leaving the manifest entry in place after the fix