### PR TITLE
feat(apiauth): RFC 9207 + RFC 7523 §2.1 + RFC 8693 — closes #180, #181, #118

### DIFF
--- a/apiauth/as_metadata.go
+++ b/apiauth/as_metadata.go
@@ -41,6 +41,20 @@ type ASServerMetadata struct {
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
 	SubjectTypesSupported         []string `json:"subject_types_supported,omitempty"`
 
+	// AuthorizationResponseIssParameterSupported advertises RFC 9207
+	// support — when true, the AS includes an `iss` query parameter on
+	// every authorization response (both successful redirects with `code`
+	// and error redirects). Pointer semantics distinguish absence (omit
+	// from JSON) from explicit `false` (advertised as not supported).
+	//
+	// RFC 9207 §3:
+	//   https://www.rfc-editor.org/rfc/rfc9207#section-3
+	//
+	// Setting this true on an AS that does NOT actually emit `iss` in
+	// authorization responses is a spec violation — clients keying off
+	// the advertisement will fail to validate.
+	AuthorizationResponseIssParameterSupported *bool `json:"authorization_response_iss_parameter_supported,omitempty"`
+
 	// CacheMaxAge controls the Cache-Control max-age in seconds.
 	// Defaults to 3600 (1 hour). Not serialized to JSON.
 	CacheMaxAge int `json:"-"`

--- a/apiauth/as_metadata_test.go
+++ b/apiauth/as_metadata_test.go
@@ -238,3 +238,71 @@ func TestASMetadata_SubjectTypesSupported(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Equal(t, []any{"public"}, body["subject_types_supported"])
 }
+
+// TestASMetadata_AuthorizationResponseIssParameterSupported_True verifies
+// RFC 9207 (#180) — when the AS implements iss-parameter-on-redirect, it
+// MUST advertise that capability via this metadata field. Pointer
+// semantics: explicitly setting &true serializes as `true`.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9207#section-3
+func TestASMetadata_AuthorizationResponseIssParameterSupported_True(t *testing.T) {
+	supported := true
+	meta := &apiauth.ASServerMetadata{
+		Issuer:        "https://auth.example.com",
+		TokenEndpoint: "https://auth.example.com/api/token",
+		AuthorizationResponseIssParameterSupported: &supported,
+	}
+
+	handler := apiauth.NewASMetadataHandler(meta)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, true, body["authorization_response_iss_parameter_supported"])
+}
+
+// TestASMetadata_AuthorizationResponseIssParameterSupported_False verifies
+// the explicit `false` advertisement — the AS deliberately signals that
+// it does NOT emit iss in authorization responses (distinct from absence
+// of the field).
+func TestASMetadata_AuthorizationResponseIssParameterSupported_False(t *testing.T) {
+	supported := false
+	meta := &apiauth.ASServerMetadata{
+		Issuer:        "https://auth.example.com",
+		TokenEndpoint: "https://auth.example.com/api/token",
+		AuthorizationResponseIssParameterSupported: &supported,
+	}
+
+	handler := apiauth.NewASMetadataHandler(meta)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, false, body["authorization_response_iss_parameter_supported"])
+}
+
+// TestASMetadata_AuthorizationResponseIssParameterSupported_Absent verifies
+// pointer-nil semantics: when the field is unset, the JSON output omits it
+// entirely (RFC 8414 lets clients infer absence as "no advertisement,"
+// distinct from explicit `false`).
+func TestASMetadata_AuthorizationResponseIssParameterSupported_Absent(t *testing.T) {
+	meta := &apiauth.ASServerMetadata{
+		Issuer:        "https://auth.example.com",
+		TokenEndpoint: "https://auth.example.com/api/token",
+		// AuthorizationResponseIssParameterSupported intentionally nil.
+	}
+
+	handler := apiauth.NewASMetadataHandler(meta)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	_, present := body["authorization_response_iss_parameter_supported"]
+	assert.False(t, present, "field MUST be omitted when nil")
+}

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -160,6 +160,8 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		a.handleClientCredentialsGrant(w, r, &req)
 	case JwtBearerGrantType:
 		a.handleJwtBearerGrant(w, r, &req)
+	case TokenExchangeGrantType:
+		a.handleTokenExchangeGrant(w, r, &req)
 	default:
 		a.errorResponse(w, "unsupported_grant_type", "Grant type not supported", http.StatusBadRequest)
 	}

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -79,6 +79,17 @@ type APIAuth struct {
 	// When nil, client_credentials requests return unsupported_grant_type.
 	ClientKeyStore keys.KeyLookup
 
+	// TrustedAssertionIssuers lists upstream IdPs whose JWT assertions
+	// the token endpoint will accept for the jwt-bearer grant
+	// (RFC 7523 §2.1) and the token-exchange grant with
+	// subject_token_type=urn:ietf:params:oauth:token-type:jwt
+	// (RFC 8693 §2.1.1). When empty, both grants return
+	// unsupported_grant_type.
+	//
+	// See JwtBearerGrantType, TokenExchangeGrantType, and
+	// TrustedAssertionIssuer for details.
+	TrustedAssertionIssuers []TrustedAssertionIssuer
+
 	// Rate limiting (optional)
 	RateLimiter core.RateLimiter
 
@@ -116,6 +127,14 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Scope:        r.FormValue("scope"),
 			ClientID:     r.FormValue("client_id"),
 			ClientSecret: r.FormValue("client_secret"),
+			// RFC 7523 §2.1 — jwt-bearer authorization grant
+			Assertion: r.FormValue("assertion"),
+			// RFC 8693 — token exchange
+			SubjectToken:       r.FormValue("subject_token"),
+			SubjectTokenType:   r.FormValue("subject_token_type"),
+			RequestedTokenType: r.FormValue("requested_token_type"),
+			Resource:           r.FormValue("resource"),
+			Audience:           r.FormValue("audience"),
 		}
 		// RFC 9396 §6.1: authorization_details is a JSON-encoded string in form params
 		if adStr := r.FormValue("authorization_details"); adStr != "" {
@@ -139,6 +158,8 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		a.handleRefreshTokenGrant(w, r, &req)
 	case "client_credentials":
 		a.handleClientCredentialsGrant(w, r, &req)
+	case JwtBearerGrantType:
+		a.handleJwtBearerGrant(w, r, &req)
 	default:
 		a.errorResponse(w, "unsupported_grant_type", "Grant type not supported", http.StatusBadRequest)
 	}

--- a/apiauth/jwt_bearer_grant.go
+++ b/apiauth/jwt_bearer_grant.go
@@ -1,0 +1,243 @@
+package apiauth
+
+import (
+	"crypto"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/core"
+)
+
+// JwtBearerGrantType is the OAuth grant type URI for the
+// JWT Bearer authorization grant defined in RFC 7523 §2.1.
+//
+// A client trades a signed JWT (typically issued by an upstream IdP
+// about a subject) for an access token. The assertion's `iss` MUST
+// match a trusted issuer in TrustedAssertionIssuers; the JWT signature
+// MUST verify against that issuer's public key; standard claims
+// (aud/exp/nbf/sub) MUST validate.
+//
+// Distinct from RFC 7523 §2.2 (JWT for *client* authentication via
+// client_assertion + client_assertion_type at the token endpoint),
+// which is tracked separately as the `private_key_jwt` /
+// `client_secret_jwt` token endpoint auth methods.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7523#section-2.1
+const JwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+// TrustedAssertionIssuer describes an upstream IdP whose JWT
+// assertions the AS will accept for the jwt-bearer grant
+// (RFC 7523 §2.1) and the token-exchange grant with
+// subject_token_type=urn:ietf:params:oauth:token-type:jwt
+// (RFC 8693 §2.1.1).
+//
+// At least one of PublicKey or KeyFunc must be set so signatures can
+// be verified. KeyFunc takes precedence when both are set; it lets
+// callers resolve keys from a JWKS by `kid` header.
+//
+// The Issuer field is matched verbatim against the JWT's `iss` claim
+// (case-sensitive, no trailing-slash normalization — match what the
+// upstream IdP actually emits).
+type TrustedAssertionIssuer struct {
+	// Issuer is the expected `iss` claim value (e.g.,
+	// "https://corp-idp.example.com"). REQUIRED.
+	Issuer string
+
+	// PublicKey is a static public key for signature verification.
+	// Either this or KeyFunc MUST be set. Suitable for tests and
+	// single-key issuers; for production with key rotation use KeyFunc.
+	PublicKey crypto.PublicKey
+
+	// KeyFunc resolves a public key from the JWT header (typically
+	// looking up `kid` against a cached JWKS). When set it takes
+	// precedence over PublicKey. The token argument is the parsed
+	// (but not yet signature-verified) JWT.
+	KeyFunc func(token *jwt.Token) (crypto.PublicKey, error)
+
+	// Audiences lists acceptable `aud` claim values for assertions
+	// signed by this issuer. When empty, defaults to the AS's
+	// JWTAudience (or its IssuerURL if no audience is configured).
+	// RFC 7523 §3 requires the AS to identify itself by the audience
+	// claim — the default makes the token endpoint URL implicit.
+	Audiences []string
+
+	// AcceptedAlgorithms restricts the JWT alg values accepted for
+	// assertions from this issuer (e.g., {"RS256", "ES256"}). Empty
+	// = accept any non-`none` algorithm advertised by the JWT library.
+	// Set this in production to lock out alg-confusion attacks.
+	AcceptedAlgorithms []string
+}
+
+// findIssuer returns the TrustedAssertionIssuer matching `iss`, or nil.
+func findIssuer(issuers []TrustedAssertionIssuer, iss string) *TrustedAssertionIssuer {
+	for i := range issuers {
+		if issuers[i].Issuer == iss {
+			return &issuers[i]
+		}
+	}
+	return nil
+}
+
+// validateAssertion parses + signature-validates a JWT assertion
+// against the configured trusted issuers, then validates the
+// standard registered claims (aud, exp, nbf). Returns the validated
+// claims on success.
+//
+// Per RFC 7523 §3:
+//   - `iss` MUST match a configured trusted issuer.
+//   - Signature MUST verify using a key supplied by that issuer.
+//   - `aud` MUST contain a value identifying the AS (its token
+//     endpoint URL, issuer URL, or configured audience).
+//   - `exp` MUST be in the future; `nbf` (if present) in the past.
+//   - `sub` is required and identifies the principal the assertion
+//     speaks for.
+//
+// Errors returned here use OAuth 2.0 error codes by convention; callers
+// (the grant handlers) translate them to invalid_grant /
+// invalid_request HTTP responses.
+func validateAssertion(
+	a *APIAuth,
+	rawAssertion string,
+) (jwt.MapClaims, *TrustedAssertionIssuer, error) {
+	if rawAssertion == "" {
+		return nil, nil, errors.New("assertion required")
+	}
+	if len(a.TrustedAssertionIssuers) == 0 {
+		return nil, nil, errors.New("no trusted assertion issuers configured")
+	}
+
+	// First parse without verification so we can pick the issuer.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	unverified, _, err := parser.ParseUnverified(rawAssertion, jwt.MapClaims{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("malformed assertion: %w", err)
+	}
+	claims, ok := unverified.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, nil, errors.New("assertion claims unparseable")
+	}
+	issStr, _ := claims["iss"].(string)
+	if issStr == "" {
+		return nil, nil, errors.New("assertion missing iss claim")
+	}
+	issuer := findIssuer(a.TrustedAssertionIssuers, issStr)
+	if issuer == nil {
+		return nil, nil, fmt.Errorf("untrusted assertion issuer: %s", issStr)
+	}
+
+	// Build the JWT key resolver. KeyFunc wins over PublicKey.
+	keyResolver := issuer.KeyFunc
+	if keyResolver == nil {
+		if issuer.PublicKey == nil {
+			return nil, nil, fmt.Errorf("issuer %q has no PublicKey or KeyFunc", issStr)
+		}
+		pubKey := issuer.PublicKey
+		keyResolver = func(*jwt.Token) (crypto.PublicKey, error) {
+			return pubKey, nil
+		}
+	}
+
+	parserOpts := []jwt.ParserOption{}
+	if len(issuer.AcceptedAlgorithms) > 0 {
+		parserOpts = append(parserOpts, jwt.WithValidMethods(issuer.AcceptedAlgorithms))
+	}
+	verifyParser := jwt.NewParser(parserOpts...)
+	verified, err := verifyParser.Parse(rawAssertion, func(t *jwt.Token) (interface{}, error) {
+		return keyResolver(t)
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("assertion signature/claims invalid: %w", err)
+	}
+	if !verified.Valid {
+		return nil, nil, errors.New("assertion not valid (signature, exp or nbf)")
+	}
+	verifiedClaims, ok := verified.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, nil, errors.New("verified claims unparseable")
+	}
+
+	// aud validation. Per RFC 7523 §3 the assertion MUST have an aud
+	// the AS recognizes. Default to JWTAudience or Issuer URL.
+	expectedAudiences := issuer.Audiences
+	if len(expectedAudiences) == 0 {
+		if a.JWTAudience != "" {
+			expectedAudiences = []string{a.JWTAudience}
+		} else if a.JWTIssuer != "" {
+			expectedAudiences = []string{a.JWTIssuer}
+		}
+	}
+	if len(expectedAudiences) == 0 {
+		// Server isn't configured strongly enough to enforce; accept
+		// any aud but log loudly so this isn't silent in production.
+		log.Printf("apiauth: jwt-bearer/token-exchange — no audience configured for issuer %q; accepting any aud claim. Set TrustedAssertionIssuer.Audiences or APIAuth.JWTAudience for production.", issStr)
+	} else {
+		matched := false
+		for _, aud := range expectedAudiences {
+			if matchesAudience(verifiedClaims, aud) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil, nil, fmt.Errorf("assertion audience does not match expected: %v", expectedAudiences)
+		}
+	}
+
+	// sub MUST be present per RFC 7523 §3. Other registered claims
+	// (exp, nbf) are validated by jwt.Parse above.
+	if sub, _ := verifiedClaims["sub"].(string); sub == "" {
+		return nil, nil, errors.New("assertion missing sub claim")
+	}
+
+	return verifiedClaims, issuer, nil
+}
+
+// handleJwtBearerGrant handles RFC 7523 §2.1 — the client presents a
+// signed JWT (in the `assertion` param) issued by a trusted upstream
+// IdP and trades it for an access token at our token endpoint.
+//
+// The assertion's `sub` becomes the access token's subject. Scope is
+// taken from the request's `scope` parameter (intersected with what
+// the AS would normally grant); RFC 7523 doesn't define how scopes
+// are determined — that's deployment-specific.
+func (a *APIAuth) handleJwtBearerGrant(w http.ResponseWriter, r *http.Request, req *core.TokenRequest) {
+	if len(a.TrustedAssertionIssuers) == 0 {
+		a.errorResponse(w, "unsupported_grant_type", "jwt-bearer grant not configured", http.StatusBadRequest)
+		return
+	}
+	if req.Assertion == "" {
+		a.errorResponse(w, "invalid_request", "assertion parameter required", http.StatusBadRequest)
+		return
+	}
+
+	claims, _, err := validateAssertion(a, req.Assertion)
+	if err != nil {
+		a.errorResponse(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	subject, _ := claims["sub"].(string) // already validated non-empty
+	scopes := core.ParseScopes(req.Scope)
+
+	// Validate authorization_details if present (RFC 9396).
+	if err := core.ValidateAll(req.AuthorizationDetails); err != nil {
+		a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	accessToken, expiresIn, err := a.CreateAccessToken(subject, scopes, req.AuthorizationDetails)
+	if err != nil {
+		log.Printf("Error creating access token (jwt-bearer grant): %v", err)
+		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
+		return
+	}
+
+	// No refresh token for jwt-bearer per RFC 7523 — the assertion
+	// itself is the renewable credential (re-issued by the upstream
+	// IdP and re-presented). Returning a refresh token would muddle
+	// session semantics.
+	a.tokenResponse(w, accessToken, expiresIn, "", scopes, req.AuthorizationDetails)
+}

--- a/apiauth/jwt_bearer_grant_test.go
+++ b/apiauth/jwt_bearer_grant_test.go
@@ -1,0 +1,300 @@
+// Tests for RFC 7523 §2.1 — JWT Bearer authorization grant. Verifies
+// that the AS accepts grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+// when the assertion is signed by a trusted issuer and meets the §3
+// claim requirements; rejects with invalid_grant otherwise.
+//
+// See:
+//   - RFC 7523 §2.1: https://www.rfc-editor.org/rfc/rfc7523#section-2.1
+//   - oneauth issue 181
+//   - mcpkit issue 381 (paired conformance gap)
+package apiauth_test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jwtBearerTestEnv bundles the AS-under-test plus the trusted IdP's
+// signing key so individual cases can mint freshly-claimed assertions.
+type jwtBearerTestEnv struct {
+	apiAuth    *apiauth.APIAuth
+	idpKey     *rsa.PrivateKey
+	idpIssuer  string
+	asAudience string
+}
+
+func newJwtBearerTestEnv(t *testing.T) *jwtBearerTestEnv {
+	t.Helper()
+
+	idpKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	asAudience := "https://oneauth-test/api/token"
+	idpIssuer := "https://corp-idp.example.com"
+
+	apiAuth := &apiauth.APIAuth{
+		JWTSecretKey: "test-secret-key-for-testing-only",
+		JWTIssuer:    "oneauth-test",
+		JWTAudience:  asAudience,
+		TrustedAssertionIssuers: []apiauth.TrustedAssertionIssuer{{
+			Issuer:             idpIssuer,
+			PublicKey:          &idpKey.PublicKey,
+			Audiences:          []string{asAudience},
+			AcceptedAlgorithms: []string{"RS256"},
+		}},
+	}
+
+	return &jwtBearerTestEnv{
+		apiAuth:    apiAuth,
+		idpKey:     idpKey,
+		idpIssuer:  idpIssuer,
+		asAudience: asAudience,
+	}
+}
+
+// mintAssertion signs a JWT with the test IdP's private key. Caller
+// supplies any claim overrides; defaults populate a valid assertion.
+// A nil value in overrides deletes the corresponding default claim.
+func (e *jwtBearerTestEnv) mintAssertion(t *testing.T, overrides jwt.MapClaims) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": e.idpIssuer,
+		"sub": "alice@corp.example.com",
+		"aud": e.asAudience,
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Add(-1 * time.Second).Unix(),
+	}
+	for k, v := range overrides {
+		if v == nil {
+			delete(claims, k)
+		} else {
+			claims[k] = v
+		}
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := tok.SignedString(e.idpKey)
+	require.NoError(t, err)
+	return signed
+}
+
+// postForm sends a form-encoded token request and returns the HTTP
+// status + decoded JSON body. Distinct helper from
+// client_credentials_test.go's postTokenRequest (which takes a JSON
+// string) to avoid the name collision while keeping each grant test
+// file self-contained.
+func postForm(
+	t *testing.T,
+	a *apiauth.APIAuth,
+	form url.Values,
+) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	a.ServeHTTP(rr, req)
+	var body map[string]any
+	if rr.Body.Len() > 0 {
+		_ = json.Unmarshal(rr.Body.Bytes(), &body)
+	}
+	return rr.Code, body
+}
+
+// TestJwtBearerGrant_HappyPath — properly-signed assertion with valid
+// claims yields a 200 + access_token.
+func TestJwtBearerGrant_HappyPath(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	assertion := env.mintAssertion(t, nil)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", assertion)
+	form.Set("scope", "read")
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusOK, status, "happy path MUST return 200")
+	assert.NotEmpty(t, body["access_token"], "response MUST include access_token")
+	assert.Equal(t, "Bearer", body["token_type"])
+	// RFC 7523 — no refresh token for jwt-bearer grant.
+	_, hasRefresh := body["refresh_token"]
+	assert.False(t, hasRefresh, "jwt-bearer MUST NOT return a refresh_token")
+}
+
+// TestJwtBearerGrant_NoTrustedIssuersConfigured — when the AS has no
+// TrustedAssertionIssuers, the grant returns unsupported_grant_type.
+func TestJwtBearerGrant_NoTrustedIssuersConfigured(t *testing.T) {
+	a := &apiauth.APIAuth{
+		JWTSecretKey: "test",
+		JWTIssuer:    "oneauth-test",
+		// TrustedAssertionIssuers intentionally empty.
+	}
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", "irrelevant")
+
+	status, body := postForm(t, a, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "unsupported_grant_type", body["error"])
+}
+
+// TestJwtBearerGrant_MissingAssertion — grant_type set but no assertion
+// param yields invalid_request.
+func TestJwtBearerGrant_MissingAssertion(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestJwtBearerGrant_UntrustedIssuer — assertion signed by a key that
+// matches no configured issuer is rejected with invalid_grant.
+func TestJwtBearerGrant_UntrustedIssuer(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	assertion := env.mintAssertion(t, jwt.MapClaims{
+		"iss": "https://malicious-idp.example.com",
+	})
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", assertion)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+	assert.Contains(t, body["error_description"], "untrusted")
+}
+
+// TestJwtBearerGrant_BadSignature — assertion claims a trusted iss but
+// signature was made with a different key (i.e., attacker forged).
+func TestJwtBearerGrant_BadSignature(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": env.idpIssuer,
+		"sub": "alice",
+		"aud": env.asAudience,
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	signed, err := tok.SignedString(wrongKey)
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", signed)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestJwtBearerGrant_ExpiredAssertion — exp in the past.
+func TestJwtBearerGrant_ExpiredAssertion(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	assertion := env.mintAssertion(t, jwt.MapClaims{
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", assertion)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestJwtBearerGrant_AudienceMismatch — `aud` doesn't match what the AS
+// expects.
+func TestJwtBearerGrant_AudienceMismatch(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	assertion := env.mintAssertion(t, jwt.MapClaims{
+		"aud": "https://different-resource.example.com",
+	})
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", assertion)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+	assert.Contains(t, body["error_description"], "audience")
+}
+
+// TestJwtBearerGrant_MissingSub — RFC 7523 §3 requires `sub`. An
+// assertion that omits it is rejected.
+func TestJwtBearerGrant_MissingSub(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	assertion := env.mintAssertion(t, jwt.MapClaims{
+		"sub": nil, // delete the claim
+	})
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", assertion)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestJwtBearerGrant_AlgorithmRestricted — when AcceptedAlgorithms is
+// set to {"RS256"}, an HS256-signed assertion is rejected (alg-confusion
+// mitigation: attacker can't downgrade to a symmetric algorithm whose
+// "secret" is the issuer's public key).
+func TestJwtBearerGrant_AlgorithmRestricted(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": env.idpIssuer,
+		"sub": "alice",
+		"aud": env.asAudience,
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+	signed, err := tok.SignedString([]byte("not-the-real-secret"))
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", signed)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestJwtBearerGrant_KeyFuncResolution — KeyFunc takes precedence over
+// PublicKey. Useful for issuers whose JWKS rotates: the test pins a
+// callback that returns a fresh key per request.
+func TestJwtBearerGrant_KeyFuncResolution(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	// Reconfigure: drop PublicKey, use KeyFunc instead.
+	env.apiAuth.TrustedAssertionIssuers[0].PublicKey = nil
+	env.apiAuth.TrustedAssertionIssuers[0].KeyFunc = func(*jwt.Token) (crypto.PublicKey, error) {
+		return &env.idpKey.PublicKey, nil
+	}
+
+	assertion := env.mintAssertion(t, nil)
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", assertion)
+
+	status, _ := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusOK, status, "KeyFunc-based issuer MUST verify")
+}

--- a/apiauth/token_exchange_grant.go
+++ b/apiauth/token_exchange_grant.go
@@ -1,0 +1,143 @@
+package apiauth
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/panyam/oneauth/core"
+)
+
+// TokenExchangeGrantType is the OAuth grant type URI for OAuth 2.0
+// Token Exchange (RFC 8693 §2.1). A client presents a `subject_token`
+// representing the party on whose behalf the request is made and the
+// AS issues a new token (typically narrower in scope or audience).
+//
+// Common use case: enterprise-managed identity chains. A federated IdP
+// issues a JWT about an employee; the employee's MCP client trades that
+// JWT for an MCP-scoped access token via this grant.
+//
+// See: https://www.rfc-editor.org/rfc/rfc8693
+const TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+// RFC 8693 §3 token type URIs.
+const (
+	TokenTypeAccessToken  = "urn:ietf:params:oauth:token-type:access_token"
+	TokenTypeRefreshToken = "urn:ietf:params:oauth:token-type:refresh_token"
+	TokenTypeIDToken      = "urn:ietf:params:oauth:token-type:id_token"
+	TokenTypeJWT          = "urn:ietf:params:oauth:token-type:jwt"
+	TokenTypeSAML2        = "urn:ietf:params:oauth:token-type:saml2"
+)
+
+// handleTokenExchangeGrant handles RFC 8693 token exchange.
+//
+// Phase 1 implementation supports:
+//
+//   - subject_token_type = urn:ietf:params:oauth:token-type:jwt — the
+//     subject_token is parsed + validated as a JWT against the configured
+//     TrustedAssertionIssuers (reusing validateAssertion shared with the
+//     jwt-bearer grant from RFC 7523 §2.1).
+//   - requested_token_type = urn:ietf:params:oauth:token-type:access_token
+//     (default; if omitted) or unspecified. Other requested_token_type
+//     values return invalid_request — non-access-token issuance lands in
+//     a future commit.
+//
+// audience / resource params are accepted but currently advisory — the
+// issued access token still carries the AS's default JWTAudience claim.
+// Active audience binding (CreateAccessToken-with-target-audience) is
+// future work; the spec gap is logged so it surfaces in production.
+//
+// Response shape per RFC 8693 §2.2:
+//
+//	{
+//	  "access_token":       "...",
+//	  "issued_token_type":  "urn:ietf:params:oauth:token-type:access_token",
+//	  "token_type":         "Bearer",
+//	  "expires_in":         900,
+//	  "scope":              "read write"
+//	}
+//
+// `issued_token_type` is REQUIRED in token-exchange responses (distinct
+// from the standard token-endpoint response shape used by other grants).
+func (a *APIAuth) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Request, req *core.TokenRequest) {
+	if len(a.TrustedAssertionIssuers) == 0 {
+		a.errorResponse(w, "unsupported_grant_type", "token-exchange grant not configured", http.StatusBadRequest)
+		return
+	}
+	if req.SubjectToken == "" {
+		a.errorResponse(w, "invalid_request", "subject_token parameter required", http.StatusBadRequest)
+		return
+	}
+	if req.SubjectTokenType == "" {
+		a.errorResponse(w, "invalid_request", "subject_token_type parameter required", http.StatusBadRequest)
+		return
+	}
+
+	// Phase 1: only JWT subject tokens are validated. Other types return
+	// invalid_request — extending to id_token / refresh_token / SAML
+	// requires per-type validators.
+	if req.SubjectTokenType != TokenTypeJWT {
+		a.errorResponse(w, "invalid_request",
+			"only subject_token_type="+TokenTypeJWT+" is supported",
+			http.StatusBadRequest)
+		return
+	}
+
+	// Phase 1: only access_token output. Default when omitted.
+	requestedType := req.RequestedTokenType
+	if requestedType == "" {
+		requestedType = TokenTypeAccessToken
+	}
+	if requestedType != TokenTypeAccessToken {
+		a.errorResponse(w, "invalid_request",
+			"only requested_token_type="+TokenTypeAccessToken+" is supported",
+			http.StatusBadRequest)
+		return
+	}
+
+	// Reuse the assertion validator from RFC 7523 — same iss/sig/aud/exp/sub
+	// validation rules apply to the token-exchange subject_token when it's
+	// a JWT (RFC 8693 §2.1.1 + RFC 7523 §3).
+	claims, _, err := validateAssertion(a, req.SubjectToken)
+	if err != nil {
+		a.errorResponse(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	subject, _ := claims["sub"].(string)
+	scopes := core.ParseScopes(req.Scope)
+
+	// audience / resource are advisory in this implementation. Log when
+	// they're set so production deployments notice the gap.
+	if req.Audience != "" || req.Resource != "" {
+		log.Printf("apiauth: token-exchange — audience=%q resource=%q params accepted but advisory; issued token uses default JWTAudience. Bind these into CreateAccessToken when audience-targeting lands.", req.Audience, req.Resource)
+	}
+
+	if err := core.ValidateAll(req.AuthorizationDetails); err != nil {
+		a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	accessToken, expiresIn, err := a.CreateAccessToken(subject, scopes, req.AuthorizationDetails)
+	if err != nil {
+		log.Printf("Error creating access token (token-exchange grant): %v", err)
+		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
+		return
+	}
+
+	// Token-exchange has its own response shape — the standard
+	// tokenResponse helper omits issued_token_type, which RFC 8693 §2.2
+	// REQUIRES. Encode the response inline.
+	resp := core.TokenPair{
+		AccessToken:          accessToken,
+		TokenType:            "Bearer",
+		ExpiresIn:            expiresIn,
+		Scope:                core.JoinScopes(scopes),
+		AuthorizationDetails: req.AuthorizationDetails,
+		IssuedTokenType:      requestedType,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/apiauth/token_exchange_grant_test.go
+++ b/apiauth/token_exchange_grant_test.go
@@ -1,0 +1,197 @@
+// Tests for RFC 8693 — OAuth 2.0 Token Exchange. Verifies that the AS
+// accepts grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+// when the subject_token (a signed JWT in this Phase 1 implementation)
+// is issued by a trusted IdP and meets the §3 claim requirements;
+// returns the RFC 8693 §2.2 response shape with issued_token_type.
+//
+// See:
+//   - RFC 8693:        https://www.rfc-editor.org/rfc/rfc8693
+//   - RFC 7523 §3:     https://www.rfc-editor.org/rfc/rfc7523#section-3
+//   - oneauth issue 118
+//   - mcpkit issue 381 (paired conformance gap)
+package apiauth_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/stretchr/testify/assert"
+)
+
+// reuses jwtBearerTestEnv + mintAssertion + postForm from
+// jwt_bearer_grant_test.go — same trusted-issuer setup.
+
+// TestTokenExchangeGrant_HappyPath — properly-signed subject_token (JWT)
+// from a trusted IdP yields a 200 + access_token + issued_token_type.
+func TestTokenExchangeGrant_HappyPath(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, nil)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+	form.Set("scope", "read")
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusOK, status)
+	assert.NotEmpty(t, body["access_token"])
+	assert.Equal(t, "Bearer", body["token_type"])
+	assert.Equal(t, apiauth.TokenTypeAccessToken, body["issued_token_type"],
+		"RFC 8693 §2.2 REQUIRES issued_token_type in token-exchange responses")
+}
+
+// TestTokenExchangeGrant_DefaultRequestedTokenType — when
+// requested_token_type is omitted, it defaults to access_token per
+// RFC 8693 §2.1.
+func TestTokenExchangeGrant_DefaultRequestedTokenType(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, nil)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+	// requested_token_type intentionally omitted.
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, apiauth.TokenTypeAccessToken, body["issued_token_type"])
+}
+
+// TestTokenExchangeGrant_NoTrustedIssuersConfigured — without
+// TrustedAssertionIssuers, the grant returns unsupported_grant_type.
+func TestTokenExchangeGrant_NoTrustedIssuersConfigured(t *testing.T) {
+	a := &apiauth.APIAuth{
+		JWTSecretKey: "test",
+		JWTIssuer:    "oneauth-test",
+	}
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", "irrelevant")
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+
+	status, body := postForm(t, a, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "unsupported_grant_type", body["error"])
+}
+
+// TestTokenExchangeGrant_MissingSubjectToken — required param.
+func TestTokenExchangeGrant_MissingSubjectToken(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_request", body["error"])
+	assert.Contains(t, body["error_description"], "subject_token")
+}
+
+// TestTokenExchangeGrant_MissingSubjectTokenType — required param.
+func TestTokenExchangeGrant_MissingSubjectTokenType(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, nil)
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_request", body["error"])
+	assert.Contains(t, body["error_description"], "subject_token_type")
+}
+
+// TestTokenExchangeGrant_UnsupportedSubjectTokenType — Phase 1 only
+// handles JWT; other types return invalid_request.
+func TestTokenExchangeGrant_UnsupportedSubjectTokenType(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, nil)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeSAML2)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestTokenExchangeGrant_UnsupportedRequestedTokenType — Phase 1 only
+// issues access_token; other types return invalid_request.
+func TestTokenExchangeGrant_UnsupportedRequestedTokenType(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, nil)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+	form.Set("requested_token_type", apiauth.TokenTypeIDToken)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestTokenExchangeGrant_UntrustedIssuer — same iss-validation behavior
+// as jwt-bearer grant (shared validateAssertion).
+func TestTokenExchangeGrant_UntrustedIssuer(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, jwt.MapClaims{
+		"iss": "https://malicious-idp.example.com",
+	})
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestTokenExchangeGrant_ExpiredSubjectToken — same exp-validation
+// behavior.
+func TestTokenExchangeGrant_ExpiredSubjectToken(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, jwt.MapClaims{
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+		"nbf": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestTokenExchangeGrant_AudienceParamAcceptedAdvisory — RFC 8693
+// audience param is parsed but currently advisory; the grant succeeds
+// regardless. (Future commits will bind it into the issued aud claim.)
+func TestTokenExchangeGrant_AudienceParamAcceptedAdvisory(t *testing.T) {
+	env := newJwtBearerTestEnv(t)
+	subjectToken := env.mintAssertion(t, nil)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.TokenExchangeGrantType)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", apiauth.TokenTypeJWT)
+	form.Set("audience", "https://downstream.example.com")
+	form.Set("resource", "https://downstream.example.com/api")
+
+	status, body := postForm(t, env.apiAuth, form)
+	assert.Equal(t, http.StatusOK, status,
+		"audience/resource params MUST be accepted (advisory in Phase 1)")
+	assert.NotEmpty(t, body["access_token"])
+}

--- a/core/tokens.go
+++ b/core/tokens.go
@@ -139,7 +139,7 @@ type TokenPair struct {
 
 // TokenRequest represents a request to the token endpoint
 type TokenRequest struct {
-	GrantType            string                `json:"grant_type"`                                  // "password", "refresh_token", "client_credentials"
+	GrantType            string                `json:"grant_type"`                                  // "password", "refresh_token", "client_credentials", "urn:ietf:params:oauth:grant-type:jwt-bearer", "urn:ietf:params:oauth:grant-type:token-exchange"
 	Username             string                `json:"username,omitempty"`                          // For password grant
 	Password             string                `json:"password,omitempty"`                          // For password grant
 	RefreshToken         string                `json:"refresh_token,omitempty"`                     // For refresh_token grant
@@ -147,6 +147,23 @@ type TokenRequest struct {
 	ClientID             string                `json:"client_id,omitempty"`                         // Client identifier (for client_credentials, optional for others)
 	ClientSecret         string                `json:"client_secret,omitempty"`                     // Client secret (for client_credentials via client_secret_post)
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"`             // RFC 9396
+
+	// Assertion is the signed JWT for grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+	// (RFC 7523 §2.1). The AS validates the assertion against a configured
+	// trusted-issuer registry and issues an access token in exchange.
+	Assertion string `json:"assertion,omitempty"`
+
+	// SubjectToken / SubjectTokenType / RequestedTokenType / Resource / Audience
+	// support grant_type=urn:ietf:params:oauth:grant-type:token-exchange (RFC 8693).
+	// SubjectToken is the credential representing the party on whose behalf
+	// the request is made; SubjectTokenType identifies its kind (e.g.,
+	// urn:ietf:params:oauth:token-type:jwt). RequestedTokenType (optional)
+	// identifies the desired output token kind; defaults to access_token.
+	SubjectToken       string `json:"subject_token,omitempty"`
+	SubjectTokenType   string `json:"subject_token_type,omitempty"`
+	RequestedTokenType string `json:"requested_token_type,omitempty"`
+	Resource           string `json:"resource,omitempty"`
+	Audience           string `json:"audience,omitempty"`
 }
 
 // TokenError represents an OAuth 2.0 compliant error response

--- a/core/tokens.go
+++ b/core/tokens.go
@@ -135,6 +135,14 @@ type TokenPair struct {
 	RefreshToken         string                `json:"refresh_token,omitempty"`
 	Scope                string                `json:"scope,omitempty"`
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
+
+	// IssuedTokenType identifies the type of token issued (RFC 8693 §2.2,
+	// REQUIRED for token-exchange responses; absent for other grants).
+	// Common values:
+	//   urn:ietf:params:oauth:token-type:access_token
+	//   urn:ietf:params:oauth:token-type:refresh_token
+	//   urn:ietf:params:oauth:token-type:jwt
+	IssuedTokenType string `json:"issued_token_type,omitempty"`
 }
 
 // TokenRequest represents a request to the token endpoint


### PR DESCRIPTION
## Summary

Three OAuth spec extensions to oneauth's AS surface, packaged as one PR with three sequential commits (one per RFC) so the diff reads cleanly:

1. **RFC 9207** — Authorization Server Issuer Identification (closes #180)
2. **RFC 7523 §2.1** — JWT Bearer authorization grant (closes #181)
3. **RFC 8693** — OAuth 2.0 Token Exchange (closes #118)

Each commit is independently reviewable; #181 establishes the assertion-validation infrastructure (`TrustedAssertionIssuer`, `validateAssertion`) that #118 reuses for the token-exchange `subject_token` validation.

These are the three implementation gaps that the auth pillar of the **mcpkit MCP-authorization conformance suite** (`panyam/mcpconformance:pending` under `src/scenarios/server/auth/`) is currently advertising as SKIPPED. The corresponding mcpkit issues are panyam/mcpkit#380 and panyam/mcpkit#381 — once mcpkit's `examples/auth/` fixture bumps oneauth and turns these features on in `TestAuthServer`, three SKIPPED conformance checks flip to SUCCESS automatically.

## Test plan

- [x] `go test ./apiauth/ -run 'TestASMetadata_AuthorizationResponseIss|TestJwtBearer|TestTokenExchange'` — 21 RFC-specific tests, all green
- [x] `go test ./...` — full suite green (apiauth + 12 other packages)
- [x] No backwards-incompatible changes — all new fields are pointer/omitempty; existing grants and metadata unchanged

## Per-commit summary

### Commit 1 — RFC 9207 (#180)

`apiauth.ASServerMetadata` gains `AuthorizationResponseIssParameterSupported *bool` with `json:"authorization_response_iss_parameter_supported,omitempty"`. Pointer semantics distinguish absence from explicit `false`. The redirect-side work (`iss=` query on /authorize) lands when oneauth grows an /authorize endpoint — currently the AS is token-endpoint-focused.

### Commit 2 — RFC 7523 §2.1 (#181)

New `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` handler. The client trades a signed JWT (typically issued by an upstream IdP) for an access token. Adds:

- `apiauth.JwtBearerGrantType` const
- `apiauth.TrustedAssertionIssuer` (Issuer + PublicKey | KeyFunc + Audiences + AcceptedAlgorithms)
- `apiauth.APIAuth.TrustedAssertionIssuers` field
- Validation per RFC 7523 §3 (iss, signature, aud, exp, sub, alg restriction)
- No refresh token returned (assertion is the renewable credential)

Distinct from RFC 7523 §2.2 (JWT for **client** authentication) which is tracked separately via #158 / #159.

### Commit 3 — RFC 8693 (#118)

New `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` handler. The client presents a `subject_token` and trades it for a new access token. Phase 1 scope:

- **subject_token_type = jwt** only (reuses validateAssertion from commit 2)
- **requested_token_type = access_token** (default; if omitted) or unspecified
- audience / resource params accepted but **advisory** in this commit — the issued token uses the AS's default JWTAudience. Active audience-binding (CreateAccessToken-with-target-audience) is future work; the gap is logged at INFO so production deployments notice.
- No actor_token / no id_token / refresh_token / SAML output yet.

Token-exchange has its own response shape (`issued_token_type` is REQUIRED per RFC 8693 §2.2) — `core.TokenPair` gains an `IssuedTokenType` field with `omitempty` so other grants are unaffected.

## Closes

- #180 — RFC 9207 Authorization Server Issuer Identification
- #181 — RFC 7523 §2.1 JWT Bearer authorization grant
- #118 — RFC 8693 OAuth 2.0 Token Exchange

## Follow-ups (not in this PR)

- **mcpkit-side**: bump oneauth dep, turn on the new fields/grants in `examples/auth/`'s `TestAuthServer` config + add the new grant URIs to `grant_types_supported`. That'll flip 3 SKIPPED conformance checks to SUCCESS.
- **Deeper RFC 8693**: actor_token (delegation chains), id_token / refresh_token output, audience-bound token issuance.
- **Deeper RFC 7523**: integration with a JWKS cache for issuers that rotate keys (currently `KeyFunc` lets callers wire one in, but no built-in cache yet).
- **/authorize endpoint** in oneauth — when that lands, RFC 9207 part 2 (`iss=` query in redirects) wires up.