### PR TITLE
refactor(apiauth): adopt ctx/req/resp convention across token interfaces

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -32,7 +32,7 @@
 - security-headers: HSTS, CSP, X-Frame-Options middleware
 - rich-authorization-requests: RFC 9396 authorization_details on token endpoint, introspection, middleware enforcement
 - token-revocation: RFC 7009 endpoint for access and refresh token revocation
-- transport-agnostic-core: OneAuth struct with composed interfaces (TokenIssuer, TokenValidator, TokenIntrospector, TokenRevoker) — usable without HTTP. The `admin/` surface — `ClientRegistrationManager` (RFC 7592 self-service, issues 168/169/170) and `ClientRegistrar` (admin CRUD: register, list, get, delete, rotate; issue 172) — is also transport-agnostic; HTTP handlers are thin wrappers. apiauth port to the same convention is tracked in 175.
+- transport-agnostic-core: Every transport-agnostic interface in the library follows the `(ctx context.Context, *XRequest) → (*XResponse, error)` convention. `apiauth/` (issue 175): `TokenIssuer` / `TokenValidator` / `TokenIntrospector` / `TokenRevoker` / `ClientAuthenticator`. `admin/` (issues 168/169/170/172): `ClientRegistrationManager` (RFC 7592 self-service) and `ClientRegistrar` (admin CRUD). HTTP handlers across both packages are thin wrappers; wire formats unchanged. Map to gRPC stubs without further refactor.
 - lifecycle-hooks: Grouped callbacks (TokenHooks, AuthHooks, ClientHooks, SecurityHooks) for audit, alerting, integration
 - interactive-examples: 10 progressive examples on demokit v0.0.16 — split into `main.go` (server with `--serve` real-port mode) + `walkthrough.go` (client demo). Slim `README.md` + generated `WALKTHROUGH.md` (mermaid + steps + copy-paste curl reproductions). Default `make demo` uses the TUI renderer.
 - client-sdk: AuthClient with credential store, auto-refresh, browser login

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -1235,10 +1235,11 @@ func (m *APIMiddleware) getValidator() TokenValidator {
 // validateJWT validates a JWT access token using the TokenValidator.
 func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) {
 	if v := m.getValidator(); v != nil {
-		info, verr := v.ValidateToken(tokenString)
+		resp, verr := v.ValidateToken(context.Background(), &ValidateTokenRequest{Token: tokenString})
 		if verr != nil {
 			return "", nil, "", nil, verr
 		}
+		info := resp.Info
 		customClaims = info.CustomClaims
 		if customClaims == nil {
 			customClaims = make(map[string]any)

--- a/apiauth/client_authenticator.go
+++ b/apiauth/client_authenticator.go
@@ -1,6 +1,9 @@
 package apiauth
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/panyam/oneauth/keys"
 )
 
@@ -22,20 +25,23 @@ func NewClientAuthenticator(kl keys.KeyLookup) ClientAuthenticator {
 }
 
 // AuthenticateClient verifies client_id + client_secret.
-func (a *clientAuthenticator) AuthenticateClient(clientID, clientSecret string) error {
-	if a.keyLookup == nil {
-		return errInvalidClient
+func (a *clientAuthenticator) AuthenticateClient(ctx context.Context, req *AuthenticateClientRequest) (*AuthenticateClientResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("AuthenticateClientRequest is required")
 	}
-	rec, err := a.keyLookup.GetKey(clientID)
+	if a.keyLookup == nil {
+		return nil, errInvalidClient
+	}
+	rec, err := a.keyLookup.GetKey(req.ClientID)
 	if err != nil || rec == nil {
-		return errInvalidClient
+		return nil, errInvalidClient
 	}
 	storedKey, ok := rec.Key.([]byte)
 	if !ok {
-		return errInvalidClient
+		return nil, errInvalidClient
 	}
-	if !constantTimeEqual(string(storedKey), clientSecret) {
-		return errInvalidClient
+	if !constantTimeEqual(string(storedKey), req.ClientSecret) {
+		return nil, errInvalidClient
 	}
-	return nil
+	return &AuthenticateClientResponse{}, nil
 }

--- a/apiauth/interfaces.go
+++ b/apiauth/interfaces.go
@@ -1,52 +1,109 @@
 package apiauth
 
 import (
+	"context"
+
 	"github.com/panyam/oneauth/core"
 )
 
 // Transport-independent interfaces for OneAuth operations.
+//
 // Each interface represents a focused capability. Implementations take only
 // the dependencies they need (Option A — composed interfaces, no god objects).
 //
 // HTTP handlers, gRPC interceptors, and MCP auth managers are thin transport
-// bindings over these interfaces.
+// bindings over these interfaces. Per the convention adopted in 169 / 172
+// every method follows:
 //
-// See: https://github.com/panyam/oneauth/issues/110
+//	MethodName(ctx context.Context, req *XRequest) (*XResponse, error)
+//
+// The ctx parameter is currently unused in most implementations but is the
+// extension point for typed library contexts and async-store cancellation
+// without changing method shapes (issue 175).
+//
+// See: https://github.com/panyam/oneauth/issues/110 (transport-independent core)
+// See: https://github.com/panyam/oneauth/issues/175 (this convention)
 
-// TokenIssuer creates signed access tokens.
+// ----------------------------------------------------------------------------
+// TokenIssuer — creates signed access tokens.
+// ----------------------------------------------------------------------------
+
+// TokenIssuer mints access tokens via the standard OAuth 2.0 grants.
 type TokenIssuer interface {
 	// CreateAccessToken mints a JWT with the given subject, scopes, and
 	// optional RFC 9396 authorization_details.
-	// Returns the signed token string and expiry in seconds.
-	CreateAccessToken(subject string, scopes []string, details []core.AuthorizationDetail) (token string, expiresIn int64, err error)
+	CreateAccessToken(ctx context.Context, req *CreateAccessTokenRequest) (*CreateAccessTokenResponse, error)
 
 	// ClientCredentials performs the full client_credentials grant:
-	// authenticates the client, validates scopes/details, and returns a token response.
-	ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error)
+	// authenticates the client, validates scopes/details, and returns a token pair.
+	ClientCredentials(ctx context.Context, req *ClientCredentialsRequest) (*ClientCredentialsResponse, error)
 
-	// RefreshGrant rotates a refresh token and returns a new access + refresh token pair.
-	// Handles theft detection (revoked token → revoke entire family).
-	RefreshGrant(refreshToken string) (*core.TokenPair, error)
+	// RefreshGrant rotates a refresh token and returns a new access + refresh
+	// token pair. Handles theft detection (revoked token → revoke entire family).
+	RefreshGrant(ctx context.Context, req *RefreshGrantRequest) (*RefreshGrantResponse, error)
 
 	// PasswordGrant authenticates a user with username/password and returns
-	// an access token. Does NOT create a refresh token — that's the caller's
+	// an access token. Does NOT create a refresh token — the caller's
 	// responsibility (via RefreshTokenStore.CreateRefreshToken), since refresh
 	// tokens may carry transport-specific metadata (device info, IP, etc.).
-	PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResult, error)
+	PasswordGrant(ctx context.Context, req *PasswordGrantRequest) (*PasswordGrantResponse, error)
+}
+
+// CreateAccessTokenRequest is the input to TokenIssuer.CreateAccessToken.
+type CreateAccessTokenRequest struct {
+	Subject              string
+	Scopes               []string
+	AuthorizationDetails []core.AuthorizationDetail
+}
+
+// CreateAccessTokenResponse is the output of TokenIssuer.CreateAccessToken.
+type CreateAccessTokenResponse struct {
+	Token     string
+	ExpiresIn int64
+}
+
+// ClientCredentialsRequest is the input to TokenIssuer.ClientCredentials.
+type ClientCredentialsRequest struct {
+	ClientID             string
+	ClientSecret         string
+	Scopes               []string
+	AuthorizationDetails []core.AuthorizationDetail
+}
+
+// ClientCredentialsResponse wraps the issued token pair. Wrapped (rather than
+// returning *core.TokenPair directly) for symmetry across the interface and
+// forward-compat headroom — same rationale as ClientRegistrationManager
+// response types in 168.
+type ClientCredentialsResponse struct {
+	Tokens *core.TokenPair
+}
+
+// RefreshGrantRequest is the input to TokenIssuer.RefreshGrant.
+type RefreshGrantRequest struct {
+	RefreshToken string
+}
+
+// RefreshGrantResponse wraps the rotated token pair.
+type RefreshGrantResponse struct {
+	Tokens *core.TokenPair
 }
 
 // PasswordGrantRequest holds the inputs for a password grant.
 type PasswordGrantRequest struct {
 	Username             string
 	Password             string
-	Scopes               []string                  // requested (intersected with allowed)
+	Scopes               []string                   // requested (intersected with allowed)
 	AuthorizationDetails []core.AuthorizationDetail // RFC 9396
 	ClientID             string                     // optional — associated client
 }
 
-// PasswordGrantResult holds the output of a successful password grant.
+// PasswordGrantResponse holds the output of a successful password grant.
 // The caller uses UserID + GrantedScopes to create a refresh token if needed.
-type PasswordGrantResult struct {
+//
+// (Renamed from PasswordGrantResult during the 175 convention port; the
+// PasswordGrantResult type alias below preserves the old name for one
+// release as a deprecation bridge.)
+type PasswordGrantResponse struct {
 	UserID               string
 	AccessToken          string
 	ExpiresIn            int64
@@ -54,48 +111,129 @@ type PasswordGrantResult struct {
 	AuthorizationDetails []core.AuthorizationDetail
 }
 
-// TokenValidator validates tokens and checks authorization.
+// PasswordGrantResult is the previous name of PasswordGrantResponse.
+//
+// Deprecated: use PasswordGrantResponse. Will be removed in a future release.
+type PasswordGrantResult = PasswordGrantResponse
+
+// ----------------------------------------------------------------------------
+// TokenValidator — validates tokens and checks authorization.
+// ----------------------------------------------------------------------------
+
+// TokenValidator parses tokens, verifies their signatures and standard claims,
+// and checks scope / RFC 9396 authorization_details requirements.
 type TokenValidator interface {
-	// ValidateToken parses and validates a token string (JWT signature,
-	// expiry, issuer, audience, blacklist). Returns the token's claims.
-	ValidateToken(token string) (*TokenInfo, error)
+	// ValidateToken parses and validates a token (signature, expiry, issuer,
+	// audience, blacklist) and returns its claims.
+	ValidateToken(ctx context.Context, req *ValidateTokenRequest) (*ValidateTokenResponse, error)
 
-	// CheckScopes validates a token and verifies it contains all required scopes.
-	// Returns an error if the token is invalid or scopes are insufficient.
-	CheckScopes(token string, required []string) error
+	// CheckScopes validates a token and verifies it carries every required scope.
+	CheckScopes(ctx context.Context, req *CheckScopesRequest) (*CheckScopesResponse, error)
 
-	// CheckAuthorizationDetails validates a token and verifies it contains
-	// authorization_details entries for all required types (RFC 9396).
-	CheckAuthorizationDetails(token string, requiredTypes []string) error
+	// CheckAuthorizationDetails validates a token and verifies it carries
+	// authorization_details entries for every required type (RFC 9396).
+	CheckAuthorizationDetails(ctx context.Context, req *CheckAuthorizationDetailsRequest) (*CheckAuthorizationDetailsResponse, error)
 }
 
-// TokenIntrospector inspects tokens per RFC 7662.
+// ValidateTokenRequest is the input to TokenValidator.ValidateToken.
+type ValidateTokenRequest struct {
+	Token string
+}
+
+// ValidateTokenResponse wraps the parsed token claims.
+type ValidateTokenResponse struct {
+	Info *TokenInfo
+}
+
+// CheckScopesRequest is the input to TokenValidator.CheckScopes.
+type CheckScopesRequest struct {
+	Token            string
+	RequiredScopes   []string
+}
+
+// CheckScopesResponse is intentionally empty — the operation is a pure
+// success/failure signal expressed via the error return. Wrapped struct
+// preserves the convention shape and gives forward-compat headroom.
+type CheckScopesResponse struct{}
+
+// CheckAuthorizationDetailsRequest is the input to TokenValidator.CheckAuthorizationDetails.
+type CheckAuthorizationDetailsRequest struct {
+	Token         string
+	RequiredTypes []string
+}
+
+// CheckAuthorizationDetailsResponse — see CheckScopesResponse rationale.
+type CheckAuthorizationDetailsResponse struct{}
+
+// ----------------------------------------------------------------------------
+// TokenIntrospector — RFC 7662.
+// ----------------------------------------------------------------------------
+
+// TokenIntrospector performs RFC 7662 token introspection.
 type TokenIntrospector interface {
 	// Introspect checks a token's validity and returns its claims.
-	// Returns {Active: false} for any invalid token (never reveals why).
-	Introspect(token string) (*IntrospectionResult, error)
+	// Returns {Active: false} on the wrapped result for any invalid token
+	// (never reveals why — RFC 7662 §2.2 confidentiality).
+	Introspect(ctx context.Context, req *IntrospectRequest) (*IntrospectResponse, error)
 }
 
-// TokenRevoker revokes tokens per RFC 7009.
+// IntrospectRequest is the input to TokenIntrospector.Introspect.
+type IntrospectRequest struct {
+	Token string
+}
+
+// IntrospectResponse wraps the RFC 7662 introspection result.
+type IntrospectResponse struct {
+	Result *IntrospectionResult
+}
+
+// ----------------------------------------------------------------------------
+// TokenRevoker — RFC 7009.
+// ----------------------------------------------------------------------------
+
+// TokenRevoker invalidates tokens per RFC 7009.
 type TokenRevoker interface {
-	// Revoke invalidates a token. The tokenTypeHint ("access_token" or
-	// "refresh_token") guides which store to check first. Empty hint
-	// tries both.
-	Revoke(token, tokenTypeHint string) error
+	// Revoke invalidates a token. The TokenTypeHint ("access_token" or
+	// "refresh_token") guides which store to check first; empty hint tries both.
+	Revoke(ctx context.Context, req *RevokeRequest) (*RevokeResponse, error)
 }
 
-// ClientAuthenticator verifies client credentials.
-// Used by transport bindings to authenticate callers of protected endpoints
-// (introspection, revocation, DCR).
+// RevokeRequest is the input to TokenRevoker.Revoke.
+type RevokeRequest struct {
+	Token         string
+	TokenTypeHint string
+}
+
+// RevokeResponse — empty (success/failure via error). Wrapped per convention.
+type RevokeResponse struct{}
+
+// ----------------------------------------------------------------------------
+// ClientAuthenticator — verifies client credentials.
+// ----------------------------------------------------------------------------
+
+// ClientAuthenticator verifies client_id + client_secret. Used by transport
+// bindings to authenticate callers of protected endpoints (introspection,
+// revocation, DCR).
 type ClientAuthenticator interface {
 	// AuthenticateClient verifies the client_id and client_secret.
-	AuthenticateClient(clientID, clientSecret string) error
+	AuthenticateClient(ctx context.Context, req *AuthenticateClientRequest) (*AuthenticateClientResponse, error)
 }
 
-// --- Result types ---
+// AuthenticateClientRequest is the input to ClientAuthenticator.AuthenticateClient.
+type AuthenticateClientRequest struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// AuthenticateClientResponse — empty (success/failure via error). Wrapped per convention.
+type AuthenticateClientResponse struct{}
+
+// ----------------------------------------------------------------------------
+// Result types (returned by interface methods, exported for wire compat)
+// ----------------------------------------------------------------------------
 
 // TokenInfo holds the validated claims extracted from a token.
-// Returned by TokenValidator.ValidateToken.
+// Returned wrapped inside ValidateTokenResponse.
 type TokenInfo struct {
 	// UserID is the subject (sub claim) — a user ID or client_id.
 	UserID string
@@ -115,7 +253,7 @@ type TokenInfo struct {
 }
 
 // Note: IntrospectionResult is defined in introspection_client.go.
-// TokenIntrospector.Introspect returns the same type used by
+// TokenIntrospector.Introspect returns the same type (wrapped) used by
 // IntrospectionValidator (the HTTP client). This keeps the result
 // consistent regardless of whether introspection is done locally
 // (via TokenIntrospector) or remotely (via IntrospectionValidator).

--- a/apiauth/introspection.go
+++ b/apiauth/introspection.go
@@ -1,7 +1,9 @@
 package apiauth
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/panyam/oneauth/keys"
@@ -43,10 +45,14 @@ type apiauthIntrospector struct {
 	auth *APIAuth
 }
 
-func (ai *apiauthIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) {
+func (ai *apiauthIntrospector) Introspect(ctx context.Context, req *IntrospectRequest) (*IntrospectResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("IntrospectRequest is required")
+	}
+	tokenString := req.Token
 	userID, scopes, _, err := ai.auth.ValidateAccessTokenFull(tokenString)
 	if err != nil {
-		return &IntrospectionResult{Active: false}, nil
+		return &IntrospectResponse{Result: &IntrospectionResult{Active: false}}, nil
 	}
 
 	rawClaims := parseRawJWTClaims(tokenString)
@@ -82,7 +88,7 @@ func (ai *apiauthIntrospector) Introspect(tokenString string) (*IntrospectionRes
 		}
 	}
 
-	return result, nil
+	return &IntrospectResponse{Result: result}, nil
 }
 
 func joinScopes(scopes []string) string {
@@ -110,7 +116,10 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil {
+	if _, err := h.Authenticator.AuthenticateClient(r.Context(), &AuthenticateClientRequest{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}); err != nil {
 		w.Header().Set("WWW-Authenticate", `Basic realm="introspection"`)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -128,12 +137,13 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Delegate to transport-independent introspector
-	result, err := h.Introspector.Introspect(token)
-	if err != nil || !result.Active {
+	introspectResp, err := h.Introspector.Introspect(r.Context(), &IntrospectRequest{Token: token})
+	if err != nil || introspectResp == nil || !introspectResp.Result.Active {
 		// RFC 7662: invalid tokens get {"active": false}, never an error
 		h.jsonResponse(w, http.StatusOK, map[string]any{"active": false})
 		return
 	}
+	result := introspectResp.Result
 
 	// Build response from IntrospectionResult
 	resp := map[string]any{

--- a/apiauth/oneauth_grants_test.go
+++ b/apiauth/oneauth_grants_test.go
@@ -7,6 +7,7 @@ package apiauth_test
 // See: https://github.com/panyam/oneauth/issues/110
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -31,17 +32,19 @@ func TestOneAuth_RefreshGrant(t *testing.T) {
 	rt, err := oa.RefreshStore.CreateRefreshToken("refresh-user", "test-client", nil, []string{"read", "write"})
 	require.NoError(t, err)
 
-	resp, err := oa.Issuer.RefreshGrant(rt.Token)
+	resp, err := oa.Issuer.RefreshGrant(context.Background(), &apiauth.RefreshGrantRequest{RefreshToken: rt.Token})
 	require.NoError(t, err)
-	assert.NotEmpty(t, resp.AccessToken)
-	assert.NotEmpty(t, resp.RefreshToken, "should get a new refresh token")
-	assert.NotEqual(t, rt.Token, resp.RefreshToken, "new refresh token should differ from old")
-	assert.Equal(t, "Bearer", resp.TokenType)
-	assert.Equal(t, "read write", resp.Scope)
+	require.NotNil(t, resp.Tokens)
+	tp := resp.Tokens
+	assert.NotEmpty(t, tp.AccessToken)
+	assert.NotEmpty(t, tp.RefreshToken, "should get a new refresh token")
+	assert.NotEqual(t, rt.Token, tp.RefreshToken, "new refresh token should differ from old")
+	assert.Equal(t, "Bearer", tp.TokenType)
+	assert.Equal(t, "read write", tp.Scope)
 
-	info, err := oa.Validator.ValidateToken(resp.AccessToken)
+	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tp.AccessToken})
 	require.NoError(t, err)
-	assert.Equal(t, "refresh-user", info.UserID)
+	assert.Equal(t, "refresh-user", vresp.Info.UserID)
 }
 
 // TestOneAuth_RefreshGrant_RevokedToken verifies that refreshing a revoked
@@ -54,7 +57,7 @@ func TestOneAuth_RefreshGrant_RevokedToken(t *testing.T) {
 	rt, _ := oa.RefreshStore.CreateRefreshToken("user-theft", "test-client", nil, []string{"read"})
 	oa.RefreshStore.RevokeRefreshToken(rt.Token)
 
-	_, err := oa.Issuer.RefreshGrant(rt.Token)
+	_, err := oa.Issuer.RefreshGrant(context.Background(), &apiauth.RefreshGrantRequest{RefreshToken: rt.Token})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token reuse")
 }
@@ -64,7 +67,7 @@ func TestOneAuth_RefreshGrant_RevokedToken(t *testing.T) {
 func TestOneAuth_RefreshGrant_InvalidToken(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	_, err := oa.Issuer.RefreshGrant("not-a-real-refresh-token")
+	_, err := oa.Issuer.RefreshGrant(context.Background(), &apiauth.RefreshGrantRequest{RefreshToken: "not-a-real-refresh-token"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid_grant")
 }
@@ -105,7 +108,7 @@ func newTestOneAuthWithPasswordGrant(t *testing.T) *apiauth.OneAuth {
 func TestOneAuth_PasswordGrant(t *testing.T) {
 	oa := newTestOneAuthWithPasswordGrant(t)
 
-	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+	result, err := oa.Issuer.PasswordGrant(context.Background(), &apiauth.PasswordGrantRequest{
 		Username: "alice@example.com",
 		Password: "correct-password",
 		Scopes:   []string{"read"},
@@ -116,9 +119,9 @@ func TestOneAuth_PasswordGrant(t *testing.T) {
 	assert.True(t, result.ExpiresIn > 0)
 	assert.Equal(t, []string{"read"}, result.GrantedScopes)
 
-	info, err := oa.Validator.ValidateToken(result.AccessToken)
+	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: result.AccessToken})
 	require.NoError(t, err)
-	assert.Equal(t, "user-alice", info.UserID)
+	assert.Equal(t, "user-alice", vresp.Info.UserID)
 }
 
 // TestOneAuth_PasswordGrant_BadPassword verifies that wrong credentials
@@ -128,7 +131,7 @@ func TestOneAuth_PasswordGrant(t *testing.T) {
 func TestOneAuth_PasswordGrant_BadPassword(t *testing.T) {
 	oa := newTestOneAuthWithPasswordGrant(t)
 
-	_, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+	_, err := oa.Issuer.PasswordGrant(context.Background(), &apiauth.PasswordGrantRequest{
 		Username: "alice@example.com",
 		Password: "wrong-password",
 	})
@@ -141,7 +144,7 @@ func TestOneAuth_PasswordGrant_BadPassword(t *testing.T) {
 func TestOneAuth_PasswordGrant_ScopeIntersection(t *testing.T) {
 	oa := newTestOneAuthWithPasswordGrant(t)
 
-	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+	result, err := oa.Issuer.PasswordGrant(context.Background(), &apiauth.PasswordGrantRequest{
 		Username: "alice@example.com",
 		Password: "correct-password",
 		Scopes:   []string{"read", "admin"},
@@ -155,7 +158,7 @@ func TestOneAuth_PasswordGrant_ScopeIntersection(t *testing.T) {
 func TestOneAuth_PasswordGrant_DefaultScopes(t *testing.T) {
 	oa := newTestOneAuthWithPasswordGrant(t)
 
-	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+	result, err := oa.Issuer.PasswordGrant(context.Background(), &apiauth.PasswordGrantRequest{
 		Username: "alice@example.com",
 		Password: "correct-password",
 	})
@@ -170,7 +173,7 @@ func TestOneAuth_PasswordGrant_CallerCreatesRefreshToken(t *testing.T) {
 	oa := newTestOneAuthWithPasswordGrant(t)
 
 	// Step 1: Password grant (core — no device info)
-	result, err := oa.Issuer.PasswordGrant(apiauth.PasswordGrantRequest{
+	result, err := oa.Issuer.PasswordGrant(context.Background(), &apiauth.PasswordGrantRequest{
 		Username: "alice@example.com",
 		Password: "correct-password",
 		Scopes:   []string{"read", "write"},
@@ -187,7 +190,7 @@ func TestOneAuth_PasswordGrant_CallerCreatesRefreshToken(t *testing.T) {
 	assert.NotEmpty(t, rt.Token)
 
 	// Step 3: Later, refresh the token via core
-	refreshResult, err := oa.Issuer.RefreshGrant(rt.Token)
+	refreshResult, err := oa.Issuer.RefreshGrant(context.Background(), &apiauth.RefreshGrantRequest{RefreshToken: rt.Token})
 	require.NoError(t, err)
-	assert.NotEmpty(t, refreshResult.AccessToken)
+	assert.NotEmpty(t, refreshResult.Tokens.AccessToken)
 }

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -7,6 +7,7 @@ package apiauth_test
 // See: https://github.com/panyam/oneauth/issues/110
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -60,10 +61,12 @@ func newTestOneAuth(t *testing.T) *apiauth.OneAuth {
 func TestOneAuth_CreateAccessToken(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	token, expiresIn, err := oa.Issuer.CreateAccessToken("alice", []string{"read", "write"}, nil)
+	tok, err := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "alice", Scopes: []string{"read", "write"},
+	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, token)
-	assert.True(t, expiresIn > 0)
+	assert.NotEmpty(t, tok.Token)
+	assert.True(t, tok.ExpiresIn > 0)
 }
 
 // TestOneAuth_ValidateToken verifies that tokens can be validated
@@ -73,11 +76,14 @@ func TestOneAuth_CreateAccessToken(t *testing.T) {
 func TestOneAuth_ValidateToken(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	token, _, err := oa.Issuer.CreateAccessToken("bob", []string{"read"}, nil)
+	tok, err := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "bob", Scopes: []string{"read"},
+	})
 	require.NoError(t, err)
 
-	info, err := oa.Validator.ValidateToken(token)
+	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tok.Token})
 	require.NoError(t, err)
+	info := vresp.Info
 	assert.Equal(t, "bob", info.UserID)
 	assert.Equal(t, []string{"read"}, info.Scopes)
 	assert.Equal(t, "jwt", info.AuthType)
@@ -93,11 +99,14 @@ func TestOneAuth_ValidateToken_WithRAR(t *testing.T) {
 	details := []core.AuthorizationDetail{
 		{Type: "payment_initiation", Actions: []string{"initiate"}},
 	}
-	token, _, err := oa.Issuer.CreateAccessToken("alice", []string{"payments"}, details)
+	tok, err := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "alice", Scopes: []string{"payments"}, AuthorizationDetails: details,
+	})
 	require.NoError(t, err)
 
-	info, err := oa.Validator.ValidateToken(token)
+	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tok.Token})
 	require.NoError(t, err)
+	info := vresp.Info
 	require.Len(t, info.AuthorizationDetails, 1)
 	assert.Equal(t, "payment_initiation", info.AuthorizationDetails[0].Type)
 }
@@ -109,10 +118,13 @@ func TestOneAuth_ValidateToken_WithRAR(t *testing.T) {
 func TestOneAuth_Introspect(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	token, _, _ := oa.Issuer.CreateAccessToken("charlie", []string{"read"}, nil)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "charlie", Scopes: []string{"read"},
+	})
 
-	result, err := oa.Introspector.Introspect(token)
+	resp, err := oa.Introspector.Introspect(context.Background(), &apiauth.IntrospectRequest{Token: tok.Token})
 	require.NoError(t, err)
+	result := resp.Result
 	assert.True(t, result.Active)
 	assert.Equal(t, "charlie", result.Sub)
 	assert.Contains(t, result.Scope, "read")
@@ -125,9 +137,9 @@ func TestOneAuth_Introspect(t *testing.T) {
 func TestOneAuth_Introspect_Invalid(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	result, err := oa.Introspector.Introspect("garbage-token")
+	resp, err := oa.Introspector.Introspect(context.Background(), &apiauth.IntrospectRequest{Token: "garbage-token"})
 	require.NoError(t, err)
-	assert.False(t, result.Active)
+	assert.False(t, resp.Result.Active)
 }
 
 // TestOneAuth_Revoke_AccessToken verifies that revoking an access token
@@ -137,22 +149,25 @@ func TestOneAuth_Introspect_Invalid(t *testing.T) {
 func TestOneAuth_Revoke_AccessToken(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	token, _, _ := oa.Issuer.CreateAccessToken("dave", []string{"read"}, nil)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "dave", Scopes: []string{"read"},
+	})
+	token := tok.Token
 
 	// Valid before revocation
-	result, _ := oa.Introspector.Introspect(token)
-	assert.True(t, result.Active)
+	iresp, _ := oa.Introspector.Introspect(context.Background(), &apiauth.IntrospectRequest{Token: token})
+	assert.True(t, iresp.Result.Active)
 
 	// Revoke
-	err := oa.Revoker.Revoke(token, "access_token")
+	_, err := oa.Revoker.Revoke(context.Background(), &apiauth.RevokeRequest{Token: token, TokenTypeHint: "access_token"})
 	require.NoError(t, err)
 
 	// Invalid after revocation
-	result, _ = oa.Introspector.Introspect(token)
-	assert.False(t, result.Active)
+	iresp, _ = oa.Introspector.Introspect(context.Background(), &apiauth.IntrospectRequest{Token: token})
+	assert.False(t, iresp.Result.Active)
 
 	// Validation also fails
-	_, err = oa.Validator.ValidateToken(token)
+	_, err = oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
 	assert.Error(t, err)
 }
 
@@ -166,7 +181,7 @@ func TestOneAuth_Revoke_RefreshToken(t *testing.T) {
 	rt, err := oa.RefreshStore.CreateRefreshToken("eve", "test-client", nil, []string{"read"})
 	require.NoError(t, err)
 
-	err = oa.Revoker.Revoke(rt.Token, "refresh_token")
+	_, err = oa.Revoker.Revoke(context.Background(), &apiauth.RevokeRequest{Token: rt.Token, TokenTypeHint: "refresh_token"})
 	require.NoError(t, err)
 
 	got, _ := oa.RefreshStore.GetRefreshToken(rt.Token)
@@ -180,18 +195,21 @@ func TestOneAuth_Revoke_RefreshToken(t *testing.T) {
 func TestOneAuth_ClientCredentials(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	resp, err := oa.Issuer.ClientCredentials(
-		"test-client", "test-client-secret-32chars-min!!",
-		[]string{"read", "write"}, nil)
+	resp, err := oa.Issuer.ClientCredentials(context.Background(), &apiauth.ClientCredentialsRequest{
+		ClientID:     "test-client",
+		ClientSecret: "test-client-secret-32chars-min!!",
+		Scopes:       []string{"read", "write"},
+	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, resp.AccessToken)
-	assert.Equal(t, "Bearer", resp.TokenType)
-	assert.Equal(t, "read write", resp.Scope)
+	tp := resp.Tokens
+	assert.NotEmpty(t, tp.AccessToken)
+	assert.Equal(t, "Bearer", tp.TokenType)
+	assert.Equal(t, "read write", tp.Scope)
 
 	// Token should be valid
-	info, err := oa.Validator.ValidateToken(resp.AccessToken)
+	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tp.AccessToken})
 	require.NoError(t, err)
-	assert.Equal(t, "test-client", info.UserID) // sub = client_id for CC
+	assert.Equal(t, "test-client", vresp.Info.UserID) // sub = client_id for CC
 }
 
 // TestOneAuth_ClientCredentials_BadSecret verifies that bad credentials
@@ -201,7 +219,10 @@ func TestOneAuth_ClientCredentials(t *testing.T) {
 func TestOneAuth_ClientCredentials_BadSecret(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	_, err := oa.Issuer.ClientCredentials("test-client", "wrong-secret", nil, nil)
+	_, err := oa.Issuer.ClientCredentials(context.Background(), &apiauth.ClientCredentialsRequest{
+		ClientID:     "test-client",
+		ClientSecret: "wrong-secret",
+	})
 	assert.Error(t, err)
 }
 
@@ -209,11 +230,17 @@ func TestOneAuth_ClientCredentials_BadSecret(t *testing.T) {
 func TestOneAuth_CheckScopes(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	token, _, _ := oa.Issuer.CreateAccessToken("frank", []string{"read"}, nil)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "frank", Scopes: []string{"read"},
+	})
+	token := tok.Token
 
-	assert.NoError(t, oa.Validator.CheckScopes(token, []string{"read"}))
-	assert.Error(t, oa.Validator.CheckScopes(token, []string{"write"}))
-	assert.Error(t, oa.Validator.CheckScopes(token, []string{"read", "write"}))
+	_, err := oa.Validator.CheckScopes(context.Background(), &apiauth.CheckScopesRequest{Token: token, RequiredScopes: []string{"read"}})
+	assert.NoError(t, err)
+	_, err = oa.Validator.CheckScopes(context.Background(), &apiauth.CheckScopesRequest{Token: token, RequiredScopes: []string{"write"}})
+	assert.Error(t, err)
+	_, err = oa.Validator.CheckScopes(context.Background(), &apiauth.CheckScopesRequest{Token: token, RequiredScopes: []string{"read", "write"}})
+	assert.Error(t, err)
 }
 
 // TestOneAuth_CheckAuthorizationDetails verifies RAR enforcement via library calls.
@@ -225,10 +252,15 @@ func TestOneAuth_CheckAuthorizationDetails(t *testing.T) {
 	details := []core.AuthorizationDetail{
 		{Type: "payment_initiation", Actions: []string{"initiate"}},
 	}
-	token, _, _ := oa.Issuer.CreateAccessToken("grace", []string{"payments"}, details)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "grace", Scopes: []string{"payments"}, AuthorizationDetails: details,
+	})
+	token := tok.Token
 
-	assert.NoError(t, oa.Validator.CheckAuthorizationDetails(token, []string{"payment_initiation"}))
-	assert.Error(t, oa.Validator.CheckAuthorizationDetails(token, []string{"account_information"}))
+	_, err := oa.Validator.CheckAuthorizationDetails(context.Background(), &apiauth.CheckAuthorizationDetailsRequest{Token: token, RequiredTypes: []string{"payment_initiation"}})
+	assert.NoError(t, err)
+	_, err = oa.Validator.CheckAuthorizationDetails(context.Background(), &apiauth.CheckAuthorizationDetailsRequest{Token: token, RequiredTypes: []string{"account_information"}})
+	assert.Error(t, err)
 }
 
 // TestOneAuth_Hooks_OnIssued verifies that the OnIssued hook fires
@@ -253,7 +285,9 @@ func TestOneAuth_Hooks_OnIssued(t *testing.T) {
 		},
 	})
 
-	oa.Issuer.CreateAccessToken("hook-user", []string{"read"}, nil)
+	oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "hook-user", Scopes: []string{"read"},
+	})
 	assert.Equal(t, "hook-user", firedSubject)
 	assert.Equal(t, "direct", firedGrant)
 }
@@ -277,8 +311,10 @@ func TestOneAuth_Hooks_OnRevoked(t *testing.T) {
 		},
 	})
 
-	token, _, _ := oa.Issuer.CreateAccessToken("user-1", []string{"read"}, nil)
-	oa.Revoker.Revoke(token, "access_token")
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "user-1", Scopes: []string{"read"},
+	})
+	oa.Revoker.Revoke(context.Background(), &apiauth.RevokeRequest{Token: tok.Token, TokenTypeHint: "access_token"})
 	assert.Equal(t, "access_token", firedHint)
 }
 
@@ -303,11 +339,14 @@ func TestOneAuth_Hooks_OnBlacklistHit(t *testing.T) {
 		},
 	})
 
-	token, _, _ := oa.Issuer.CreateAccessToken("user-2", []string{"read"}, nil)
-	oa.Revoker.Revoke(token, "access_token")
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "user-2", Scopes: []string{"read"},
+	})
+	token := tok.Token
+	oa.Revoker.Revoke(context.Background(), &apiauth.RevokeRequest{Token: token, TokenTypeHint: "access_token"})
 
 	// Try to validate the revoked token — should trigger blacklist hit hook
-	_, err := oa.Validator.ValidateToken(token)
+	_, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
 	assert.Error(t, err)
 	assert.NotEmpty(t, firedJTI, "OnBlacklistHit should have fired")
 }
@@ -322,7 +361,10 @@ func TestOneAuth_IntrospectionHTTPHandler(t *testing.T) {
 	oa := newTestOneAuth(t)
 	handler := oa.IntrospectionHTTPHandler()
 
-	token, _, _ := oa.Issuer.CreateAccessToken("http-user", []string{"read"}, nil)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "http-user", Scopes: []string{"read"},
+	})
+	token := tok.Token
 
 	// Introspect via HTTP
 	rr := postIntrospect(t, handler, token, "test-client", "test-client-secret-32chars-min!!")
@@ -338,7 +380,10 @@ func TestOneAuth_RevocationHTTPHandler(t *testing.T) {
 	revHandler := oa.RevocationHTTPHandler()
 	introHandler := oa.IntrospectionHTTPHandler()
 
-	token, _, _ := oa.Issuer.CreateAccessToken("revoke-http", []string{"read"}, nil)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "revoke-http", Scopes: []string{"read"},
+	})
+	token := tok.Token
 
 	// Revoke via HTTP
 	form := url.Values{"token": {token}, "token_type_hint": {"access_token"}}
@@ -360,7 +405,10 @@ func TestOneAuth_HTTPMiddleware(t *testing.T) {
 	oa := newTestOneAuth(t)
 	mw := oa.HTTPMiddleware()
 
-	token, _, _ := oa.Issuer.CreateAccessToken("mw-user", []string{"read"}, nil)
+	tok, _ := oa.Issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "mw-user", Scopes: []string{"read"},
+	})
+	token := tok.Token
 
 	handler := mw.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userID := apiauth.GetUserIDFromAPIContext(r.Context())
@@ -380,7 +428,10 @@ func TestOneAuth_HTTPMiddleware(t *testing.T) {
 func TestOneAuth_AuthenticateClient(t *testing.T) {
 	oa := newTestOneAuth(t)
 
-	assert.NoError(t, oa.Authenticator.AuthenticateClient("test-client", "test-client-secret-32chars-min!!"))
-	assert.Error(t, oa.Authenticator.AuthenticateClient("test-client", "wrong"))
-	assert.Error(t, oa.Authenticator.AuthenticateClient("unknown", "secret"))
+	_, err := oa.Authenticator.AuthenticateClient(context.Background(), &apiauth.AuthenticateClientRequest{ClientID: "test-client", ClientSecret: "test-client-secret-32chars-min!!"})
+	assert.NoError(t, err)
+	_, err = oa.Authenticator.AuthenticateClient(context.Background(), &apiauth.AuthenticateClientRequest{ClientID: "test-client", ClientSecret: "wrong"})
+	assert.Error(t, err)
+	_, err = oa.Authenticator.AuthenticateClient(context.Background(), &apiauth.AuthenticateClientRequest{ClientID: "unknown", ClientSecret: "secret"})
+	assert.Error(t, err)
 }

--- a/apiauth/revocation.go
+++ b/apiauth/revocation.go
@@ -58,7 +58,10 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.errorResponse(w, "invalid_client", "Authentication required", http.StatusUnauthorized)
 		return
 	}
-	if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil {
+	if _, err := h.Authenticator.AuthenticateClient(r.Context(), &AuthenticateClientRequest{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}); err != nil {
 		w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
 		h.errorResponse(w, "invalid_client", "Invalid client credentials", http.StatusUnauthorized)
 		return
@@ -73,7 +76,7 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hint := r.FormValue("token_type_hint")
 
 	// Delegate to transport-independent revoker
-	h.Revoker.Revoke(token, hint)
+	h.Revoker.Revoke(r.Context(), &RevokeRequest{Token: token, TokenTypeHint: hint})
 
 	// RFC 7009 §2.2: always 200 OK
 	h.okResponse(w)

--- a/apiauth/token_introspector.go
+++ b/apiauth/token_introspector.go
@@ -1,6 +1,8 @@
 package apiauth
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -19,11 +21,16 @@ func NewTokenIntrospector(v TokenValidator) TokenIntrospector {
 
 // Introspect checks a token and returns the result per RFC 7662.
 // Returns {Active: false} for any invalid token — never reveals why.
-func (ti *tokenIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) {
-	info, err := ti.validator.ValidateToken(tokenString)
-	if err != nil {
-		return &IntrospectionResult{Active: false}, nil
+func (ti *tokenIntrospector) Introspect(ctx context.Context, req *IntrospectRequest) (*IntrospectResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("IntrospectRequest is required")
 	}
+	tokenString := req.Token
+	resp, err := ti.validator.ValidateToken(ctx, &ValidateTokenRequest{Token: tokenString})
+	if err != nil {
+		return &IntrospectResponse{Result: &IntrospectionResult{Active: false}}, nil
+	}
+	info := resp.Info
 
 	// Parse raw claims for the full introspection response
 	// (ValidateToken strips standard claims from custom, but introspection
@@ -63,7 +70,7 @@ func (ti *tokenIntrospector) Introspect(tokenString string) (*IntrospectionResul
 		}
 	}
 
-	return result, nil
+	return &IntrospectResponse{Result: result}, nil
 }
 
 // parseRawJWTClaims extracts all claims from a JWT without validation.

--- a/apiauth/token_revoker.go
+++ b/apiauth/token_revoker.go
@@ -1,6 +1,8 @@
 package apiauth
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -34,21 +36,24 @@ func NewTokenRevoker(cfg TokenRevokerConfig) TokenRevoker {
 
 // Revoke invalidates a token. Tries refresh token first if no hint or
 // hint is "refresh_token", then tries access token blacklisting.
-func (r *tokenRevoker) Revoke(token, tokenTypeHint string) error {
-	switch tokenTypeHint {
+func (r *tokenRevoker) Revoke(ctx context.Context, req *RevokeRequest) (*RevokeResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("RevokeRequest is required")
+	}
+	switch req.TokenTypeHint {
 	case "refresh_token":
-		r.revokeRefreshToken(token)
+		r.revokeRefreshToken(req.Token)
 	case "access_token":
-		r.revokeAccessToken(token)
+		r.revokeAccessToken(req.Token)
 	default:
 		// No hint — try refresh first (cheaper lookup), then access
-		if !r.revokeRefreshToken(token) {
-			r.revokeAccessToken(token)
+		if !r.revokeRefreshToken(req.Token) {
+			r.revokeAccessToken(req.Token)
 		}
 	}
 
-	r.hooks.fireOnRevoked(token, tokenTypeHint)
-	return nil
+	r.hooks.fireOnRevoked(req.Token, req.TokenTypeHint)
+	return &RevokeResponse{}, nil
 }
 
 // revokeRefreshToken attempts to revoke a refresh token. Returns true if

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -1,6 +1,7 @@
 package apiauth
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -42,8 +43,14 @@ func NewJWTValidator(cfg JWTValidatorConfig) TokenValidator {
 	}
 }
 
-// ValidateToken parses and validates a JWT, returning the extracted claims.
-func (v *jwtValidator) ValidateToken(tokenString string) (*TokenInfo, error) {
+// ValidateToken parses and validates a JWT, returning the extracted claims
+// wrapped in a ValidateTokenResponse per the (ctx, *Req) → (*Resp, error)
+// convention adopted in 175.
+func (v *jwtValidator) ValidateToken(ctx context.Context, req *ValidateTokenRequest) (*ValidateTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ValidateTokenRequest is required")
+	}
+	tokenString := req.Token
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		return v.resolveKey(token)
 	})
@@ -125,44 +132,51 @@ func (v *jwtValidator) ValidateToken(tokenString string) (*TokenInfo, error) {
 		}
 	}
 
-	return &TokenInfo{
+	return &ValidateTokenResponse{Info: &TokenInfo{
 		UserID:               userID,
 		Scopes:               scopes,
 		AuthorizationDetails: authzDetails,
 		CustomClaims:         customClaims,
 		AuthType:             "jwt",
-	}, nil
+	}}, nil
 }
 
 // CheckScopes validates a token and verifies it contains all required scopes.
-func (v *jwtValidator) CheckScopes(token string, required []string) error {
-	info, err := v.ValidateToken(token)
+func (v *jwtValidator) CheckScopes(ctx context.Context, req *CheckScopesRequest) (*CheckScopesResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CheckScopesRequest is required")
+	}
+	resp, err := v.ValidateToken(ctx, &ValidateTokenRequest{Token: req.Token})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if !core.ContainsAllScopes(info.Scopes, required) {
-		return fmt.Errorf("insufficient scope: requires %v, has %v", required, info.Scopes)
+	if !core.ContainsAllScopes(resp.Info.Scopes, req.RequiredScopes) {
+		return nil, fmt.Errorf("insufficient scope: requires %v, has %v", req.RequiredScopes, resp.Info.Scopes)
 	}
-	return nil
+	return &CheckScopesResponse{}, nil
 }
 
 // CheckAuthorizationDetails validates a token and verifies it contains
 // authorization_details entries for all required types.
-func (v *jwtValidator) CheckAuthorizationDetails(token string, requiredTypes []string) error {
-	info, err := v.ValidateToken(token)
-	if err != nil {
-		return err
+func (v *jwtValidator) CheckAuthorizationDetails(ctx context.Context, req *CheckAuthorizationDetailsRequest) (*CheckAuthorizationDetailsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CheckAuthorizationDetailsRequest is required")
 	}
+	resp, err := v.ValidateToken(ctx, &ValidateTokenRequest{Token: req.Token})
+	if err != nil {
+		return nil, err
+	}
+	info := resp.Info
 	grantedTypes := make(map[string]bool)
 	for _, ad := range info.AuthorizationDetails {
 		grantedTypes[ad.Type] = true
 	}
-	for _, reqType := range requiredTypes {
+	for _, reqType := range req.RequiredTypes {
 		if !grantedTypes[reqType] {
-			return fmt.Errorf("missing required authorization_details type: %s", reqType)
+			return nil, fmt.Errorf("missing required authorization_details type: %s", reqType)
 		}
 	}
-	return nil
+	return &CheckAuthorizationDetailsResponse{}, nil
 }
 
 // resolveKey finds the appropriate signing key for a JWT token.
@@ -256,14 +270,20 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer {
 	}
 }
 
-// CreateAccessToken mints a signed JWT.
-func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details []core.AuthorizationDetail) (string, int64, error) {
+// CreateAccessToken mints a signed JWT. Convention shape per 175.
+func (i *jwtIssuer) CreateAccessToken(ctx context.Context, req *CreateAccessTokenRequest) (*CreateAccessTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateAccessTokenRequest is required")
+	}
+	subject := req.Subject
+	scopes := req.Scopes
+	details := req.AuthorizationDetails
 	now := time.Now()
 	expiresAt := now.Add(i.accessExpiry)
 
 	jti, err := core.GenerateSecureToken()
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to generate jti: %w", err)
+		return nil, fmt.Errorf("failed to generate jti: %w", err)
 	}
 
 	claims := jwt.MapClaims{
@@ -290,7 +310,7 @@ func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details [
 		if _, ok := i.signingKey.([]byte); ok {
 			signingMethod = jwt.SigningMethodHS256
 		} else {
-			return "", 0, fmt.Errorf("invalid signing algorithm: %w", err)
+			return nil, fmt.Errorf("invalid signing algorithm: %w", err)
 		}
 	}
 
@@ -301,21 +321,24 @@ func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details [
 
 	tokenString, err := token.SignedString(i.signingKey)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to sign token: %w", err)
+		return nil, fmt.Errorf("failed to sign token: %w", err)
 	}
 
 	i.hooks.fireOnIssued(subject, "direct")
-	return tokenString, int64(i.accessExpiry.Seconds()), nil
+	return &CreateAccessTokenResponse{Token: tokenString, ExpiresIn: int64(i.accessExpiry.Seconds())}, nil
 }
 
 // ClientCredentials performs the client_credentials grant.
-func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error) {
+func (i *jwtIssuer) ClientCredentials(ctx context.Context, req *ClientCredentialsRequest) (*ClientCredentialsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ClientCredentialsRequest is required")
+	}
 	if i.clientKeyLookup == nil {
 		return nil, fmt.Errorf("client_credentials not configured")
 	}
 
 	// Authenticate client
-	rec, err := i.clientKeyLookup.GetKey(clientID)
+	rec, err := i.clientKeyLookup.GetKey(req.ClientID)
 	if err != nil || rec == nil {
 		return nil, fmt.Errorf("invalid_client: unknown client")
 	}
@@ -323,43 +346,49 @@ func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []st
 	if !ok {
 		return nil, fmt.Errorf("invalid_client: client does not support secret authentication")
 	}
-	if !constantTimeEqual(string(storedKey), clientSecret) {
+	if !constantTimeEqual(string(storedKey), req.ClientSecret) {
 		return nil, fmt.Errorf("invalid_client: invalid credentials")
 	}
 
 	// Validate authorization_details
-	if err := core.ValidateAll(details); err != nil {
+	if err := core.ValidateAll(req.AuthorizationDetails); err != nil {
 		return nil, err
 	}
 
 	// Create token
-	tokenStr, expiresIn, err := i.CreateAccessToken(clientID, scopes, details)
+	tok, err := i.CreateAccessToken(ctx, &CreateAccessTokenRequest{
+		Subject:              req.ClientID,
+		Scopes:               req.Scopes,
+		AuthorizationDetails: req.AuthorizationDetails,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	i.hooks.fireOnIssued(clientID, "client_credentials")
+	i.hooks.fireOnIssued(req.ClientID, "client_credentials")
 
-	resp := &core.TokenPair{
-		AccessToken:          tokenStr,
+	return &ClientCredentialsResponse{Tokens: &core.TokenPair{
+		AccessToken:          tok.Token,
 		TokenType:            "Bearer",
-		ExpiresIn:            expiresIn,
-		Scope:                strings.Join(scopes, " "),
-		AuthorizationDetails: details,
-	}
-	return resp, nil
+		ExpiresIn:            tok.ExpiresIn,
+		Scope:                strings.Join(req.Scopes, " "),
+		AuthorizationDetails: req.AuthorizationDetails,
+	}}, nil
 }
 
 // RefreshGrant rotates a refresh token and returns new access + refresh tokens.
 // Handles theft detection: if the old token was already revoked, revokes the
 // entire token family (all sessions from that initial login).
-func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) {
+func (i *jwtIssuer) RefreshGrant(ctx context.Context, req *RefreshGrantRequest) (*RefreshGrantResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("RefreshGrantRequest is required")
+	}
 	if i.refreshStore == nil {
 		return nil, fmt.Errorf("refresh_token grant not configured")
 	}
 
 	// Get and validate the refresh token
-	rt, err := i.refreshStore.GetRefreshToken(refreshToken)
+	rt, err := i.refreshStore.GetRefreshToken(req.RefreshToken)
 	if err != nil {
 		if err == core.ErrTokenNotFound {
 			return nil, fmt.Errorf("invalid_grant: invalid refresh token")
@@ -377,7 +406,7 @@ func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) {
 	}
 
 	// Rotate: invalidate old, create new in same family
-	newRT, err := i.refreshStore.RotateRefreshToken(refreshToken)
+	newRT, err := i.refreshStore.RotateRefreshToken(req.RefreshToken)
 	if err != nil {
 		if err == core.ErrTokenReused {
 			i.refreshStore.RevokeTokenFamily(rt.Family)
@@ -387,27 +416,34 @@ func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) {
 	}
 
 	// Create new access token (carry forward scopes + authorization_details)
-	tokenStr, expiresIn, err := i.CreateAccessToken(rt.UserID, rt.Scopes, rt.AuthorizationDetails)
+	tok, err := i.CreateAccessToken(ctx, &CreateAccessTokenRequest{
+		Subject:              rt.UserID,
+		Scopes:               rt.Scopes,
+		AuthorizationDetails: rt.AuthorizationDetails,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("server_error: %w", err)
 	}
 
 	i.hooks.fireOnIssued(rt.UserID, "refresh_token")
 
-	return &core.TokenPair{
-		AccessToken:          tokenStr,
+	return &RefreshGrantResponse{Tokens: &core.TokenPair{
+		AccessToken:          tok.Token,
 		TokenType:            "Bearer",
-		ExpiresIn:            expiresIn,
+		ExpiresIn:            tok.ExpiresIn,
 		RefreshToken:         newRT.Token,
 		Scope:                strings.Join(rt.Scopes, " "),
 		AuthorizationDetails: rt.AuthorizationDetails,
-	}, nil
+	}}, nil
 }
 
 // PasswordGrant authenticates a user and returns an access token.
 // Does NOT create a refresh token — the caller handles that with
 // transport-specific metadata (device info, IP, etc.).
-func (i *jwtIssuer) PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResult, error) {
+func (i *jwtIssuer) PasswordGrant(ctx context.Context, req *PasswordGrantRequest) (*PasswordGrantResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("PasswordGrantRequest is required")
+	}
 	if i.validateCredentials == nil {
 		return nil, fmt.Errorf("server_error: password grant not configured")
 	}
@@ -442,17 +478,21 @@ func (i *jwtIssuer) PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResul
 	}
 
 	// Create access token
-	tokenStr, expiresIn, err := i.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
+	tok, err := i.CreateAccessToken(ctx, &CreateAccessTokenRequest{
+		Subject:              user.Id(),
+		Scopes:               grantedScopes,
+		AuthorizationDetails: req.AuthorizationDetails,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("server_error: %w", err)
 	}
 
 	i.hooks.fireOnIssued(user.Id(), "password")
 
-	return &PasswordGrantResult{
+	return &PasswordGrantResponse{
 		UserID:               user.Id(),
-		AccessToken:          tokenStr,
-		ExpiresIn:            expiresIn,
+		AccessToken:          tok.Token,
+		ExpiresIn:            tok.ExpiresIn,
 		GrantedScopes:        grantedScopes,
 		AuthorizationDetails: req.AuthorizationDetails,
 	}, nil

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -206,7 +206,7 @@ The `(ctx, *Req) → (*Resp, error)` convention adopted in 169 propagates to the
 | # | Surface | Status |
 |---|---------|--------|
 | 172 | Legacy `admin/` — `ClientRegistrar` interface for `DCRHandler.ServeHTTP` + legacy `/apps/register` + admin CRUD + secret rotation. HTTP handlers reduced to thin wrappers. Wire format unchanged. | In progress |
-| 175 | `apiauth/` — `TokenIssuer` / `TokenValidator` / `TokenIntrospector` / `TokenRevoker` adopt the same shape | Pending |
+| 175 | `apiauth/` — `TokenIssuer` / `TokenValidator` / `TokenIntrospector` / `TokenRevoker` / `ClientAuthenticator` adopt the same shape; HTTP handlers (auth.go, introspection.go, revocation.go) reduced to thin wrappers; wire format unchanged | In progress |
 | 189 | Follow-up: remove `/apps/register` once a quota story for `MaxRooms` / `MaxMsgRate` is decided | Pending |
 
 ---


### PR DESCRIPTION
## Summary
- 5 interfaces (`TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`) — 10 methods total — adopt the `(ctx context.Context, *XRequest) → (*XResponse, error)` convention established in 169 (admin/management) and 172 (admin/registrar).
- 10 dedicated `XRequest` + 10 `XResponse` types, with `TokenInfo` / `IntrospectionResult` / `TokenPair` wrapped inside responses (no breaking type renames).
- HTTP wrappers in `apiauth/auth.go` (middleware ValidateJWT path), `apiauth/introspection.go`, `apiauth/revocation.go` updated to build request types and pass `r.Context()`.
- `PasswordGrantResult` renamed to `PasswordGrantResponse` for consistency; old name retained as a type alias for one release as a deprecation bridge.
- Closes 175. With this PR every interface across `apiauth/` and `admin/` follows the same gRPC-shaped signature.

## Wire format unchanged
`make e2e` is the regression gate — full e2e suite green (21s, race detector). No protocol-level changes; all 12 test files in `apiauth/` pass after mechanical signature updates to two of them (`oneauth_test.go`, `oneauth_grants_test.go`). Other tests exercise HTTP wrappers and stay unchanged.

## Test plan
- [x] `make test` — unit tests green.
- [x] `make e2e` — in-process race-detector e2e green (21.4s).
- [x] Tests for the two refactored test files (oneauth_test.go, oneauth_grants_test.go) updated to unpack response wrappers (e.g., `resp.Tokens.AccessToken`); 0 weakened assertions elsewhere.

## Diff summary
- 12 files changed, +450 / -186 LoC
- 5 interface impl files + 3 HTTP wrappers + 2 test files + 2 doc files