### PR TITLE
feat(testutil): TestAuthServer Options for RFC 9207 + 7523 + 8693

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -57,10 +57,13 @@ type TestAuthServer struct {
 
 // config holds TestAuthServer configuration set via functional options.
 type config struct {
-	adminKey string
-	issuer   string
-	audience string
-	scopes   []string
+	adminKey                string
+	issuer                  string
+	audience                string
+	scopes                  []string
+	grantTypesSupported     []string                         // overrides default when non-nil
+	issParameterSupported   *bool                            // RFC 9207 advertisement (nil = omit)
+	trustedAssertionIssuers []apiauth.TrustedAssertionIssuer // RFC 7523 §2.1 + RFC 8693
 }
 
 // Option configures a TestAuthServer.
@@ -88,6 +91,67 @@ func WithAudience(aud string) Option {
 // Default: ["read", "write", "admin"].
 func WithScopes(scopes []string) Option {
 	return func(c *config) { c.scopes = scopes }
+}
+
+// WithGrantTypesSupported overrides the `grant_types_supported` field
+// advertised in AS metadata (RFC 8414). Use this when enabling a grant
+// beyond the default (`client_credentials`) — e.g., advertising the
+// jwt-bearer (RFC 7523 §2.1) or token-exchange (RFC 8693) grants
+// alongside the default.
+//
+// The values supplied REPLACE the default. Callers that want to keep
+// `client_credentials` and add more must include it in the slice.
+//
+// Note: advertising a grant in metadata does NOT enable its handler at
+// the token endpoint. Pair this with WithTrustedAssertionIssuers to
+// actually serve jwt-bearer / token-exchange requests.
+func WithGrantTypesSupported(grants []string) Option {
+	return func(c *config) { c.grantTypesSupported = grants }
+}
+
+// WithIssParameterSupported sets the
+// `authorization_response_iss_parameter_supported` field in AS metadata
+// (RFC 9207 §3). Mitigates mix-up attacks against clients that interact
+// with multiple ASes by signaling that the AS includes an `iss`
+// parameter on every authorization response.
+//
+// Note: TestAuthServer does NOT currently implement an authorization
+// endpoint, so the *behavior* RFC 9207 §2 mandates (`iss=` in redirects)
+// is not yet driven by this flag — the flag affects only the metadata
+// advertisement. Setting it true on a real AS that does NOT actually
+// emit `iss` in authorization responses is a spec violation.
+func WithIssParameterSupported(supported bool) Option {
+	return func(c *config) { c.issParameterSupported = &supported }
+}
+
+// WithTrustedAssertionIssuers configures the AS to accept
+// jwt-bearer (RFC 7523 §2.1) and token-exchange (RFC 8693) grants from
+// the listed upstream IdPs. Each entry binds an issuer URL to a public
+// key (or KeyFunc) so the AS can verify assertion signatures.
+//
+// When the supplied slice is non-empty, this Option AUTOMATICALLY
+// extends the advertised `grant_types_supported` to include the two new
+// grant URIs (so callers don't need to remember the pair). Callers can
+// still pass WithGrantTypesSupported AFTER this option to fully replace
+// the advertised list — last-option-wins for the slice.
+//
+// See:
+//   - RFC 7523 §2.1: https://www.rfc-editor.org/rfc/rfc7523#section-2.1
+//   - RFC 8693:      https://www.rfc-editor.org/rfc/rfc8693
+func WithTrustedAssertionIssuers(issuers []apiauth.TrustedAssertionIssuer) Option {
+	return func(c *config) {
+		c.trustedAssertionIssuers = issuers
+		// Extend the advertised grants unless the caller already pinned
+		// a specific list. Append-don't-replace keeps client_credentials
+		// alongside the new grants by default.
+		if c.grantTypesSupported == nil {
+			c.grantTypesSupported = []string{
+				"client_credentials",
+				apiauth.JwtBearerGrantType,
+				apiauth.TokenExchangeGrantType,
+			}
+		}
+	}
 }
 
 // NewTestAuthServer creates and starts an in-process authorization server
@@ -138,12 +202,13 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 	registrar := admin.NewAppRegistrar(ks, admin.NewAPIKeyAuth(cfg.adminKey))
 
 	apiAuth := &apiauth.APIAuth{
-		JWTSigningAlg:  "RS256",
-		JWTSigningKey:  privKey,
-		JWTVerifyKey:   &privKey.PublicKey,
-		JWTIssuer:      cfg.issuer,
-		JWTAudience:    cfg.audience,
-		ClientKeyStore: ks,
+		JWTSigningAlg:           "RS256",
+		JWTSigningKey:           privKey,
+		JWTVerifyKey:            &privKey.PublicKey,
+		JWTIssuer:               cfg.issuer,
+		JWTAudience:             cfg.audience,
+		ClientKeyStore:          ks,
+		TrustedAssertionIssuers: cfg.trustedAssertionIssuers,
 	}
 
 	introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
@@ -168,6 +233,10 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		issuer = baseURL
 		apiAuth.JWTIssuer = issuer
 	}
+	grants := cfg.grantTypesSupported
+	if grants == nil {
+		grants = []string{"client_credentials"}
+	}
 	apiauth.MountASMetadata(mux, &apiauth.ASServerMetadata{
 		Issuer:                        issuer,
 		TokenEndpoint:                 baseURL + "/api/token",
@@ -175,10 +244,11 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		IntrospectionEndpoint:         baseURL + "/oauth/introspect",
 		RegistrationEndpoint:          baseURL + "/apps/register",
 		ScopesSupported:               cfg.scopes,
-		GrantTypesSupported:           []string{"client_credentials"},
+		GrantTypesSupported:           grants,
 		ResponseTypesSupported:        []string{"token"},
 		TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
 		CodeChallengeMethodsSupported: []string{"S256"},
+		AuthorizationResponseIssParameterSupported: cfg.issParameterSupported,
 	})
 
 	return &TestAuthServer{

--- a/testutil/server_test.go
+++ b/testutil/server_test.go
@@ -1,13 +1,18 @@
 package testutil_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/apiauth"
 	"github.com/panyam/oneauth/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -357,4 +362,143 @@ func registerTestApp(t *testing.T, srv *testutil.TestAuthServer, domain string) 
 	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
 	return result["client_id"].(string), result["client_secret"].(string)
+}
+
+
+// TestWithGrantTypesSupported_Override verifies that the Option replaces
+// the default grant_types_supported in AS metadata.
+//
+// See: oneauth issue 188 (RFC 7523 §2.1 + RFC 8693 follow-up wiring)
+func TestWithGrantTypesSupported_Override(t *testing.T) {
+	srv := testutil.NewTestAuthServer(t, testutil.WithGrantTypesSupported([]string{
+		"client_credentials",
+		apiauth.JwtBearerGrantType,
+		apiauth.TokenExchangeGrantType,
+	}))
+
+	resp, err := http.Get(srv.URL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	grants, ok := meta["grant_types_supported"].([]any)
+	require.True(t, ok, "grant_types_supported MUST be an array")
+	require.Len(t, grants, 3)
+	assert.Contains(t, grants, "client_credentials")
+	assert.Contains(t, grants, apiauth.JwtBearerGrantType)
+	assert.Contains(t, grants, apiauth.TokenExchangeGrantType)
+}
+
+// TestWithIssParameterSupported_True verifies that RFC 9207 advertisement
+// flips on with the Option (the panyam/mcpconformance Phase 3b
+// auth-iss-param-as-metadata-advertises-support check flips
+// SKIPPED → SUCCESS once a downstream fixture sets this).
+func TestWithIssParameterSupported_True(t *testing.T) {
+	srv := testutil.NewTestAuthServer(t, testutil.WithIssParameterSupported(true))
+
+	resp, err := http.Get(srv.URL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	val, present := meta["authorization_response_iss_parameter_supported"]
+	require.True(t, present, "field MUST be present when Option set")
+	assert.Equal(t, true, val)
+}
+
+// TestWithIssParameterSupported_OmittedByDefault — without the Option
+// the field is absent (consistent with the AS not yet implementing
+// RFC 9207).
+func TestWithIssParameterSupported_OmittedByDefault(t *testing.T) {
+	srv := testutil.NewTestAuthServer(t)
+
+	resp, err := http.Get(srv.URL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	_, present := meta["authorization_response_iss_parameter_supported"]
+	assert.False(t, present, "field MUST be absent without the Option")
+}
+
+// TestWithTrustedAssertionIssuers_AdvertisesGrants — when trusted
+// issuers are configured, the advertised grants automatically extend
+// to include jwt-bearer and token-exchange (so callers don't have to
+// remember to opt into both via separate Options).
+func TestWithTrustedAssertionIssuers_AdvertisesGrants(t *testing.T) {
+	idpKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	srv := testutil.NewTestAuthServer(t, testutil.WithTrustedAssertionIssuers([]apiauth.TrustedAssertionIssuer{{
+		Issuer:    "https://corp-idp.example.com",
+		PublicKey: &idpKey.PublicKey,
+	}}))
+
+	resp, err := http.Get(srv.URL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	grants, ok := meta["grant_types_supported"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, grants, "client_credentials",
+		"default grant retained alongside the new ones")
+	assert.Contains(t, grants, apiauth.JwtBearerGrantType)
+	assert.Contains(t, grants, apiauth.TokenExchangeGrantType)
+}
+
+// TestWithTrustedAssertionIssuers_HandlerActive — the trusted-issuer
+// registry wires through to APIAuth so jwt-bearer is actually accepted
+// at the token endpoint (not just advertised). Smoke-tests by minting
+// an upstream-IdP-style assertion and exchanging it.
+func TestWithTrustedAssertionIssuers_HandlerActive(t *testing.T) {
+	idpKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	idpIssuer := "https://corp-idp.example.com"
+
+	asAudience := "test-as"
+	srv := testutil.NewTestAuthServer(t,
+		testutil.WithAudience(asAudience),
+		testutil.WithTrustedAssertionIssuers([]apiauth.TrustedAssertionIssuer{{
+			Issuer:             idpIssuer,
+			PublicKey:          &idpKey.PublicKey,
+			Audiences:          []string{asAudience},
+			AcceptedAlgorithms: []string{"RS256"},
+		}}),
+	)
+
+	now := time.Now()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": idpIssuer,
+		"sub": "alice",
+		"aud": asAudience,
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Add(-1 * time.Second).Unix(),
+	})
+	signed, err := tok.SignedString(idpKey)
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("grant_type", apiauth.JwtBearerGrantType)
+	form.Set("assertion", signed)
+	resp, err := http.Post(srv.URL()+"/api/token",
+		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"jwt-bearer grant MUST be accepted; got %d: %s", resp.StatusCode, body)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(body, &out))
+	assert.NotEmpty(t, out["access_token"])
 }


### PR DESCRIPTION
## Summary

Follow-up to #188 (which added the spec extensions in `apiauth`). This PR wires those extensions into `testutil.TestAuthServer`'s functional-Options surface so downstream consumers can opt into the new metadata fields and grants without constructing `apiauth.APIAuth` manually.

Specifically: mcpkit's `examples/auth/` fixture (the reference implementation behind the panyam/mcpconformance suite for MCP authorization) currently has three SKIPPED conformance checks waiting for the AS to advertise the new fields/grants in its RFC 8414 metadata. With this PR shipped + tagged + bumped in mcpkit, those checks flip to SUCCESS automatically — same pattern we just used for the apiauth-side extensions.

## Three new Options

```go
testutil.WithGrantTypesSupported(grants []string)
testutil.WithIssParameterSupported(supported bool)
testutil.WithTrustedAssertionIssuers(issuers []apiauth.TrustedAssertionIssuer)
```

- **`WithGrantTypesSupported`** — replaces the default `["client_credentials"]` in `grant_types_supported`. Use to advertise the new grants alongside the existing one.
- **`WithIssParameterSupported`** — sets the `AuthorizationResponseIssParameterSupported *bool` field on `ASServerMetadata` (RFC 9207 §3). Pointer semantics handled internally so the field is omitted from JSON when this Option isn't called.
- **`WithTrustedAssertionIssuers`** — configures the AS to accept jwt-bearer (RFC 7523 §2.1) and token-exchange (RFC 8693) grants from the listed upstream IdPs. Convenience: when the supplied slice is non-empty, this Option **automatically extends** `grant_types_supported` to include the two new grant URIs (so callers don't have to remember the pair). Callers can still pass `WithGrantTypesSupported` AFTER this option for full override (last-option-wins).

## Test plan

- [x] `go test ./testutil/` — 18 tests, all green (15 existing + 3 new for the Options + smoke test that the handler actually fires)
- [x] No backwards-incompat — all new Options are additive; existing callers unaffected
- [x] `go test ./...` — full suite green

## Tests added

- `TestWithGrantTypesSupported_Override` — replaces default grants in metadata
- `TestWithIssParameterSupported_True` — RFC 9207 advertisement turns on
- `TestWithIssParameterSupported_OmittedByDefault` — field absent without the Option (consistent with the AS not yet implementing RFC 9207 fully)
- `TestWithTrustedAssertionIssuers_AdvertisesGrants` — auto-extension of advertised grants when trusted issuers are wired
- `TestWithTrustedAssertionIssuers_HandlerActive` — end-to-end smoke: trusted-issuer + jwt-bearer round-trip works at the token endpoint (proves advertisement + handler are both active, not just one)

## Follow-ups (not in this PR)

- mcpkit-side: bump oneauth to whatever version this lands as, turn on these Options in `examples/auth/`'s `TestAuthServer` config. That'll flip 3 SKIPPED conformance checks (panyam/mcpkit#380, panyam/mcpkit#381) on the panyam/mcpconformance pending branch into SUCCESS.
- Future: when oneauth grows an `/authorize` endpoint, the RFC 9207 part 2 (`iss=` query in redirects) wires through this Option becomes "metadata + behavior" rather than "metadata only" — the doc on `WithIssParameterSupported` flags that gap.