### PR TITLE
feat(conformance): always write reports; derive path from package scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,18 +449,12 @@ kcllogs:
 # =============================================================================
 # Runs every known conformance test (passing AND expected-fail) and diffs
 # the outcome against tests/conformance/known-gaps.yaml. Exits non-zero on
-# any drift: regression, ratchet-up, stale entry, or t.Skip().
+# any drift: regression, ratchet-up, stale entry, or t.Skip(). Also writes
+# a Markdown report at test-reports/conformance.md — scoped runs derive
+# distinct filenames (e.g., conformance-as_metadata.md), so parallel runs
+# of different suites don't clobber each other.
 testconformance:
 	@cd tests/conformance && GOWORK=off go run ./cmd/runner -package ./...
-
-# Same suite plus a Markdown report at test-reports/conformance-<date>.md.
-# The report is for humans (gap surface, expires audit). CI gating still
-# comes from the ratchet exit code, not the report.
-testconformance-report:
-	@mkdir -p $(REPORT_DIR)
-	@cd tests/conformance && GOWORK=off go run ./cmd/runner \
-		-package ./... \
-		-report ../../$(REPORT_DIR)/conformance-$$(date +%Y-%m-%d).md
 
 # Run Keycloak interop tests (starts container if not running)
 testkcl:

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -6,12 +6,32 @@ for the full strategy; this README covers mechanics.
 
 ## Running
 
+From the repo root:
+
 ```bash
-make testconformance         # gating: exit non-zero on any ratchet diff
-make testconformance-report  # plus a Markdown summary at test-reports/
+make testconformance         # full run + report at test-reports/conformance.md
 ```
 
-Both targets run from the repo root; the runner lives in this submodule.
+Reports are always written. The filename is derived from the package
+pattern, so a full run and a scoped run produce different files and can
+run in parallel without clobbering:
+
+| Command | Report path |
+|---|---|
+| `make testconformance` | `test-reports/conformance.md` |
+| `go run ./cmd/runner -package ./as_metadata/...` | `test-reports/conformance-as_metadata.md` |
+| `go run ./cmd/runner -package ./prm/...` | `test-reports/conformance-prm.md` |
+
+Scoped runs go through the runner binary directly:
+
+```bash
+cd tests/conformance
+GOWORK=off go run ./cmd/runner -package ./as_metadata/...
+```
+
+The runner finds `test-reports/` by walking up to the workspace root
+(the directory containing `go.work`), so it works the same from any
+subdirectory.
 
 ## The model
 
@@ -89,10 +109,17 @@ fails until the entry is removed.
 
 ```
 runner [flags]
-  -manifest string   path to known-gaps.yaml (default ./known-gaps.yaml)
-  -package string    Go package pattern (default ./...)
-  -report string     if set, write a Markdown report to this path
+  -manifest string     path to known-gaps.yaml (default ./known-gaps.yaml)
+  -package string      Go package pattern (default ./...)
+  -report-dir string   directory for reports (default: <workspace>/test-reports)
+  -report string       explicit report path (overrides -report-dir)
+  -no-report           skip writing a report
 ```
+
+Default behavior: every run writes to
+`<workspace>/test-reports/conformance[-<scope>].md`. Use `-report` to
+override the path, `-report-dir` to redirect just the directory, or
+`-no-report` to skip.
 
 Exit codes: `0` clean, `1` ratchet diff, `2` invalid manifest, `3` `go test`
 infra failure (compile error, etc.).

--- a/tests/conformance/cmd/runner/main.go
+++ b/tests/conformance/cmd/runner/main.go
@@ -5,6 +5,11 @@
 // non-zero on any diff. See tests/conformance/README.md and
 // docs/CONFORMANCE.md §1 for the model.
 //
+// Reports: every run writes a Markdown summary by default. The path is
+// derived from the -package pattern so a full run and a scoped run
+// produce distinct files (e.g., conformance.md vs conformance-as_metadata.md).
+// Use -report to override the path explicitly, or -no-report to skip.
+//
 // Exit codes:
 //
 //	0 — manifest matches reality
@@ -29,7 +34,9 @@ import (
 func main() {
 	manifestPath := flag.String("manifest", "known-gaps.yaml", "path to known-gaps manifest")
 	pkg := flag.String("package", "./...", "Go package pattern to test (excludes ./cmd/...)")
-	report := flag.String("report", "", "if set, write a Markdown report to this path")
+	reportDir := flag.String("report-dir", "", "directory for reports (default: <workspace>/test-reports)")
+	report := flag.String("report", "", "explicit report path (overrides -report-dir)")
+	noReport := flag.Bool("no-report", false, "skip writing a report")
 	flag.Parse()
 
 	manifest, err := LoadManifest(*manifestPath)
@@ -49,16 +56,93 @@ func main() {
 	out := FormatIssues(issues)
 	fmt.Fprint(os.Stderr, out)
 
-	if *report != "" {
-		if err := writeReport(*report, results, manifest, issues); err != nil {
+	reportPath := resolveReportPath(*pkg, *reportDir, *report, *noReport)
+	if reportPath != "" {
+		if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "report dir error: %v\n", err)
+			os.Exit(3)
+		}
+		if err := writeReport(reportPath, *pkg, results, manifest, issues); err != nil {
 			fmt.Fprintf(os.Stderr, "report error: %v\n", err)
 			os.Exit(3)
 		}
-		fmt.Fprintf(os.Stderr, "report written: %s\n", *report)
+		fmt.Fprintf(os.Stderr, "report written: %s\n", reportPath)
 	}
 
 	if len(issues) > 0 {
 		os.Exit(1)
+	}
+}
+
+// resolveReportPath picks the report file based on flags, returning ""
+// when no report should be written (i.e., -no-report).
+//
+// Precedence: -no-report > -report > derived from -report-dir + -package.
+// When -report-dir is unset, defaults to <workspace>/test-reports where
+// <workspace> is the nearest ancestor containing go.work; falls back to
+// ./test-reports relative to CWD if no workspace is found.
+func resolveReportPath(pkg, reportDir, reportFile string, noReport bool) string {
+	if noReport {
+		return ""
+	}
+	if reportFile != "" {
+		return reportFile
+	}
+	if reportDir == "" {
+		if root := findWorkspaceRoot(); root != "" {
+			reportDir = filepath.Join(root, "test-reports")
+		} else {
+			reportDir = "test-reports"
+		}
+	}
+	return filepath.Join(reportDir, reportFilename(pkg))
+}
+
+// reportFilename derives the report basename from a Go package pattern.
+// "./..." (full run) → "conformance.md"; "./<suite>/..." or "./<suite>" →
+// "conformance-<suite>.md". Anything more complex (multi-pattern, nested
+// path, glob) falls back to "conformance.md".
+func reportFilename(pkg string) string {
+	if scope := scopeFromPackage(pkg); scope != "" {
+		return "conformance-" + scope + ".md"
+	}
+	return "conformance.md"
+}
+
+// scopeFromPackage extracts a single suite name when the pattern targets
+// one specific subdirectory. Returns "" for full runs ("./...") or
+// patterns the runner doesn't try to interpret (multi-pattern, nested,
+// or absolute paths) — caller treats "" as "full".
+func scopeFromPackage(pattern string) string {
+	p := strings.TrimPrefix(pattern, "./")
+	p = strings.TrimSuffix(p, "/...")
+	p = strings.TrimSuffix(p, "/")
+	if p == "" || p == "..." {
+		return ""
+	}
+	if strings.ContainsAny(p, "/,") {
+		return ""
+	}
+	return p
+}
+
+// findWorkspaceRoot walks up from CWD looking for go.work. Returns ""
+// if not found. The runner's submodule sits at <root>/tests/conformance,
+// so the walk-up from any subdir reliably lands on the workspace root.
+func findWorkspaceRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if fi, err := os.Stat(filepath.Join(dir, "go.work")); err == nil && !fi.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
 	}
 }
 

--- a/tests/conformance/cmd/runner/main_test.go
+++ b/tests/conformance/cmd/runner/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestScopeFromPackage(t *testing.T) {
+	tests := map[string]string{
+		"./...":              "",
+		"./":                 "",
+		"...":                "",
+		"./as_metadata/...":  "as_metadata",
+		"./as_metadata":      "as_metadata",
+		"./as_metadata/":     "as_metadata",
+		"as_metadata/...":    "as_metadata",
+		"as_metadata":        "as_metadata",
+		"./a/b/...":          "", // nested, not a single suite
+		"./a,./b":            "", // multi-pattern, fall back
+		"./a/...,./b/...":    "", // multi-pattern, fall back
+		"github.com/x/y/...": "", // import path with slashes
+	}
+	for in, want := range tests {
+		if got := scopeFromPackage(in); got != want {
+			t.Errorf("scopeFromPackage(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReportFilename(t *testing.T) {
+	tests := map[string]string{
+		"./...":             "conformance.md",
+		"./as_metadata/...": "conformance-as_metadata.md",
+		"./prm":             "conformance-prm.md",
+		"./a,./b":           "conformance.md",
+	}
+	for in, want := range tests {
+		if got := reportFilename(in); got != want {
+			t.Errorf("reportFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveReportPath(t *testing.T) {
+	tmp := t.TempDir()
+
+	tests := []struct {
+		name     string
+		pkg      string
+		dir      string
+		file     string
+		noReport bool
+		want     string
+	}{
+		{
+			name: "explicit report path wins",
+			pkg:  "./...",
+			file: "/tmp/explicit.md",
+			want: "/tmp/explicit.md",
+		},
+		{
+			name:     "no-report short-circuits everything",
+			pkg:      "./as_metadata/...",
+			file:     "/tmp/explicit.md",
+			noReport: true,
+			want:     "",
+		},
+		{
+			name: "report-dir + full run",
+			pkg:  "./...",
+			dir:  tmp,
+			want: filepath.Join(tmp, "conformance.md"),
+		},
+		{
+			name: "report-dir + scoped run",
+			pkg:  "./as_metadata/...",
+			dir:  tmp,
+			want: filepath.Join(tmp, "conformance-as_metadata.md"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveReportPath(tt.pkg, tt.dir, tt.file, tt.noReport)
+			if got != tt.want {
+				t.Errorf("resolveReportPath(pkg=%q, dir=%q, file=%q, noReport=%v) = %q, want %q",
+					tt.pkg, tt.dir, tt.file, tt.noReport, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/conformance/cmd/runner/report.go
+++ b/tests/conformance/cmd/runner/report.go
@@ -11,12 +11,17 @@ import (
 // writeReport emits a Markdown summary of a runner invocation, suitable
 // for checking into test-reports/. It's purely advisory — exit codes
 // drive CI, the report is for humans reading the gap surface.
-func writeReport(path string, results []Result, manifest map[string]Entry, issues []Issue) error {
+//
+// pkg is the Go package pattern that scoped this run; it's emitted in
+// the header so the file is self-describing (a scoped report and a full
+// report otherwise look identical when only one suite exists).
+func writeReport(path, pkg string, results []Result, manifest map[string]Entry, issues []Issue) error {
 	var b strings.Builder
 
 	now := time.Now().UTC().Format("2006-01-02 15:04:05 UTC")
 	fmt.Fprintf(&b, "# OneAuth Conformance Report\n\n")
-	fmt.Fprintf(&b, "Generated: %s\n\n", now)
+	fmt.Fprintf(&b, "Generated: %s  \n", now)
+	fmt.Fprintf(&b, "Package pattern: `%s`\n\n", pkg)
 
 	pass, fail, skip, gapped := 0, 0, 0, 0
 	for _, r := range results {


### PR DESCRIPTION
## Summary

Collapses the two Make targets from PR 177 (`testconformance` and `testconformance-report`) into one. Reports are now written on every run, with the filename derived from the `-package` pattern so a full run and a scoped run produce different files and don't clobber each other.

| Command | Report path |
|---|---|
| `make testconformance` | `test-reports/conformance.md` |
| `cd tests/conformance && go run ./cmd/runner -package ./as_metadata/...` | `test-reports/conformance-as_metadata.md` |
| `... -package ./prm/...` | `test-reports/conformance-prm.md` |

This also unblocks running multiple scoped suites in parallel — each writes to its own file. The report header now includes the package pattern so files are self-describing.

## Runner flags

- New: `-report-dir <dir>` (directory override; default = `<workspace>/test-reports`)
- New: `-no-report` (skip writing a report)
- Kept: `-report <path>` (explicit single-file override)

The runner walks up from CWD to find the dir containing `go.work` and uses `<that>/test-reports/` as the default report dir. Works the same from any subdirectory.

## Make changes

- `testconformance-report` removed (redundant now).
- `testconformance` keeps its name; just always writes the report.

## Test plan

- [x] `go test ./cmd/runner/...` — green; new `TestScopeFromPackage`, `TestReportFilename`, `TestResolveReportPath`
- [x] `make testconformance` — exits 0; writes `test-reports/conformance.md` with header `Package pattern: ./...`
- [x] Scoped run via binary direct — exits 0; writes `test-reports/conformance-as_metadata.md` with header `Package pattern: ./as_metadata/...`
- [x] Both reports coexist after running both commands; neither clobbers the other
- [x] `go vet` and `staticcheck` clean across the conformance module