### PR TITLE
feat(stores/fs): FSAppStore — filesystem-backed AppRegistrationStore

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -15,7 +15,7 @@
 - refresh-token-rotation: Refresh tokens with theft detection (family-based revocation)
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
-- pluggable-app-registry: AppRegistrationStore interface for persisting registered apps; in-memory backend ships now, FS / GORM backends pending (issues 166, 167)
+- pluggable-app-registry: AppRegistrationStore interface for persisting registered apps. In-memory (issue 165) and filesystem (issue 166) backends ship; GORM backend pending (issue 167)
 - dcr-management-rfc7592: Full RFC 7592 verb trio at /apps/dcr/{client_id} — GET (issue 168), PUT with registration_access_token rotation (issue 169), DELETE with credential invalidation (issue 170), Keycloak lifecycle interop (issue 171). Clients receive registration_access_token + registration_client_uri at registration time. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go) following the (ctx, *Req) → (*Resp, error) convention adopted across the library.
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -182,8 +182,8 @@ Splits issue 20 (Persist AppRegistrar state) into shippable backend chunks. The 
 
 | # | Scope | Status |
 |---|-------|--------|
-| 165 | `AppRegistrationStore` interface + `InMemoryAppStore` + AppRegistrar refactor (cache + write-through) + `appstoretest` contract suite + e2e simulated-restart test | In progress |
-| 166 | `FSAppStore` (filesystem backend) | Pending |
+| 165 | `AppRegistrationStore` interface + `InMemoryAppStore` + AppRegistrar refactor (cache + write-through) + `appstoretest` contract suite + e2e simulated-restart test | Merged |
+| 166 | `FSAppStore` (filesystem backend) — file-per-app, atomic writes, safeName traversal defense, partial recovery on corrupt files | In progress |
 | 167 | `GORMAppStore` + reference-server config wiring | Pending |
 
 After 167 lands, parent issue 20 can close. The chain unblocks the entire RFC 7592 track (issues 168 / 169 / 170 / 171) tracked under issue 157.

--- a/docs/STORES.md
+++ b/docs/STORES.md
@@ -97,7 +97,10 @@ tokenStore := fs.NewFSTokenStore(storagePath)
 usernameStore := fs.NewFSUsernameStore(storagePath)
 refreshTokenStore := fs.NewFSRefreshTokenStore(storagePath)
 apiKeyStore := fs.NewFSAPIKeyStore(storagePath)
+appStore := fs.NewFSAppStore(storagePath) // RFC 7591 / 7592 client registrations (issue 166)
 ```
+
+The `FSAppStore` writes one JSON file per registration under `{storagePath}/apps/{client_id}.json`, with atomic writes (temp file + rename), `safeName` path-traversal defense, and lazy directory creation. Corrupt files surface as parse errors from `GetApp` (so operators can detect data integrity issues) but are silently skipped by `ListApps` (so admin tooling stays usable when one file is hand-edited badly).
 
 ### GORM (SQL Databases)
 
@@ -281,7 +284,7 @@ type AppRegistrationStore interface {
 | Backend | Status | Use case |
 |---------|--------|----------|
 | `admin.InMemoryAppStore` | Available | Tests, dev (registrations lost on restart) |
-| `stores/fs.FSAppStore` | Pending — issue 166 | Single-node, dev-friendly persistence |
+| `stores/fs.FSAppStore` | Available (issue 166) | Single-node, dev-friendly persistence |
 | `stores/gorm.GORMAppStore` | Pending — issue 167 | Production, multi-node (Postgres / MySQL / SQLite) |
 
 Construct with `admin.NewAppRegistrar(keyStore, auth)` for the default in-memory store, or `admin.NewAppRegistrarWithStore(keyStore, auth, store)` to plug in a persistent backend.

--- a/stores/fs/fsappstore.go
+++ b/stores/fs/fsappstore.go
@@ -1,0 +1,160 @@
+package fs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/panyam/oneauth/admin"
+)
+
+// FSAppStore implements admin.AppRegistrationStore by persisting each
+// registration as a JSON file under {basePath}/apps/{client_id}.json.
+//
+// Mirrors the FSKeyStore design: file-per-record (so concurrent ops don't
+// serialize on a single mutex outside this process), atomic writes via
+// temp-file + rename (so a crash mid-write leaves either the old file or
+// the new file intact, never a half-written one), and safeName guarding
+// path-traversal in client_ids.
+//
+// In-process concurrency is mediated by sync.RWMutex. Multi-process
+// deployments need a backend with real transaction semantics — see
+// GORMAppStore (#167).
+type FSAppStore struct {
+	StoragePath string
+	mu          sync.RWMutex
+}
+
+// NewFSAppStore creates a filesystem-backed AppRegistrationStore. The
+// {basePath}/apps/ directory is created lazily on first write.
+func NewFSAppStore(storagePath string) *FSAppStore {
+	return &FSAppStore{StoragePath: storagePath}
+}
+
+func (s *FSAppStore) appsDir() string {
+	return filepath.Join(s.StoragePath, "apps")
+}
+
+func (s *FSAppStore) appPath(clientID string) (string, error) {
+	safeID, err := safeName(clientID)
+	if err != nil {
+		return "", fmt.Errorf("invalid clientID: %w", err)
+	}
+	return filepath.Join(s.appsDir(), safeID+".json"), nil
+}
+
+// SaveApp persists app to disk. Overwrites any existing registration with
+// the same client_id. Empty client_id is rejected.
+func (s *FSAppStore) SaveApp(app *admin.AppRegistration) error {
+	if app == nil || app.ClientID == "" {
+		return fmt.Errorf("AppRegistration.ClientID required")
+	}
+
+	path, err := s.appPath(app.ClientID)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(s.appsDir(), 0700); err != nil {
+		return fmt.Errorf("create apps dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(app, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal AppRegistration: %w", err)
+	}
+	return writeAtomicFile(path, data)
+}
+
+// GetApp returns the registration for clientID, or admin.ErrAppNotFound if
+// no such file exists. A corrupt JSON file surfaces as a parse error rather
+// than ErrAppNotFound — callers should distinguish "registration absent"
+// from "registration unreadable" so an unexpected on-disk corruption isn't
+// silently treated as a missing client.
+func (s *FSAppStore) GetApp(clientID string) (*admin.AppRegistration, error) {
+	path, err := s.appPath(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, admin.ErrAppNotFound
+		}
+		return nil, err
+	}
+	var app admin.AppRegistration
+	if err := json.Unmarshal(data, &app); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+	return &app, nil
+}
+
+// ListApps returns every registration in the store. Files that fail to
+// parse are skipped (with no error returned) so a single hand-corrupted
+// file does not lock out admin tooling — partial recovery beats total
+// failure here. Callers needing strict integrity should validate at the
+// store level (e.g., periodic fsck) rather than relying on ListApps.
+//
+// Returns an empty slice (not an error) when the apps dir does not yet
+// exist, matching the InMemory backend's "fresh store has no apps" shape.
+func (s *FSAppStore) ListApps() ([]*admin.AppRegistration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dir := s.appsDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []*admin.AppRegistration{}, nil
+		}
+		return nil, err
+	}
+
+	out := make([]*admin.AppRegistration, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var app admin.AppRegistration
+		if err := json.Unmarshal(data, &app); err != nil {
+			// Skip corrupt files — see godoc for rationale.
+			continue
+		}
+		// Take address of a fresh copy; ranging by value re-uses the loop var.
+		clone := app
+		out = append(out, &clone)
+	}
+	return out, nil
+}
+
+// DeleteApp removes the registration for clientID. Returns admin.ErrAppNotFound
+// if no such registration exists, matching InMemoryAppStore semantics.
+func (s *FSAppStore) DeleteApp(clientID string) error {
+	path, err := s.appPath(clientID)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return admin.ErrAppNotFound
+	}
+	return os.Remove(path)
+}

--- a/stores/fs/fsappstore_test.go
+++ b/stores/fs/fsappstore_test.go
@@ -1,0 +1,192 @@
+// Tests for the filesystem-backed AppRegistrationStore. Pairs the shared
+// appstoretest contract suite (every backend runs this) with FS-specific
+// edge cases that cannot be expressed in a backend-agnostic suite —
+// path-traversal rejection, corrupt-file behavior, lazy directory creation,
+// and atomic-write integrity.
+package fs_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/appstoretest"
+	"github.com/panyam/oneauth/stores/fs"
+)
+
+// TestFSAppStore_Contract runs the shared AppRegistrationStore contract suite
+// against the filesystem backend. Each sub-test gets a fresh tempdir so
+// state cannot leak between cases.
+func TestFSAppStore_Contract(t *testing.T) {
+	appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
+		return fs.NewFSAppStore(t.TempDir())
+	})
+}
+
+// TestFSAppStore_PathTraversalRejected verifies that maliciously-crafted
+// client_ids cannot escape the apps/ directory. safeName is the single
+// point of defense for all FS store path construction; this guards against
+// regressions in that contract.
+func TestFSAppStore_PathTraversalRejected(t *testing.T) {
+	store := fs.NewFSAppStore(t.TempDir())
+
+	for _, badID := range []string{
+		"../etc/passwd",
+		"foo/../bar",
+		"/absolute/path",
+		"\x00null",
+		"..",
+		".",
+	} {
+		t.Run(badID, func(t *testing.T) {
+			err := store.SaveApp(&admin.AppRegistration{ClientID: badID, SigningAlg: "HS256", CreatedAt: time.Now()})
+			if err == nil {
+				t.Fatalf("SaveApp(%q) should have rejected the traversal attempt", badID)
+			}
+			// Same defense at read + delete time so we never load a path
+			// composed by a non-safeName route.
+			if _, err := store.GetApp(badID); err == nil {
+				t.Errorf("GetApp(%q) should have rejected the traversal attempt", badID)
+			}
+			if err := store.DeleteApp(badID); err == nil {
+				t.Errorf("DeleteApp(%q) should have rejected the traversal attempt", badID)
+			}
+		})
+	}
+}
+
+// TestFSAppStore_CorruptFile_GetReturnsError verifies that a hand-corrupted
+// JSON file under apps/ surfaces as a parse error from GetApp, not as
+// ErrAppNotFound. Callers must distinguish "registration absent" (safe to
+// recreate) from "registration unreadable" (data integrity issue requiring
+// operator attention).
+func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	store := fs.NewFSAppStore(dir)
+
+	// Save a real entry to materialize the apps/ directory.
+	if err := store.SaveApp(&admin.AppRegistration{ClientID: "good", SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveApp: %v", err)
+	}
+	// Drop a hand-corrupted file alongside it.
+	corrupt := filepath.Join(dir, "apps", "corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not valid json"), 0600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+
+	_, err := store.GetApp("corrupt")
+	if err == nil {
+		t.Fatalf("GetApp on corrupt file should have errored")
+	}
+	if errors.Is(err, admin.ErrAppNotFound) {
+		t.Fatalf("GetApp on corrupt file must NOT return ErrAppNotFound — got %v", err)
+	}
+
+	// Good entry still readable — corruption of one file does not poison
+	// the rest of the store.
+	got, err := store.GetApp("good")
+	if err != nil {
+		t.Fatalf("GetApp(good): %v", err)
+	}
+	if got.ClientID != "good" {
+		t.Errorf("ClientID=%q, want good", got.ClientID)
+	}
+}
+
+// TestFSAppStore_CorruptFile_ListSkips verifies that ListApps skips corrupt
+// files rather than failing the whole call. Partial recovery beats total
+// failure when one file is hand-edited badly — admin tooling stays usable.
+func TestFSAppStore_CorruptFile_ListSkips(t *testing.T) {
+	dir := t.TempDir()
+	store := fs.NewFSAppStore(dir)
+
+	for _, id := range []string{"alpha", "beta"} {
+		if err := store.SaveApp(&admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("SaveApp(%s): %v", id, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "apps", "trash.json"), []byte("garbage"), 0600); err != nil {
+		t.Fatalf("seed trash file: %v", err)
+	}
+
+	apps, err := store.ListApps()
+	if err != nil {
+		t.Fatalf("ListApps: %v", err)
+	}
+	if len(apps) != 2 {
+		t.Errorf("expected 2 apps (corrupt file skipped), got %d", len(apps))
+	}
+}
+
+// TestFSAppStore_LazyDirectoryCreation verifies that constructing FSAppStore
+// against a non-existent base path is fine, and that the apps/ subdirectory
+// is created on first write. Avoids a "you must mkdir first" footgun.
+func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist-yet", "nor-this")
+	store := fs.NewFSAppStore(dir)
+
+	// Pre-condition: the directory does not exist.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("test setup: dir should not exist yet, got %v", err)
+	}
+
+	// First write must succeed and materialize the directory.
+	if err := store.SaveApp(&admin.AppRegistration{ClientID: "lazy", SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveApp: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "apps")); err != nil {
+		t.Errorf("apps dir should exist after SaveApp: %v", err)
+	}
+
+	// Pre-condition for ListApps on a fresh store with no writes: returns
+	// an empty slice, not an error. Verify against a separate path.
+	emptyStore := fs.NewFSAppStore(filepath.Join(t.TempDir(), "another-fresh-dir"))
+	apps, err := emptyStore.ListApps()
+	if err != nil {
+		t.Errorf("ListApps on fresh store: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("ListApps on fresh store should return empty slice, got %d entries", len(apps))
+	}
+}
+
+// TestFSAppStore_OverwriteIsAtomicallyVisible verifies that an overwrite
+// either leaves the OLD value or the NEW value visible to a concurrent
+// reader, never partial bytes — courtesy of writeAtomicFile's
+// temp-file-then-rename pattern. We don't simulate a crash mid-rename
+// (renames are atomic on POSIX); instead we verify the on-disk file is
+// always parseable and matches one of the two values, even after rapid
+// successive overwrites.
+func TestFSAppStore_OverwriteIsAtomicallyVisible(t *testing.T) {
+	dir := t.TempDir()
+	store := fs.NewFSAppStore(dir)
+
+	const id = "overwriter"
+	for i, name := range []string{"first", "second", "third"} {
+		if err := store.SaveApp(&admin.AppRegistration{
+			ClientID: id, ClientName: name, SigningAlg: "HS256", CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("SaveApp #%d: %v", i, err)
+		}
+
+		// Read the file directly — it must always parse and contain the
+		// last-written name. This catches a regression where a partial
+		// rename or non-atomic write would leave the file in an unparseable
+		// state between writes.
+		data, err := os.ReadFile(filepath.Join(dir, "apps", id+".json"))
+		if err != nil {
+			t.Fatalf("read after SaveApp #%d: %v", i, err)
+		}
+		var got admin.AppRegistration
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("file unparseable after SaveApp #%d: %v", i, err)
+		}
+		if got.ClientName != name {
+			t.Errorf("after SaveApp #%d: ClientName=%q, want %q", i, got.ClientName, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Single-node persistence for `admin.AppRegistrationStore` (introduced in 165). File-per-app under `{basePath}/apps/{client_id}.json`, mirroring `FSKeyStore`: atomic writes via `writeAtomicFile` (temp file + rename), `safeName` guarding path-traversal in `client_id`, `sync.RWMutex` for in-process concurrency, lazy directory creation on first write.
- Documented failure-mode rationale: `GetApp` on a corrupt JSON file returns the parse error (callers must distinguish "absent" from "unreadable"); `ListApps` skips unparseable files (partial recovery beats total failure when one file is hand-edited badly). Operators wanting strict integrity should validate at the store level.
- Closes 166. Persistence chain progresses: 165 ✓ → 166 ✓ → 167 (GORM + reference-server config wiring) remaining.

## Test plan
- [x] `make test` — adds 19 new sub-tests (9 contract from `appstoretest.RunAll`, 6 path-traversal sub-tests, 4 FS-specific edges: corrupt file Get-vs-List behavior, lazy directory creation, atomic-write integrity).
- [x] `make e2e` — clean.
- [x] No new dependencies; `stores/fs` stays in the main module (not a sub-module bump).