### PR TITLE
feat(persistence): GORMAppStore + reference-server config + iss-claim fix

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -15,7 +15,7 @@
 - refresh-token-rotation: Refresh tokens with theft detection (family-based revocation)
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
-- pluggable-app-registry: AppRegistrationStore interface for persisting registered apps. In-memory (issue 165) and filesystem (issue 166) backends ship; GORM backend pending (issue 167)
+- pluggable-app-registry: AppRegistrationStore interface for persisting registered apps. In-memory (issue 165), filesystem (issue 166), and GORM SQL (issue 167) backends all ship. Reference server (cmd/oneauth-server) exposes the choice via `app_store.type`. Closes parent issue 20.
 - dcr-management-rfc7592: Full RFC 7592 verb trio at /apps/dcr/{client_id} — GET (issue 168), PUT with registration_access_token rotation (issue 169), DELETE with credential invalidation (issue 170), Keycloak lifecycle interop (issue 171). Clients receive registration_access_token + registration_client_uri at registration time. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go) following the (ctx, *Req) → (*Resp, error) convention adopted across the library.
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model

--- a/cmd/oneauth-server/config.go
+++ b/cmd/oneauth-server/config.go
@@ -46,6 +46,14 @@ type JWTConfig struct {
 type ServerConfig struct {
 	Port string `yaml:"port"`
 	Host string `yaml:"host"`
+	// PublicURL is the externally-visible base URL clients use to reach
+	// this server (e.g., "http://localhost:8181" or "https://auth.example").
+	// Used for the OIDC `iss` claim and the RFC 8414 metadata document.
+	// When empty, falls back to scheme://host:port — fine for dev where
+	// host is loopback, but unreliable when host is 0.0.0.0 (bind-all),
+	// behind a reverse proxy, or otherwise differs from the public URL.
+	// See issue 184.
+	PublicURL string `yaml:"public_url"`
 }
 
 type KeyStoreConfig struct {

--- a/cmd/oneauth-server/config.go
+++ b/cmd/oneauth-server/config.go
@@ -13,10 +13,20 @@ import (
 type Config struct {
 	Server     ServerConfig     `yaml:"server"`
 	KeyStore   KeyStoreConfig   `yaml:"keystore"`
+	AppStore   AppStoreConfig   `yaml:"app_store"`
 	UserStores UserStoresConfig `yaml:"user_stores"`
 	JWT        JWTConfig        `yaml:"jwt"`
 	AdminAuth  AdminAuthConfig  `yaml:"admin_auth"`
 	TLS        TLSConfig        `yaml:"tls"`
+}
+
+// AppStoreConfig configures the AppRegistrationStore backing AppRegistrar
+// (issue 167 — closes parent 20). Mirrors KeyStoreConfig so deployments
+// see consistent shape.
+type AppStoreConfig struct {
+	Type string     `yaml:"type"` // memory, fs, gorm (defaults to memory)
+	FS   FSConfig   `yaml:"fs"`
+	GORM GORMConfig `yaml:"gorm"`
 }
 
 // UserStoresConfig configures persistent stores for users, identities, channels, tokens.
@@ -123,6 +133,9 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.KeyStore.Type == "" {
 		cfg.KeyStore.Type = "memory"
 	}
+	if cfg.AppStore.Type == "" {
+		cfg.AppStore.Type = "memory"
+	}
 	if cfg.AdminAuth.Type == "" {
 		cfg.AdminAuth.Type = "none"
 	}
@@ -160,6 +173,16 @@ func configFromEnv() Config {
 			GAE: GAEConfig{
 				Project:   os.Getenv("GCP_PROJECT"),
 				Namespace: os.Getenv("GAE_NAMESPACE"),
+			},
+		},
+		AppStore: AppStoreConfig{
+			Type: os.Getenv("APP_STORE_TYPE"),
+			FS: FSConfig{
+				Path: os.Getenv("APP_STORE_PATH"),
+			},
+			GORM: GORMConfig{
+				Driver: os.Getenv("APP_STORE_GORM_DRIVER"),
+				DSN:    os.Getenv("APP_STORE_DATABASE_URL"),
 			},
 		},
 		AdminAuth: AdminAuthConfig{

--- a/cmd/oneauth-server/deploy-examples/rar-test.yaml
+++ b/cmd/oneauth-server/deploy-examples/rar-test.yaml
@@ -16,6 +16,11 @@
 server:
   port: ${RAR_ISSUER_PORT:-8181}
   host: 0.0.0.0
+  # Public-facing URL used as the OIDC `iss` claim and `issuer` in AS metadata.
+  # Without this, host: 0.0.0.0 leaks into iss as "http://0.0.0.0:8181",
+  # which then fails iss-claim validation in tests that connect via localhost.
+  # See issue 184.
+  public_url: ${RAR_ISSUER_PUBLIC_URL:-http://localhost:8181}
 
 keystore:
   type: memory

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -261,10 +261,21 @@ func main() {
 	jwksHandler := &keys.JWKSHandler{KeyStore: keyStore}
 	mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
 
-	// AS Metadata / OIDC Discovery (RFC 8414)
-	baseURL := fmt.Sprintf("http://%s:%s", cfg.Server.Host, cfg.Server.Port)
-	if cfg.TLS.Enabled {
-		baseURL = fmt.Sprintf("https://%s:%s", cfg.Server.Host, cfg.Server.Port)
+	// AS Metadata / OIDC Discovery (RFC 8414).
+	//
+	// Issuer is the canonical externally-visible URL — used as the OIDC `iss`
+	// claim on every minted token AND as the `issuer` in discovery metadata.
+	// When cfg.Server.PublicURL is set, use it verbatim (correct behind
+	// reverse proxies and when bind host is 0.0.0.0). Otherwise fall back to
+	// scheme://host:port — works for loopback dev but breaks for 0.0.0.0
+	// because clients connect via localhost / a routable address. See 184.
+	baseURL := cfg.Server.PublicURL
+	if baseURL == "" {
+		scheme := "http"
+		if cfg.TLS.Enabled {
+			scheme = "https"
+		}
+		baseURL = fmt.Sprintf("%s://%s:%s", scheme, cfg.Server.Host, cfg.Server.Port)
 	}
 	apiauth.MountASMetadata(mux, &apiauth.ASServerMetadata{
 		Issuer:                             baseURL,

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -76,8 +76,12 @@ func main() {
 		log.Fatalf("Failed to create user stores: %v", err)
 	}
 
-	// Build AppRegistrar
-	registrar := admin.NewAppRegistrar(keyStore, adminAuth)
+	// Build AppRegistrar with the configured AppRegistrationStore (issue 167).
+	appStore, err := buildAppStore(cfg, db)
+	if err != nil {
+		log.Fatalf("Failed to create AppStore: %v", err)
+	}
+	registrar := admin.NewAppRegistrarWithStore(keyStore, adminAuth, appStore)
 
 	// Build LocalAuth
 	localAuth := &localauth.LocalAuth{
@@ -417,6 +421,46 @@ func buildKeyStore(cfg *Config) (keys.KeyStorage, *gorm.DB, error) {
 	}
 
 	return store, db, nil
+}
+
+// buildAppStore builds the admin.AppRegistrationStore that AppRegistrar uses
+// to persist client registrations across restarts (issue 167; closes parent
+// 20). Mirrors buildKeyStore: memory for tests/dev, fs for single-node, gorm
+// for production multi-node. Reuses an existing GORM DB connection passed
+// from buildKeyStore when both are configured for the same database; opens
+// a fresh one otherwise.
+func buildAppStore(cfg *Config, sharedDB *gorm.DB) (admin.AppRegistrationStore, error) {
+	switch cfg.AppStore.Type {
+	case "memory":
+		log.Println("Using in-memory AppStore (registrations lost on restart)")
+		return admin.NewInMemoryAppStore(), nil
+
+	case "fs":
+		log.Printf("Using filesystem AppStore at %s", cfg.AppStore.FS.Path)
+		return fsstore.NewFSAppStore(cfg.AppStore.FS.Path), nil
+
+	case "gorm":
+		// Reuse the keystore's DB connection if config matches, otherwise
+		// open a fresh one. Reuse keeps the connection pool small for
+		// deployments using one DB for both stores; separate is the
+		// honest fallback when the configs differ.
+		db := sharedDB
+		if db == nil || cfg.KeyStore.GORM.DSN != cfg.AppStore.GORM.DSN || cfg.KeyStore.GORM.Driver != cfg.AppStore.GORM.Driver {
+			fresh, err := openGORM(cfg.AppStore.GORM)
+			if err != nil {
+				return nil, err
+			}
+			db = fresh
+		}
+		if err := gormstore.AutoMigrate(db); err != nil {
+			return nil, err
+		}
+		log.Printf("Using GORM AppStore (driver=%s)", cfg.AppStore.GORM.Driver)
+		return gormstore.NewAppStore(db), nil
+
+	default:
+		return nil, fmt.Errorf("unknown app_store type: %s", cfg.AppStore.Type)
+	}
 }
 
 func openGORM(cfg GORMConfig) (*gorm.DB, error) {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,8 +183,8 @@ Splits issue 20 (Persist AppRegistrar state) into shippable backend chunks. The 
 | # | Scope | Status |
 |---|-------|--------|
 | 165 | `AppRegistrationStore` interface + `InMemoryAppStore` + AppRegistrar refactor (cache + write-through) + `appstoretest` contract suite + e2e simulated-restart test | Merged |
-| 166 | `FSAppStore` (filesystem backend) — file-per-app, atomic writes, safeName traversal defense, partial recovery on corrupt files | In progress |
-| 167 | `GORMAppStore` + reference-server config wiring | Pending |
+| 166 | `FSAppStore` (filesystem backend) — file-per-app, atomic writes, safeName traversal defense, partial recovery on corrupt files | Merged |
+| 167 | `GORMAppStore` (multi-node persistence — Postgres/MySQL/SQLite) + `app_store` config block in `cmd/oneauth-server`. Closes parent issue 20. | In progress |
 
 After 167 lands, parent issue 20 can close. The chain unblocks the entire RFC 7592 track (issues 168 / 169 / 170 / 171) tracked under issue 157.
 

--- a/docs/STORES.md
+++ b/docs/STORES.md
@@ -285,9 +285,21 @@ type AppRegistrationStore interface {
 |---------|--------|----------|
 | `admin.InMemoryAppStore` | Available | Tests, dev (registrations lost on restart) |
 | `stores/fs.FSAppStore` | Available (issue 166) | Single-node, dev-friendly persistence |
-| `stores/gorm.GORMAppStore` | Pending — issue 167 | Production, multi-node (Postgres / MySQL / SQLite) |
+| `stores/gorm.GORMAppStore` | Available (issue 167) | Production, multi-node (Postgres / MySQL / SQLite) |
 
-Construct with `admin.NewAppRegistrar(keyStore, auth)` for the default in-memory store, or `admin.NewAppRegistrarWithStore(keyStore, auth, store)` to plug in a persistent backend.
+Construct with `admin.NewAppRegistrar(keyStore, auth)` for the default in-memory store, or `admin.NewAppRegistrarWithStore(keyStore, auth, store)` to plug in a persistent backend. The `cmd/oneauth-server` reference deployment exposes the choice via `app_store.type` (`memory` | `fs` | `gorm`) — see config schema below.
+
+```yaml
+app_store:
+  type: gorm  # memory | fs | gorm
+  fs:
+    path: ${DATA_DIR}/apps
+  gorm:
+    driver: postgres
+    dsn: ${DATABASE_URL}
+```
+
+When the `app_store.gorm` config matches the `keystore.gorm` config (same driver + DSN), `cmd/oneauth-server` reuses the same connection pool. They open separate pools otherwise. The shared `appstoretest` contract suite runs against in-memory SQLite by default and against PostgreSQL when `ONEAUTH_TEST_PGDB` is set.
 
 ### appstoretest Shared Test Suite
 

--- a/stores/gorm/appstore.go
+++ b/stores/gorm/appstore.go
@@ -1,0 +1,163 @@
+//go:build !wasm
+// +build !wasm
+
+package gorm
+
+import (
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
+	"gorm.io/gorm"
+)
+
+// AppRegistrationModel is the GORM model for app registrations. Slice fields
+// are JSON-encoded on the database side via the gorm:"serializer:json" tag —
+// works identically across SQLite, MySQL, Postgres without DB-specific JSONB
+// quirks. Auto-migrated alongside the other oneauth tables.
+type AppRegistrationModel struct {
+	ClientID                  string                     `gorm:"primaryKey;size:128"`
+	ClientDomain              string                     `gorm:"size:256"`
+	SigningAlg                string                     `gorm:"size:16;not null"`
+	MaxRooms                  int                        `gorm:"not null;default:0"`
+	MaxMsgRate                float64                    `gorm:"not null;default:0"`
+	AuthorizationDetailsTypes []string                   `gorm:"serializer:json"` // RFC 9396
+	CreatedAt                 time.Time                  `gorm:"autoCreateTime"`
+	UpdatedAt                 time.Time                  `gorm:"autoUpdateTime"`
+	Revoked                   bool                       `gorm:"not null;default:false"`
+
+	// RFC 7591 / 7592 client metadata (issue 168 / 169 / 172).
+	ClientName              string   `gorm:"size:256"`
+	ClientURI               string   `gorm:"size:256"`
+	RedirectURIs            []string `gorm:"serializer:json"`
+	GrantTypes              []string `gorm:"serializer:json"`
+	Scope                   string   `gorm:"size:512"`
+	TokenEndpointAuthMethod string   `gorm:"size:64"`
+
+	// RFC 7592 §3 management credentials (issue 168). Persisted so the
+	// management endpoints can authenticate subsequent requests after restart.
+	RegistrationAccessToken string `gorm:"size:256"`
+	RegistrationClientURI   string `gorm:"size:512"`
+}
+
+func (AppRegistrationModel) TableName() string {
+	return "app_registrations"
+}
+
+// AppStore implements admin.AppRegistrationStore on GORM. Production-grade
+// backend for the persistence chain started in 165 — multi-node compatible
+// (database is the shared source-of-truth) and works against any GORM-supported
+// driver (Postgres / MySQL / SQLite).
+type AppStore struct {
+	db *gorm.DB
+}
+
+// NewAppStore creates a GORM-backed AppRegistrationStore.
+//
+// Callers MUST run AutoMigrate (or equivalent migration) before use to
+// ensure the app_registrations table exists. AutoMigrate in this package
+// covers AppRegistrationModel along with the rest of the oneauth tables.
+func NewAppStore(db *gorm.DB) *AppStore {
+	return &AppStore{db: db}
+}
+
+// SaveApp inserts or replaces the registration for app.ClientID. Empty
+// client_id is rejected with the same error pattern as InMemoryAppStore.
+func (s *AppStore) SaveApp(app *admin.AppRegistration) error {
+	if app == nil || app.ClientID == "" {
+		return errClientIDRequired
+	}
+	model := appRegistrationToModel(app)
+	return s.db.Save(model).Error
+}
+
+// GetApp returns the registration for clientID, or admin.ErrAppNotFound.
+func (s *AppStore) GetApp(clientID string) (*admin.AppRegistration, error) {
+	var model AppRegistrationModel
+	if err := s.db.First(&model, "client_id = ?", clientID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, admin.ErrAppNotFound
+		}
+		return nil, err
+	}
+	return modelToAppRegistration(&model), nil
+}
+
+// ListApps returns every registration in the store. Order is unspecified.
+func (s *AppStore) ListApps() ([]*admin.AppRegistration, error) {
+	var models []AppRegistrationModel
+	if err := s.db.Find(&models).Error; err != nil {
+		return nil, err
+	}
+	out := make([]*admin.AppRegistration, len(models))
+	for i := range models {
+		out[i] = modelToAppRegistration(&models[i])
+	}
+	return out, nil
+}
+
+// DeleteApp removes the registration for clientID. Returns admin.ErrAppNotFound
+// if no such registration exists, matching InMemoryAppStore semantics.
+func (s *AppStore) DeleteApp(clientID string) error {
+	result := s.db.Delete(&AppRegistrationModel{}, "client_id = ?", clientID)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return admin.ErrAppNotFound
+	}
+	return nil
+}
+
+// errClientIDRequired matches the InMemoryAppStore error message so the
+// shared appstoretest contract suite passes uniformly across backends.
+var errClientIDRequired = &appStoreError{"AppRegistration.ClientID required"}
+
+type appStoreError struct{ msg string }
+
+func (e *appStoreError) Error() string { return e.msg }
+
+func appRegistrationToModel(app *admin.AppRegistration) *AppRegistrationModel {
+	return &AppRegistrationModel{
+		ClientID:                  app.ClientID,
+		ClientDomain:              app.ClientDomain,
+		SigningAlg:                app.SigningAlg,
+		MaxRooms:                  app.MaxRooms,
+		MaxMsgRate:                app.MaxMsgRate,
+		AuthorizationDetailsTypes: app.AuthorizationDetailsTypes,
+		CreatedAt:                 app.CreatedAt,
+		Revoked:                   app.Revoked,
+		ClientName:                app.ClientName,
+		ClientURI:                 app.ClientURI,
+		RedirectURIs:              app.RedirectURIs,
+		GrantTypes:                app.GrantTypes,
+		Scope:                     app.Scope,
+		TokenEndpointAuthMethod:   app.TokenEndpointAuthMethod,
+		RegistrationAccessToken:   app.RegistrationAccessToken,
+		RegistrationClientURI:     app.RegistrationClientURI,
+	}
+}
+
+func modelToAppRegistration(m *AppRegistrationModel) *admin.AppRegistration {
+	return &admin.AppRegistration{
+		ClientID:                  m.ClientID,
+		ClientDomain:              m.ClientDomain,
+		SigningAlg:                m.SigningAlg,
+		MaxRooms:                  m.MaxRooms,
+		MaxMsgRate:                m.MaxMsgRate,
+		AuthorizationDetailsTypes: m.AuthorizationDetailsTypes,
+		CreatedAt:                 m.CreatedAt,
+		Revoked:                   m.Revoked,
+		ClientName:                m.ClientName,
+		ClientURI:                 m.ClientURI,
+		RedirectURIs:              m.RedirectURIs,
+		GrantTypes:                m.GrantTypes,
+		Scope:                     m.Scope,
+		TokenEndpointAuthMethod:   m.TokenEndpointAuthMethod,
+		RegistrationAccessToken:   m.RegistrationAccessToken,
+		RegistrationClientURI:     m.RegistrationClientURI,
+	}
+}
+
+// _ keeps core imported for build determinism if unused fields appear later.
+var _ = core.AuthorizationDetail{}

--- a/stores/gorm/appstore_test.go
+++ b/stores/gorm/appstore_test.go
@@ -1,0 +1,24 @@
+//go:build !wasm
+// +build !wasm
+
+// Tests for the GORM-backed AppRegistrationStore — runs the shared
+// appstoretest contract suite against SQLite (default) or PostgreSQL when
+// ONEAUTH_TEST_PGDB is set, mirroring the GORMKeyStore test setup.
+package gorm
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/appstoretest"
+)
+
+// TestGORMAppStore runs the shared AppRegistrationStore contract suite
+// against the GORM-backed implementation. Each sub-test gets a fresh DB
+// connection (and, for Postgres, an isolated schema) so state cannot leak
+// between cases.
+func TestGORMAppStore(t *testing.T) {
+	appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
+		return NewAppStore(setupTestDB(t))
+	})
+}

--- a/stores/gorm/stores.go
+++ b/stores/gorm/stores.go
@@ -27,6 +27,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&APIKeyModel{},
 		&UsernameModel{},
 		&SigningKeyModel{},
+		&AppRegistrationModel{},
 	)
 }
 


### PR DESCRIPTION
## Summary
Two commits, two issues — both touch `cmd/oneauth-server/`'s config layer so they're naturally bundled:

### Commit 1 — #167 GORMAppStore (closes parent 20)
- New `stores/gorm/AppStore` implementing `admin.AppRegistrationStore`. Mirrors the GORMKeyStore pattern: primary key on `client_id`, `gorm:"serializer:json"` for slice fields. Auto-migrated alongside the other oneauth tables.
- Test wires `appstoretest.RunAll` against in-memory SQLite (Postgres-gated via `ONEAUTH_TEST_PGDB` like existing GORM tests). 9 contract tests pass.
- `cmd/oneauth-server` gains an `app_store` config block (memory | fs | gorm) mirroring `keystore`. `buildAppStore` reuses the keystore's GORM connection when configs match, opens fresh otherwise. Wires into `NewAppRegistrarWithStore`.
- Closes the AppRegistrar persistence chain that started with 165: in-memory ✓ → FS ✓ → GORM ✓. Parent issue 20 closes on merge.

### Commit 2 — #184 iss claim fix
- New `server.public_url` config field. When set, used verbatim as the AS metadata `issuer` (and the base URL for token/introspect/revoke/jwks/registration endpoints). When unset, falls back to `scheme://host:port`.
- `rar-test.yaml` sets `public_url: http://localhost:8181`. Before this fix, discovery reported `iss: http://0.0.0.0:8181` (the bind-all host) which broke iss-claim validation in tests connecting via `localhost`.

### Open follow-up on #184
The `TestRAR_JWKS_ValidateToken` and `TestRAR_JWKS_RequireAuthorizationDetails` tests in `tests/keycloak/rar_interop_test.go` remain broken. Root cause is NOT the iss claim — it's that the rar-test issuer uses HS256 signing (via `jwt.secret_key`), and HS256 secrets are correctly omitted from JWKS by design. JWKS validation can't find a key. A separate PR needs to add RS256 issuer mode to `cmd/oneauth-server` (auto-generate keypair on startup, register in keystore, expose public half via JWKS). I've left #184 open with this finding — clean scope for a follow-up.

## Test plan
- [x] `make test` — adds 9 sub-tests in `stores/gorm/TestGORMAppStore` (the appstoretest contract suite). Green.
- [x] `make e2e` — clean (21s, race detector).
- [x] `cmd/oneauth-server` compiles cleanly with both new config fields.
- [x] Manual: `curl /.well-known/openid-configuration` against the rar-test issuer reports `iss: http://localhost:8181` (was `http://0.0.0.0:8181`).
- [x] Existing `TestKeycloak_*` tests continue to pass.

## Diff summary
- 11 files, +302 / -11
- Commit 1: 8 files (stores/gorm + cmd/oneauth-server + 3 doc files)
- Commit 2: 3 files (cmd/oneauth-server + rar-test deploy-example)