### PR TITLE
fix(cmd/oneauth-server): RS256 signing mode + JWKS round-trip

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -16,6 +16,7 @@
 - csrf-protection: Double-submit cookie CSRF protection
 - multi-backend-storage: Store implementations for filesystem, GORM (PostgreSQL/MySQL), Google Datastore
 - pluggable-app-registry: AppRegistrationStore interface for persisting registered apps. In-memory (issue 165), filesystem (issue 166), and GORM SQL (issue 167) backends all ship. Reference server (cmd/oneauth-server) exposes the choice via `app_store.type`. Closes parent issue 20.
+- asymmetric-issuer-signing: Reference server supports RS256/ES256 token signing (`jwt.signing_alg`). Public half is registered in the keystore so JWKS exposes it for remote resource servers to validate without a shared secret. Production deployments set `jwt.private_key_path`; tests/dev opt into ephemeral keys via explicit `jwt.ephemeral_signing_key: true` so misconfiguration fails loudly. Closes issue 184.
 - dcr-management-rfc7592: Full RFC 7592 verb trio at /apps/dcr/{client_id} — GET (issue 168), PUT with registration_access_token rotation (issue 169), DELETE with credential invalidation (issue 170), Keycloak lifecycle interop (issue 171). Clients receive registration_access_token + registration_client_uri at registration time. Backed by a transport-agnostic ClientRegistrationManager interface (admin/client_management.go) following the (ctx, *Req) → (*Resp, error) convention adopted across the library.
 - http-middleware: Auth middleware for HTTP handlers with scope enforcement
 - user-identity-model: Three-layer User→Identity→Channel model

--- a/cmd/oneauth-server/config.go
+++ b/cmd/oneauth-server/config.go
@@ -38,9 +38,28 @@ type UserStoresConfig struct {
 
 // JWTConfig configures JWT signing for browser sessions and API tokens.
 type JWTConfig struct {
-	SecretKey                string   `yaml:"secret_key"`                 // Secret key for signing JWTs
-	Issuer                   string   `yaml:"issuer"`                     // JWT issuer claim
+	SecretKey                 string   `yaml:"secret_key"`                  // Secret key for signing JWTs (HS256 mode only)
+	Issuer                    string   `yaml:"issuer"`                      // JWT issuer claim
 	AuthorizationDetailsTypes []string `yaml:"authorization_details_types"` // RFC 9396 supported types (advertised in AS metadata)
+
+	// SigningAlg controls how access tokens are signed. Defaults to HS256
+	// (uses SecretKey). Set to "RS256" / "ES256" for asymmetric signing —
+	// the public half is exposed via JWKS so remote resource servers can
+	// validate without a shared secret. See issue 184.
+	SigningAlg string `yaml:"signing_alg"`
+
+	// PrivateKeyPath is the path to a PEM-encoded private key (RSA / EC)
+	// used for asymmetric signing. Required for RS256/ES256 in production.
+	PrivateKeyPath string `yaml:"private_key_path"`
+
+	// EphemeralSigningKey, when true with SigningAlg=RS256/ES256, generates
+	// a fresh keypair on each startup. Tokens issued under one instance are
+	// invalid after a restart (kid changes, JWKS rotates). This is a
+	// **test / dev only** convenience — production deployments must set
+	// PrivateKeyPath. The flag is explicit (rather than implicit fallback)
+	// so misconfiguration fails loudly: "set private_key_path or
+	// ephemeral_signing_key".
+	EphemeralSigningKey bool `yaml:"ephemeral_signing_key"`
 }
 
 type ServerConfig struct {

--- a/cmd/oneauth-server/deploy-examples/rar-test.yaml
+++ b/cmd/oneauth-server/deploy-examples/rar-test.yaml
@@ -29,6 +29,17 @@ user_stores:
   type: memory
 
 jwt:
+  # Sign tokens with RS256 so the public half can be exposed via JWKS,
+  # enabling remote resource servers to validate without a shared secret
+  # (issue 184). secret_key stays defined for legacy code paths
+  # (browser-session cookies still HS256 today) but tokens minted by the
+  # /api/token endpoint use the RS256 keypair below.
+  signing_alg: RS256
+  # Test-only: generate a fresh RSA-2048 keypair on every startup. Tokens
+  # become invalid after restart, JWKS rotates. Production deployments must
+  # set jwt.private_key_path to a stable PEM file instead. The flag is
+  # explicit so misconfiguration in prod fails loudly.
+  ephemeral_signing_key: true
   secret_key: ${JWT_SECRET_KEY:-rar-test-secret-change-in-prod!!!!}
   issuer: ${JWT_ISSUER:-http://localhost:8181}
   authorization_details_types:

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto"
 	"embed"
 	"encoding/json"
 	"flag"
@@ -22,6 +23,7 @@ import (
 	"github.com/panyam/oneauth/httpauth"
 	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/localauth"
+	"github.com/panyam/oneauth/utils"
 	"golang.org/x/oauth2"
 	fsstore "github.com/panyam/oneauth/stores/fs"
 	gaestore "github.com/panyam/oneauth/stores/gae"
@@ -29,6 +31,12 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
+
+// issuerClientID is the keystore client_id under which the asymmetric issuer
+// signing key is registered when JWT.SigningAlg is RS256/ES256. The JWKS
+// handler iterates all asymmetric keys in the keystore — this constant gives
+// the issuer's identity a stable, recognizable name in admin tooling.
+const issuerClientID = "oneauth-issuer"
 
 //go:embed templates/*.html
 var templateFS embed.FS
@@ -110,7 +118,7 @@ func main() {
 	// Token blacklist for immediate access token revocation
 	blacklist := core.NewInMemoryBlacklist()
 
-	// Build APIAuth (for API token endpoint)
+	// Build APIAuth (for API token endpoint).
 	apiAuth := &apiauth.APIAuth{
 		RefreshTokenStore:   stores.refreshTokenStore,
 		JWTSecretKey:        cfg.JWT.SecretKey,
@@ -118,6 +126,37 @@ func main() {
 		ValidateCredentials: localAuth.ValidateCredentials,
 		Blacklist:           blacklist,
 		ClientKeyStore:      keyStore, // enables client_credentials grant
+	}
+
+	// Wire asymmetric signing if configured (issue 184). The public half is
+	// registered in the keystore under a stable client_id so the JWKS handler
+	// exposes it — remote resource servers can then validate tokens without
+	// any shared secret.
+	if alg := cfg.JWT.SigningAlg; alg == "RS256" || alg == "ES256" {
+		priv, pubPEM, err := loadOrGenerateSigningKey(cfg.JWT, alg)
+		if err != nil {
+			log.Fatalf("Failed to load/generate %s signing key: %v", alg, err)
+		}
+		apiAuth.JWTSigningAlg = alg
+		apiAuth.JWTSigningKey = priv
+		// JWTVerifyKey is the parsed public key. utils.DecodeVerifyKey
+		// accepts the same PEM bytes the keystore stores, so we round-trip.
+		pubKey, err := utils.DecodeVerifyKey(pubPEM, alg)
+		if err != nil {
+			log.Fatalf("Failed to parse issuer public key: %v", err)
+		}
+		apiAuth.JWTVerifyKey = pubKey
+
+		// Register the public key in the keystore so JWKS exposes it.
+		// kid is auto-derived from the key material by the keystore.
+		if err := keyStore.PutKey(&keys.KeyRecord{
+			ClientID:  issuerClientID,
+			Key:       pubPEM,
+			Algorithm: alg,
+		}); err != nil {
+			log.Fatalf("Failed to register issuer public key: %v", err)
+		}
+		log.Printf("Asymmetric token signing enabled (alg=%s, public key registered as %q for JWKS)", alg, issuerClientID)
 	}
 
 	// CSRF middleware for browser form endpoints
@@ -440,6 +479,59 @@ func buildKeyStore(cfg *Config) (keys.KeyStorage, *gorm.DB, error) {
 // for production multi-node. Reuses an existing GORM DB connection passed
 // from buildKeyStore when both are configured for the same database; opens
 // a fresh one otherwise.
+// loadOrGenerateSigningKey resolves the asymmetric issuer signing key per
+// JWT config. Returns the parsed private key (for token signing) and the
+// PEM-encoded public key (for keystore registration → JWKS exposure).
+//
+// Resolution rules:
+//   - PrivateKeyPath set → load from file (production path).
+//   - PrivateKeyPath empty + EphemeralSigningKey true → generate a fresh
+//     RSA-2048 keypair (test/dev convenience). Logs prominent warning that
+//     tokens will be invalidated on every restart.
+//   - Both empty → error. Misconfiguration must fail loudly so production
+//     deployments don't silently get ephemeral keys.
+//
+// ES256 is accepted as alg but currently only RSA generation is implemented
+// for the ephemeral path; ES256 deployments must supply PrivateKeyPath.
+func loadOrGenerateSigningKey(cfg JWTConfig, alg string) (priv crypto.PrivateKey, pubPEM []byte, err error) {
+	if cfg.PrivateKeyPath != "" {
+		data, err := os.ReadFile(cfg.PrivateKeyPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s: %w", cfg.PrivateKeyPath, err)
+		}
+		priv, err = utils.ParsePrivateKeyPEM(data)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse private key: %w", err)
+		}
+		signer, ok := priv.(crypto.Signer)
+		if !ok {
+			return nil, nil, fmt.Errorf("private key does not implement crypto.Signer")
+		}
+		pubPEM, err = utils.EncodePublicKeyPEM(signer.Public())
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode public key: %w", err)
+		}
+		log.Printf("Loaded %s signing key from %s", alg, cfg.PrivateKeyPath)
+		return priv, pubPEM, nil
+	}
+	if !cfg.EphemeralSigningKey {
+		return nil, nil, fmt.Errorf("jwt.signing_alg=%s requires either jwt.private_key_path or jwt.ephemeral_signing_key=true", alg)
+	}
+	// Test/dev path: ephemeral RSA keypair. Loud warning — tokens go
+	// stale on restart, JWKS rotates.
+	log.Printf("WARNING: jwt.ephemeral_signing_key=true — generating fresh RSA-2048 keypair. " +
+		"Tokens issued by this instance will be INVALID after restart. Use jwt.private_key_path in production.")
+	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate RSA keypair: %w", err)
+	}
+	priv, err = utils.ParsePrivateKeyPEM(privPEM)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse generated private key: %w", err)
+	}
+	return priv, pubPEM, nil
+}
+
 func buildAppStore(cfg *Config, sharedDB *gorm.DB) (admin.AppRegistrationStore, error) {
 	switch cfg.AppStore.Type {
 	case "memory":

--- a/test-reports/coverage.html
+++ b/test-reports/coverage.html
@@ -55,159 +55,193 @@
 			<div id="nav">
 				<select id="files">
 				
-				<option value="file0">github.com/panyam/oneauth/admin/auth.go (100.0%)</option>
+				<option value="file0">github.com/panyam/oneauth/admin/appstore.go (96.4%)</option>
 				
-				<option value="file1">github.com/panyam/oneauth/admin/dcr.go (75.7%)</option>
+				<option value="file1">github.com/panyam/oneauth/admin/auth.go (100.0%)</option>
 				
-				<option value="file2">github.com/panyam/oneauth/admin/mint.go (76.2%)</option>
+				<option value="file2">github.com/panyam/oneauth/admin/dcr.go (78.3%)</option>
 				
-				<option value="file3">github.com/panyam/oneauth/admin/registrar.go (74.1%)</option>
+				<option value="file3">github.com/panyam/oneauth/admin/dcr_management.go (84.0%)</option>
 				
-				<option value="file4">github.com/panyam/oneauth/apiauth/as_metadata.go (93.3%)</option>
+				<option value="file4">github.com/panyam/oneauth/admin/mint.go (76.2%)</option>
 				
-				<option value="file5">github.com/panyam/oneauth/apiauth/as_metadata_proxy.go (91.9%)</option>
+				<option value="file5">github.com/panyam/oneauth/admin/registrar.go (79.3%)</option>
 				
-				<option value="file6">github.com/panyam/oneauth/apiauth/auth.go (66.0%)</option>
+				<option value="file6">github.com/panyam/oneauth/apiauth/as_metadata.go (94.4%)</option>
 				
-				<option value="file7">github.com/panyam/oneauth/apiauth/client_authenticator.go (76.9%)</option>
+				<option value="file7">github.com/panyam/oneauth/apiauth/as_metadata_proxy.go (91.9%)</option>
 				
-				<option value="file8">github.com/panyam/oneauth/apiauth/hooks.go (80.0%)</option>
+				<option value="file8">github.com/panyam/oneauth/apiauth/auth.go (66.3%)</option>
 				
-				<option value="file9">github.com/panyam/oneauth/apiauth/introspection.go (92.1%)</option>
+				<option value="file9">github.com/panyam/oneauth/apiauth/client_authenticator.go (73.3%)</option>
 				
-				<option value="file10">github.com/panyam/oneauth/apiauth/introspection_client.go (85.7%)</option>
+				<option value="file10">github.com/panyam/oneauth/apiauth/hooks.go (80.0%)</option>
 				
-				<option value="file11">github.com/panyam/oneauth/apiauth/oneauth.go (100.0%)</option>
+				<option value="file11">github.com/panyam/oneauth/apiauth/introspection.go (91.2%)</option>
 				
-				<option value="file12">github.com/panyam/oneauth/apiauth/protected_resource.go (92.6%)</option>
+				<option value="file12">github.com/panyam/oneauth/apiauth/introspection_client.go (85.7%)</option>
 				
-				<option value="file13">github.com/panyam/oneauth/apiauth/revocation.go (93.9%)</option>
+				<option value="file13">github.com/panyam/oneauth/apiauth/jwt_bearer_grant.go (77.5%)</option>
 				
-				<option value="file14">github.com/panyam/oneauth/apiauth/token_introspector.go (86.7%)</option>
+				<option value="file14">github.com/panyam/oneauth/apiauth/oneauth.go (100.0%)</option>
 				
-				<option value="file15">github.com/panyam/oneauth/apiauth/token_revoker.go (87.5%)</option>
+				<option value="file15">github.com/panyam/oneauth/apiauth/protected_resource.go (92.6%)</option>
 				
-				<option value="file16">github.com/panyam/oneauth/apiauth/token_validator.go (77.4%)</option>
+				<option value="file16">github.com/panyam/oneauth/apiauth/revocation.go (93.9%)</option>
 				
-				<option value="file17">github.com/panyam/oneauth/client/as_cache.go (100.0%)</option>
+				<option value="file17">github.com/panyam/oneauth/apiauth/token_exchange_grant.go (87.2%)</option>
 				
-				<option value="file18">github.com/panyam/oneauth/client/auth_method.go (93.8%)</option>
+				<option value="file18">github.com/panyam/oneauth/apiauth/token_introspector.go (85.3%)</option>
 				
-				<option value="file19">github.com/panyam/oneauth/client/browser_login.go (82.5%)</option>
+				<option value="file19">github.com/panyam/oneauth/apiauth/token_revoker.go (85.3%)</option>
 				
-				<option value="file20">github.com/panyam/oneauth/client/client.go (76.2%)</option>
+				<option value="file20">github.com/panyam/oneauth/apiauth/token_validator.go (75.9%)</option>
 				
-				<option value="file21">github.com/panyam/oneauth/client/client_credentials_source.go (90.9%)</option>
+				<option value="file21">github.com/panyam/oneauth/appstoretest/appstoretest.go (0.0%)</option>
 				
-				<option value="file22">github.com/panyam/oneauth/client/credentials.go (87.5%)</option>
+				<option value="file22">github.com/panyam/oneauth/client/as_cache.go (100.0%)</option>
 				
-				<option value="file23">github.com/panyam/oneauth/client/dcr.go (80.0%)</option>
+				<option value="file23">github.com/panyam/oneauth/client/auth_method.go (93.8%)</option>
 				
-				<option value="file24">github.com/panyam/oneauth/client/discovery.go (91.8%)</option>
+				<option value="file24">github.com/panyam/oneauth/client/browser_login.go (82.5%)</option>
 				
-				<option value="file25">github.com/panyam/oneauth/client/stores/fs/credentials.go (77.9%)</option>
+				<option value="file25">github.com/panyam/oneauth/client/client.go (76.2%)</option>
 				
-				<option value="file26">github.com/panyam/oneauth/client/transport.go (0.0%)</option>
+				<option value="file26">github.com/panyam/oneauth/client/client_credentials_source.go (90.9%)</option>
 				
-				<option value="file27">github.com/panyam/oneauth/client/validation.go (100.0%)</option>
+				<option value="file27">github.com/panyam/oneauth/client/credentials.go (87.5%)</option>
 				
-				<option value="file28">github.com/panyam/oneauth/core/authorization_details.go (93.6%)</option>
+				<option value="file28">github.com/panyam/oneauth/client/dcr.go (82.8%)</option>
 				
-				<option value="file29">github.com/panyam/oneauth/core/blacklist.go (0.0%)</option>
+				<option value="file29">github.com/panyam/oneauth/client/discovery.go (91.8%)</option>
 				
-				<option value="file30">github.com/panyam/oneauth/core/context.go (0.0%)</option>
+				<option value="file30">github.com/panyam/oneauth/client/stores/fs/credentials.go (77.9%)</option>
 				
-				<option value="file31">github.com/panyam/oneauth/core/credentials.go (0.0%)</option>
+				<option value="file31">github.com/panyam/oneauth/client/transport.go (0.0%)</option>
 				
-				<option value="file32">github.com/panyam/oneauth/core/email.go (0.0%)</option>
+				<option value="file32">github.com/panyam/oneauth/client/validation.go (100.0%)</option>
 				
-				<option value="file33">github.com/panyam/oneauth/core/ratelimiter.go (0.0%)</option>
+				<option value="file33">github.com/panyam/oneauth/core/authorization_details.go (93.6%)</option>
 				
-				<option value="file34">github.com/panyam/oneauth/core/scopes.go (14.5%)</option>
+				<option value="file34">github.com/panyam/oneauth/core/blacklist.go (0.0%)</option>
 				
-				<option value="file35">github.com/panyam/oneauth/core/tokens.go (0.0%)</option>
+				<option value="file35">github.com/panyam/oneauth/core/context.go (0.0%)</option>
 				
-				<option value="file36">github.com/panyam/oneauth/core/user.go (0.0%)</option>
+				<option value="file36">github.com/panyam/oneauth/core/credentials.go (0.0%)</option>
 				
-				<option value="file37">github.com/panyam/oneauth/examples/01-client-credentials/main.go (0.0%)</option>
+				<option value="file37">github.com/panyam/oneauth/core/email.go (0.0%)</option>
 				
-				<option value="file38">github.com/panyam/oneauth/examples/02-resource-token-hs256/main.go (0.0%)</option>
+				<option value="file38">github.com/panyam/oneauth/core/ratelimiter.go (0.0%)</option>
 				
-				<option value="file39">github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks/main.go (0.0%)</option>
+				<option value="file39">github.com/panyam/oneauth/core/scopes.go (14.5%)</option>
 				
-				<option value="file40">github.com/panyam/oneauth/examples/04-discovery/main.go (0.0%)</option>
+				<option value="file40">github.com/panyam/oneauth/core/tokens.go (0.0%)</option>
 				
-				<option value="file41">github.com/panyam/oneauth/examples/05-introspection/main.go (0.0%)</option>
+				<option value="file41">github.com/panyam/oneauth/core/user.go (0.0%)</option>
 				
-				<option value="file42">github.com/panyam/oneauth/examples/06-dynamic-client-registration/main.go (0.0%)</option>
+				<option value="file42">github.com/panyam/oneauth/examples/01-client-credentials/main.go (0.0%)</option>
 				
-				<option value="file43">github.com/panyam/oneauth/examples/07-client-sdk/main.go (0.0%)</option>
+				<option value="file43">github.com/panyam/oneauth/examples/01-client-credentials/walkthrough.go (0.0%)</option>
 				
-				<option value="file44">github.com/panyam/oneauth/examples/08-rich-authorization-requests/main.go (0.0%)</option>
+				<option value="file44">github.com/panyam/oneauth/examples/02-resource-token-hs256/main.go (0.0%)</option>
 				
-				<option value="file45">github.com/panyam/oneauth/examples/09-key-rotation/main.go (0.0%)</option>
+				<option value="file45">github.com/panyam/oneauth/examples/02-resource-token-hs256/walkthrough.go (0.0%)</option>
 				
-				<option value="file46">github.com/panyam/oneauth/examples/10-security/main.go (0.0%)</option>
+				<option value="file46">github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks/main.go (0.0%)</option>
 				
-				<option value="file47">github.com/panyam/oneauth/httpauth/bodylimit.go (50.0%)</option>
+				<option value="file47">github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks/walkthrough.go (0.0%)</option>
 				
-				<option value="file48">github.com/panyam/oneauth/httpauth/csrf.go (88.1%)</option>
+				<option value="file48">github.com/panyam/oneauth/examples/04-discovery/main.go (0.0%)</option>
 				
-				<option value="file49">github.com/panyam/oneauth/httpauth/middleware.go (0.0%)</option>
+				<option value="file49">github.com/panyam/oneauth/examples/04-discovery/walkthrough.go (0.0%)</option>
 				
-				<option value="file50">github.com/panyam/oneauth/httpauth/mux.go (0.0%)</option>
+				<option value="file50">github.com/panyam/oneauth/examples/05-introspection/main.go (0.0%)</option>
 				
-				<option value="file51">github.com/panyam/oneauth/httpauth/securityheaders.go (97.1%)</option>
+				<option value="file51">github.com/panyam/oneauth/examples/05-introspection/walkthrough.go (0.0%)</option>
 				
-				<option value="file52">github.com/panyam/oneauth/keys/encrypted.go (80.8%)</option>
+				<option value="file52">github.com/panyam/oneauth/examples/06-dynamic-client-registration/main.go (0.0%)</option>
 				
-				<option value="file53">github.com/panyam/oneauth/keys/jwks_handler.go (52.5%)</option>
+				<option value="file53">github.com/panyam/oneauth/examples/06-dynamic-client-registration/walkthrough.go (0.0%)</option>
 				
-				<option value="file54">github.com/panyam/oneauth/keys/jwks_keystore.go (76.7%)</option>
+				<option value="file54">github.com/panyam/oneauth/examples/07-client-sdk/main.go (0.0%)</option>
 				
-				<option value="file55">github.com/panyam/oneauth/keys/keystore.go (86.4%)</option>
+				<option value="file55">github.com/panyam/oneauth/examples/07-client-sdk/walkthrough.go (0.0%)</option>
 				
-				<option value="file56">github.com/panyam/oneauth/keys/kid.go (84.8%)</option>
+				<option value="file56">github.com/panyam/oneauth/examples/08-rich-authorization-requests/main.go (0.0%)</option>
 				
-				<option value="file57">github.com/panyam/oneauth/keystoretest/keystoretest.go (0.0%)</option>
+				<option value="file57">github.com/panyam/oneauth/examples/08-rich-authorization-requests/walkthrough.go (0.0%)</option>
 				
-				<option value="file58">github.com/panyam/oneauth/localauth/helpers.go (77.0%)</option>
+				<option value="file58">github.com/panyam/oneauth/examples/09-key-rotation/main.go (0.0%)</option>
 				
-				<option value="file59">github.com/panyam/oneauth/localauth/local.go (56.1%)</option>
+				<option value="file59">github.com/panyam/oneauth/examples/09-key-rotation/walkthrough.go (0.0%)</option>
 				
-				<option value="file60">github.com/panyam/oneauth/localauth/signup.go (60.7%)</option>
+				<option value="file60">github.com/panyam/oneauth/examples/10-security/main.go (0.0%)</option>
 				
-				<option value="file61">github.com/panyam/oneauth/stores/fs/fsapikey_store.go (14.3%)</option>
+				<option value="file61">github.com/panyam/oneauth/examples/10-security/walkthrough.go (0.0%)</option>
 				
-				<option value="file62">github.com/panyam/oneauth/stores/fs/fschannel_store.go (21.7%)</option>
+				<option value="file62">github.com/panyam/oneauth/examples/common/setup.go (0.0%)</option>
 				
-				<option value="file63">github.com/panyam/oneauth/stores/fs/fsidentity_store.go (18.3%)</option>
+				<option value="file63">github.com/panyam/oneauth/httpauth/bodylimit.go (50.0%)</option>
 				
-				<option value="file64">github.com/panyam/oneauth/stores/fs/fskeystore.go (71.8%)</option>
+				<option value="file64">github.com/panyam/oneauth/httpauth/csrf.go (88.1%)</option>
 				
-				<option value="file65">github.com/panyam/oneauth/stores/fs/fsrefreshtoken_store.go (8.8%)</option>
+				<option value="file65">github.com/panyam/oneauth/httpauth/middleware.go (0.0%)</option>
 				
-				<option value="file66">github.com/panyam/oneauth/stores/fs/fstoken_store.go (16.7%)</option>
+				<option value="file66">github.com/panyam/oneauth/httpauth/mux.go (0.0%)</option>
 				
-				<option value="file67">github.com/panyam/oneauth/stores/fs/fsuser_store.go (54.1%)</option>
+				<option value="file67">github.com/panyam/oneauth/httpauth/securityheaders.go (97.1%)</option>
 				
-				<option value="file68">github.com/panyam/oneauth/stores/fs/fsusername_store.go (16.5%)</option>
+				<option value="file68">github.com/panyam/oneauth/keys/encrypted.go (80.8%)</option>
 				
-				<option value="file69">github.com/panyam/oneauth/stores/fs/utils.go (72.7%)</option>
+				<option value="file69">github.com/panyam/oneauth/keys/jwks_handler.go (52.5%)</option>
 				
-				<option value="file70">github.com/panyam/oneauth/testutil/helpers.go (71.9%)</option>
+				<option value="file70">github.com/panyam/oneauth/keys/jwks_keystore.go (76.7%)</option>
 				
-				<option value="file71">github.com/panyam/oneauth/testutil/server.go (82.5%)</option>
+				<option value="file71">github.com/panyam/oneauth/keys/keystore.go (86.4%)</option>
 				
-				<option value="file72">github.com/panyam/oneauth/testutil/token.go (90.5%)</option>
+				<option value="file72">github.com/panyam/oneauth/keys/kid.go (84.8%)</option>
 				
-				<option value="file73">github.com/panyam/oneauth/utils/crypto_helpers.go (78.9%)</option>
+				<option value="file73">github.com/panyam/oneauth/keystoretest/keystoretest.go (0.0%)</option>
 				
-				<option value="file74">github.com/panyam/oneauth/utils/flask.go (4.9%)</option>
+				<option value="file74">github.com/panyam/oneauth/localauth/helpers.go (77.0%)</option>
 				
-				<option value="file75">github.com/panyam/oneauth/utils/jwk.go (83.0%)</option>
+				<option value="file75">github.com/panyam/oneauth/localauth/local.go (56.1%)</option>
 				
-				<option value="file76">github.com/panyam/oneauth/utils/jwk_thumbprint.go (83.9%)</option>
+				<option value="file76">github.com/panyam/oneauth/localauth/signup.go (60.7%)</option>
+				
+				<option value="file77">github.com/panyam/oneauth/stores/fs/fsapikey_store.go (14.3%)</option>
+				
+				<option value="file78">github.com/panyam/oneauth/stores/fs/fsappstore.go (88.7%)</option>
+				
+				<option value="file79">github.com/panyam/oneauth/stores/fs/fschannel_store.go (21.7%)</option>
+				
+				<option value="file80">github.com/panyam/oneauth/stores/fs/fsidentity_store.go (18.3%)</option>
+				
+				<option value="file81">github.com/panyam/oneauth/stores/fs/fskeystore.go (71.8%)</option>
+				
+				<option value="file82">github.com/panyam/oneauth/stores/fs/fsrefreshtoken_store.go (8.8%)</option>
+				
+				<option value="file83">github.com/panyam/oneauth/stores/fs/fstoken_store.go (16.7%)</option>
+				
+				<option value="file84">github.com/panyam/oneauth/stores/fs/fsuser_store.go (54.1%)</option>
+				
+				<option value="file85">github.com/panyam/oneauth/stores/fs/fsusername_store.go (16.5%)</option>
+				
+				<option value="file86">github.com/panyam/oneauth/stores/fs/utils.go (72.7%)</option>
+				
+				<option value="file87">github.com/panyam/oneauth/testutil/helpers.go (71.9%)</option>
+				
+				<option value="file88">github.com/panyam/oneauth/testutil/server.go (84.9%)</option>
+				
+				<option value="file89">github.com/panyam/oneauth/testutil/token.go (90.5%)</option>
+				
+				<option value="file90">github.com/panyam/oneauth/utils/crypto_helpers.go (78.9%)</option>
+				
+				<option value="file91">github.com/panyam/oneauth/utils/flask.go (4.9%)</option>
+				
+				<option value="file92">github.com/panyam/oneauth/utils/jwk.go (83.0%)</option>
+				
+				<option value="file93">github.com/panyam/oneauth/utils/jwk_thumbprint.go (83.9%)</option>
 				
 				</select>
 			</div>
@@ -222,6 +256,97 @@
 		<div id="content">
 		
 		<pre class="file" id="file0" style="display: none">package admin
+
+import (
+        "errors"
+        "sync"
+)
+
+// ErrAppNotFound is returned by AppRegistrationStore.GetApp and DeleteApp
+// when the requested client_id does not exist.
+var ErrAppNotFound = errors.New("app registration not found")
+
+// AppRegistrationStore persists app registration metadata.
+//
+// It is the source of truth for registered apps; AppRegistrar holds a
+// hot-path in-memory cache that is hydrated from the store on construction
+// and updated on every write.
+//
+// Backends: InMemoryAppStore (admin/), FSAppStore (stores/fs/, see issue #166),
+// GORMAppStore (stores/gorm/, see issue #167).
+type AppRegistrationStore interface {
+        // SaveApp inserts or replaces the registration for app.ClientID.
+        SaveApp(app *AppRegistration) error
+
+        // GetApp returns the registration for clientID, or ErrAppNotFound.
+        GetApp(clientID string) (*AppRegistration, error)
+
+        // ListApps returns every registration in the store. Order is unspecified.
+        ListApps() ([]*AppRegistration, error)
+
+        // DeleteApp removes the registration for clientID. Returns ErrAppNotFound
+        // if no such registration exists.
+        DeleteApp(clientID string) error
+}
+
+// InMemoryAppStore is a process-local AppRegistrationStore. State is lost on
+// restart — suitable for tests and dev. Production deployments should use a
+// persistent backend (FS, GORM).
+type InMemoryAppStore struct {
+        mu   sync.RWMutex
+        apps map[string]*AppRegistration
+}
+
+// NewInMemoryAppStore returns an empty InMemoryAppStore.
+func NewInMemoryAppStore() *InMemoryAppStore <span class="cov8" title="1">{
+        return &amp;InMemoryAppStore{apps: make(map[string]*AppRegistration)}
+}</span>
+
+func (s *InMemoryAppStore) SaveApp(app *AppRegistration) error <span class="cov8" title="1">{
+        if app == nil || app.ClientID == "" </span><span class="cov0" title="0">{
+                return errors.New("AppRegistration.ClientID required")
+        }</span>
+        <span class="cov8" title="1">s.mu.Lock()
+        defer s.mu.Unlock()
+        clone := *app
+        s.apps[app.ClientID] = &amp;clone
+        return nil</span>
+}
+
+func (s *InMemoryAppStore) GetApp(clientID string) (*AppRegistration, error) <span class="cov8" title="1">{
+        s.mu.RLock()
+        defer s.mu.RUnlock()
+        app, ok := s.apps[clientID]
+        if !ok </span><span class="cov8" title="1">{
+                return nil, ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">clone := *app
+        return &amp;clone, nil</span>
+}
+
+func (s *InMemoryAppStore) ListApps() ([]*AppRegistration, error) <span class="cov8" title="1">{
+        s.mu.RLock()
+        defer s.mu.RUnlock()
+        out := make([]*AppRegistration, 0, len(s.apps))
+        for _, app := range s.apps </span><span class="cov8" title="1">{
+                clone := *app
+                out = append(out, &amp;clone)
+        }</span>
+        <span class="cov8" title="1">return out, nil</span>
+}
+
+func (s *InMemoryAppStore) DeleteApp(clientID string) error <span class="cov8" title="1">{
+        s.mu.Lock()
+        defer s.mu.Unlock()
+        if _, ok := s.apps[clientID]; !ok </span><span class="cov8" title="1">{
+                return ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">delete(s.apps, clientID)
+        return nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file1" style="display: none">package admin
 
 import (
         "crypto/subtle"
@@ -273,15 +398,15 @@ func (a *APIKeyAuth) Authenticate(r *http.Request) error <span class="cov8" titl
 }
 </pre>
 		
-		<pre class="file" id="file1" style="display: none">package admin
+		<pre class="file" id="file2" style="display: none">package admin
 
 import (
         "crypto/rand"
         "encoding/hex"
         "encoding/json"
+        "errors"
         "fmt"
         "net/http"
-        "time"
 
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
@@ -294,7 +419,12 @@ import (
 // Automatically mounted by AppRegistrar.Handler() at POST /apps/dcr.
 // Existing /apps/* endpoints continue working unchanged.
 //
+// On successful registration the response includes a registration access
+// token + management URI (RFC 7592 §3) which the client uses to read,
+// update, or delete its own registration via /apps/dcr/{client_id}.
+//
 // See: https://www.rfc-editor.org/rfc/rfc7591
+// See: https://www.rfc-editor.org/rfc/rfc7592
 type DCRHandler struct {
         // KeyStore stores client credentials (same KeyStore as AppRegistrar).
         KeyStore keys.KeyStorage
@@ -308,17 +438,36 @@ type DCRHandler struct {
         // Registrar is the underlying AppRegistrar for metadata storage.
         // If nil, client metadata is not persisted (only KeyStore is used).
         Registrar *AppRegistrar
+
+        // IssuerBaseURL is the public base URL used to construct
+        // registration_client_uri values returned in DCR responses
+        // (e.g. "https://auth.example.com"). When empty, the URI is
+        // built from the incoming request's scheme + Host header — fine
+        // for tests but unreliable behind proxies, so production
+        // deployments should set this explicitly.
+        IssuerBaseURL string
 }
 
-// DCRRequest is the RFC 7591 client registration request.
+// DCRRequest is the RFC 7591 client registration request, also reused as the
+// RFC 7592 §2.2 update request body.
+//
+// On RFC 7591 registration the ClientID field is unused — the server assigns
+// the value. On RFC 7592 PUT the client MUST include its existing client_id;
+// the HTTP wrapper validates that it matches the URL path before invoking
+// ClientRegistrationManager.UpdateRegistration.
+//
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-2
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
 type DCRRequest struct {
+        // ClientID is required for PUT (RFC 7592 §2.2), ignored for register.
+        ClientID string `json:"client_id,omitempty"`
+
         // Client metadata
-        ClientName  string   `json:"client_name,omitempty"`
-        ClientURI   string   `json:"client_uri,omitempty"`
-        RedirectURIs []string `json:"redirect_uris,omitempty"`
-        GrantTypes  []string `json:"grant_types,omitempty"`
-        Scope       string   `json:"scope,omitempty"`
+        ClientName              string   `json:"client_name,omitempty"`
+        ClientURI               string   `json:"client_uri,omitempty"`
+        RedirectURIs            []string `json:"redirect_uris,omitempty"`
+        GrantTypes              []string `json:"grant_types,omitempty"`
+        Scope                   string   `json:"scope,omitempty"`
 
         // Authentication method
         TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
@@ -330,31 +479,41 @@ type DCRRequest struct {
         JWKS *utils.JWKSet `json:"jwks,omitempty"`
 }
 
-// DCRResponse is the RFC 7591 client registration response.
+// DCRResponse is the RFC 7591 client registration response, extended with the
+// RFC 7592 §3 management credentials (registration_access_token +
+// registration_client_uri) so that registered clients can subsequently call
+// /apps/dcr/{client_id} to read, update, or delete their own registration.
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-3
 type DCRResponse struct {
-        ClientID                string   `json:"client_id"`
-        ClientSecret            string   `json:"client_secret,omitempty"`
-        ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
-        ClientSecretExpiresAt   int64    `json:"client_secret_expires_at"`
-        ClientName              string   `json:"client_name,omitempty"`
-        ClientURI               string   `json:"client_uri,omitempty"`
-        RedirectURIs            []string `json:"redirect_uris,omitempty"`
+        ClientID                  string   `json:"client_id"`
+        ClientSecret              string   `json:"client_secret,omitempty"`
+        ClientIDIssuedAt          int64    `json:"client_id_issued_at"`
+        ClientSecretExpiresAt     int64    `json:"client_secret_expires_at"`
+        ClientName                string   `json:"client_name,omitempty"`
+        ClientURI                 string   `json:"client_uri,omitempty"`
+        RedirectURIs              []string `json:"redirect_uris,omitempty"`
         GrantTypes                []string `json:"grant_types,omitempty"`
         TokenEndpointAuthMethod   string   `json:"token_endpoint_auth_method,omitempty"`
         Scope                     string   `json:"scope,omitempty"`
         AuthorizationDetailsTypes []string `json:"authorization_details_types,omitempty"` // RFC 9396
+
+        // RFC 7592 §3 — management credentials.
+        RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+        RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 }
 
-// ServeHTTP handles POST /register per RFC 7591.
+// ServeHTTP is the HTTP wrapper for ClientRegistrar.Register (RFC 7591 DCR).
+// All protocol logic lives behind the interface; this method just parses,
+// authenticates, calls the manager, and formats the response. See #172 for
+// the convention this follows (the same shape used by ClientRegistrationManager
+// in #168 / #169 / #170).
 func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
         if r.Method != http.MethodPost </span><span class="cov8" title="1">{
                 w.Header().Set("Allow", "POST")
                 http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
                 return
         }</span>
-
-        // Authenticate caller — try Bearer token first, then X-Admin-Key
         <span class="cov8" title="1">if h.Auth != nil </span><span class="cov8" title="1">{
                 if err := h.Auth.Authenticate(r); err != nil </span><span class="cov8" title="1">{
                         h.jsonError(w, "invalid_token", "Authentication required", http.StatusUnauthorized)
@@ -362,103 +521,46 @@ func (h *DCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span cla
                 }</span>
         }
 
-        // Parse DCR request
-        <span class="cov8" title="1">var req DCRRequest
-        if err := json.NewDecoder(r.Body).Decode(&amp;req); err != nil </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">var body DCRRequest
+        if err := json.NewDecoder(r.Body).Decode(&amp;body); err != nil </span><span class="cov0" title="0">{
                 h.jsonError(w, "invalid_client_metadata", "Invalid JSON body", http.StatusBadRequest)
                 return
         }</span>
-
-        // Determine signing algorithm from auth method
-        <span class="cov8" title="1">signingAlg := "HS256" // default
-        if req.TokenEndpointAuthMethod == "private_key_jwt" </span><span class="cov8" title="1">{
-                // Asymmetric — need JWKS
-                if req.JWKS == nil || len(req.JWKS.Keys) == 0 </span><span class="cov8" title="1">{
-                        h.jsonError(w, "invalid_client_metadata", "jwks required for private_key_jwt", http.StatusBadRequest)
-                        return
+        // IssuerBaseURL falls back to the inbound request's scheme + host when
+        // no explicit value is configured on the handler — matches pre-refactor
+        // behavior (see DCRHandler.buildRegistrationClientURI).
+        <span class="cov8" title="1">issuerBase := h.IssuerBaseURL
+        if issuerBase == "" </span><span class="cov8" title="1">{
+                scheme := "http"
+                if r.TLS != nil </span><span class="cov0" title="0">{
+                        scheme = "https"
                 }</span>
-                // Use the first key's algorithm
-                <span class="cov8" title="1">signingAlg = req.JWKS.Keys[0].Alg
-                if signingAlg == "" </span><span class="cov0" title="0">{
-                        signingAlg = "RS256" // default asymmetric
-                }</span>
+                <span class="cov8" title="1">issuerBase = scheme + "://" + r.Host</span>
         }
 
-        // Generate client ID
-        <span class="cov8" title="1">clientID, err := generateDCRClientID()
-        if err != nil </span><span class="cov0" title="0">{
-                h.jsonError(w, "server_error", "Failed to generate client_id", http.StatusInternalServerError)
+        <span class="cov8" title="1">if h.Registrar == nil </span><span class="cov0" title="0">{
+                // Defensive — Handler() always wires a registrar. A nil here would
+                // be a programming error and the manager has no place to store
+                // registration metadata.
+                h.jsonError(w, "server_error", "Registrar not configured", http.StatusInternalServerError)
                 return
         }</span>
-
-        <span class="cov8" title="1">resp := DCRResponse{
-                ClientID:                  clientID,
-                ClientIDIssuedAt:          time.Now().Unix(),
-                ClientSecretExpiresAt:     0, // never expires
-                ClientName:                req.ClientName,
-                ClientURI:                 req.ClientURI,
-                RedirectURIs:              req.RedirectURIs,
-                GrantTypes:                req.GrantTypes,
-                TokenEndpointAuthMethod:   req.TokenEndpointAuthMethod,
-                Scope:                     req.Scope,
-                AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
-        }
-
-        if utils.IsAsymmetricAlg(signingAlg) </span><span class="cov8" title="1">{
-                // Convert JWK to PEM and store
-                jwk := req.JWKS.Keys[0]
-                pubKey, _, err := utils.JWKToPublicKey(jwk)
-                if err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "invalid_client_metadata", "Invalid JWK: "+err.Error(), http.StatusBadRequest)
+        <span class="cov8" title="1">resp, err := h.Registrar.Register(r.Context(), &amp;RegisterRequest{
+                Metadata:      &amp;body,
+                IssuerBaseURL: issuerBase,
+        })
+        if err != nil </span><span class="cov8" title="1">{
+                if errors.Is(err, ErrInvalidClientMetadata) </span><span class="cov8" title="1">{
+                        h.jsonError(w, "invalid_client_metadata", err.Error(), http.StatusBadRequest)
                         return
                 }</span>
-                <span class="cov8" title="1">pemBytes, err := utils.EncodePublicKeyPEM(pubKey)
-                if err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to encode public key", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: pemBytes, Algorithm: signingAlg}); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to store key", http.StatusInternalServerError)
-                        return
-                }</span>
-        } else<span class="cov8" title="1"> {
-                // Symmetric — generate secret
-                secret, err := generateDCRSecret()
-                if err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to generate secret", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to store key", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">resp.ClientSecret = secret
-                if resp.TokenEndpointAuthMethod == "" </span><span class="cov8" title="1">{
-                        resp.TokenEndpointAuthMethod = "client_secret_post"
-                }</span>
-        }
-
-        // Store metadata in AppRegistrar if available
-        <span class="cov8" title="1">if h.Registrar != nil </span><span class="cov8" title="1">{
-                domain := req.ClientURI
-                if domain == "" </span><span class="cov8" title="1">{
-                        domain = req.ClientName
-                }</span>
-                <span class="cov8" title="1">reg := &amp;AppRegistration{
-                        ClientID:                  clientID,
-                        ClientDomain:              domain,
-                        SigningAlg:                signingAlg,
-                        AuthorizationDetailsTypes: req.AuthorizationDetailsTypes,
-                        CreatedAt:                 time.Now(),
-                }
-                h.Registrar.mu.Lock()
-                h.Registrar.apps[clientID] = reg
-                h.Registrar.mu.Unlock()</span>
+                <span class="cov0" title="0">h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)
+                return</span>
         }
 
         <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
         w.WriteHeader(http.StatusCreated)
-        json.NewEncoder(w).Encode(resp)</span>
+        json.NewEncoder(w).Encode(resp.Registration)</span>
 }
 
 func (h *DCRHandler) jsonError(w http.ResponseWriter, errCode, description string, status int) <span class="cov8" title="1">{
@@ -485,9 +587,219 @@ func generateDCRSecret() (string, error) <span class="cov8" title="1">{
         }</span>
         <span class="cov8" title="1">return hex.EncodeToString(b), nil</span>
 }
+
+// generateRegistrationAccessToken returns a 32-byte (256-bit) hex-encoded random
+// token used as the RFC 7592 management credential for a DCR-registered client.
+// The token is stored on AppRegistration.RegistrationAccessToken and validated
+// on every /apps/dcr/{client_id} request via DCRManagementHandler.
+func generateRegistrationAccessToken() (string, error) <span class="cov8" title="1">{
+        b := make([]byte, 32)
+        if _, err := rand.Read(b); err != nil </span><span class="cov0" title="0">{
+                return "", fmt.Errorf("failed to generate registration access token: %w", err)
+        }</span>
+        <span class="cov8" title="1">return hex.EncodeToString(b), nil</span>
+}
+
 </pre>
 		
-		<pre class="file" id="file2" style="display: none">package admin
+		<pre class="file" id="file3" style="display: none">package admin
+
+import (
+        "encoding/json"
+        "errors"
+        "net/http"
+        "strings"
+)
+
+// DCRManagementHandler is the HTTP transport adapter for the RFC 7592
+// management protocol — it parses the request, hands off to a
+// ClientRegistrationManager, then formats the response. All protocol /
+// authorization decisions live behind the interface so the same logic is
+// usable from gRPC, in-process callers, and tests without HTTP machinery.
+//
+// #168 ships GET; #169 ships PUT; #170 ships DELETE — completing the verb
+// trio. Other HTTP methods return 405 with an Allow header advertising the
+// supported set.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592
+type DCRManagementHandler struct {
+        // Manager is the transport-agnostic core. Required.
+        Manager ClientRegistrationManager
+}
+
+// allowedMethods is the value of the Allow header on 405 responses. Updated
+// when new verbs come online so a single string captures the supported set.
+const allowedMethods = "GET, PUT, DELETE"
+
+// ServeHTTP routes /apps/dcr/{client_id} requests by HTTP method.
+func (h *DCRManagementHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
+        clientID := extractClientID(r.URL.Path)
+        if clientID == "" </span><span class="cov0" title="0">{
+                dcrUnauthorized(w, "invalid_token", "Missing client identifier")
+                return
+        }</span>
+
+        <span class="cov8" title="1">switch r.Method </span>{
+        case http.MethodGet:<span class="cov8" title="1">
+                h.handleGet(w, r, clientID)</span>
+        case http.MethodPut:<span class="cov8" title="1">
+                h.handlePut(w, r, clientID)</span>
+        case http.MethodDelete:<span class="cov8" title="1">
+                h.handleDelete(w, r, clientID)</span>
+        default:<span class="cov8" title="1">
+                // 405 does not depend on client_id or auth, so it leaks no per-client
+                // information. The Allow header advertises what's currently supported.
+                w.Header().Set("Allow", allowedMethods)
+                http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)</span>
+        }
+}
+
+func (h *DCRManagementHandler) handleDelete(w http.ResponseWriter, r *http.Request, clientID string) <span class="cov8" title="1">{
+        token := bearerToken(r.Header.Get("Authorization"))
+        _, err := h.Manager.DeleteRegistration(r.Context(), &amp;DeleteRegistrationRequest{
+                ClientID:    clientID,
+                AccessToken: token,
+        })
+        if errors.Is(err, ErrUnauthorized) </span><span class="cov8" title="1">{
+                dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
+                return
+        }</span>
+        <span class="cov8" title="1">if err != nil </span><span class="cov0" title="0">{
+                http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+                return
+        }</span>
+        // RFC 7592 §2.3: 204 No Content with no body.
+        <span class="cov8" title="1">w.Header().Set("Cache-Control", "no-store")
+        w.Header().Set("Pragma", "no-cache")
+        w.WriteHeader(http.StatusNoContent)</span>
+}
+
+func (h *DCRManagementHandler) handlePut(w http.ResponseWriter, r *http.Request, clientID string) <span class="cov8" title="1">{
+        token := bearerToken(r.Header.Get("Authorization"))
+
+        // Limit body size to prevent unbounded JSON payloads from exhausting memory.
+        // 64 KiB is generous for client metadata; tighten if it ever feels too loose.
+        r.Body = http.MaxBytesReader(w, r.Body, 64&lt;&lt;10)
+
+        var body DCRRequest
+        if err := json.NewDecoder(r.Body).Decode(&amp;body); err != nil </span><span class="cov8" title="1">{
+                dcrBadRequest(w, "invalid_client_metadata", "Invalid JSON body")
+                return
+        }</span>
+
+        // RFC 7592 §2.2: the client MUST include the client_id and it MUST match
+        // the registered identifier. We enforce here so the manager only sees
+        // validated requests.
+        <span class="cov8" title="1">if body.ClientID == "" || body.ClientID != clientID </span><span class="cov8" title="1">{
+                dcrBadRequest(w, "invalid_client_metadata", "client_id in body must match URL path")
+                return
+        }</span>
+
+        <span class="cov8" title="1">resp, err := h.Manager.UpdateRegistration(r.Context(), &amp;UpdateRegistrationRequest{
+                ClientID:    clientID,
+                AccessToken: token,
+                Metadata:    &amp;body,
+        })
+        switch </span>{
+        case errors.Is(err, ErrUnauthorized):<span class="cov8" title="1">
+                dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
+                return</span>
+        case errors.Is(err, ErrInvalidClientMetadata):<span class="cov0" title="0">
+                dcrBadRequest(w, "invalid_client_metadata", "Update rejected: "+err.Error())
+                return</span>
+        case err != nil:<span class="cov0" title="0">
+                http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+                return</span>
+        }
+
+        <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Cache-Control", "no-store")
+        w.Header().Set("Pragma", "no-cache")
+        w.WriteHeader(http.StatusOK)
+        _ = json.NewEncoder(w).Encode(resp.Registration)</span>
+}
+
+func (h *DCRManagementHandler) handleGet(w http.ResponseWriter, r *http.Request, clientID string) <span class="cov8" title="1">{
+        token := bearerToken(r.Header.Get("Authorization"))
+        resp, err := h.Manager.GetRegistration(r.Context(), &amp;GetRegistrationRequest{
+                ClientID:    clientID,
+                AccessToken: token,
+        })
+        if errors.Is(err, ErrUnauthorized) </span><span class="cov8" title="1">{
+                dcrUnauthorized(w, "invalid_token", "Invalid registration access token")
+                return
+        }</span>
+        <span class="cov8" title="1">if err != nil </span><span class="cov0" title="0">{
+                http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+                return
+        }</span>
+        <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Cache-Control", "no-store")
+        w.Header().Set("Pragma", "no-cache")
+        w.WriteHeader(http.StatusOK)
+        _ = json.NewEncoder(w).Encode(resp.Registration)</span>
+}
+
+// extractClientID parses the trailing segment of /apps/dcr/{client_id}.
+// Returns "" if the path doesn't match. Trailing slashes are tolerated;
+// nested paths (which #169 / #170 might add for sub-resources) are not.
+func extractClientID(path string) string <span class="cov8" title="1">{
+        const prefix = "/apps/dcr/"
+        if !strings.HasPrefix(path, prefix) </span><span class="cov0" title="0">{
+                return ""
+        }</span>
+        <span class="cov8" title="1">rest := strings.TrimPrefix(path, prefix)
+        rest = strings.TrimSuffix(rest, "/")
+        if rest == "" || strings.Contains(rest, "/") </span><span class="cov0" title="0">{
+                return ""
+        }</span>
+        <span class="cov8" title="1">return rest</span>
+}
+
+// bearerToken extracts the token from an "Authorization: Bearer &lt;token&gt;"
+// header. Returns "" when the header is missing, malformed, or uses a
+// different scheme (Basic, etc.).
+func bearerToken(header string) string <span class="cov8" title="1">{
+        const scheme = "Bearer "
+        if len(header) &lt; len(scheme) </span><span class="cov8" title="1">{
+                return ""
+        }</span>
+        <span class="cov8" title="1">if !strings.EqualFold(header[:len(scheme)], scheme) </span><span class="cov0" title="0">{
+                return ""
+        }</span>
+        <span class="cov8" title="1">return strings.TrimSpace(header[len(scheme):])</span>
+}
+
+// dcrUnauthorized writes an RFC 6750-shaped error response with the standard
+// no-store cache headers required for token-bearing endpoints.
+func dcrUnauthorized(w http.ResponseWriter, errCode, description string) <span class="cov8" title="1">{
+        w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Cache-Control", "no-store")
+        w.Header().Set("Pragma", "no-cache")
+        w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+        w.WriteHeader(http.StatusUnauthorized)
+        _ = json.NewEncoder(w).Encode(map[string]string{
+                "error":             errCode,
+                "error_description": description,
+        })
+}</span>
+
+// dcrBadRequest writes an RFC 7591/7592 client-metadata error (HTTP 400).
+// Used when the request is well-authenticated but the body fails validation
+// (malformed JSON, missing/mismatched client_id, locked-field change, etc.).
+func dcrBadRequest(w http.ResponseWriter, errCode, description string) <span class="cov8" title="1">{
+        w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Cache-Control", "no-store")
+        w.Header().Set("Pragma", "no-cache")
+        w.WriteHeader(http.StatusBadRequest)
+        _ = json.NewEncoder(w).Encode(map[string]string{
+                "error":             errCode,
+                "error_description": description,
+        })
+}</span>
+</pre>
+		
+		<pre class="file" id="file4" style="display: none">package admin
 
 import (
         "crypto/ecdsa"
@@ -566,12 +878,15 @@ func signingMethodFromKey(key any) (jwt.SigningMethod, error) <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file3" style="display: none">package admin
+		<pre class="file" id="file5" style="display: none">package admin
 
 import (
+        "context"
         "crypto/rand"
+        "crypto/subtle"
         "encoding/hex"
         "encoding/json"
+        "errors"
         "fmt"
         "net/http"
         "strings"
@@ -583,6 +898,13 @@ import (
 )
 
 // AppRegistration holds metadata about a registered App.
+//
+// The DCR / RFC 7592 fields below (ClientName, ClientURI, RedirectURIs,
+// GrantTypes, Scope, TokenEndpointAuthMethod, RegistrationAccessToken,
+// RegistrationClientURI) are persisted starting in issue #165 so that
+// the schema is stable when issue #157 (RFC 7592 Management) populates
+// them. They may be empty for apps registered via the legacy
+// /apps/register endpoint.
 type AppRegistration struct {
         ClientID                  string    `json:"client_id"`
         ClientDomain              string    `json:"client_domain"`
@@ -592,11 +914,24 @@ type AppRegistration struct {
         AuthorizationDetailsTypes []string  `json:"authorization_details_types,omitempty"` // RFC 9396
         CreatedAt                 time.Time `json:"created_at"`
         Revoked                   bool      `json:"revoked"`
+
+        // RFC 7591 / 7592 client metadata (populated by DCR; see #157).
+        ClientName              string   `json:"client_name,omitempty"`
+        ClientURI               string   `json:"client_uri,omitempty"`
+        RedirectURIs            []string `json:"redirect_uris,omitempty"`
+        GrantTypes              []string `json:"grant_types,omitempty"`
+        Scope                   string   `json:"scope,omitempty"`
+        TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+
+        // RFC 7592 management credentials. Issued when the management protocol
+        // is implemented (#168); empty for legacy registrations.
+        RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+        RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 }
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.
 // Mount it on any admin service's mux to let apps register and obtain signing credentials.
-// Create with NewAppRegistrar().
+// Create with NewAppRegistrar() (in-memory store) or NewAppRegistrarWithStore.
 type AppRegistrar struct {
         KeyStore keys.KeyStorage
         Auth     AdminAuth
@@ -610,18 +945,587 @@ type AppRegistrar struct {
         // when not specified in the request. Defaults to 24h.
         DefaultGracePeriod time.Duration
 
+        // Store persists app registration metadata. It is the source of truth;
+        // the apps map below is a hot-path cache hydrated on construction and
+        // updated synchronously on every write.
+        Store AppRegistrationStore
+
         mu   sync.RWMutex
         apps map[string]*AppRegistration
 }
 
-// NewAppRegistrar creates an AppRegistrar with initialized internal state.
+// NewAppRegistrar creates an AppRegistrar backed by an in-memory store.
+// Equivalent to NewAppRegistrarWithStore(keyStore, auth, NewInMemoryAppStore()).
+//
+// For deployments that need registrations to survive restart, use
+// NewAppRegistrarWithStore with a persistent backend (FSAppStore, GORMAppStore).
 func NewAppRegistrar(keyStore keys.KeyStorage, auth AdminAuth) *AppRegistrar <span class="cov8" title="1">{
-        return &amp;AppRegistrar{
+        return NewAppRegistrarWithStore(keyStore, auth, NewInMemoryAppStore())
+}</span>
+
+// NewAppRegistrarWithStore creates an AppRegistrar backed by the given store.
+// Existing registrations in the store are loaded into the in-memory cache so
+// that subsequent reads (RLockApps, GET /apps) reflect the persisted state
+// immediately after construction.
+//
+// If store.ListApps returns an error during hydration, the AppRegistrar is
+// returned with an empty cache; subsequent writes proceed normally. (We do
+// not panic — a transient store error at startup should not crash the host
+// process. The error is intentionally swallowed here since there is no
+// caller-visible context to report it through; callers wanting strict
+// startup semantics should call store.ListApps themselves first.)
+func NewAppRegistrarWithStore(keyStore keys.KeyStorage, auth AdminAuth, store AppRegistrationStore) *AppRegistrar <span class="cov8" title="1">{
+        r := &amp;AppRegistrar{
                 KeyStore: keyStore,
                 Auth:     auth,
+                Store:    store,
                 apps:     make(map[string]*AppRegistration),
         }
-}</span>
+        if existing, err := store.ListApps(); err == nil </span><span class="cov8" title="1">{
+                for _, app := range existing </span><span class="cov8" title="1">{
+                        clone := *app
+                        r.apps[app.ClientID] = &amp;clone
+                }</span>
+        }
+        <span class="cov8" title="1">return r</span>
+}
+
+// Register implements ClientRegistrar — RFC 7591 Dynamic Client Registration.
+// Generates a client_id, allocates either a symmetric secret or stores the
+// caller-supplied JWK public key, issues RFC 7592 §3 management credentials,
+// and persists the resulting AppRegistration. Returns an error mapped by
+// the wrapper:
+//
+//   - ErrInvalidClientMetadata: missing JWKS for private_key_jwt, or invalid JWK → HTTP 400
+//   - other errors (KeyStore failures, RNG failures): bubble up → HTTP 500
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops.
+func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*RegisterResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.Metadata == nil </span><span class="cov0" title="0">{
+                return nil, ErrInvalidClientMetadata
+        }</span>
+        <span class="cov8" title="1">md := req.Metadata
+
+        // Determine signing algorithm from the requested auth method. Default
+        // HS256 (symmetric) when the client doesn't ask for private_key_jwt.
+        signingAlg := "HS256"
+        if md.TokenEndpointAuthMethod == "private_key_jwt" </span><span class="cov8" title="1">{
+                if md.JWKS == nil || len(md.JWKS.Keys) == 0 </span><span class="cov8" title="1">{
+                        return nil, ErrInvalidClientMetadata
+                }</span>
+                <span class="cov8" title="1">signingAlg = md.JWKS.Keys[0].Alg
+                if signingAlg == "" </span><span class="cov0" title="0">{
+                        signingAlg = "RS256"
+                }</span>
+        }
+
+        <span class="cov8" title="1">clientID, err := generateDCRClientID()
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("generate client_id: %w", err)
+        }</span>
+
+        // RFC 7592 §3 management credentials — issued at registration time so
+        // the client can read / update / delete its own registration via
+        // /apps/dcr/{client_id} (#168 / #169 / #170).
+        <span class="cov8" title="1">regAccessToken, err := generateRegistrationAccessToken()
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("generate registration_access_token: %w", err)
+        }</span>
+        <span class="cov8" title="1">regClientURI := req.IssuerBaseURL + "/apps/dcr/" + clientID
+
+        resp := &amp;DCRResponse{
+                ClientID:                  clientID,
+                ClientIDIssuedAt:          time.Now().Unix(),
+                ClientSecretExpiresAt:     0, // never expires
+                ClientName:                md.ClientName,
+                ClientURI:                 md.ClientURI,
+                RedirectURIs:              md.RedirectURIs,
+                GrantTypes:                md.GrantTypes,
+                TokenEndpointAuthMethod:   md.TokenEndpointAuthMethod,
+                Scope:                     md.Scope,
+                AuthorizationDetailsTypes: md.AuthorizationDetailsTypes,
+                RegistrationAccessToken:   regAccessToken,
+                RegistrationClientURI:     regClientURI,
+        }
+
+        if utils.IsAsymmetricAlg(signingAlg) </span><span class="cov8" title="1">{
+                // Asymmetric: convert JWK → PEM and store.
+                jwk := md.JWKS.Keys[0]
+                pubKey, _, err := utils.JWKToPublicKey(jwk)
+                if err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("%w: invalid JWK: %v", ErrInvalidClientMetadata, err)
+                }</span>
+                <span class="cov8" title="1">pemBytes, err := utils.EncodePublicKeyPEM(pubKey)
+                if err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("encode public key: %w", err)
+                }</span>
+                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: pemBytes, Algorithm: signingAlg}); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("store key: %w", err)
+                }</span>
+                // No client_secret in response for asymmetric.
+        } else<span class="cov8" title="1"> {
+                secret, err := generateDCRSecret()
+                if err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("generate secret: %w", err)
+                }</span>
+                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("store key: %w", err)
+                }</span>
+                <span class="cov8" title="1">resp.ClientSecret = secret
+                if resp.TokenEndpointAuthMethod == "" </span><span class="cov8" title="1">{
+                        resp.TokenEndpointAuthMethod = "client_secret_post"
+                }</span>
+        }
+
+        // Persist registration metadata. ClientDomain mirrors DCRHandler's
+        // previous derivation so the wire format stays unchanged.
+        <span class="cov8" title="1">domain := md.ClientURI
+        if domain == "" </span><span class="cov8" title="1">{
+                domain = md.ClientName
+        }</span>
+        <span class="cov8" title="1">reg := &amp;AppRegistration{
+                ClientID:                  clientID,
+                ClientDomain:              domain,
+                SigningAlg:                signingAlg,
+                AuthorizationDetailsTypes: md.AuthorizationDetailsTypes,
+                CreatedAt:                 time.Now(),
+                ClientName:                md.ClientName,
+                ClientURI:                 md.ClientURI,
+                RedirectURIs:              md.RedirectURIs,
+                GrantTypes:                md.GrantTypes,
+                Scope:                     md.Scope,
+                TokenEndpointAuthMethod:   md.TokenEndpointAuthMethod,
+                RegistrationAccessToken:   regAccessToken,
+                RegistrationClientURI:     regClientURI,
+        }
+        if err := h.SaveRegistration(reg); err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("persist registration: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">return &amp;RegisterResponse{Registration: resp}, nil</span>
+}
+
+// RegisterLegacy implements ClientRegistrar — the proprietary /apps/register
+// path. Distinct from Register because the wire shape diverges and the
+// legacy endpoint carries OneAuth-specific quota fields (MaxRooms /
+// MaxMsgRate) that DCR has no place for.
+//
+// Eventual removal of this surface is tracked under issue #189.
+//
+// Errors:
+//   - ErrPublicKeyRequired: asymmetric alg requested without PublicKey → HTTP 400
+//   - ErrInvalidPublicKey: PublicKey fails PEM parse → HTTP 400
+//   - other errors (KeyStore failures, RNG failures): bubble up → HTTP 500
+func (h *AppRegistrar) RegisterLegacy(ctx context.Context, req *RegisterLegacyRequest) (*RegisterLegacyResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, ErrInvalidClientMetadata
+        }</span>
+        <span class="cov8" title="1">signingAlg := req.SigningAlg
+        if signingAlg == "" </span><span class="cov8" title="1">{
+                signingAlg = "HS256"
+        }</span>
+
+        <span class="cov8" title="1">clientID, err := generateClientID()
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("generate client_id: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">resp := &amp;RegisterLegacyResponse{
+                ClientID:     clientID,
+                ClientDomain: req.ClientDomain,
+                SigningAlg:   signingAlg,
+                MaxRooms:     req.MaxRooms,
+                MaxMsgRate:   req.MaxMsgRate,
+        }
+
+        if utils.IsAsymmetricAlg(signingAlg) </span><span class="cov8" title="1">{
+                if req.PublicKey == "" </span><span class="cov8" title="1">{
+                        return nil, fmt.Errorf("%w: %s", ErrPublicKeyRequired, signingAlg)
+                }</span>
+                <span class="cov8" title="1">if _, err := utils.DecodeVerifyKey([]byte(req.PublicKey), signingAlg); err != nil </span><span class="cov8" title="1">{
+                        return nil, fmt.Errorf("%w: %v", ErrInvalidPublicKey, err)
+                }</span>
+                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(req.PublicKey), Algorithm: signingAlg}); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("store key: %w", err)
+                }</span>
+                // No client_secret in response for asymmetric.
+        } else<span class="cov8" title="1"> {
+                secret, err := generateSecret()
+                if err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("generate secret: %w", err)
+                }</span>
+                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("store key: %w", err)
+                }</span>
+                <span class="cov8" title="1">resp.ClientSecret = secret</span>
+        }
+
+        <span class="cov8" title="1">reg := &amp;AppRegistration{
+                ClientID:     clientID,
+                ClientDomain: req.ClientDomain,
+                SigningAlg:   signingAlg,
+                MaxRooms:     req.MaxRooms,
+                MaxMsgRate:   req.MaxMsgRate,
+                CreatedAt:    time.Now(),
+        }
+        if err := h.SaveRegistration(reg); err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("persist registration: %w", err)
+        }</span>
+        <span class="cov8" title="1">resp.CreatedAt = reg.CreatedAt
+        return resp, nil</span>
+}
+
+// ListClients implements ClientRegistrar — admin read of every registered
+// app. Reads from the in-memory cache hydrated from AppRegistrationStore on
+// construction. Returned entries are clones; callers cannot mutate the
+// cache via this value.
+func (h *AppRegistrar) ListClients(ctx context.Context, req *ListClientsRequest) (*ListClientsResponse, error) <span class="cov8" title="1">{
+        h.mu.RLock()
+        defer h.mu.RUnlock()
+        apps := make([]*AppRegistration, 0, len(h.apps))
+        for _, reg := range h.apps </span><span class="cov8" title="1">{
+                clone := *reg
+                apps = append(apps, &amp;clone)
+        }</span>
+        <span class="cov8" title="1">return &amp;ListClientsResponse{Apps: apps}, nil</span>
+}
+
+// GetClient implements ClientRegistrar — admin read of a single registration.
+// Returns ErrAppNotFound if the client does not exist.
+func (h *AppRegistrar) GetClient(ctx context.Context, req *GetClientRequest) (*GetClientResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.ClientID == "" </span><span class="cov0" title="0">{
+                return nil, ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">h.mu.RLock()
+        reg, ok := h.apps[req.ClientID]
+        h.mu.RUnlock()
+        if !ok </span><span class="cov8" title="1">{
+                return nil, ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">clone := *reg
+        return &amp;GetClientResponse{Registration: &amp;clone}, nil</span>
+}
+
+// DeleteClient implements ClientRegistrar — admin delete. Removes the
+// registration from Store + in-memory cache and invalidates the KeyStore
+// entry. Returns ErrAppNotFound if the client does not exist.
+//
+// Distinct from ClientRegistrationManager.DeleteRegistration which
+// authenticates via the client's own registration_access_token. This admin
+// path is reachable only by AdminAuth-passing callers.
+func (h *AppRegistrar) DeleteClient(ctx context.Context, req *DeleteClientRequest) (*DeleteClientResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.ClientID == "" </span><span class="cov0" title="0">{
+                return nil, ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">h.mu.RLock()
+        _, ok := h.apps[req.ClientID]
+        h.mu.RUnlock()
+        if !ok </span><span class="cov8" title="1">{
+                return nil, ErrAppNotFound
+        }</span>
+
+        // Persist the deletion before invalidating the cache or credentials —
+        // same ordering as DeleteRegistration so a store error leaves the
+        // registration intact and the call retryable.
+        <span class="cov8" title="1">if err := h.Store.DeleteApp(req.ClientID); err != nil &amp;&amp; err != ErrAppNotFound </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("delete registration: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">h.mu.Lock()
+        delete(h.apps, req.ClientID)
+        h.mu.Unlock()
+
+        // KeyStore deletion is best-effort: a stranded key is unreachable
+        // once the registration is gone (same rationale as DeleteRegistration).
+        _ = h.KeyStore.DeleteKey(req.ClientID)
+
+        return &amp;DeleteClientResponse{}, nil</span>
+}
+
+// RotateSecret implements ClientRegistrar — rotates the signing key for
+// req.ClientID. For symmetric algs a fresh secret is generated and returned.
+// For asymmetric algs the caller MUST supply req.PublicKey (PEM); there is
+// no server-side keypair generation today.
+//
+// When KidStore is configured on AppRegistrar, the previous key material is
+// retained for req.GracePeriod (defaulting to AppRegistrar.DefaultGracePeriod
+// or 24h) so in-flight tokens stay verifiable. The returned PreviousKid /
+// GracePeriod fields are populated only when retention actually happened.
+//
+// Errors:
+//   - ErrAppNotFound: req.ClientID not registered
+//   - ErrPublicKeyRequired: asymmetric alg without PublicKey
+//   - ErrInvalidPublicKey: PublicKey fails PEM parse for the registered alg
+func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretRequest) (*RotateSecretResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.ClientID == "" </span><span class="cov0" title="0">{
+                return nil, ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">h.mu.RLock()
+        reg, ok := h.apps[req.ClientID]
+        h.mu.RUnlock()
+        if !ok </span><span class="cov8" title="1">{
+                return nil, ErrAppNotFound
+        }</span>
+
+        <span class="cov8" title="1">gracePeriod := req.GracePeriod
+        if gracePeriod == 0 </span><span class="cov8" title="1">{
+                gracePeriod = h.DefaultGracePeriod
+        }</span>
+        <span class="cov8" title="1">if gracePeriod == 0 </span><span class="cov8" title="1">{
+                gracePeriod = 24 * time.Hour
+        }</span>
+
+        // Snapshot old key material before overwrite (for grace period retention).
+        <span class="cov8" title="1">var oldKey any
+        var oldAlg, oldKid string
+        if h.KidStore != nil </span><span class="cov0" title="0">{
+                if oldRec, err := h.KeyStore.GetKey(req.ClientID); err == nil </span><span class="cov0" title="0">{
+                        oldKey = oldRec.Key
+                        oldAlg = oldRec.Algorithm
+                        oldKid = oldRec.Kid
+                        if oldKid == "" &amp;&amp; oldKey != nil </span><span class="cov0" title="0">{
+                                oldKid, _ = utils.ComputeKid(oldKey, oldAlg)
+                        }</span>
+                }
+        }
+
+        <span class="cov8" title="1">resp := &amp;RotateSecretResponse{ClientID: req.ClientID}
+
+        if utils.IsAsymmetricAlg(reg.SigningAlg) </span><span class="cov8" title="1">{
+                if req.PublicKey == "" </span><span class="cov8" title="1">{
+                        return nil, fmt.Errorf("%w: %s", ErrPublicKeyRequired, reg.SigningAlg)
+                }</span>
+                <span class="cov8" title="1">if _, err := utils.DecodeVerifyKey([]byte(req.PublicKey), reg.SigningAlg); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("%w: %v", ErrInvalidPublicKey, err)
+                }</span>
+                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: req.ClientID, Key: []byte(req.PublicKey), Algorithm: reg.SigningAlg}); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("update key: %w", err)
+                }</span>
+        } else<span class="cov8" title="1"> {
+                newSecret, err := generateSecret()
+                if err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("generate secret: %w", err)
+                }</span>
+                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: req.ClientID, Key: []byte(newSecret), Algorithm: reg.SigningAlg}); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("update key: %w", err)
+                }</span>
+                <span class="cov8" title="1">resp.ClientSecret = newSecret</span>
+        }
+
+        <span class="cov8" title="1">if h.KidStore != nil &amp;&amp; oldKey != nil &amp;&amp; oldKid != "" </span><span class="cov0" title="0">{
+                h.KidStore.Add(oldKid, oldKey, oldAlg, req.ClientID, time.Now().Add(gracePeriod))
+                resp.PreviousKid = oldKid
+                resp.GracePeriod = gracePeriod
+        }</span>
+
+        <span class="cov8" title="1">if newRec, err := h.KeyStore.GetKey(req.ClientID); err == nil &amp;&amp; newRec.Kid != "" </span><span class="cov8" title="1">{
+                resp.Kid = newRec.Kid
+        }</span>
+        <span class="cov8" title="1">return resp, nil</span>
+}
+
+// SaveRegistration persists the registration to the store and updates the
+// in-memory cache. Used by handleRegister, DCRHandler, and (in #157) the
+// RFC 7592 management endpoints. If the store write fails, the cache is
+// not updated and the error is returned.
+func (h *AppRegistrar) SaveRegistration(reg *AppRegistration) error <span class="cov8" title="1">{
+        if err := h.Store.SaveApp(reg); err != nil </span><span class="cov0" title="0">{
+                return err
+        }</span>
+        <span class="cov8" title="1">h.mu.Lock()
+        clone := *reg
+        h.apps[reg.ClientID] = &amp;clone
+        h.mu.Unlock()
+        return nil</span>
+}
+
+// GetRegistration implements ClientRegistrationManager. It returns the
+// RFC 7591 registration for req.ClientID iff req.AccessToken matches the
+// stored registration_access_token. Returns ErrUnauthorized for every
+// failure mode — wrong/missing token, unknown client_id, or a registration
+// that lacks a management token (e.g., a legacy /apps/register entry) — so
+// the management endpoint cannot be used to probe for valid client_ids.
+//
+// The returned DCRResponse intentionally omits client_secret. RFC 7592 §3
+// permits but does not require echoing the secret on read; re-emitting
+// symmetric credentials on every read enlarges the disclosure window if the
+// registration access token is ever logged or proxied. Clients that lose
+// the secret can rotate via PUT (#169).
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops, and for parity with the rest of
+// the manager interface.
+func (h *AppRegistrar) GetRegistration(ctx context.Context, req *GetRegistrationRequest) (*GetRegistrationResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.ClientID == "" || req.AccessToken == "" </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">reg, err := h.Store.GetApp(req.ClientID)
+        if err != nil || reg == nil </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">if reg.RegistrationAccessToken == "" </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(req.AccessToken)) != 1 </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">return &amp;GetRegistrationResponse{
+                Registration: &amp;DCRResponse{
+                        ClientID:                  reg.ClientID,
+                        ClientIDIssuedAt:          reg.CreatedAt.Unix(),
+                        ClientSecretExpiresAt:     0,
+                        ClientName:                reg.ClientName,
+                        ClientURI:                 reg.ClientURI,
+                        RedirectURIs:              reg.RedirectURIs,
+                        GrantTypes:                reg.GrantTypes,
+                        TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
+                        Scope:                     reg.Scope,
+                        AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
+                        RegistrationAccessToken:   reg.RegistrationAccessToken,
+                        RegistrationClientURI:     reg.RegistrationClientURI,
+                },
+        }, nil</span>
+}
+
+// UpdateRegistration implements ClientRegistrationManager (RFC 7592 §2.2).
+// It performs a full replacement of the editable metadata fields and rotates
+// the registration_access_token; the new token is returned in the response.
+// The old token becomes invalid as soon as SaveRegistration succeeds.
+//
+// Editable fields (overwritten from req.Metadata on success): ClientName,
+// ClientURI, RedirectURIs, GrantTypes, Scope, AuthorizationDetailsTypes,
+// ClientDomain (derived from ClientURI / ClientName, mirroring DCRHandler's
+// logic).
+//
+// Locked fields (return ErrInvalidClientMetadata on attempted change):
+//   - TokenEndpointAuthMethod — would require re-keying; out of scope for #169.
+// Locked fields (silently retained):
+//   - SigningAlg, ClientID, CreatedAt, RegistrationClientURI, the key material
+//     in KeyStore.
+//
+// req.Metadata is treated as RFC 7591 client metadata; req.Metadata.JWKS is
+// currently ignored (auth-method changes are rejected, so the JWKS cannot
+// usefully change either).
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops, and for parity with the rest of
+// the manager interface.
+func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*UpdateRegistrationResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.ClientID == "" || req.AccessToken == "" || req.Metadata == nil </span><span class="cov0" title="0">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">reg, err := h.Store.GetApp(req.ClientID)
+        if err != nil || reg == nil </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">if reg.RegistrationAccessToken == "" </span><span class="cov0" title="0">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(req.AccessToken)) != 1 </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+
+        // Authenticated — past this point, validation errors return
+        // ErrInvalidClientMetadata so the wrapper can map to 400 instead of 401.
+        // Auth method changes are out of scope for #169 (would require re-keying).
+        <span class="cov8" title="1">md := req.Metadata
+        if md.TokenEndpointAuthMethod != "" &amp;&amp; md.TokenEndpointAuthMethod != reg.TokenEndpointAuthMethod </span><span class="cov8" title="1">{
+                return nil, ErrInvalidClientMetadata
+        }</span>
+
+        <span class="cov8" title="1">newToken, err := generateRegistrationAccessToken()
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        // Replace the editable metadata fields. ClientDomain mirrors the derivation
+        // in DCRHandler.ServeHTTP so callers see consistent behavior on register
+        // and update.
+        <span class="cov8" title="1">domain := md.ClientURI
+        if domain == "" </span><span class="cov8" title="1">{
+                domain = md.ClientName
+        }</span>
+        <span class="cov8" title="1">reg.ClientName = md.ClientName
+        reg.ClientURI = md.ClientURI
+        reg.RedirectURIs = md.RedirectURIs
+        reg.GrantTypes = md.GrantTypes
+        reg.Scope = md.Scope
+        reg.AuthorizationDetailsTypes = md.AuthorizationDetailsTypes
+        reg.ClientDomain = domain
+        reg.RegistrationAccessToken = newToken
+
+        if err := h.SaveRegistration(reg); err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+        <span class="cov8" title="1">return &amp;UpdateRegistrationResponse{
+                Registration: &amp;DCRResponse{
+                        ClientID:                  reg.ClientID,
+                        ClientIDIssuedAt:          reg.CreatedAt.Unix(),
+                        ClientSecretExpiresAt:     0,
+                        ClientName:                reg.ClientName,
+                        ClientURI:                 reg.ClientURI,
+                        RedirectURIs:              reg.RedirectURIs,
+                        GrantTypes:                reg.GrantTypes,
+                        TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
+                        Scope:                     reg.Scope,
+                        AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
+                        RegistrationAccessToken:   reg.RegistrationAccessToken,
+                        RegistrationClientURI:     reg.RegistrationClientURI,
+                },
+        }, nil</span>
+}
+
+// DeleteRegistration implements ClientRegistrationManager (RFC 7592 §2.3).
+// On success it removes the registration from the AppRegistrationStore (and
+// the in-memory cache), and deletes the client's signing key from KeyStore
+// so any tokens already issued under this client_id fail subsequent
+// signature-validation — satisfying the spec requirement that "the
+// authorization server MUST invalidate" all tokens for a deleted client.
+//
+// Failure ordering mirrors handleDeleteApp: we persist the deletion in the
+// store first; only on success do we drop the cache entry and the KeyStore
+// key. If the store write fails we return early without touching the
+// in-memory cache or the credentials, so the registration remains
+// authoritatively present (deletion can be retried).
+//
+// ctx is currently unused but threaded through for cancellation / deadline
+// propagation once stores grow async ops.
+func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegistrationRequest) (*DeleteRegistrationResponse, error) <span class="cov8" title="1">{
+        if req == nil || req.ClientID == "" || req.AccessToken == "" </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">reg, err := h.Store.GetApp(req.ClientID)
+        if err != nil || reg == nil </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">if reg.RegistrationAccessToken == "" </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+        <span class="cov8" title="1">if subtle.ConstantTimeCompare([]byte(reg.RegistrationAccessToken), []byte(req.AccessToken)) != 1 </span><span class="cov8" title="1">{
+                return nil, ErrUnauthorized
+        }</span>
+
+        // Persist deletion first. If the store write fails we leave the cache
+        // and KeyStore intact so the client retains a known-consistent state
+        // and the caller can retry; otherwise we'd leave dangling key material
+        // without a registration to bind it.
+        <span class="cov8" title="1">if err := h.Store.DeleteApp(req.ClientID); err != nil &amp;&amp; err != ErrAppNotFound </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        <span class="cov8" title="1">h.mu.Lock()
+        delete(h.apps, req.ClientID)
+        h.mu.Unlock()
+
+        // Invalidate the signing credentials. Errors here are non-fatal — the
+        // registration is gone, which is the user-visible deletion contract;
+        // a stranded key is at worst an internal cleanup concern (the KeyStore
+        // entry is unreachable without an AppRegistration to point at it).
+        _ = h.KeyStore.DeleteKey(req.ClientID)
+
+        return &amp;DeleteRegistrationResponse{}, nil</span>
+}
 
 // RLockApps calls fn with a read-locked view of all registered apps.
 func (h *AppRegistrar) RLockApps(fn func(map[string]*AppRegistration)) <span class="cov0" title="0">{
@@ -631,23 +1535,31 @@ func (h *AppRegistrar) RLockApps(fn func(map[string]*AppRegistration)) <span cla
 }</span>
 
 // Handler returns an http.Handler for app registration endpoints.
-// Includes both custom OneAuth API and RFC 7591 DCR endpoint:
+// Includes both custom OneAuth API, RFC 7591 DCR, and RFC 7592 DCR Management:
 //
-//        POST /apps/register  — OneAuth custom registration
-//        POST /apps/dcr       — RFC 7591 Dynamic Client Registration
-//        GET  /apps           — List all apps
-//        GET  /apps/{id}      — Get app metadata
-//        DELETE /apps/{id}    — Delete app
-//        POST /apps/{id}/rotate — Rotate secret/key
+//        POST   /apps/register         — OneAuth custom registration
+//        POST   /apps/dcr              — RFC 7591 Dynamic Client Registration
+//        GET    /apps/dcr/{client_id}  — RFC 7592 DCR Management read (issue #168)
+//        GET    /apps                  — List all apps
+//        GET    /apps/{id}             — Get app metadata
+//        DELETE /apps/{id}             — Delete app
+//        POST   /apps/{id}/rotate      — Rotate secret/key
+//
+// Routing precedence note: Go's ServeMux uses longest-prefix matching, so the
+// "/apps/dcr/" prefix below wins over the "/apps/" catch-all without further
+// fiddling. The exact-match "/apps/dcr" route handles RFC 7591 registration.
 func (h *AppRegistrar) Handler() http.Handler <span class="cov8" title="1">{
         dcr := &amp;DCRHandler{
                 KeyStore:  h.KeyStore,
                 Auth:      h.Auth,
                 Registrar: h,
         }
+        dcrMgmt := &amp;DCRManagementHandler{Manager: h}
+
         mux := http.NewServeMux()
         mux.HandleFunc("/apps/register", h.withAuth(h.handleRegister))
         mux.Handle("/apps/dcr", http.HandlerFunc(dcr.ServeHTTP))
+        mux.Handle("/apps/dcr/", http.HandlerFunc(dcrMgmt.ServeHTTP))
         mux.HandleFunc("/apps/", h.withAuth(h.handleAppByID))
         mux.HandleFunc("/apps", h.withAuth(h.handleListApps))
         return mux
@@ -669,110 +1581,48 @@ func (h *AppRegistrar) withAuth(next http.HandlerFunc) http.HandlerFunc <span cl
         }
 }
 
+// handleRegister is the HTTP wrapper for ClientRegistrar.RegisterLegacy
+// (the proprietary /apps/register path). All registration logic lives behind
+// the interface; this method just parses, calls the manager, maps errors
+// to HTTP status codes, and formats the response.
 func (h *AppRegistrar) handleRegister(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
         if r.Method != http.MethodPost </span><span class="cov0" title="0">{
                 h.jsonError(w, "method_not_allowed", "POST required", http.StatusMethodNotAllowed)
                 return
         }</span>
-
-        <span class="cov8" title="1">var req struct {
-                ClientDomain string  `json:"client_domain"`
-                SigningAlg   string  `json:"signing_alg"`
-                PublicKey    string  `json:"public_key"` // PEM-encoded public key (required for RS256/ES256)
-                MaxRooms     int     `json:"max_rooms"`
-                MaxMsgRate   float64 `json:"max_msg_rate"`
-        }
+        <span class="cov8" title="1">var req RegisterLegacyRequest
         if err := json.NewDecoder(r.Body).Decode(&amp;req); err != nil </span><span class="cov0" title="0">{
                 h.jsonError(w, "invalid_request", "Invalid JSON body", http.StatusBadRequest)
                 return
         }</span>
-
-        <span class="cov8" title="1">if req.SigningAlg == "" </span><span class="cov8" title="1">{
-                req.SigningAlg = "HS256"
-        }</span>
-
-        // Generate client ID
-        <span class="cov8" title="1">clientID, err := generateClientID()
-        if err != nil </span><span class="cov0" title="0">{
-                h.jsonError(w, "server_error", "Failed to generate client ID", http.StatusInternalServerError)
-                return
-        }</span>
-
-        <span class="cov8" title="1">resp := map[string]any{
-                "client_id":     clientID,
-                "client_domain": req.ClientDomain,
-                "signing_alg":   req.SigningAlg,
-                "max_rooms":     req.MaxRooms,
-                "max_msg_rate":  req.MaxMsgRate,
+        <span class="cov8" title="1">resp, err := h.RegisterLegacy(r.Context(), &amp;req)
+        if err != nil </span><span class="cov8" title="1">{
+                switch </span>{
+                case errors.Is(err, ErrPublicKeyRequired), errors.Is(err, ErrInvalidPublicKey), errors.Is(err, ErrInvalidClientMetadata):<span class="cov8" title="1">
+                        h.jsonError(w, "invalid_request", err.Error(), http.StatusBadRequest)</span>
+                default:<span class="cov0" title="0">
+                        h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)</span>
+                }
+                <span class="cov8" title="1">return</span>
         }
-
-        if utils.IsAsymmetricAlg(req.SigningAlg) </span><span class="cov8" title="1">{
-                // Asymmetric: require public_key PEM, no secret generated
-                if req.PublicKey == "" </span><span class="cov8" title="1">{
-                        h.jsonError(w, "invalid_request", "public_key is required for "+req.SigningAlg, http.StatusBadRequest)
-                        return
-                }</span>
-                // Validate PEM parses to a valid public key of the right type
-                <span class="cov8" title="1">if _, err := utils.DecodeVerifyKey([]byte(req.PublicKey), req.SigningAlg); err != nil </span><span class="cov8" title="1">{
-                        h.jsonError(w, "invalid_request", "Invalid public key: "+err.Error(), http.StatusBadRequest)
-                        return
-                }</span>
-                // Store PEM bytes
-                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(req.PublicKey), Algorithm: req.SigningAlg}); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to store key", http.StatusInternalServerError)
-                        return
-                }</span>
-                // No client_secret in response for asymmetric
-        } else<span class="cov8" title="1"> {
-                // Symmetric: generate secret
-                secret, err := generateSecret()
-                if err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to generate secret", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: req.SigningAlg}); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to store key", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">resp["client_secret"] = secret</span>
-        }
-
-        // Store registration metadata
-        <span class="cov8" title="1">reg := &amp;AppRegistration{
-                ClientID:     clientID,
-                ClientDomain: req.ClientDomain,
-                SigningAlg:   req.SigningAlg,
-                MaxRooms:     req.MaxRooms,
-                MaxMsgRate:   req.MaxMsgRate,
-                CreatedAt:    time.Now(),
-        }
-        h.mu.Lock()
-        h.apps[clientID] = reg
-        h.mu.Unlock()
-
-        resp["created_at"] = reg.CreatedAt
-
-        w.Header().Set("Content-Type", "application/json")
+        <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
         w.WriteHeader(http.StatusCreated)
         json.NewEncoder(w).Encode(resp)</span>
 }
 
+// handleListApps is the HTTP wrapper for ClientRegistrar.ListClients.
 func (h *AppRegistrar) handleListApps(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
         if r.Method != http.MethodGet </span><span class="cov0" title="0">{
                 h.jsonError(w, "method_not_allowed", "GET required", http.StatusMethodNotAllowed)
                 return
         }</span>
-
-        <span class="cov8" title="1">h.mu.RLock()
-        
-        apps := make([]*AppRegistration, 0, len(h.apps))
-        for _, reg := range h.apps </span><span class="cov8" title="1">{
-                apps = append(apps, reg)
+        <span class="cov8" title="1">resp, err := h.ListClients(r.Context(), &amp;ListClientsRequest{})
+        if err != nil </span><span class="cov0" title="0">{
+                h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)
+                return
         }</span>
-        <span class="cov8" title="1">h.mu.RUnlock()
-
-        w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(map[string]any{"apps": apps})</span>
+        <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(map[string]any{"apps": resp.Apps})</span>
 }
 
 func (h *AppRegistrar) handleAppByID(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
@@ -802,130 +1652,93 @@ func (h *AppRegistrar) handleAppByID(w http.ResponseWriter, r *http.Request) <sp
         }
 }
 
-func (h *AppRegistrar) handleGetApp(w http.ResponseWriter, _ *http.Request, clientID string) <span class="cov8" title="1">{
-        h.mu.RLock()
-        reg, ok := h.apps[clientID]
-        h.mu.RUnlock()
-
-        if !ok </span><span class="cov8" title="1">{
-                h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
-                return
-        }</span>
-
+// handleGetApp is the HTTP wrapper for ClientRegistrar.GetClient.
+func (h *AppRegistrar) handleGetApp(w http.ResponseWriter, r *http.Request, clientID string) <span class="cov8" title="1">{
+        resp, err := h.GetClient(r.Context(), &amp;GetClientRequest{ClientID: clientID})
+        if err != nil </span><span class="cov8" title="1">{
+                if errors.Is(err, ErrAppNotFound) </span><span class="cov8" title="1">{
+                        h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
+                        return
+                }</span>
+                <span class="cov0" title="0">h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)
+                return</span>
+        }
         <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(reg)</span>
+        json.NewEncoder(w).Encode(resp.Registration)</span>
 }
 
-func (h *AppRegistrar) handleDeleteApp(w http.ResponseWriter, _ *http.Request, clientID string) <span class="cov8" title="1">{
-        h.mu.Lock()
-        _, ok := h.apps[clientID]
-        if !ok </span><span class="cov8" title="1">{
-                h.mu.Unlock()
-                h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
-                return
-        }</span>
-        <span class="cov8" title="1">delete(h.apps, clientID)
-        h.mu.Unlock()
-
-        // Remove from KeyStore
-        h.KeyStore.DeleteKey(clientID)
-
-        w.Header().Set("Content-Type", "application/json")
+// handleDeleteApp is the HTTP wrapper for ClientRegistrar.DeleteClient.
+func (h *AppRegistrar) handleDeleteApp(w http.ResponseWriter, r *http.Request, clientID string) <span class="cov8" title="1">{
+        if _, err := h.DeleteClient(r.Context(), &amp;DeleteClientRequest{ClientID: clientID}); err != nil </span><span class="cov8" title="1">{
+                if errors.Is(err, ErrAppNotFound) </span><span class="cov8" title="1">{
+                        h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
+                        return
+                }</span>
+                <span class="cov0" title="0">h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)
+                return</span>
+        }
+        <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
         json.NewEncoder(w).Encode(map[string]any{"deleted": true, "client_id": clientID})</span>
 }
 
+// handleRotateSecret is the HTTP wrapper for ClientRegistrar.RotateSecret.
+// Parses the optional public_key + grace_period body, calls the manager,
+// and emits the proprietary response shape (which varies by algorithm and
+// whether KidStore retained the previous key).
 func (h *AppRegistrar) handleRotateSecret(w http.ResponseWriter, r *http.Request, clientID string) <span class="cov8" title="1">{
         if r.Method != http.MethodPost </span><span class="cov0" title="0">{
                 h.jsonError(w, "method_not_allowed", "POST required", http.StatusMethodNotAllowed)
                 return
         }</span>
 
-        <span class="cov8" title="1">h.mu.RLock()
-        reg, ok := h.apps[clientID]
-        h.mu.RUnlock()
-
-        if !ok </span><span class="cov8" title="1">{
-                h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
-                return
-        }</span>
-
-        // Parse optional grace period from request body
-        <span class="cov8" title="1">var reqBody struct {
-                PublicKey    string `json:"public_key"`
+        <span class="cov8" title="1">var body struct {
+                PublicKey   string `json:"public_key"`
                 GracePeriod string `json:"grace_period"` // e.g. "24h", "1h30m"
         }
-        // We need to read the body for both symmetric and asymmetric
-        json.NewDecoder(r.Body).Decode(&amp;reqBody)
+        // Body is optional; symmetric rotations may omit it entirely.
+        json.NewDecoder(r.Body).Decode(&amp;body)
 
-        gracePeriod := h.DefaultGracePeriod
-        if gracePeriod == 0 </span><span class="cov8" title="1">{
-                gracePeriod = 24 * time.Hour
-        }</span>
-        <span class="cov8" title="1">if reqBody.GracePeriod != "" </span><span class="cov0" title="0">{
-                if parsed, err := time.ParseDuration(reqBody.GracePeriod); err == nil </span><span class="cov0" title="0">{
-                        gracePeriod = parsed
+        var grace time.Duration
+        if body.GracePeriod != "" </span><span class="cov0" title="0">{
+                if parsed, err := time.ParseDuration(body.GracePeriod); err == nil </span><span class="cov0" title="0">{
+                        grace = parsed
                 }</span>
         }
 
-        // Snapshot old key material before overwrite (for grace period retention)
-        <span class="cov8" title="1">var oldKey any
-        var oldAlg string
-        var oldKid string
-        if h.KidStore != nil </span><span class="cov0" title="0">{
-                if oldRec, err := h.KeyStore.GetKey(clientID); err == nil </span><span class="cov0" title="0">{
-                        oldKey = oldRec.Key
-                        oldAlg = oldRec.Algorithm
-                        oldKid = oldRec.Kid
-                        if oldKid == "" &amp;&amp; oldKey != nil </span><span class="cov0" title="0">{
-                                oldKid, _ = utils.ComputeKid(oldKey, oldAlg)
-                        }</span>
+        <span class="cov8" title="1">resp, err := h.RotateSecret(r.Context(), &amp;RotateSecretRequest{
+                ClientID:    clientID,
+                PublicKey:   body.PublicKey,
+                GracePeriod: grace,
+        })
+        if err != nil </span><span class="cov8" title="1">{
+                switch </span>{
+                case errors.Is(err, ErrAppNotFound):<span class="cov8" title="1">
+                        h.jsonError(w, "not_found", "App not found", http.StatusNotFound)</span>
+                case errors.Is(err, ErrPublicKeyRequired), errors.Is(err, ErrInvalidPublicKey):<span class="cov8" title="1">
+                        h.jsonError(w, "invalid_request", err.Error(), http.StatusBadRequest)</span>
+                default:<span class="cov0" title="0">
+                        h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)</span>
                 }
+                <span class="cov8" title="1">return</span>
         }
 
-        <span class="cov8" title="1">resp := map[string]any{"client_id": clientID}
-
-        if utils.IsAsymmetricAlg(reg.SigningAlg) </span><span class="cov8" title="1">{
-                // Asymmetric: require new public_key in request body
-                if reqBody.PublicKey == "" </span><span class="cov8" title="1">{
-                        h.jsonError(w, "invalid_request", "public_key is required for key rotation with "+reg.SigningAlg, http.StatusBadRequest)
-                        return
-                }</span>
-                <span class="cov8" title="1">if _, err := utils.DecodeVerifyKey([]byte(reqBody.PublicKey), reg.SigningAlg); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "invalid_request", "Invalid public key: "+err.Error(), http.StatusBadRequest)
-                        return
-                }</span>
-                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(reqBody.PublicKey), Algorithm: reg.SigningAlg}); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to update key", http.StatusInternalServerError)
-                        return
-                }</span>
-        } else<span class="cov8" title="1"> {
-                // Symmetric: generate new secret
-                newSecret, err := generateSecret()
-                if err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to generate secret", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">if err := h.KeyStore.PutKey(&amp;keys.KeyRecord{ClientID: clientID, Key: []byte(newSecret), Algorithm: reg.SigningAlg}); err != nil </span><span class="cov0" title="0">{
-                        h.jsonError(w, "server_error", "Failed to update key", http.StatusInternalServerError)
-                        return
-                }</span>
-                <span class="cov8" title="1">resp["client_secret"] = newSecret</span>
-        }
-
-        // Retain old key in KidStore for grace period
-        <span class="cov8" title="1">if h.KidStore != nil &amp;&amp; oldKey != nil &amp;&amp; oldKid != "" </span><span class="cov0" title="0">{
-                h.KidStore.Add(oldKid, oldKey, oldAlg, clientID, time.Now().Add(gracePeriod))
-                resp["previous_kid"] = oldKid
-                resp["grace_period"] = gracePeriod.String()
+        // Build the proprietary response shape — manager returns a typed
+        // struct, but the wire format is a map so empty fields are silently
+        // omitted (preserves byte-identical output with the pre-refactor handler).
+        <span class="cov8" title="1">out := map[string]any{"client_id": resp.ClientID}
+        if resp.ClientSecret != "" </span><span class="cov8" title="1">{
+                out["client_secret"] = resp.ClientSecret
         }</span>
-
-        // Include new kid in response
-        <span class="cov8" title="1">if newRec, err := h.KeyStore.GetKey(clientID); err == nil &amp;&amp; newRec.Kid != "" </span><span class="cov8" title="1">{
-                resp["kid"] = newRec.Kid
+        <span class="cov8" title="1">if resp.Kid != "" </span><span class="cov8" title="1">{
+                out["kid"] = resp.Kid
+        }</span>
+        <span class="cov8" title="1">if resp.PreviousKid != "" </span><span class="cov0" title="0">{
+                out["previous_kid"] = resp.PreviousKid
+                out["grace_period"] = resp.GracePeriod.String()
         }</span>
 
         <span class="cov8" title="1">w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(resp)</span>
+        json.NewEncoder(w).Encode(out)</span>
 }
 
 func (h *AppRegistrar) jsonError(w http.ResponseWriter, code, message string, status int) <span class="cov8" title="1">{
@@ -953,7 +1766,7 @@ func generateSecret() (string, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file4" style="display: none">package apiauth
+		<pre class="file" id="file6" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -962,9 +1775,10 @@ import (
 )
 
 // ASServerMetadata describes an OAuth 2.0 Authorization Server per RFC 8414
-// and OpenID Connect Discovery 1.0 §4. The auth server serves this at
-// GET /.well-known/openid-configuration so OIDC-aware clients can
-// auto-discover endpoints.
+// and OpenID Connect Discovery 1.0 §4. RFC 8414 §3 mandates this metadata
+// be served at /.well-known/oauth-authorization-server; OIDC Discovery
+// places the same document at /.well-known/openid-configuration. Use
+// MountASMetadata to register both paths in one call.
 //
 // This is metadata-only — serving this does NOT make the server a full OIDC
 // provider. It simply advertises what endpoints exist (token, JWKS,
@@ -995,13 +1809,29 @@ type ASServerMetadata struct {
         CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
         SubjectTypesSupported         []string `json:"subject_types_supported,omitempty"`
 
+        // AuthorizationResponseIssParameterSupported advertises RFC 9207
+        // support — when true, the AS includes an `iss` query parameter on
+        // every authorization response (both successful redirects with `code`
+        // and error redirects). Pointer semantics distinguish absence (omit
+        // from JSON) from explicit `false` (advertised as not supported).
+        //
+        // RFC 9207 §3:
+        //   https://www.rfc-editor.org/rfc/rfc9207#section-3
+        //
+        // Setting this true on an AS that does NOT actually emit `iss` in
+        // authorization responses is a spec violation — clients keying off
+        // the advertisement will fail to validate.
+        AuthorizationResponseIssParameterSupported *bool `json:"authorization_response_iss_parameter_supported,omitempty"`
+
         // CacheMaxAge controls the Cache-Control max-age in seconds.
         // Defaults to 3600 (1 hour). Not serialized to JSON.
         CacheMaxAge int `json:"-"`
 }
 
-// NewASMetadataHandler returns an http.Handler that serves Authorization Server
-// metadata JSON at GET /.well-known/openid-configuration.
+// NewASMetadataHandler returns an http.Handler that serves Authorization
+// Server metadata JSON. The handler is path-agnostic — register it at
+// whichever well-known path you need, or use MountASMetadata to register
+// at both required paths at once.
 //
 // The handler:
 //   - Responds to GET only (405 for other methods)
@@ -1033,9 +1863,32 @@ func NewASMetadataHandler(meta *ASServerMetadata) http.Handler <span class="cov8
                 w.Write(body)</span>
         })
 }
+
+// MountASMetadata registers AS metadata at both well-known paths required
+// by the OAuth/OIDC ecosystem:
+//
+//   - /.well-known/oauth-authorization-server (RFC 8414 §3, MUST)
+//   - /.well-known/openid-configuration       (OIDC Discovery 1.0 §4)
+//
+// Both paths serve the same handler, so the documents are byte-identical.
+// OAuth-only clients (which know about RFC 8414 but not OIDC Discovery)
+// and OIDC clients (which look up openid-configuration) can both
+// auto-discover the AS without falling back.
+//
+// Callers that want only one path can register NewASMetadataHandler
+// directly. This helper is the recommended default.
+//
+// See:
+//   - RFC 8414 §3 (https://www.rfc-editor.org/rfc/rfc8414#section-3)
+//   - OIDC Discovery 1.0 §4
+func MountASMetadata(mux *http.ServeMux, meta *ASServerMetadata) <span class="cov8" title="1">{
+        h := NewASMetadataHandler(meta)
+        mux.Handle("GET /.well-known/oauth-authorization-server", h)
+        mux.Handle("GET /.well-known/openid-configuration", h)
+}</span>
 </pre>
 		
-		<pre class="file" id="file5" style="display: none">package apiauth
+		<pre class="file" id="file7" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -1202,7 +2055,7 @@ func splitASOriginPath(rawURL string) (origin, path string) <span class="cov8" t
 }
 </pre>
 		
-		<pre class="file" id="file6" style="display: none">package apiauth
+		<pre class="file" id="file8" style="display: none">package apiauth
 
 import (
         "context"
@@ -1283,6 +2136,17 @@ type APIAuth struct {
         // When nil, client_credentials requests return unsupported_grant_type.
         ClientKeyStore keys.KeyLookup
 
+        // TrustedAssertionIssuers lists upstream IdPs whose JWT assertions
+        // the token endpoint will accept for the jwt-bearer grant
+        // (RFC 7523 §2.1) and the token-exchange grant with
+        // subject_token_type=urn:ietf:params:oauth:token-type:jwt
+        // (RFC 8693 §2.1.1). When empty, both grants return
+        // unsupported_grant_type.
+        //
+        // See JwtBearerGrantType, TokenExchangeGrantType, and
+        // TrustedAssertionIssuer for details.
+        TrustedAssertionIssuers []TrustedAssertionIssuer
+
         // Rate limiting (optional)
         RateLimiter core.RateLimiter
 
@@ -1320,6 +2184,14 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class=
                         Scope:        r.FormValue("scope"),
                         ClientID:     r.FormValue("client_id"),
                         ClientSecret: r.FormValue("client_secret"),
+                        // RFC 7523 §2.1 — jwt-bearer authorization grant
+                        Assertion: r.FormValue("assertion"),
+                        // RFC 8693 — token exchange
+                        SubjectToken:       r.FormValue("subject_token"),
+                        SubjectTokenType:   r.FormValue("subject_token_type"),
+                        RequestedTokenType: r.FormValue("requested_token_type"),
+                        Resource:           r.FormValue("resource"),
+                        Audience:           r.FormValue("audience"),
                 }
                 // RFC 9396 §6.1: authorization_details is a JSON-encoded string in form params
                 if adStr := r.FormValue("authorization_details"); adStr != "" </span><span class="cov8" title="1">{
@@ -1343,6 +2215,10 @@ func (a *APIAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) <span class=
                 a.handleRefreshTokenGrant(w, r, &amp;req)</span>
         case "client_credentials":<span class="cov8" title="1">
                 a.handleClientCredentialsGrant(w, r, &amp;req)</span>
+        case JwtBearerGrantType:<span class="cov8" title="1">
+                a.handleJwtBearerGrant(w, r, &amp;req)</span>
+        case TokenExchangeGrantType:<span class="cov8" title="1">
+                a.handleTokenExchangeGrant(w, r, &amp;req)</span>
         default:<span class="cov8" title="1">
                 a.errorResponse(w, "unsupported_grant_type", "Grant type not supported", http.StatusBadRequest)</span>
         }
@@ -1721,7 +2597,7 @@ func (a *APIAuth) CreateAccessToken(userID string, scopes []string, authzDetails
         <span class="cov8" title="1">if a.JWTIssuer != "" </span><span class="cov8" title="1">{
                 claims["iss"] = a.JWTIssuer
         }</span>
-        <span class="cov8" title="1">if a.JWTAudience != "" </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if a.JWTAudience != "" </span><span class="cov8" title="1">{
                 claims["aud"] = a.JWTAudience
         }</span>
 
@@ -2416,11 +3292,12 @@ func (m *APIMiddleware) getValidator() TokenValidator <span class="cov8" title="
 // validateJWT validates a JWT access token using the TokenValidator.
 func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes []string, authType string, customClaims map[string]any, err error) <span class="cov8" title="1">{
         if v := m.getValidator(); v != nil </span><span class="cov8" title="1">{
-                info, verr := v.ValidateToken(tokenString)
+                resp, verr := v.ValidateToken(context.Background(), &amp;ValidateTokenRequest{Token: tokenString})
                 if verr != nil </span><span class="cov8" title="1">{
                         return "", nil, "", nil, verr
                 }</span>
-                <span class="cov8" title="1">customClaims = info.CustomClaims
+                <span class="cov8" title="1">info := resp.Info
+                customClaims = info.CustomClaims
                 if customClaims == nil </span><span class="cov0" title="0">{
                         customClaims = make(map[string]any)
                 }</span>
@@ -2747,9 +3624,12 @@ func (m *APIMiddleware) RequireAuthorizationDetails(requiredTypes ...string) fun
 }
 </pre>
 		
-		<pre class="file" id="file7" style="display: none">package apiauth
+		<pre class="file" id="file9" style="display: none">package apiauth
 
 import (
+        "context"
+        "fmt"
+
         "github.com/panyam/oneauth/keys"
 )
 
@@ -2771,26 +3651,29 @@ func NewClientAuthenticator(kl keys.KeyLookup) ClientAuthenticator <span class="
 }</span>
 
 // AuthenticateClient verifies client_id + client_secret.
-func (a *clientAuthenticator) AuthenticateClient(clientID, clientSecret string) error <span class="cov8" title="1">{
-        if a.keyLookup == nil </span><span class="cov0" title="0">{
-                return errInvalidClient
+func (a *clientAuthenticator) AuthenticateClient(ctx context.Context, req *AuthenticateClientRequest) (*AuthenticateClientResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("AuthenticateClientRequest is required")
         }</span>
-        <span class="cov8" title="1">rec, err := a.keyLookup.GetKey(clientID)
+        <span class="cov8" title="1">if a.keyLookup == nil </span><span class="cov0" title="0">{
+                return nil, errInvalidClient
+        }</span>
+        <span class="cov8" title="1">rec, err := a.keyLookup.GetKey(req.ClientID)
         if err != nil || rec == nil </span><span class="cov8" title="1">{
-                return errInvalidClient
+                return nil, errInvalidClient
         }</span>
         <span class="cov8" title="1">storedKey, ok := rec.Key.([]byte)
         if !ok </span><span class="cov0" title="0">{
-                return errInvalidClient
+                return nil, errInvalidClient
         }</span>
-        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), clientSecret) </span><span class="cov8" title="1">{
-                return errInvalidClient
+        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), req.ClientSecret) </span><span class="cov8" title="1">{
+                return nil, errInvalidClient
         }</span>
-        <span class="cov8" title="1">return nil</span>
+        <span class="cov8" title="1">return &amp;AuthenticateClientResponse{}, nil</span>
 }
 </pre>
 		
-		<pre class="file" id="file8" style="display: none">package apiauth
+		<pre class="file" id="file10" style="display: none">package apiauth
 
 // Hooks provides lifecycle callbacks for OneAuth operations.
 // Grouped by concern — each implementation receives only its relevant group.
@@ -2905,10 +3788,12 @@ func (h *SecurityHooks) fireOnAlgorithmMismatch(expected, got string) <span clas
 }
 </pre>
 		
-		<pre class="file" id="file9" style="display: none">package apiauth
+		<pre class="file" id="file11" style="display: none">package apiauth
 
 import (
+        "context"
         "encoding/json"
+        "fmt"
         "net/http"
 
         "github.com/panyam/oneauth/keys"
@@ -2950,10 +3835,14 @@ type apiauthIntrospector struct {
         auth *APIAuth
 }
 
-func (ai *apiauthIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) <span class="cov8" title="1">{
+func (ai *apiauthIntrospector) Introspect(ctx context.Context, req *IntrospectRequest) (*IntrospectResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("IntrospectRequest is required")
+        }</span>
+        <span class="cov8" title="1">tokenString := req.Token
         userID, scopes, _, err := ai.auth.ValidateAccessTokenFull(tokenString)
         if err != nil </span><span class="cov8" title="1">{
-                return &amp;IntrospectionResult{Active: false}, nil
+                return &amp;IntrospectResponse{Result: &amp;IntrospectionResult{Active: false}}, nil
         }</span>
 
         <span class="cov8" title="1">rawClaims := parseRawJWTClaims(tokenString)
@@ -2989,7 +3878,7 @@ func (ai *apiauthIntrospector) Introspect(tokenString string) (*IntrospectionRes
                 }</span>
         }
 
-        <span class="cov8" title="1">return result, nil</span>
+        <span class="cov8" title="1">return &amp;IntrospectResponse{Result: result}, nil</span>
 }
 
 func joinScopes(scopes []string) string <span class="cov8" title="1">{
@@ -3017,7 +3906,10 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
                 http.Error(w, "Unauthorized", http.StatusUnauthorized)
                 return
         }</span>
-        <span class="cov8" title="1">if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if _, err := h.Authenticator.AuthenticateClient(r.Context(), &amp;AuthenticateClientRequest{
+                ClientID:     clientID,
+                ClientSecret: clientSecret,
+        }); err != nil </span><span class="cov8" title="1">{
                 w.Header().Set("WWW-Authenticate", `Basic realm="introspection"`)
                 http.Error(w, "Unauthorized", http.StatusUnauthorized)
                 return
@@ -3035,15 +3927,16 @@ func (h *IntrospectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
         }</span>
 
         // Delegate to transport-independent introspector
-        <span class="cov8" title="1">result, err := h.Introspector.Introspect(token)
-        if err != nil || !result.Active </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">introspectResp, err := h.Introspector.Introspect(r.Context(), &amp;IntrospectRequest{Token: token})
+        if err != nil || introspectResp == nil || !introspectResp.Result.Active </span><span class="cov8" title="1">{
                 // RFC 7662: invalid tokens get {"active": false}, never an error
                 h.jsonResponse(w, http.StatusOK, map[string]any{"active": false})
                 return
         }</span>
+        <span class="cov8" title="1">result := introspectResp.Result
 
         // Build response from IntrospectionResult
-        <span class="cov8" title="1">resp := map[string]any{
+        resp := map[string]any{
                 "active":     true,
                 "sub":        result.Sub,
                 "token_type": result.TokenType,
@@ -3089,7 +3982,7 @@ func (h *IntrospectionHandler) jsonResponse(w http.ResponseWriter, status int, b
 }</span>
 </pre>
 		
-		<pre class="file" id="file10" style="display: none">package apiauth
+		<pre class="file" id="file12" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -3279,7 +4172,252 @@ func (v *IntrospectionValidator) putCached(token string, result *IntrospectionRe
 }
 </pre>
 		
-		<pre class="file" id="file11" style="display: none">package apiauth
+		<pre class="file" id="file13" style="display: none">package apiauth
+
+import (
+        "crypto"
+        "errors"
+        "fmt"
+        "log"
+        "net/http"
+
+        "github.com/golang-jwt/jwt/v5"
+        "github.com/panyam/oneauth/core"
+)
+
+// JwtBearerGrantType is the OAuth grant type URI for the
+// JWT Bearer authorization grant defined in RFC 7523 §2.1.
+//
+// A client trades a signed JWT (typically issued by an upstream IdP
+// about a subject) for an access token. The assertion's `iss` MUST
+// match a trusted issuer in TrustedAssertionIssuers; the JWT signature
+// MUST verify against that issuer's public key; standard claims
+// (aud/exp/nbf/sub) MUST validate.
+//
+// Distinct from RFC 7523 §2.2 (JWT for *client* authentication via
+// client_assertion + client_assertion_type at the token endpoint),
+// which is tracked separately as the `private_key_jwt` /
+// `client_secret_jwt` token endpoint auth methods.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7523#section-2.1
+const JwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+// TrustedAssertionIssuer describes an upstream IdP whose JWT
+// assertions the AS will accept for the jwt-bearer grant
+// (RFC 7523 §2.1) and the token-exchange grant with
+// subject_token_type=urn:ietf:params:oauth:token-type:jwt
+// (RFC 8693 §2.1.1).
+//
+// At least one of PublicKey or KeyFunc must be set so signatures can
+// be verified. KeyFunc takes precedence when both are set; it lets
+// callers resolve keys from a JWKS by `kid` header.
+//
+// The Issuer field is matched verbatim against the JWT's `iss` claim
+// (case-sensitive, no trailing-slash normalization — match what the
+// upstream IdP actually emits).
+type TrustedAssertionIssuer struct {
+        // Issuer is the expected `iss` claim value (e.g.,
+        // "https://corp-idp.example.com"). REQUIRED.
+        Issuer string
+
+        // PublicKey is a static public key for signature verification.
+        // Either this or KeyFunc MUST be set. Suitable for tests and
+        // single-key issuers; for production with key rotation use KeyFunc.
+        PublicKey crypto.PublicKey
+
+        // KeyFunc resolves a public key from the JWT header (typically
+        // looking up `kid` against a cached JWKS). When set it takes
+        // precedence over PublicKey. The token argument is the parsed
+        // (but not yet signature-verified) JWT.
+        KeyFunc func(token *jwt.Token) (crypto.PublicKey, error)
+
+        // Audiences lists acceptable `aud` claim values for assertions
+        // signed by this issuer. When empty, defaults to the AS's
+        // JWTAudience (or its IssuerURL if no audience is configured).
+        // RFC 7523 §3 requires the AS to identify itself by the audience
+        // claim — the default makes the token endpoint URL implicit.
+        Audiences []string
+
+        // AcceptedAlgorithms restricts the JWT alg values accepted for
+        // assertions from this issuer (e.g., {"RS256", "ES256"}). Empty
+        // = accept any non-`none` algorithm advertised by the JWT library.
+        // Set this in production to lock out alg-confusion attacks.
+        AcceptedAlgorithms []string
+}
+
+// findIssuer returns the TrustedAssertionIssuer matching `iss`, or nil.
+func findIssuer(issuers []TrustedAssertionIssuer, iss string) *TrustedAssertionIssuer <span class="cov8" title="1">{
+        for i := range issuers </span><span class="cov8" title="1">{
+                if issuers[i].Issuer == iss </span><span class="cov8" title="1">{
+                        return &amp;issuers[i]
+                }</span>
+        }
+        <span class="cov8" title="1">return nil</span>
+}
+
+// validateAssertion parses + signature-validates a JWT assertion
+// against the configured trusted issuers, then validates the
+// standard registered claims (aud, exp, nbf). Returns the validated
+// claims on success.
+//
+// Per RFC 7523 §3:
+//   - `iss` MUST match a configured trusted issuer.
+//   - Signature MUST verify using a key supplied by that issuer.
+//   - `aud` MUST contain a value identifying the AS (its token
+//     endpoint URL, issuer URL, or configured audience).
+//   - `exp` MUST be in the future; `nbf` (if present) in the past.
+//   - `sub` is required and identifies the principal the assertion
+//     speaks for.
+//
+// Errors returned here use OAuth 2.0 error codes by convention; callers
+// (the grant handlers) translate them to invalid_grant /
+// invalid_request HTTP responses.
+func validateAssertion(
+        a *APIAuth,
+        rawAssertion string,
+) (jwt.MapClaims, *TrustedAssertionIssuer, error) <span class="cov8" title="1">{
+        if rawAssertion == "" </span><span class="cov0" title="0">{
+                return nil, nil, errors.New("assertion required")
+        }</span>
+        <span class="cov8" title="1">if len(a.TrustedAssertionIssuers) == 0 </span><span class="cov0" title="0">{
+                return nil, nil, errors.New("no trusted assertion issuers configured")
+        }</span>
+
+        // First parse without verification so we can pick the issuer.
+        <span class="cov8" title="1">parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+        unverified, _, err := parser.ParseUnverified(rawAssertion, jwt.MapClaims{})
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, nil, fmt.Errorf("malformed assertion: %w", err)
+        }</span>
+        <span class="cov8" title="1">claims, ok := unverified.Claims.(jwt.MapClaims)
+        if !ok </span><span class="cov0" title="0">{
+                return nil, nil, errors.New("assertion claims unparseable")
+        }</span>
+        <span class="cov8" title="1">issStr, _ := claims["iss"].(string)
+        if issStr == "" </span><span class="cov0" title="0">{
+                return nil, nil, errors.New("assertion missing iss claim")
+        }</span>
+        <span class="cov8" title="1">issuer := findIssuer(a.TrustedAssertionIssuers, issStr)
+        if issuer == nil </span><span class="cov8" title="1">{
+                return nil, nil, fmt.Errorf("untrusted assertion issuer: %s", issStr)
+        }</span>
+
+        // Build the JWT key resolver. KeyFunc wins over PublicKey.
+        <span class="cov8" title="1">keyResolver := issuer.KeyFunc
+        if keyResolver == nil </span><span class="cov8" title="1">{
+                if issuer.PublicKey == nil </span><span class="cov0" title="0">{
+                        return nil, nil, fmt.Errorf("issuer %q has no PublicKey or KeyFunc", issStr)
+                }</span>
+                <span class="cov8" title="1">pubKey := issuer.PublicKey
+                keyResolver = func(*jwt.Token) (crypto.PublicKey, error) </span><span class="cov8" title="1">{
+                        return pubKey, nil
+                }</span>
+        }
+
+        <span class="cov8" title="1">parserOpts := []jwt.ParserOption{}
+        if len(issuer.AcceptedAlgorithms) &gt; 0 </span><span class="cov8" title="1">{
+                parserOpts = append(parserOpts, jwt.WithValidMethods(issuer.AcceptedAlgorithms))
+        }</span>
+        <span class="cov8" title="1">verifyParser := jwt.NewParser(parserOpts...)
+        verified, err := verifyParser.Parse(rawAssertion, func(t *jwt.Token) (interface{}, error) </span><span class="cov8" title="1">{
+                return keyResolver(t)
+        }</span>)
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
+                return nil, nil, fmt.Errorf("assertion signature/claims invalid: %w", err)
+        }</span>
+        <span class="cov8" title="1">if !verified.Valid </span><span class="cov0" title="0">{
+                return nil, nil, errors.New("assertion not valid (signature, exp or nbf)")
+        }</span>
+        <span class="cov8" title="1">verifiedClaims, ok := verified.Claims.(jwt.MapClaims)
+        if !ok </span><span class="cov0" title="0">{
+                return nil, nil, errors.New("verified claims unparseable")
+        }</span>
+
+        // aud validation. Per RFC 7523 §3 the assertion MUST have an aud
+        // the AS recognizes. Default to JWTAudience or Issuer URL.
+        <span class="cov8" title="1">expectedAudiences := issuer.Audiences
+        if len(expectedAudiences) == 0 </span><span class="cov0" title="0">{
+                if a.JWTAudience != "" </span><span class="cov0" title="0">{
+                        expectedAudiences = []string{a.JWTAudience}
+                }</span> else<span class="cov0" title="0"> if a.JWTIssuer != "" </span><span class="cov0" title="0">{
+                        expectedAudiences = []string{a.JWTIssuer}
+                }</span>
+        }
+        <span class="cov8" title="1">if len(expectedAudiences) == 0 </span><span class="cov0" title="0">{
+                // Server isn't configured strongly enough to enforce; accept
+                // any aud but log loudly so this isn't silent in production.
+                log.Printf("apiauth: jwt-bearer/token-exchange — no audience configured for issuer %q; accepting any aud claim. Set TrustedAssertionIssuer.Audiences or APIAuth.JWTAudience for production.", issStr)
+        }</span> else<span class="cov8" title="1"> {
+                matched := false
+                for _, aud := range expectedAudiences </span><span class="cov8" title="1">{
+                        if matchesAudience(verifiedClaims, aud) </span><span class="cov8" title="1">{
+                                matched = true
+                                break</span>
+                        }
+                }
+                <span class="cov8" title="1">if !matched </span><span class="cov8" title="1">{
+                        return nil, nil, fmt.Errorf("assertion audience does not match expected: %v", expectedAudiences)
+                }</span>
+        }
+
+        // sub MUST be present per RFC 7523 §3. Other registered claims
+        // (exp, nbf) are validated by jwt.Parse above.
+        <span class="cov8" title="1">if sub, _ := verifiedClaims["sub"].(string); sub == "" </span><span class="cov8" title="1">{
+                return nil, nil, errors.New("assertion missing sub claim")
+        }</span>
+
+        <span class="cov8" title="1">return verifiedClaims, issuer, nil</span>
+}
+
+// handleJwtBearerGrant handles RFC 7523 §2.1 — the client presents a
+// signed JWT (in the `assertion` param) issued by a trusted upstream
+// IdP and trades it for an access token at our token endpoint.
+//
+// The assertion's `sub` becomes the access token's subject. Scope is
+// taken from the request's `scope` parameter (intersected with what
+// the AS would normally grant); RFC 7523 doesn't define how scopes
+// are determined — that's deployment-specific.
+func (a *APIAuth) handleJwtBearerGrant(w http.ResponseWriter, r *http.Request, req *core.TokenRequest) <span class="cov8" title="1">{
+        if len(a.TrustedAssertionIssuers) == 0 </span><span class="cov8" title="1">{
+                a.errorResponse(w, "unsupported_grant_type", "jwt-bearer grant not configured", http.StatusBadRequest)
+                return
+        }</span>
+        <span class="cov8" title="1">if req.Assertion == "" </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_request", "assertion parameter required", http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">claims, _, err := validateAssertion(a, req.Assertion)
+        if err != nil </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">subject, _ := claims["sub"].(string) // already validated non-empty
+        scopes := core.ParseScopes(req.Scope)
+
+        // Validate authorization_details if present (RFC 9396).
+        if err := core.ValidateAll(req.AuthorizationDetails); err != nil </span><span class="cov0" title="0">{
+                a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(subject, scopes, req.AuthorizationDetails)
+        if err != nil </span><span class="cov0" title="0">{
+                log.Printf("Error creating access token (jwt-bearer grant): %v", err)
+                a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
+                return
+        }</span>
+
+        // No refresh token for jwt-bearer per RFC 7523 — the assertion
+        // itself is the renewable credential (re-issued by the upstream
+        // IdP and re-presented). Returning a refresh token would muddle
+        // session semantics.
+        <span class="cov8" title="1">a.tokenResponse(w, accessToken, expiresIn, "", scopes, req.AuthorizationDetails)</span>
+}
+</pre>
+		
+		<pre class="file" id="file14" style="display: none">package apiauth
 
 import (
         "time"
@@ -3437,7 +4575,7 @@ func (oa *OneAuth) HTTPMiddleware() *APIMiddleware <span class="cov8" title="1">
 }</span>
 </pre>
 		
-		<pre class="file" id="file12" style="display: none">package apiauth
+		<pre class="file" id="file15" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -3584,7 +4722,7 @@ func NewProtectedResourceHandler(meta *ProtectedResourceMetadata) http.Handler <
 }
 </pre>
 		
-		<pre class="file" id="file13" style="display: none">package apiauth
+		<pre class="file" id="file16" style="display: none">package apiauth
 
 import (
         "encoding/json"
@@ -3644,7 +4782,10 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <s
                 h.errorResponse(w, "invalid_client", "Authentication required", http.StatusUnauthorized)
                 return
         }</span>
-        <span class="cov8" title="1">if err := h.Authenticator.AuthenticateClient(clientID, clientSecret); err != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if _, err := h.Authenticator.AuthenticateClient(r.Context(), &amp;AuthenticateClientRequest{
+                ClientID:     clientID,
+                ClientSecret: clientSecret,
+        }); err != nil </span><span class="cov8" title="1">{
                 w.Header().Set("WWW-Authenticate", `Basic realm="revocation"`)
                 h.errorResponse(w, "invalid_client", "Invalid client credentials", http.StatusUnauthorized)
                 return
@@ -3659,7 +4800,7 @@ func (h *RevocationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <s
         <span class="cov8" title="1">hint := r.FormValue("token_type_hint")
 
         // Delegate to transport-independent revoker
-        h.Revoker.Revoke(token, hint)
+        h.Revoker.Revoke(r.Context(), &amp;RevokeRequest{Token: token, TokenTypeHint: hint})
 
         // RFC 7009 §2.2: always 200 OK
         h.okResponse(w)</span>
@@ -3682,9 +4823,156 @@ func (h *RevocationHandler) errorResponse(w http.ResponseWriter, errCode, descri
 }</span>
 </pre>
 		
-		<pre class="file" id="file14" style="display: none">package apiauth
+		<pre class="file" id="file17" style="display: none">package apiauth
 
 import (
+        "encoding/json"
+        "log"
+        "net/http"
+
+        "github.com/panyam/oneauth/core"
+)
+
+// TokenExchangeGrantType is the OAuth grant type URI for OAuth 2.0
+// Token Exchange (RFC 8693 §2.1). A client presents a `subject_token`
+// representing the party on whose behalf the request is made and the
+// AS issues a new token (typically narrower in scope or audience).
+//
+// Common use case: enterprise-managed identity chains. A federated IdP
+// issues a JWT about an employee; the employee's MCP client trades that
+// JWT for an MCP-scoped access token via this grant.
+//
+// See: https://www.rfc-editor.org/rfc/rfc8693
+const TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+// RFC 8693 §3 token type URIs.
+const (
+        TokenTypeAccessToken  = "urn:ietf:params:oauth:token-type:access_token"
+        TokenTypeRefreshToken = "urn:ietf:params:oauth:token-type:refresh_token"
+        TokenTypeIDToken      = "urn:ietf:params:oauth:token-type:id_token"
+        TokenTypeJWT          = "urn:ietf:params:oauth:token-type:jwt"
+        TokenTypeSAML2        = "urn:ietf:params:oauth:token-type:saml2"
+)
+
+// handleTokenExchangeGrant handles RFC 8693 token exchange.
+//
+// Phase 1 implementation supports:
+//
+//   - subject_token_type = urn:ietf:params:oauth:token-type:jwt — the
+//     subject_token is parsed + validated as a JWT against the configured
+//     TrustedAssertionIssuers (reusing validateAssertion shared with the
+//     jwt-bearer grant from RFC 7523 §2.1).
+//   - requested_token_type = urn:ietf:params:oauth:token-type:access_token
+//     (default; if omitted) or unspecified. Other requested_token_type
+//     values return invalid_request — non-access-token issuance lands in
+//     a future commit.
+//
+// audience / resource params are accepted but currently advisory — the
+// issued access token still carries the AS's default JWTAudience claim.
+// Active audience binding (CreateAccessToken-with-target-audience) is
+// future work; the spec gap is logged so it surfaces in production.
+//
+// Response shape per RFC 8693 §2.2:
+//
+//        {
+//          "access_token":       "...",
+//          "issued_token_type":  "urn:ietf:params:oauth:token-type:access_token",
+//          "token_type":         "Bearer",
+//          "expires_in":         900,
+//          "scope":              "read write"
+//        }
+//
+// `issued_token_type` is REQUIRED in token-exchange responses (distinct
+// from the standard token-endpoint response shape used by other grants).
+func (a *APIAuth) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Request, req *core.TokenRequest) <span class="cov8" title="1">{
+        if len(a.TrustedAssertionIssuers) == 0 </span><span class="cov8" title="1">{
+                a.errorResponse(w, "unsupported_grant_type", "token-exchange grant not configured", http.StatusBadRequest)
+                return
+        }</span>
+        <span class="cov8" title="1">if req.SubjectToken == "" </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_request", "subject_token parameter required", http.StatusBadRequest)
+                return
+        }</span>
+        <span class="cov8" title="1">if req.SubjectTokenType == "" </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_request", "subject_token_type parameter required", http.StatusBadRequest)
+                return
+        }</span>
+
+        // Phase 1: only JWT subject tokens are validated. Other types return
+        // invalid_request — extending to id_token / refresh_token / SAML
+        // requires per-type validators.
+        <span class="cov8" title="1">if req.SubjectTokenType != TokenTypeJWT </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_request",
+                        "only subject_token_type="+TokenTypeJWT+" is supported",
+                        http.StatusBadRequest)
+                return
+        }</span>
+
+        // Phase 1: only access_token output. Default when omitted.
+        <span class="cov8" title="1">requestedType := req.RequestedTokenType
+        if requestedType == "" </span><span class="cov8" title="1">{
+                requestedType = TokenTypeAccessToken
+        }</span>
+        <span class="cov8" title="1">if requestedType != TokenTypeAccessToken </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_request",
+                        "only requested_token_type="+TokenTypeAccessToken+" is supported",
+                        http.StatusBadRequest)
+                return
+        }</span>
+
+        // Reuse the assertion validator from RFC 7523 — same iss/sig/aud/exp/sub
+        // validation rules apply to the token-exchange subject_token when it's
+        // a JWT (RFC 8693 §2.1.1 + RFC 7523 §3).
+        <span class="cov8" title="1">claims, _, err := validateAssertion(a, req.SubjectToken)
+        if err != nil </span><span class="cov8" title="1">{
+                a.errorResponse(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">subject, _ := claims["sub"].(string)
+        scopes := core.ParseScopes(req.Scope)
+
+        // audience / resource are advisory in this implementation. Log when
+        // they're set so production deployments notice the gap.
+        if req.Audience != "" || req.Resource != "" </span><span class="cov8" title="1">{
+                log.Printf("apiauth: token-exchange — audience=%q resource=%q params accepted but advisory; issued token uses default JWTAudience. Bind these into CreateAccessToken when audience-targeting lands.", req.Audience, req.Resource)
+        }</span>
+
+        <span class="cov8" title="1">if err := core.ValidateAll(req.AuthorizationDetails); err != nil </span><span class="cov0" title="0">{
+                a.errorResponse(w, "invalid_authorization_details", err.Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">accessToken, expiresIn, err := a.CreateAccessToken(subject, scopes, req.AuthorizationDetails)
+        if err != nil </span><span class="cov0" title="0">{
+                log.Printf("Error creating access token (token-exchange grant): %v", err)
+                a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
+                return
+        }</span>
+
+        // Token-exchange has its own response shape — the standard
+        // tokenResponse helper omits issued_token_type, which RFC 8693 §2.2
+        // REQUIRES. Encode the response inline.
+        <span class="cov8" title="1">resp := core.TokenPair{
+                AccessToken:          accessToken,
+                TokenType:            "Bearer",
+                ExpiresIn:            expiresIn,
+                Scope:                core.JoinScopes(scopes),
+                AuthorizationDetails: req.AuthorizationDetails,
+                IssuedTokenType:      requestedType,
+        }
+        w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("Cache-Control", "no-store")
+        w.Header().Set("Pragma", "no-cache")
+        json.NewEncoder(w).Encode(resp)</span>
+}
+</pre>
+		
+		<pre class="file" id="file18" style="display: none">package apiauth
+
+import (
+        "context"
+        "fmt"
         "strings"
 
         "github.com/golang-jwt/jwt/v5"
@@ -3703,16 +4991,21 @@ func NewTokenIntrospector(v TokenValidator) TokenIntrospector <span class="cov8"
 
 // Introspect checks a token and returns the result per RFC 7662.
 // Returns {Active: false} for any invalid token — never reveals why.
-func (ti *tokenIntrospector) Introspect(tokenString string) (*IntrospectionResult, error) <span class="cov8" title="1">{
-        info, err := ti.validator.ValidateToken(tokenString)
-        if err != nil </span><span class="cov8" title="1">{
-                return &amp;IntrospectionResult{Active: false}, nil
+func (ti *tokenIntrospector) Introspect(ctx context.Context, req *IntrospectRequest) (*IntrospectResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("IntrospectRequest is required")
         }</span>
+        <span class="cov8" title="1">tokenString := req.Token
+        resp, err := ti.validator.ValidateToken(ctx, &amp;ValidateTokenRequest{Token: tokenString})
+        if err != nil </span><span class="cov8" title="1">{
+                return &amp;IntrospectResponse{Result: &amp;IntrospectionResult{Active: false}}, nil
+        }</span>
+        <span class="cov8" title="1">info := resp.Info
 
         // Parse raw claims for the full introspection response
         // (ValidateToken strips standard claims from custom, but introspection
         // needs them all)
-        <span class="cov8" title="1">rawClaims := parseRawJWTClaims(tokenString)
+        rawClaims := parseRawJWTClaims(tokenString)
 
         result := &amp;IntrospectionResult{
                 Active:    true,
@@ -3747,7 +5040,7 @@ func (ti *tokenIntrospector) Introspect(tokenString string) (*IntrospectionResul
                 }</span>
         }
 
-        <span class="cov8" title="1">return result, nil</span>
+        <span class="cov8" title="1">return &amp;IntrospectResponse{Result: result}, nil</span>
 }
 
 // parseRawJWTClaims extracts all claims from a JWT without validation.
@@ -3765,9 +5058,11 @@ func parseRawJWTClaims(tokenStr string) map[string]any <span class="cov8" title=
 }
 </pre>
 		
-		<pre class="file" id="file15" style="display: none">package apiauth
+		<pre class="file" id="file19" style="display: none">package apiauth
 
 import (
+        "context"
+        "fmt"
         "time"
 
         "github.com/golang-jwt/jwt/v5"
@@ -3801,21 +5096,24 @@ func NewTokenRevoker(cfg TokenRevokerConfig) TokenRevoker <span class="cov8" tit
 
 // Revoke invalidates a token. Tries refresh token first if no hint or
 // hint is "refresh_token", then tries access token blacklisting.
-func (r *tokenRevoker) Revoke(token, tokenTypeHint string) error <span class="cov8" title="1">{
-        switch tokenTypeHint </span>{
+func (r *tokenRevoker) Revoke(ctx context.Context, req *RevokeRequest) (*RevokeResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("RevokeRequest is required")
+        }</span>
+        <span class="cov8" title="1">switch req.TokenTypeHint </span>{
         case "refresh_token":<span class="cov8" title="1">
-                r.revokeRefreshToken(token)</span>
+                r.revokeRefreshToken(req.Token)</span>
         case "access_token":<span class="cov8" title="1">
-                r.revokeAccessToken(token)</span>
+                r.revokeAccessToken(req.Token)</span>
         default:<span class="cov8" title="1">
                 // No hint — try refresh first (cheaper lookup), then access
-                if !r.revokeRefreshToken(token) </span><span class="cov8" title="1">{
-                        r.revokeAccessToken(token)
+                if !r.revokeRefreshToken(req.Token) </span><span class="cov8" title="1">{
+                        r.revokeAccessToken(req.Token)
                 }</span>
         }
 
-        <span class="cov8" title="1">r.hooks.fireOnRevoked(token, tokenTypeHint)
-        return nil</span>
+        <span class="cov8" title="1">r.hooks.fireOnRevoked(req.Token, req.TokenTypeHint)
+        return &amp;RevokeResponse{}, nil</span>
 }
 
 // revokeRefreshToken attempts to revoke a refresh token. Returns true if
@@ -3865,9 +5163,10 @@ func (r *tokenRevoker) revokeAccessToken(token string) <span class="cov8" title=
 }
 </pre>
 		
-		<pre class="file" id="file16" style="display: none">package apiauth
+		<pre class="file" id="file20" style="display: none">package apiauth
 
 import (
+        "context"
         "fmt"
         "strings"
         "time"
@@ -3909,8 +5208,14 @@ func NewJWTValidator(cfg JWTValidatorConfig) TokenValidator <span class="cov8" t
         }
 }</span>
 
-// ValidateToken parses and validates a JWT, returning the extracted claims.
-func (v *jwtValidator) ValidateToken(tokenString string) (*TokenInfo, error) <span class="cov8" title="1">{
+// ValidateToken parses and validates a JWT, returning the extracted claims
+// wrapped in a ValidateTokenResponse per the (ctx, *Req) → (*Resp, error)
+// convention adopted in 175.
+func (v *jwtValidator) ValidateToken(ctx context.Context, req *ValidateTokenRequest) (*ValidateTokenResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("ValidateTokenRequest is required")
+        }</span>
+        <span class="cov8" title="1">tokenString := req.Token
         token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) </span><span class="cov8" title="1">{
                 return v.resolveKey(token)
         }</span>)
@@ -3992,44 +5297,51 @@ func (v *jwtValidator) ValidateToken(tokenString string) (*TokenInfo, error) <sp
                 }
         }
 
-        <span class="cov8" title="1">return &amp;TokenInfo{
+        <span class="cov8" title="1">return &amp;ValidateTokenResponse{Info: &amp;TokenInfo{
                 UserID:               userID,
                 Scopes:               scopes,
                 AuthorizationDetails: authzDetails,
                 CustomClaims:         customClaims,
                 AuthType:             "jwt",
-        }, nil</span>
+        }}, nil</span>
 }
 
 // CheckScopes validates a token and verifies it contains all required scopes.
-func (v *jwtValidator) CheckScopes(token string, required []string) error <span class="cov8" title="1">{
-        info, err := v.ValidateToken(token)
+func (v *jwtValidator) CheckScopes(ctx context.Context, req *CheckScopesRequest) (*CheckScopesResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("CheckScopesRequest is required")
+        }</span>
+        <span class="cov8" title="1">resp, err := v.ValidateToken(ctx, &amp;ValidateTokenRequest{Token: req.Token})
         if err != nil </span><span class="cov0" title="0">{
-                return err
+                return nil, err
         }</span>
-        <span class="cov8" title="1">if !core.ContainsAllScopes(info.Scopes, required) </span><span class="cov8" title="1">{
-                return fmt.Errorf("insufficient scope: requires %v, has %v", required, info.Scopes)
+        <span class="cov8" title="1">if !core.ContainsAllScopes(resp.Info.Scopes, req.RequiredScopes) </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("insufficient scope: requires %v, has %v", req.RequiredScopes, resp.Info.Scopes)
         }</span>
-        <span class="cov8" title="1">return nil</span>
+        <span class="cov8" title="1">return &amp;CheckScopesResponse{}, nil</span>
 }
 
 // CheckAuthorizationDetails validates a token and verifies it contains
 // authorization_details entries for all required types.
-func (v *jwtValidator) CheckAuthorizationDetails(token string, requiredTypes []string) error <span class="cov8" title="1">{
-        info, err := v.ValidateToken(token)
-        if err != nil </span><span class="cov0" title="0">{
-                return err
+func (v *jwtValidator) CheckAuthorizationDetails(ctx context.Context, req *CheckAuthorizationDetailsRequest) (*CheckAuthorizationDetailsResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("CheckAuthorizationDetailsRequest is required")
         }</span>
-        <span class="cov8" title="1">grantedTypes := make(map[string]bool)
+        <span class="cov8" title="1">resp, err := v.ValidateToken(ctx, &amp;ValidateTokenRequest{Token: req.Token})
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+        <span class="cov8" title="1">info := resp.Info
+        grantedTypes := make(map[string]bool)
         for _, ad := range info.AuthorizationDetails </span><span class="cov8" title="1">{
                 grantedTypes[ad.Type] = true
         }</span>
-        <span class="cov8" title="1">for _, reqType := range requiredTypes </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">for _, reqType := range req.RequiredTypes </span><span class="cov8" title="1">{
                 if !grantedTypes[reqType] </span><span class="cov8" title="1">{
-                        return fmt.Errorf("missing required authorization_details type: %s", reqType)
+                        return nil, fmt.Errorf("missing required authorization_details type: %s", reqType)
                 }</span>
         }
-        <span class="cov8" title="1">return nil</span>
+        <span class="cov8" title="1">return &amp;CheckAuthorizationDetailsResponse{}, nil</span>
 }
 
 // resolveKey finds the appropriate signing key for a JWT token.
@@ -4123,14 +5435,20 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer <span class="cov8" title="1">
         }</span>
 }
 
-// CreateAccessToken mints a signed JWT.
-func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details []core.AuthorizationDetail) (string, int64, error) <span class="cov8" title="1">{
+// CreateAccessToken mints a signed JWT. Convention shape per 175.
+func (i *jwtIssuer) CreateAccessToken(ctx context.Context, req *CreateAccessTokenRequest) (*CreateAccessTokenResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("CreateAccessTokenRequest is required")
+        }</span>
+        <span class="cov8" title="1">subject := req.Subject
+        scopes := req.Scopes
+        details := req.AuthorizationDetails
         now := time.Now()
         expiresAt := now.Add(i.accessExpiry)
 
         jti, err := core.GenerateSecureToken()
         if err != nil </span><span class="cov0" title="0">{
-                return "", 0, fmt.Errorf("failed to generate jti: %w", err)
+                return nil, fmt.Errorf("failed to generate jti: %w", err)
         }</span>
 
         <span class="cov8" title="1">claims := jwt.MapClaims{
@@ -4157,7 +5475,7 @@ func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details [
                 if _, ok := i.signingKey.([]byte); ok </span><span class="cov0" title="0">{
                         signingMethod = jwt.SigningMethodHS256
                 }</span> else<span class="cov0" title="0"> {
-                        return "", 0, fmt.Errorf("invalid signing algorithm: %w", err)
+                        return nil, fmt.Errorf("invalid signing algorithm: %w", err)
                 }</span>
         }
 
@@ -4168,21 +5486,24 @@ func (i *jwtIssuer) CreateAccessToken(subject string, scopes []string, details [
 
         <span class="cov8" title="1">tokenString, err := token.SignedString(i.signingKey)
         if err != nil </span><span class="cov0" title="0">{
-                return "", 0, fmt.Errorf("failed to sign token: %w", err)
+                return nil, fmt.Errorf("failed to sign token: %w", err)
         }</span>
 
         <span class="cov8" title="1">i.hooks.fireOnIssued(subject, "direct")
-        return tokenString, int64(i.accessExpiry.Seconds()), nil</span>
+        return &amp;CreateAccessTokenResponse{Token: tokenString, ExpiresIn: int64(i.accessExpiry.Seconds())}, nil</span>
 }
 
 // ClientCredentials performs the client_credentials grant.
-func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []string, details []core.AuthorizationDetail) (*core.TokenPair, error) <span class="cov8" title="1">{
-        if i.clientKeyLookup == nil </span><span class="cov0" title="0">{
+func (i *jwtIssuer) ClientCredentials(ctx context.Context, req *ClientCredentialsRequest) (*ClientCredentialsResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("ClientCredentialsRequest is required")
+        }</span>
+        <span class="cov8" title="1">if i.clientKeyLookup == nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("client_credentials not configured")
         }</span>
 
         // Authenticate client
-        <span class="cov8" title="1">rec, err := i.clientKeyLookup.GetKey(clientID)
+        <span class="cov8" title="1">rec, err := i.clientKeyLookup.GetKey(req.ClientID)
         if err != nil || rec == nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("invalid_client: unknown client")
         }</span>
@@ -4190,43 +5511,49 @@ func (i *jwtIssuer) ClientCredentials(clientID, clientSecret string, scopes []st
         if !ok </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("invalid_client: client does not support secret authentication")
         }</span>
-        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), clientSecret) </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if !constantTimeEqual(string(storedKey), req.ClientSecret) </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid_client: invalid credentials")
         }</span>
 
         // Validate authorization_details
-        <span class="cov8" title="1">if err := core.ValidateAll(details); err != nil </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if err := core.ValidateAll(req.AuthorizationDetails); err != nil </span><span class="cov0" title="0">{
                 return nil, err
         }</span>
 
         // Create token
-        <span class="cov8" title="1">tokenStr, expiresIn, err := i.CreateAccessToken(clientID, scopes, details)
+        <span class="cov8" title="1">tok, err := i.CreateAccessToken(ctx, &amp;CreateAccessTokenRequest{
+                Subject:              req.ClientID,
+                Scopes:               req.Scopes,
+                AuthorizationDetails: req.AuthorizationDetails,
+        })
         if err != nil </span><span class="cov0" title="0">{
                 return nil, err
         }</span>
 
-        <span class="cov8" title="1">i.hooks.fireOnIssued(clientID, "client_credentials")
+        <span class="cov8" title="1">i.hooks.fireOnIssued(req.ClientID, "client_credentials")
 
-        resp := &amp;core.TokenPair{
-                AccessToken:          tokenStr,
+        return &amp;ClientCredentialsResponse{Tokens: &amp;core.TokenPair{
+                AccessToken:          tok.Token,
                 TokenType:            "Bearer",
-                ExpiresIn:            expiresIn,
-                Scope:                strings.Join(scopes, " "),
-                AuthorizationDetails: details,
-        }
-        return resp, nil</span>
+                ExpiresIn:            tok.ExpiresIn,
+                Scope:                strings.Join(req.Scopes, " "),
+                AuthorizationDetails: req.AuthorizationDetails,
+        }}, nil</span>
 }
 
 // RefreshGrant rotates a refresh token and returns new access + refresh tokens.
 // Handles theft detection: if the old token was already revoked, revokes the
 // entire token family (all sessions from that initial login).
-func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) <span class="cov8" title="1">{
-        if i.refreshStore == nil </span><span class="cov0" title="0">{
+func (i *jwtIssuer) RefreshGrant(ctx context.Context, req *RefreshGrantRequest) (*RefreshGrantResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("RefreshGrantRequest is required")
+        }</span>
+        <span class="cov8" title="1">if i.refreshStore == nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("refresh_token grant not configured")
         }</span>
 
         // Get and validate the refresh token
-        <span class="cov8" title="1">rt, err := i.refreshStore.GetRefreshToken(refreshToken)
+        <span class="cov8" title="1">rt, err := i.refreshStore.GetRefreshToken(req.RefreshToken)
         if err != nil </span><span class="cov8" title="1">{
                 if err == core.ErrTokenNotFound </span><span class="cov8" title="1">{
                         return nil, fmt.Errorf("invalid_grant: invalid refresh token")
@@ -4244,7 +5571,7 @@ func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) <
         }</span>
 
         // Rotate: invalidate old, create new in same family
-        <span class="cov8" title="1">newRT, err := i.refreshStore.RotateRefreshToken(refreshToken)
+        <span class="cov8" title="1">newRT, err := i.refreshStore.RotateRefreshToken(req.RefreshToken)
         if err != nil </span><span class="cov0" title="0">{
                 if err == core.ErrTokenReused </span><span class="cov0" title="0">{
                         i.refreshStore.RevokeTokenFamily(rt.Family)
@@ -4254,28 +5581,35 @@ func (i *jwtIssuer) RefreshGrant(refreshToken string) (*core.TokenPair, error) <
         }
 
         // Create new access token (carry forward scopes + authorization_details)
-        <span class="cov8" title="1">tokenStr, expiresIn, err := i.CreateAccessToken(rt.UserID, rt.Scopes, rt.AuthorizationDetails)
+        <span class="cov8" title="1">tok, err := i.CreateAccessToken(ctx, &amp;CreateAccessTokenRequest{
+                Subject:              rt.UserID,
+                Scopes:               rt.Scopes,
+                AuthorizationDetails: rt.AuthorizationDetails,
+        })
         if err != nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("server_error: %w", err)
         }</span>
 
         <span class="cov8" title="1">i.hooks.fireOnIssued(rt.UserID, "refresh_token")
 
-        return &amp;core.TokenPair{
-                AccessToken:          tokenStr,
+        return &amp;RefreshGrantResponse{Tokens: &amp;core.TokenPair{
+                AccessToken:          tok.Token,
                 TokenType:            "Bearer",
-                ExpiresIn:            expiresIn,
+                ExpiresIn:            tok.ExpiresIn,
                 RefreshToken:         newRT.Token,
                 Scope:                strings.Join(rt.Scopes, " "),
                 AuthorizationDetails: rt.AuthorizationDetails,
-        }, nil</span>
+        }}, nil</span>
 }
 
 // PasswordGrant authenticates a user and returns an access token.
 // Does NOT create a refresh token — the caller handles that with
 // transport-specific metadata (device info, IP, etc.).
-func (i *jwtIssuer) PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResult, error) <span class="cov8" title="1">{
-        if i.validateCredentials == nil </span><span class="cov0" title="0">{
+func (i *jwtIssuer) PasswordGrant(ctx context.Context, req *PasswordGrantRequest) (*PasswordGrantResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("PasswordGrantRequest is required")
+        }</span>
+        <span class="cov8" title="1">if i.validateCredentials == nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("server_error: password grant not configured")
         }</span>
 
@@ -4309,24 +5643,290 @@ func (i *jwtIssuer) PasswordGrant(req PasswordGrantRequest) (*PasswordGrantResul
         }</span>
 
         // Create access token
-        <span class="cov8" title="1">tokenStr, expiresIn, err := i.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
+        <span class="cov8" title="1">tok, err := i.CreateAccessToken(ctx, &amp;CreateAccessTokenRequest{
+                Subject:              user.Id(),
+                Scopes:               grantedScopes,
+                AuthorizationDetails: req.AuthorizationDetails,
+        })
         if err != nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("server_error: %w", err)
         }</span>
 
         <span class="cov8" title="1">i.hooks.fireOnIssued(user.Id(), "password")
 
-        return &amp;PasswordGrantResult{
+        return &amp;PasswordGrantResponse{
                 UserID:               user.Id(),
-                AccessToken:          tokenStr,
-                ExpiresIn:            expiresIn,
+                AccessToken:          tok.Token,
+                ExpiresIn:            tok.ExpiresIn,
                 GrantedScopes:        grantedScopes,
                 AuthorizationDetails: req.AuthorizationDetails,
         }, nil</span>
 }
 </pre>
 		
-		<pre class="file" id="file17" style="display: none">package client
+		<pre class="file" id="file21" style="display: none">// Package appstoretest provides a shared contract test suite for all
+// AppRegistrationStore implementations. Each backend (inmem, fs, gorm)
+// calls these tests with its own factory function. Mirrors keystoretest.
+package appstoretest
+
+import (
+        "sort"
+        "testing"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+)
+
+// Factory creates a fresh AppRegistrationStore for each test.
+type Factory func(t *testing.T) admin.AppRegistrationStore
+
+// RunAll runs the complete AppRegistrationStore test suite against the provided factory.
+func RunAll(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        t.Run("SaveAndGet", func(t *testing.T) </span><span class="cov0" title="0">{ TestSaveAndGet(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("NotFound", func(t *testing.T) </span><span class="cov0" title="0">{ TestNotFound(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("DeleteApp", func(t *testing.T) </span><span class="cov0" title="0">{ TestDeleteApp(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("DeleteNonexistent", func(t *testing.T) </span><span class="cov0" title="0">{ TestDeleteNonexistent(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("OverwriteApp", func(t *testing.T) </span><span class="cov0" title="0">{ TestOverwriteApp(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("ListApps", func(t *testing.T) </span><span class="cov0" title="0">{ TestListApps(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("ListAppsEmpty", func(t *testing.T) </span><span class="cov0" title="0">{ TestListAppsEmpty(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("Persistence", func(t *testing.T) </span><span class="cov0" title="0">{ TestPersistence(t, factory) }</span>)
+        <span class="cov0" title="0">t.Run("AllFieldsRoundTrip", func(t *testing.T) </span><span class="cov0" title="0">{ TestAllFieldsRoundTrip(t, factory) }</span>)
+}
+
+// TestSaveAndGet verifies that SaveApp followed by GetApp returns the saved registration.
+func TestSaveAndGet(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        app := &amp;admin.AppRegistration{
+                ClientID:     "app_abc",
+                ClientDomain: "example.com",
+                SigningAlg:   "HS256",
+                CreatedAt:    time.Now().UTC().Truncate(time.Second),
+        }
+
+        if err := s.SaveApp(app); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("SaveApp failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">got, err := s.GetApp("app_abc")
+        if err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("GetApp failed: %v", err)
+        }</span>
+        <span class="cov0" title="0">if got.ClientID != "app_abc" </span><span class="cov0" title="0">{
+                t.Errorf("ClientID=%q, want app_abc", got.ClientID)
+        }</span>
+        <span class="cov0" title="0">if got.ClientDomain != "example.com" </span><span class="cov0" title="0">{
+                t.Errorf("ClientDomain=%q, want example.com", got.ClientDomain)
+        }</span>
+        <span class="cov0" title="0">if got.SigningAlg != "HS256" </span><span class="cov0" title="0">{
+                t.Errorf("SigningAlg=%q, want HS256", got.SigningAlg)
+        }</span>
+}
+
+// TestNotFound verifies that GetApp on a missing client_id returns ErrAppNotFound.
+func TestNotFound(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        _, err := s.GetApp("does-not-exist")
+        if err != admin.ErrAppNotFound </span><span class="cov0" title="0">{
+                t.Errorf("expected ErrAppNotFound, got %v", err)
+        }</span>
+}
+
+// TestDeleteApp verifies that DeleteApp removes the registration and subsequent
+// GetApp returns ErrAppNotFound.
+func TestDeleteApp(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        app := &amp;admin.AppRegistration{ClientID: "app_del", SigningAlg: "HS256", CreatedAt: time.Now()}
+        if err := s.SaveApp(app); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("SaveApp failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">if err := s.DeleteApp("app_del"); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("DeleteApp failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">if _, err := s.GetApp("app_del"); err != admin.ErrAppNotFound </span><span class="cov0" title="0">{
+                t.Errorf("expected ErrAppNotFound after delete, got %v", err)
+        }</span>
+}
+
+// TestDeleteNonexistent verifies that deleting a missing client_id returns ErrAppNotFound,
+// matching KeyStorage.DeleteKey semantics.
+func TestDeleteNonexistent(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        err := s.DeleteApp("never-existed")
+        if err != admin.ErrAppNotFound </span><span class="cov0" title="0">{
+                t.Errorf("expected ErrAppNotFound, got %v", err)
+        }</span>
+}
+
+// TestOverwriteApp verifies that SaveApp on an existing client_id replaces the
+// stored registration with the new metadata.
+func TestOverwriteApp(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        original := &amp;admin.AppRegistration{ClientID: "app_ow", ClientDomain: "old.example", SigningAlg: "HS256", CreatedAt: time.Now()}
+        updated := &amp;admin.AppRegistration{ClientID: "app_ow", ClientDomain: "new.example", SigningAlg: "RS256", CreatedAt: time.Now()}
+
+        if err := s.SaveApp(original); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("SaveApp original failed: %v", err)
+        }</span>
+        <span class="cov0" title="0">if err := s.SaveApp(updated); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("SaveApp updated failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">got, err := s.GetApp("app_ow")
+        if err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("GetApp failed: %v", err)
+        }</span>
+        <span class="cov0" title="0">if got.ClientDomain != "new.example" </span><span class="cov0" title="0">{
+                t.Errorf("ClientDomain=%q, want new.example (overwrite)", got.ClientDomain)
+        }</span>
+        <span class="cov0" title="0">if got.SigningAlg != "RS256" </span><span class="cov0" title="0">{
+                t.Errorf("SigningAlg=%q, want RS256 (overwrite)", got.SigningAlg)
+        }</span>
+}
+
+// TestListApps verifies that ListApps returns every saved registration.
+func TestListApps(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        for _, id := range []string{"app_alpha", "app_beta", "app_gamma"} </span><span class="cov0" title="0">{
+                if err := s.SaveApp(&amp;admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil </span><span class="cov0" title="0">{
+                        t.Fatalf("SaveApp %s failed: %v", id, err)
+                }</span>
+        }
+
+        <span class="cov0" title="0">apps, err := s.ListApps()
+        if err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("ListApps failed: %v", err)
+        }</span>
+        <span class="cov0" title="0">if len(apps) != 3 </span><span class="cov0" title="0">{
+                t.Fatalf("expected 3 apps, got %d", len(apps))
+        }</span>
+
+        <span class="cov0" title="0">gotIDs := make([]string, 0, len(apps))
+        for _, a := range apps </span><span class="cov0" title="0">{
+                gotIDs = append(gotIDs, a.ClientID)
+        }</span>
+        <span class="cov0" title="0">sort.Strings(gotIDs)
+        want := []string{"app_alpha", "app_beta", "app_gamma"}
+        for i, id := range want </span><span class="cov0" title="0">{
+                if gotIDs[i] != id </span><span class="cov0" title="0">{
+                        t.Errorf("apps[%d]=%s, want %s", i, gotIDs[i], id)
+                }</span>
+        }
+}
+
+// TestListAppsEmpty verifies that ListApps on a fresh store returns an empty slice
+// (not an error).
+func TestListAppsEmpty(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        apps, err := s.ListApps()
+        if err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("ListApps failed: %v", err)
+        }</span>
+        <span class="cov0" title="0">if len(apps) != 0 </span><span class="cov0" title="0">{
+                t.Errorf("expected 0 apps, got %d", len(apps))
+        }</span>
+}
+
+// TestPersistence verifies that a saved registration is visible to subsequent reads
+// from the same store handle. For persistent backends (FS, GORM) this catches
+// write-buffering bugs; for InMem it is trivially true.
+func TestPersistence(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        app := &amp;admin.AppRegistration{ClientID: "app_persist", ClientDomain: "p.example", SigningAlg: "HS256", CreatedAt: time.Now()}
+        if err := s.SaveApp(app); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("SaveApp failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">got, err := s.GetApp("app_persist")
+        if err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("GetApp after save failed: %v", err)
+        }</span>
+        <span class="cov0" title="0">if got.ClientDomain != "p.example" </span><span class="cov0" title="0">{
+                t.Errorf("ClientDomain=%q, want p.example", got.ClientDomain)
+        }</span>
+}
+
+// TestAllFieldsRoundTrip verifies that every field on AppRegistration survives a
+// SaveApp/GetApp round-trip. Catches backend serialization bugs (e.g., GORM
+// forgetting to JSON-encode slice fields).
+func TestAllFieldsRoundTrip(t *testing.T, factory Factory) <span class="cov0" title="0">{
+        s := factory(t)
+
+        created := time.Now().UTC().Truncate(time.Second)
+        app := &amp;admin.AppRegistration{
+                ClientID:                  "app_full",
+                ClientDomain:              "full.example",
+                SigningAlg:                "RS256",
+                MaxRooms:                  42,
+                MaxMsgRate:                3.14,
+                AuthorizationDetailsTypes: []string{"payment_initiation", "account_information"},
+                CreatedAt:                 created,
+                Revoked:                   false,
+                ClientName:                "Full App",
+                ClientURI:                 "https://full.example",
+                RedirectURIs:              []string{"https://full.example/cb", "http://localhost/cb"},
+                GrantTypes:                []string{"authorization_code", "refresh_token"},
+                Scope:                     "read write",
+                TokenEndpointAuthMethod:   "private_key_jwt",
+                RegistrationAccessToken:   "reg-tok-abc",
+                RegistrationClientURI:     "https://issuer.example/apps/dcr/app_full",
+        }
+
+        if err := s.SaveApp(app); err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("SaveApp failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">got, err := s.GetApp("app_full")
+        if err != nil </span><span class="cov0" title="0">{
+                t.Fatalf("GetApp failed: %v", err)
+        }</span>
+
+        <span class="cov0" title="0">if got.ClientName != "Full App" </span><span class="cov0" title="0">{
+                t.Errorf("ClientName=%q, want %q", got.ClientName, "Full App")
+        }</span>
+        <span class="cov0" title="0">if got.ClientURI != "https://full.example" </span><span class="cov0" title="0">{
+                t.Errorf("ClientURI=%q", got.ClientURI)
+        }</span>
+        <span class="cov0" title="0">if len(got.RedirectURIs) != 2 || got.RedirectURIs[0] != "https://full.example/cb" </span><span class="cov0" title="0">{
+                t.Errorf("RedirectURIs=%v", got.RedirectURIs)
+        }</span>
+        <span class="cov0" title="0">if len(got.GrantTypes) != 2 || got.GrantTypes[0] != "authorization_code" </span><span class="cov0" title="0">{
+                t.Errorf("GrantTypes=%v", got.GrantTypes)
+        }</span>
+        <span class="cov0" title="0">if got.Scope != "read write" </span><span class="cov0" title="0">{
+                t.Errorf("Scope=%q", got.Scope)
+        }</span>
+        <span class="cov0" title="0">if got.TokenEndpointAuthMethod != "private_key_jwt" </span><span class="cov0" title="0">{
+                t.Errorf("TokenEndpointAuthMethod=%q", got.TokenEndpointAuthMethod)
+        }</span>
+        <span class="cov0" title="0">if got.RegistrationAccessToken != "reg-tok-abc" </span><span class="cov0" title="0">{
+                t.Errorf("RegistrationAccessToken=%q", got.RegistrationAccessToken)
+        }</span>
+        <span class="cov0" title="0">if got.RegistrationClientURI != "https://issuer.example/apps/dcr/app_full" </span><span class="cov0" title="0">{
+                t.Errorf("RegistrationClientURI=%q", got.RegistrationClientURI)
+        }</span>
+        <span class="cov0" title="0">if len(got.AuthorizationDetailsTypes) != 2 || got.AuthorizationDetailsTypes[0] != "payment_initiation" </span><span class="cov0" title="0">{
+                t.Errorf("AuthorizationDetailsTypes=%v", got.AuthorizationDetailsTypes)
+        }</span>
+        <span class="cov0" title="0">if got.MaxRooms != 42 </span><span class="cov0" title="0">{
+                t.Errorf("MaxRooms=%d", got.MaxRooms)
+        }</span>
+        <span class="cov0" title="0">if got.MaxMsgRate != 3.14 </span><span class="cov0" title="0">{
+                t.Errorf("MaxMsgRate=%f", got.MaxMsgRate)
+        }</span>
+}
+</pre>
+		
+		<pre class="file" id="file22" style="display: none">package client
 
 import (
         "sync"
@@ -4426,7 +6026,7 @@ func (s *MemoryASMetadataStore) Put(issuer string, md *ASMetadata, ttl time.Dura
 var _ ASMetadataStore = (*MemoryASMetadataStore)(nil)
 </pre>
 		
-		<pre class="file" id="file18" style="display: none">package client
+		<pre class="file" id="file23" style="display: none">package client
 
 import "net/url"
 
@@ -4533,7 +6133,7 @@ func applyAuthToForm(method TokenEndpointAuthMethod, clientID, clientSecret stri
 }
 </pre>
 		
-		<pre class="file" id="file19" style="display: none">package client
+		<pre class="file" id="file24" style="display: none">package client
 
 import (
         "context"
@@ -4978,7 +6578,7 @@ func openBrowserDefault(url string) error <span class="cov0" title="0">{
 
 </pre>
 		
-		<pre class="file" id="file20" style="display: none">package client
+		<pre class="file" id="file25" style="display: none">package client
 
 import (
         "bytes"
@@ -5534,7 +7134,7 @@ func parseAuthzDetailsFromRaw(raw []any) []core.AuthorizationDetail <span class=
 }
 </pre>
 		
-		<pre class="file" id="file21" style="display: none">package client
+		<pre class="file" id="file26" style="display: none">package client
 
 import (
         "fmt"
@@ -5793,7 +7393,7 @@ func (s *ClientCredentialsSource) TokenForScopes(scopes []string) (string, error
 }</span>
 </pre>
 		
-		<pre class="file" id="file22" style="display: none">// Package client provides client-side authentication utilities for oneauth.
+		<pre class="file" id="file27" style="display: none">// Package client provides client-side authentication utilities for oneauth.
 // It includes credential storage, automatic token refresh, and HTTP client helpers.
 package client
 
@@ -5864,36 +7464,70 @@ func (noopCredentialStore) ListServers() ([]string, error)                  <spa
 func (noopCredentialStore) Save() error                                     <span class="cov8" title="1">{ return nil }</span>
 </pre>
 		
-		<pre class="file" id="file23" style="display: none">package client
+		<pre class="file" id="file28" style="display: none">package client
 
 import (
         "bytes"
+        "context"
         "encoding/json"
         "fmt"
         "io"
         "net/http"
 )
 
+// Method-shape convention (issue 169): every transport-agnostic SDK call
+// follows MethodName(ctx context.Context, req *XRequest) (*XResponse, error).
+// Two-arg / two-return signatures map cleanly to gRPC stub generation should
+// we ever need it. Helpers that only make HTTP calls (RegisterClient — the
+// pre-convention shape) are kept as-is for now; converting them lives under
+// issue 175.
+
 // ClientRegistrationRequest is the payload for RFC 7591 Dynamic Client
-// Registration. This represents a client requesting registration at an
-// authorization server's registration endpoint.
+// Registration and the RFC 7592 §2.2 update body. This represents a client
+// requesting registration (or replacing its registration) at an authorization
+// server's endpoint.
+//
+// On register the ClientID field is unused (the server assigns the value).
+// On update the ClientID MUST equal the client's existing identifier — the
+// server returns 400 otherwise. UpdateRegistration auto-fills it for callers.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-2
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
 type ClientRegistrationRequest struct {
+        ClientID                string   `json:"client_id,omitempty"`
         ClientName              string   `json:"client_name"`
+        ClientURI               string   `json:"client_uri,omitempty"`
         RedirectURIs            []string `json:"redirect_uris"`
         GrantTypes              []string `json:"grant_types,omitempty"`
         ResponseTypes           []string `json:"response_types,omitempty"`
         TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+        Scope                   string   `json:"scope,omitempty"`
 }
 
 // ClientRegistrationResponse is the parsed response from a DCR endpoint,
-// containing the assigned client_id and optional client_secret.
+// extended with the RFC 7592 §3 management credentials so callers can
+// subsequently use GetRegistration / UpdateRegistration / DeleteRegistration
+// against the issuer's management endpoint.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-3
 type ClientRegistrationResponse struct {
-        ClientID     string `json:"client_id"`
-        ClientSecret string `json:"client_secret,omitempty"`
+        ClientID                string   `json:"client_id"`
+        ClientSecret            string   `json:"client_secret,omitempty"`
+        ClientIDIssuedAt        int64    `json:"client_id_issued_at,omitempty"`
+        ClientSecretExpiresAt   int64    `json:"client_secret_expires_at,omitempty"`
+        ClientName              string   `json:"client_name,omitempty"`
+        ClientURI               string   `json:"client_uri,omitempty"`
+        RedirectURIs            []string `json:"redirect_uris,omitempty"`
+        GrantTypes              []string `json:"grant_types,omitempty"`
+        TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+        Scope                   string   `json:"scope,omitempty"`
+
+        // RFC 7592 §3 — management credentials. RegistrationClientURI is the
+        // management endpoint for this specific registration; RegistrationAccessToken
+        // is the Bearer token that authorizes calls against it.
+        RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+        RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 }
 
 // RegisterClient performs RFC 7591 Dynamic Client Registration against the
@@ -5937,9 +7571,263 @@ func RegisterClient(endpoint string, meta ClientRegistrationRequest, httpClient 
 
         <span class="cov8" title="1">return &amp;result, nil</span>
 }
+
+// ErrRegistrationUnauthorized is returned by GetRegistration (and, in #169 / #170,
+// UpdateRegistration / DeleteRegistration) when the authorization server rejects
+// the registration access token. Per RFC 7592 the server returns 401 for any
+// auth failure — wrong token, missing token, or unknown client_id — so callers
+// cannot use this error to distinguish those cases.
+var ErrRegistrationUnauthorized = fmt.Errorf("registration management: unauthorized")
+
+// GetRegistrationRequest is the input to GetRegistration.
+type GetRegistrationRequest struct {
+        // RegistrationClientURI is the management endpoint returned at
+        // registration time (RFC 7592 §3 registration_client_uri).
+        RegistrationClientURI string
+        // RegistrationAccessToken authorizes calls to RegistrationClientURI
+        // (RFC 7592 §3).
+        RegistrationAccessToken string
+        // HTTPClient is used to make the request. nil → http.DefaultClient.
+        // Conceptually this is a transport option (analog of gRPC CallOption);
+        // it lives on the request struct so the method retains a strict
+        // (ctx, req) → (resp, err) signature.
+        HTTPClient *http.Client
+}
+
+// GetRegistrationResponse wraps the parsed registration metadata. Wrapped
+// (rather than returning *ClientRegistrationResponse directly) for symmetry
+// with the server-side ClientRegistrationManager interface and so future
+// fields can be added without changing the method signature.
+type GetRegistrationResponse struct {
+        Registration *ClientRegistrationResponse
+}
+
+// GetRegistration performs an RFC 7592 §2.1 read of a previously-registered
+// client.
+//
+// The server is required to return 401 for any authentication failure; this
+// function maps that case to ErrRegistrationUnauthorized so callers can branch
+// on errors.Is. Other non-2xx responses surface as a generic error including
+// status code and body for diagnostics.
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.1
+func GetRegistration(ctx context.Context, req *GetRegistrationRequest) (*GetRegistrationResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("request is required")
+        }</span>
+        <span class="cov8" title="1">if req.RegistrationClientURI == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("registration_client_uri is required")
+        }</span>
+        <span class="cov8" title="1">if req.RegistrationAccessToken == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("registration_access_token is required")
+        }</span>
+        <span class="cov8" title="1">httpClient := req.HTTPClient
+        if httpClient == nil </span><span class="cov8" title="1">{
+                httpClient = http.DefaultClient
+        }</span>
+
+        <span class="cov8" title="1">httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.RegistrationClientURI, nil)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("build GetRegistration request: %w", err)
+        }</span>
+        <span class="cov8" title="1">httpReq.Header.Set("Authorization", "Bearer "+req.RegistrationAccessToken)
+        httpReq.Header.Set("Accept", "application/json")
+
+        resp, err := httpClient.Do(httpReq)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("GetRegistration GET: %w", err)
+        }</span>
+        <span class="cov8" title="1">defer resp.Body.Close()
+
+        body, err := io.ReadAll(resp.Body)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("read GetRegistration response: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if resp.StatusCode == http.StatusUnauthorized </span><span class="cov8" title="1">{
+                return nil, ErrRegistrationUnauthorized
+        }</span>
+        <span class="cov8" title="1">if resp.StatusCode != http.StatusOK </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("GetRegistration returned %d: %s", resp.StatusCode, string(body))
+        }</span>
+
+        <span class="cov8" title="1">var result ClientRegistrationResponse
+        if err := json.Unmarshal(body, &amp;result); err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("parse GetRegistration response: %w (body: %s)", err, string(body))
+        }</span>
+        <span class="cov8" title="1">if result.ClientID == "" </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("GetRegistration returned empty client_id: %s", string(body))
+        }</span>
+        <span class="cov8" title="1">return &amp;GetRegistrationResponse{Registration: &amp;result}, nil</span>
+}
+
+// UpdateRegistrationRequest is the input to UpdateRegistration.
+type UpdateRegistrationRequest struct {
+        RegistrationClientURI   string
+        RegistrationAccessToken string
+        // ClientID is the client's existing client_id. Required by RFC 7592 §2.2;
+        // auto-filled into Metadata.ClientID by the SDK before sending if the
+        // caller hasn't already set it.
+        ClientID string
+        // Metadata is the full RFC 7591/7592 client metadata that will replace
+        // the existing registration. Treated as a full replacement (not PATCH).
+        Metadata ClientRegistrationRequest
+        // HTTPClient — see GetRegistrationRequest for rationale.
+        HTTPClient *http.Client
+}
+
+// UpdateRegistrationResponse wraps the post-update registration. Registration
+// includes the rotated registration_access_token, which supersedes the one in
+// the request. Callers MUST persist the new token before discarding the old
+// one.
+type UpdateRegistrationResponse struct {
+        Registration *ClientRegistrationResponse
+}
+
+// DeleteRegistrationRequest is the input to DeleteRegistration.
+type DeleteRegistrationRequest struct {
+        RegistrationClientURI   string
+        RegistrationAccessToken string
+        // HTTPClient — see GetRegistrationRequest for rationale.
+        HTTPClient *http.Client
+}
+
+// DeleteRegistrationResponse is intentionally empty today: the AS returns
+// 204 No Content with no body. Wrapped struct preserves the convention's
+// (ctx, *Req) → (*Resp, error) shape and gives forward-compat headroom.
+type DeleteRegistrationResponse struct{}
+
+// UpdateRegistration performs an RFC 7592 §2.2 full-replace update.
+//
+// On success the AS rotates the registration_access_token; the new token
+// surfaces on the response.
+//
+// Maps server responses:
+//   - 200 OK → returns the parsed response (with the rotated token)
+//   - 401 → ErrRegistrationUnauthorized
+//   - 400 → returns a generic error including the AS's error_description
+//   - others → generic error including status + body
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.2
+func UpdateRegistration(ctx context.Context, req *UpdateRegistrationRequest) (*UpdateRegistrationResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("request is required")
+        }</span>
+        <span class="cov8" title="1">if req.RegistrationClientURI == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("registration_client_uri is required")
+        }</span>
+        <span class="cov8" title="1">if req.RegistrationAccessToken == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("registration_access_token is required")
+        }</span>
+        <span class="cov8" title="1">if req.ClientID == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("clientID is required (RFC 7592 §2.2)")
+        }</span>
+        <span class="cov8" title="1">httpClient := req.HTTPClient
+        if httpClient == nil </span><span class="cov8" title="1">{
+                httpClient = http.DefaultClient
+        }</span>
+
+        // RFC 7592 §2.2 requires the body's client_id to match the registered
+        // identifier; auto-fill if the caller hasn't set it explicitly.
+        <span class="cov8" title="1">md := req.Metadata
+        if md.ClientID == "" </span><span class="cov8" title="1">{
+                md.ClientID = req.ClientID
+        }</span>
+
+        <span class="cov8" title="1">body, err := json.Marshal(md)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("marshal UpdateRegistration request: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, req.RegistrationClientURI, bytes.NewReader(body))
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("build UpdateRegistration request: %w", err)
+        }</span>
+        <span class="cov8" title="1">httpReq.Header.Set("Authorization", "Bearer "+req.RegistrationAccessToken)
+        httpReq.Header.Set("Content-Type", "application/json")
+        httpReq.Header.Set("Accept", "application/json")
+
+        resp, err := httpClient.Do(httpReq)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("UpdateRegistration PUT: %w", err)
+        }</span>
+        <span class="cov8" title="1">defer resp.Body.Close()
+
+        respBody, err := io.ReadAll(resp.Body)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("read UpdateRegistration response: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if resp.StatusCode == http.StatusUnauthorized </span><span class="cov8" title="1">{
+                return nil, ErrRegistrationUnauthorized
+        }</span>
+        <span class="cov8" title="1">if resp.StatusCode != http.StatusOK </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("UpdateRegistration returned %d: %s", resp.StatusCode, string(respBody))
+        }</span>
+
+        <span class="cov8" title="1">var result ClientRegistrationResponse
+        if err := json.Unmarshal(respBody, &amp;result); err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("parse UpdateRegistration response: %w (body: %s)", err, string(respBody))
+        }</span>
+        <span class="cov8" title="1">if result.ClientID == "" </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("UpdateRegistration returned empty client_id: %s", string(respBody))
+        }</span>
+        <span class="cov8" title="1">if result.RegistrationAccessToken == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("UpdateRegistration response missing registration_access_token")
+        }</span>
+        <span class="cov8" title="1">return &amp;UpdateRegistrationResponse{Registration: &amp;result}, nil</span>
+}
+
+// DeleteRegistration performs an RFC 7592 §2.3 deletion. After it returns
+// successfully the AS has removed the registration and invalidated the
+// signing credentials, so any tokens already issued under this client_id
+// will fail subsequent validation.
+//
+// Maps server responses:
+//   - 204 No Content → nil error + empty response struct
+//   - 401 → ErrRegistrationUnauthorized
+//   - others → generic error including status + body
+//
+// See: https://www.rfc-editor.org/rfc/rfc7592#section-2.3
+func DeleteRegistration(ctx context.Context, req *DeleteRegistrationRequest) (*DeleteRegistrationResponse, error) <span class="cov8" title="1">{
+        if req == nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("request is required")
+        }</span>
+        <span class="cov8" title="1">if req.RegistrationClientURI == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("registration_client_uri is required")
+        }</span>
+        <span class="cov8" title="1">if req.RegistrationAccessToken == "" </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("registration_access_token is required")
+        }</span>
+        <span class="cov8" title="1">httpClient := req.HTTPClient
+        if httpClient == nil </span><span class="cov8" title="1">{
+                httpClient = http.DefaultClient
+        }</span>
+
+        <span class="cov8" title="1">httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, req.RegistrationClientURI, nil)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("build DeleteRegistration request: %w", err)
+        }</span>
+        <span class="cov8" title="1">httpReq.Header.Set("Authorization", "Bearer "+req.RegistrationAccessToken)
+
+        resp, err := httpClient.Do(httpReq)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("DeleteRegistration DELETE: %w", err)
+        }</span>
+        <span class="cov8" title="1">defer resp.Body.Close()
+
+        if resp.StatusCode == http.StatusNoContent </span><span class="cov8" title="1">{
+                return &amp;DeleteRegistrationResponse{}, nil
+        }</span>
+        <span class="cov8" title="1">if resp.StatusCode == http.StatusUnauthorized </span><span class="cov8" title="1">{
+                return nil, ErrRegistrationUnauthorized
+        }</span>
+        <span class="cov8" title="1">body, _ := io.ReadAll(resp.Body)
+        return nil, fmt.Errorf("DeleteRegistration returned %d: %s", resp.StatusCode, string(body))</span>
+}
 </pre>
 		
-		<pre class="file" id="file24" style="display: none">package client
+		<pre class="file" id="file29" style="display: none">package client
 
 import (
         "encoding/json"
@@ -6137,7 +8025,7 @@ func fetchMetadata(client *http.Client, url string) (*ASMetadata, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file25" style="display: none">// Package fs provides a file system-based credential store for oneauth client.
+		<pre class="file" id="file30" style="display: none">// Package fs provides a file system-based credential store for oneauth client.
 package fs
 
 import (
@@ -6328,7 +8216,7 @@ func (s *FSCredentialStore) Path() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file26" style="display: none">package client
+		<pre class="file" id="file31" style="display: none">package client
 
 import (
         "net/http"
@@ -6374,7 +8262,7 @@ func NewAuthTransportWithBase(base http.RoundTripper, token string) *AuthTranspo
 }</span>
 </pre>
 		
-		<pre class="file" id="file27" style="display: none">package client
+		<pre class="file" id="file32" style="display: none">package client
 
 import (
         "fmt"
@@ -6444,7 +8332,7 @@ func ValidateCIMDURL(rawURL string) error <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file28" style="display: none">package core
+		<pre class="file" id="file33" style="display: none">package core
 
 import (
         "encoding/json"
@@ -6599,7 +8487,7 @@ func (ad *AuthorizationDetail) UnmarshalJSON(data []byte) error <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file29" style="display: none">package core
+		<pre class="file" id="file34" style="display: none">package core
 
 import (
         "sync"
@@ -6679,7 +8567,7 @@ func (b *InMemoryBlacklist) Len() int <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file30" style="display: none">package core
+		<pre class="file" id="file35" style="display: none">package core
 
 import "context"
 
@@ -6705,7 +8593,7 @@ func SetUserIDInContext(ctx context.Context, userID string) context.Context <spa
 }</span>
 </pre>
 		
-		<pre class="file" id="file31" style="display: none">package core
+		<pre class="file" id="file36" style="display: none">package core
 
 import (
         "fmt"
@@ -6923,7 +8811,7 @@ func DetectUsernameType(username string) string <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file32" style="display: none">package core
+		<pre class="file" id="file37" style="display: none">package core
 
 import "log"
 
@@ -6955,7 +8843,7 @@ func (c *ConsoleEmailSender) SendPasswordResetEmail(to string, resetLink string)
 }</span>
 </pre>
 		
-		<pre class="file" id="file33" style="display: none">package core
+		<pre class="file" id="file38" style="display: none">package core
 
 import (
         "sync"
@@ -7115,7 +9003,7 @@ func (l *AccountLockout) Reset(key string) <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file34" style="display: none">package core
+		<pre class="file" id="file39" style="display: none">package core
 
 import (
         "sort"
@@ -7279,7 +9167,7 @@ func ScopesEqual(a, b []string) bool <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file35" style="display: none">package core
+		<pre class="file" id="file40" style="display: none">package core
 
 import (
         "crypto/rand"
@@ -7416,11 +9304,19 @@ type TokenPair struct {
         RefreshToken         string                `json:"refresh_token,omitempty"`
         Scope                string                `json:"scope,omitempty"`
         AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"` // RFC 9396
+
+        // IssuedTokenType identifies the type of token issued (RFC 8693 §2.2,
+        // REQUIRED for token-exchange responses; absent for other grants).
+        // Common values:
+        //   urn:ietf:params:oauth:token-type:access_token
+        //   urn:ietf:params:oauth:token-type:refresh_token
+        //   urn:ietf:params:oauth:token-type:jwt
+        IssuedTokenType string `json:"issued_token_type,omitempty"`
 }
 
 // TokenRequest represents a request to the token endpoint
 type TokenRequest struct {
-        GrantType            string                `json:"grant_type"`                                  // "password", "refresh_token", "client_credentials"
+        GrantType            string                `json:"grant_type"`                                  // "password", "refresh_token", "client_credentials", "urn:ietf:params:oauth:grant-type:jwt-bearer", "urn:ietf:params:oauth:grant-type:token-exchange"
         Username             string                `json:"username,omitempty"`                          // For password grant
         Password             string                `json:"password,omitempty"`                          // For password grant
         RefreshToken         string                `json:"refresh_token,omitempty"`                     // For refresh_token grant
@@ -7428,6 +9324,23 @@ type TokenRequest struct {
         ClientID             string                `json:"client_id,omitempty"`                         // Client identifier (for client_credentials, optional for others)
         ClientSecret         string                `json:"client_secret,omitempty"`                     // Client secret (for client_credentials via client_secret_post)
         AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"`             // RFC 9396
+
+        // Assertion is the signed JWT for grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+        // (RFC 7523 §2.1). The AS validates the assertion against a configured
+        // trusted-issuer registry and issues an access token in exchange.
+        Assertion string `json:"assertion,omitempty"`
+
+        // SubjectToken / SubjectTokenType / RequestedTokenType / Resource / Audience
+        // support grant_type=urn:ietf:params:oauth:grant-type:token-exchange (RFC 8693).
+        // SubjectToken is the credential representing the party on whose behalf
+        // the request is made; SubjectTokenType identifies its kind (e.g.,
+        // urn:ietf:params:oauth:token-type:jwt). RequestedTokenType (optional)
+        // identifies the desired output token kind; defaults to access_token.
+        SubjectToken       string `json:"subject_token,omitempty"`
+        SubjectTokenType   string `json:"subject_token_type,omitempty"`
+        RequestedTokenType string `json:"requested_token_type,omitempty"`
+        Resource           string `json:"resource,omitempty"`
+        Audience           string `json:"audience,omitempty"`
 }
 
 // TokenError represents an OAuth 2.0 compliant error response
@@ -7455,7 +9368,7 @@ func GenerateAPIKeySecret() (string, error) <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file36" style="display: none">package core
+		<pre class="file" id="file41" style="display: none">package core
 
 import (
         "net/http"
@@ -7519,16 +9432,132 @@ func IdentityKey(identityType, identityValue string) string <span class="cov0" t
 type HandleUserFunc func(authtype string, provider string, token *oauth2.Token, userInfo map[string]any, w http.ResponseWriter, r *http.Request)
 </pre>
 		
-		<pre class="file" id="file37" style="display: none">// Example 01: OAuth 2.0 Client Credentials Flow
+		<pre class="file" id="file42" style="display: none">// Example 01: OAuth 2.0 Client Credentials Flow.
 //
-// The simplest way to get a token from OneAuth. A client authenticates with
-// its client_id and client_secret, and receives a JWT access token.
+// Two-process architecture:
 //
-// Run:   go run ./examples/01-client-credentials/
-// Docs:  Run with --readme to regenerate README.md
+//        Terminal 1:  make serve    # auth server :8081, resource server :8082
+//        Terminal 2:  make demo     # demokit walkthrough (--tui for the TUI)
+//
+// The servers in --serve mode are real HTTP servers — any OAuth client
+// (curl, your own app, MCP host, …) can hit them. The walkthrough is
+// just one such client: it spins up the same servers in-process via
+// httptest and drives them step-by-step. See walkthrough.go.
+//
+// Run:
+//
+//        make demo                     # interactive walkthrough (default)
+//        make demo --tui               # styled TUI walkthrough
+//        make serve                    # just run the servers, block
+//        make walkthrough              # regenerate WALKTHROUGH.md
 //
 // See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
 package main
+
+import (
+        "encoding/json"
+        "flag"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+// jwtSecret is the HS256 secret shared by the AS that signs tokens and
+// the RS that validates them. Real deployments rotate this and use
+// per-client keys via KeyStore — see example 02.
+const jwtSecret = "example-jwt-secret-at-least-32ch"
+
+const jwtIssuer = "oneauth-example-01"
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+// serve binds the auth server and resource server on real ports so an
+// external client (curl, your app, an MCP host) can drive them.
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "resource server listen address")
+        // Re-parse the flags after stripping --serve (which we already
+        // consumed) so flag.Parse doesn't choke on it.
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        ks := keys.NewInMemoryKeyStore()
+        asMux := newAuthServer(ks)
+        rsMux := newResourceServer()
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-01] resource server listening on %s", *rsAddr)
+                if err := http.ListenAndServe(*rsAddr, rsMux); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-01] auth server listening on %s", *asAddr)
+        log.Printf("[example-01] try: curl -X POST http://localhost%s/apps/register -d '{\"client_domain\":\"my.example.com\",\"signing_alg\":\"HS256\"}'", *asAddr)
+        if err := http.ListenAndServe(*asAddr, asMux); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer builds the auth-server HTTP handler. Used by both --serve
+// (real listener) and the walkthrough (httptest.Server). The shared
+// builder keeps the two modes byte-identical so a curl reproduction in
+// the README always matches what the walkthrough exercises.
+func newAuthServer(ks keys.KeyStorage) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        apiAuth := &amp;apiauth.APIAuth{
+                JWTSecretKey:   jwtSecret,
+                JWTIssuer:      jwtIssuer,
+                ClientKeyStore: ks,
+        }
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+        return mux
+}</span>
+
+// newResourceServer builds the resource-server HTTP handler. Validates
+// JWTs with the same secret the AS signs with — for HS256, AS and RS
+// must share the secret. RS256 (example 03) splits this via JWKS.
+func newResourceServer() http.Handler <span class="cov0" title="0">{
+        middleware := &amp;apiauth.APIMiddleware{
+                JWTSecretKey: jwtSecret,
+                JWTIssuer:    jwtIssuer,
+        }
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "message": "hello from protected resource",
+                                "sub":     apiauth.GetUserIDFromAPIContext(r.Context()),
+                                "scopes":  apiauth.GetScopesFromAPIContext(r.Context()),
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file43" style="display: none">package main
 
 import (
         "encoding/json"
@@ -7539,17 +9568,31 @@ import (
         "net/url"
         "strings"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
-func main() <span class="cov0" title="0">{
-        // Shared state across steps
-        var authServer, resourceServer *httptest.Server
-        var ks keys.KeyStorage
+// runDemo is the walkthrough — a demokit demo that acts as an OAuth
+// client driving the auth server and resource server step by step.
+//
+// The demo is structurally identical to a real OAuth client. The only
+// difference is that the AS+RS run inside this process via httptest
+// instead of being separate processes. With `make serve` running, you
+// can replicate every step of this walkthrough with curl — the demo
+// renders a copy-paste curl command beside each step that hits the wire.
+func runDemo() <span class="cov0" title="0">{
+        // Servers are spun up in-process from the same builders main.go
+        // uses for --serve, so the walkthrough stays byte-identical to the
+        // real-server case.
+        ks := keys.NewInMemoryKeyStore()
+        authServer := httptest.NewServer(newAuthServer(ks))
+        defer authServer.Close()
+        resourceServer := httptest.NewServer(newResourceServer())
+        defer resourceServer.Close()
+
+        // State threaded across steps via closure capture.
         var clientID, clientSecret, accessToken string
 
         demo := demokit.New("01: Client Credentials Flow").
@@ -7570,75 +9613,32 @@ func main() <span class="cov0" title="0">{
                 "credentials and receives an access token.",
                 "",
                 "Common use cases: service-to-service calls, background jobs, CLI tools.",
+                "",
+                "This walkthrough acts as a scripted OAuth client. The auth server and",
+                "resource server it talks to are the same code `make serve` boots — see",
+                "`main.go`. Run `make serve` in another terminal and you can replay every",
+                "step on the wire with the `curl` blocks shown below.",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server and resource server").
-                Note("We spin up two in-process HTTP servers: one for the AS (issues tokens) and one for the RS (validates them). Both share the same KeyStore.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-
-                        apiAuth := &amp;apiauth.APIAuth{
-                                JWTSecretKey:   "example-jwt-secret-at-least-32ch",
-                                JWTIssuer:      "example-issuer",
-                                ClientKeyStore: ks,
-                        }
-
-                        authMux := http.NewServeMux()
-                        authMux.Handle("/apps/", registrar.Handler())
-                        authMux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
-                        authServer = httptest.NewServer(authMux)
-
-                        middleware := &amp;apiauth.APIMiddleware{
-                                JWTSecretKey: "example-jwt-secret-at-least-32ch",
-                                JWTIssuer:    "example-issuer",
-                        }
-                        resMux := http.NewServeMux()
-                        resMux.Handle("GET /resource", middleware.ValidateToken(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "message": "hello from protected resource",
-                                                "sub":     apiauth.GetUserIDFromAPIContext(r.Context()),
-                                                "scopes":  apiauth.GetScopesFromAPIContext(r.Context()),
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
-
-                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
-                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)</span>
-                })
-
-        <span class="cov0" title="0">demo.Section("How client registration works",
-                "Before a client can get tokens, it needs to register with the auth server",
-                "and receive a `client_id` + `client_secret` pair. This is the equivalent",
-                "of going to GitHub Developer Settings → OAuth Apps → \"New OAuth App\".",
-                "",
-                "In this example, registration is **open** (`NewNoAuth()`) for simplicity.",
-                "In production, gate registration with authentication — see",
-                "[How does an App get registered?](../README.md#how-does-an-app-get-registered)",
-                "for the full spectrum from web dashboards to automated DCR.",
-                "",
-                "**The `client_secret` is a backend credential.** It lives in your server,",
-                "not in a browser or mobile app. Never expose it in frontend code.",
-        )
-
-        // --- Step 1: Register ---
         demo.Step("Register a client").
                 Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST /apps/register {domain, signing_alg}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
-                Note("The client receives credentials it will use to authenticate in the next step.").
-                Run(func() </span><span class="cov0" title="0">{
+                Note("The client receives credentials it will use to authenticate in the next step. Open registration (`NewNoAuth`) is for the demo only — gate this in production.").
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/apps/register \
+  -H 'Content-Type: application/json' \
+  -d '{"client_domain":"my-service.example.com","signing_alg":"HS256"}'`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         body, _ := json.Marshal(map[string]any{
                                 "client_domain": "my-service.example.com",
                                 "signing_alg":   "HS256",
                         })
-                        resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+                        resp, err := http.Post(authServer.URL+"/apps/register", "application/json",
                                 strings.NewReader(string(body)))
-                        var reg map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("register: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;reg)
                         resp.Body.Close()
 
@@ -7646,23 +9646,31 @@ func main() <span class="cov0" title="0">{
                         clientSecret = reg["client_secret"].(string)
                         fmt.Printf("    client_id:     %s\n", clientID)
                         fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Step 2: Token ---
         <span class="cov0" title="0">demo.Step("Request an access token").
                 Ref(refs.RFC6749_ClientCredentials).
                 Ref(refs.RFC7519).
                 Arrow("App", "AS", "POST /api/token {grant_type: client_credentials}").
                 DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
                 Note("The AS verifies the client credentials and returns a signed JWT. The token carries sub=client_id (no user context in this flow).").
-                Run(func() </span><span class="cov0" title="0">{
-                        resp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/api/token \
+  -d 'grant_type=client_credentials' \
+  -d 'client_id=&lt;from previous step&gt;' \
+  -d 'client_secret=&lt;from previous step&gt;' \
+  -d 'scope=read write'`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        resp, err := http.PostForm(authServer.URL+"/api/token", url.Values{
                                 "grant_type":    {"client_credentials"},
                                 "client_id":     {clientID},
                                 "client_secret": {clientSecret},
                                 "scope":         {"read write"},
                         })
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;tokenData)
                         resp.Body.Close()
 
@@ -7671,7 +9679,8 @@ func main() <span class="cov0" title="0">{
                         fmt.Printf("    scope:        %s\n", tokenData["scope"])
                         fmt.Printf("    expires_in:   %.0fs\n", tokenData["expires_in"])
                         fmt.Printf("    access_token: %s...\n", accessToken[:40])
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("What's in the JWT?",
                 "The access token is a signed JWT containing:",
@@ -7685,7 +9694,6 @@ func main() <span class="cov0" title="0">{
                 "signature — no callback to the auth server needed.",
         )
 
-        // --- Step 3: Use token ---
         demo.Step("Access a protected resource").
                 Ref(refs.RFC6750).
                 Ref(refs.RFC7515).
@@ -7693,11 +9701,16 @@ func main() <span class="cov0" title="0">{
                 Arrow("RS", "RS", "Validate JWT signature + claims").
                 DashedArrow("RS", "App", "200 {data}").
                 Note("The resource server validates the JWT signature and extracts claims from it. No network call to the auth server.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;access_token from previous step&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+accessToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("resource: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         fmt.Printf("    status: %d\n", res.StatusCode)
@@ -7705,20 +9718,25 @@ func main() <span class="cov0" title="0">{
                         json.Unmarshal(body, &amp;resource)
                         pretty, _ := json.MarshalIndent(resource, "    ", "  ")
                         fmt.Printf("    response: %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Step 4: No token ---
         <span class="cov0" title="0">demo.Step("Access without a token (expect rejection)").
                 Ref(refs.RFC6750).
                 Arrow("App", "RS", "GET /resource (no Authorization header)").
                 DashedArrow("RS", "App", "401 Unauthorized").
                 Note("Without a valid Bearer token, the resource server rejects the request.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8082/resource`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
-                        res, _ := http.DefaultClient.Do(req)
-                        res.Body.Close()
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("resource: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">res.Body.Close()
                         fmt.Printf("    status: %d (correctly rejected)\n", res.StatusCode)
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("What's next?",
                 "In [02 — Resource Token (HS256)](../02-resource-token-hs256/), you'll see",
@@ -7727,32 +9745,116 @@ func main() <span class="cov0" title="0">{
                 "multi-app architecture.",
         )
 
-        demo.Execute()
-
-        // Cleanup
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
-        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
-                resourceServer.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 </pre>
 		
-		<pre class="file" id="file38" style="display: none">// Example 02: Resource Token with HS256 (Federated Auth)
+		<pre class="file" id="file44" style="display: none">// Example 02: Resource Token with HS256 (Federated Auth).
 //
-// Building on Example 01, this shows how a registered app can mint
-// resource-scoped tokens for individual users — not just for itself.
-// This is OneAuth's federated authentication pattern.
+// Building on Example 01: a registered app mints resource-scoped tokens
+// for individual users — not just for itself. The resource server
+// validates with the same KeyStore the app's secret was registered into.
 //
-// In Example 01: client_credentials → token with sub=client_id (machine identity)
-// In this example: app registers → mints per-user tokens → resource server validates
+// Two-process architecture (mirrors Example 01):
 //
-// Run:   go run ./examples/02-resource-token-hs256/
-// Docs:  Run with --readme to regenerate README.md
+//        make serve      # auth server :8081, resource server :8082
+//        make demo       # demokit walkthrough (--tui for the styled TUI)
+//
+// In --serve mode the auth server and resource server share an
+// in-process KeyStore (registration on the AS makes the secret visible
+// to the RS for validation). A real deployment would back this with a
+// persisted KeyStore (FS / GORM / GAE).
 //
 // See: https://www.rfc-editor.org/rfc/rfc7519 (JWT)
 package main
+
+import (
+        "encoding/json"
+        "flag"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "resource server listen address")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        ks := keys.NewInMemoryKeyStore()
+        asMux := newAuthServer(ks)
+        rsMux := newResourceServer(ks)
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-02] resource server listening on %s", *rsAddr)
+                if err := http.ListenAndServe(*rsAddr, rsMux); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-02] auth server listening on %s", *asAddr)
+        log.Printf("[example-02] register: curl -X POST http://localhost%s/apps/register -d '{\"client_domain\":\"my.example.com\",\"signing_alg\":\"HS256\"}'", *asAddr)
+        if err := http.ListenAndServe(*asAddr, asMux); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer exposes the AppRegistrar — open registration so the
+// walkthrough (and any external client) can register fresh apps and
+// pull a fresh secret. Real deployments gate this with AdminAuth.
+func newAuthServer(ks keys.KeyStorage) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        return mux
+}</span>
+
+// newResourceServer validates JWTs using the same KeyStore the AS
+// registered each app's secret into. The RS extracts the user, scopes,
+// and the quota claims (max_rooms, max_msg_rate) without ever calling
+// back to the auth server.
+func newResourceServer(ks keys.KeyStorage) http.Handler <span class="cov0" title="0">{
+        middleware := &amp;apiauth.APIMiddleware{KeyStore: ks}
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        ctx := r.Context()
+                        custom := apiauth.GetCustomClaimsFromContext(ctx)
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "user":      apiauth.GetUserIDFromAPIContext(ctx),
+                                "scopes":    apiauth.GetScopesFromAPIContext(ctx),
+                                "client_id": custom["client_id"],
+                                "max_rooms": custom["max_rooms"],
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file45" style="display: none">package main
 
 import (
         "bytes"
@@ -7762,16 +9864,20 @@ import (
         "net/http"
         "net/http/httptest"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
-func main() <span class="cov0" title="0">{
-        var authServer, resourceServer *httptest.Server
-        var ks keys.KeyStorage
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+        authServer := httptest.NewServer(newAuthServer(ks))
+        defer authServer.Close()
+        resourceServer := httptest.NewServer(newResourceServer(ks))
+        defer resourceServer.Close()
+
         var clientID, clientSecret string
         var aliceToken, bobToken string
 
@@ -7804,52 +9910,25 @@ func main() <span class="cov0" title="0">{
                 "the app's signing key without calling back to the auth server.",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server and resource server").
-                Note("Same as Example 01, but now the resource server also extracts the `client_id` claim to know which app minted the token.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-
-                        authMux := http.NewServeMux()
-                        authMux.Handle("/apps/", registrar.Handler())
-                        authServer = httptest.NewServer(authMux)
-
-                        middleware := &amp;apiauth.APIMiddleware{KeyStore: ks}
-                        resMux := http.NewServeMux()
-                        resMux.Handle("GET /resource", middleware.ValidateToken(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        ctx := r.Context()
-                                        custom := apiauth.GetCustomClaimsFromContext(ctx)
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "user":      apiauth.GetUserIDFromAPIContext(ctx),
-                                                "scopes":    apiauth.GetScopesFromAPIContext(ctx),
-                                                "client_id": custom["client_id"],
-                                                "max_rooms": custom["max_rooms"],
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
-
-                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
-                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)</span>
-                })
-
-        // --- Register ---
-        <span class="cov0" title="0">demo.Step("Register an app with HS256 signing").
+        demo.Step("Register an app with HS256 signing").
                 Ref(refs.RFC7515).
                 Arrow("App", "AS", "POST /apps/register {domain: myapp.example.com, signing_alg: HS256}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
-                Note("The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app and resource server can use it for signing/verification.").
-                Run(func() </span><span class="cov0" title="0">{
+                Note("The app gets a client_id and a shared secret. The secret is stored in the KeyStore — both the app (for minting) and the resource server (for validation) read from there.").
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/apps/register \
+  -H 'Content-Type: application/json' \
+  -d '{"client_domain":"myapp.example.com","signing_alg":"HS256"}'`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         body, _ := json.Marshal(map[string]any{
                                 "client_domain": "myapp.example.com",
                                 "signing_alg":   "HS256",
                         })
-                        resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+                        resp, err := http.Post(authServer.URL+"/apps/register", "application/json",
                                 bytes.NewReader(body))
-                        var reg map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("register: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;reg)
                         resp.Body.Close()
 
@@ -7857,7 +9936,8 @@ func main() <span class="cov0" title="0">{
                         clientSecret = reg["client_secret"].(string)
                         fmt.Printf("    client_id:     %s\n", clientID)
                         fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("MintResourceToken vs client_credentials",
                 "`MintResourceToken` is a library call, not an HTTP endpoint. The app calls it",
@@ -7872,47 +9952,44 @@ func main() <span class="cov0" title="0">{
                 "- **MintResourceToken**: \"I'll make a token FOR this user, signed with my key\"",
         )
 
-        // --- Mint for Alice ---
         demo.Step("Mint a resource token for user Alice").
                 Ref(refs.RFC7519).
                 Ref(refs.RFC7515).
                 Ref(refs.RFC7638).
                 Arrow("App", "App", "MintResourceToken(alice, scopes=[read,write], max_rooms=10)").
                 Note("The app creates a JWT with sub=alice, signed with its HS256 secret. The token includes quota claims (max_rooms) for resource-level enforcement.").
-                Run(func() </span><span class="cov0" title="0">{
-                        var err error
-                        aliceToken, err = admin.MintResourceToken(
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        tok, err := admin.MintResourceToken(
                                 "alice", clientID, clientSecret,
                                 admin.AppQuota{MaxRooms: 10, MaxMsgRate: 30.0},
                                 []string{"read", "write"}, nil,
                         )
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("mint alice: %v", err)
                         }</span>
-                        <span class="cov0" title="0">fmt.Printf("    token for alice: %s...\n", aliceToken[:40])</span>
+                        <span class="cov0" title="0">aliceToken = tok
+                        fmt.Printf("    token for alice: %s...\n", aliceToken[:40])
+                        return nil</span>
                 })
 
-        // --- Mint for Bob ---
         <span class="cov0" title="0">demo.Step("Mint a resource token for user Bob (different scopes)").
                 Ref(refs.RFC7519).
                 Arrow("App", "App", "MintResourceToken(bob, scopes=[read], max_rooms=3)").
                 Note("Same app, different user, different permissions. Bob gets read-only access with a lower room quota.").
-                Run(func() </span><span class="cov0" title="0">{
-                        var err error
-                        bobToken, err = admin.MintResourceToken(
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        tok, err := admin.MintResourceToken(
                                 "bob", clientID, clientSecret,
                                 admin.AppQuota{MaxRooms: 3},
                                 []string{"read"}, nil,
                         )
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("mint bob: %v", err)
                         }</span>
-                        <span class="cov0" title="0">fmt.Printf("    token for bob: %s...\n", bobToken[:40])</span>
+                        <span class="cov0" title="0">bobToken = tok
+                        fmt.Printf("    token for bob: %s...\n", bobToken[:40])
+                        return nil</span>
                 })
 
-        // --- Validate Alice ---
         <span class="cov0" title="0">demo.Step("Resource server validates Alice's token").
                 Ref(refs.RFC6750).
                 Ref(refs.RFC7515).
@@ -7920,11 +9997,16 @@ func main() <span class="cov0" title="0">{
                 Arrow("RS", "RS", "Validate HS256 signature via KeyStore").
                 DashedArrow("RS", "App", "200 {user: alice, scopes: [read,write], max_rooms: 10}").
                 Note("The resource server validates the JWT using the app's key from the shared KeyStore. It extracts the user ID, scopes, and quota claims.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;alice's token&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+aliceToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("get: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         fmt.Printf("    status: %d\n", res.StatusCode)
@@ -7932,18 +10014,23 @@ func main() <span class="cov0" title="0">{
                         json.Unmarshal(body, &amp;data)
                         pretty, _ := json.MarshalIndent(data, "    ", "  ")
                         fmt.Printf("    response: %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Validate Bob ---
         <span class="cov0" title="0">demo.Step("Resource server validates Bob's token").
                 Arrow("App", "RS", "GET /resource (Bearer: bob's token)").
                 DashedArrow("RS", "App", "200 {user: bob, scopes: [read], max_rooms: 3}").
                 Note("Same resource server, different user — Bob's token has fewer scopes and a lower quota.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;bob's token&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+bobToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("get: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         fmt.Printf("    status: %d\n", res.StatusCode)
@@ -7951,26 +10038,33 @@ func main() <span class="cov0" title="0">{
                         json.Unmarshal(body, &amp;data)
                         pretty, _ := json.MarshalIndent(data, "    ", "  ")
                         fmt.Printf("    response: %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Wrong secret ---
         <span class="cov0" title="0">demo.Step("Token signed with wrong secret is rejected").
                 Ref(refs.RFC7515).
                 Arrow("App", "App", "MintResourceToken(eve, secret=wrong-secret)").
                 Arrow("App", "RS", "GET /resource (Bearer: bad token)").
                 DashedArrow("RS", "App", "401 Unauthorized").
                 Note("A token signed with the wrong secret fails signature verification — the resource server rejects it immediately.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -o /dev/null -w '%{http_code}\n' \
+  http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;token signed with a different secret&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         badToken, _ := admin.MintResourceToken(
                                 "eve", clientID, "wrong-secret",
                                 admin.AppQuota{}, []string{"admin"}, nil,
                         )
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+badToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        res.Body.Close()
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("get: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">res.Body.Close()
                         fmt.Printf("    status: %d (correctly rejected — wrong signing key)\n", res.StatusCode)
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("What's next?",
                 "In [03 — Resource Token (RS256 + JWKS)](../03-resource-token-rs256-jwks/),",
@@ -7979,54 +10073,147 @@ func main() <span class="cov0" title="0">{
                 "secrets — the resource server never sees the private key.",
         )
 
-        demo.Execute()
-
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
-        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
-                resourceServer.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 </pre>
 		
-		<pre class="file" id="file39" style="display: none">// Example 03: Resource Token with RS256 + JWKS Discovery
+		<pre class="file" id="file46" style="display: none">// Example 03: Resource Token with RS256 + JWKS Discovery.
 //
-// Building on Example 02 (HS256 shared secret), this shows the asymmetric
-// alternative: the app generates an RSA key pair, registers only the PUBLIC
-// key, and the resource server discovers it via JWKS. The private key never
-// leaves the app.
+// Asymmetric variant of Example 02. The app generates an RSA key pair,
+// registers only the public key, and the resource server discovers the
+// public key via JWKS — the private key never leaves the app.
 //
-// In Example 02: shared secret (HS256) — both sides know the key
-// In this example: public/private key pair (RS256) — only the app has the private key
+// Two-process architecture:
 //
-// Run:   go run ./examples/03-resource-token-rs256-jwks/
-// Docs:  Run with --readme to regenerate README.md
+//        make serve   # auth :8081 (registration + JWKS), resource :8082 (JWKS-discovered RS)
+//        make demo    # walkthrough that drives both
 //
 // See: https://www.rfc-editor.org/rfc/rfc7517 (JWK)
 package main
 
 import (
+        "encoding/json"
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "resource server listen address")
+        asPublicURL := flag.String("as-url", "", "auth server URL the RS uses to fetch JWKS (default http://localhost&lt;as-addr&gt;)")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        ks := keys.NewInMemoryKeyStore()
+        asMux := newAuthServer(ks)
+
+        jwksURL := *asPublicURL
+        if jwksURL == "" </span><span class="cov0" title="0">{
+                jwksURL = fmt.Sprintf("http://localhost%s/.well-known/jwks.json", *asAddr)
+        }</span> else<span class="cov0" title="0"> {
+                jwksURL = strings.TrimRight(jwksURL, "/") + "/.well-known/jwks.json"
+        }</span>
+        <span class="cov0" title="0">rsMux := newResourceServer(jwksURL)
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-03] resource server listening on %s (JWKS source: %s)", *rsAddr, jwksURL)
+                if err := http.ListenAndServe(*rsAddr, rsMux); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-03] auth server listening on %s", *asAddr)
+        log.Printf("[example-03] register an RS256 app with a PEM-encoded public_key field — see WALKTHROUGH.md")
+        if err := http.ListenAndServe(*asAddr, asMux); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer builds the auth server: AppRegistrar (open) and a JWKS
+// endpoint that serves only public keys (HS256 secrets are excluded by
+// JWKSHandler — see keys/jwks.go).
+func newAuthServer(ks keys.KeyStorage) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.Handle("GET /.well-known/jwks.json", jwksHandler)
+        return mux
+}</span>
+
+// newResourceServer wires APIMiddleware to a JWKSKeyStore that fetches
+// and caches the public keys from the AS's JWKS endpoint. The RS never
+// shares storage with the AS — discovery is purely over HTTP.
+func newResourceServer(jwksURL string) http.Handler <span class="cov0" title="0">{
+        jwksKS := keys.NewJWKSKeyStore(jwksURL, keys.WithMinRefreshGap(0))
+        jwksKS.Start()
+
+        middleware := &amp;apiauth.APIMiddleware{KeyStore: jwksKS}
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        ctx := r.Context()
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "user":   apiauth.GetUserIDFromAPIContext(ctx),
+                                "scopes": apiauth.GetScopesFromAPIContext(ctx),
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file47" style="display: none">package main
+
+import (
         "bytes"
+        "crypto/rsa"
         "encoding/json"
         "fmt"
         "io"
         "net/http"
         "net/http/httptest"
 
-        "crypto/rsa"
-
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
 )
 
-func main() <span class="cov0" title="0">{
-        var authServer, resourceServer *httptest.Server
-        var ks keys.KeyStorage
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+        authServer := httptest.NewServer(newAuthServer(ks))
+        defer authServer.Close()
+        resourceServer := httptest.NewServer(newResourceServer(authServer.URL + "/.well-known/jwks.json"))
+        defer resourceServer.Close()
+
         var clientID string
         var privKey *rsa.PrivateKey
         var aliceToken string
@@ -8058,75 +10245,65 @@ func main() <span class="cov0" title="0">{
                 "- Key rotation is seamless: publish a new key to JWKS, resource servers pick it up",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server with JWKS endpoint").
-                Ref(refs.RFC7517).
-                Note("The auth server now serves two endpoints: /apps/ for registration and /.well-known/jwks.json for public key discovery.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
-
-                        authMux := http.NewServeMux()
-                        authMux.Handle("/apps/", registrar.Handler())
-                        authMux.Handle("GET /.well-known/jwks.json", jwksHandler)
-                        authServer = httptest.NewServer(authMux)
-
-                        fmt.Printf("    Auth server: %s\n", authServer.URL)
-                        fmt.Printf("    JWKS:        %s/.well-known/jwks.json\n", authServer.URL)
-                }</span>)
-
-        // --- Generate key pair ---
-        <span class="cov0" title="0">demo.Step("App generates an RSA key pair").
+        demo.Step("App generates an RSA key pair").
                 Ref(refs.RFC7515).
                 Note("The app generates a 2048-bit RSA key pair. The private key stays with the app. The public key will be registered with the auth server.").
-                Run(func() </span><span class="cov0" title="0">{
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("keygen: %v", err)
                         }</span>
                         <span class="cov0" title="0">parsed, _ := utils.ParsePrivateKeyPEM(privPEM)
                         privKey = parsed.(*rsa.PrivateKey)
-
                         fmt.Printf("    Private key: %d bytes (stays with app)\n", len(privPEM))
-                        fmt.Printf("    Public key:  %d bytes (will be registered)\n", len(pubPEM))</span>
+                        fmt.Printf("    Public key:  %d bytes (will be registered)\n", len(pubPEM))
+                        return nil</span>
                 })
 
-        // --- Register with public key ---
         <span class="cov0" title="0">demo.Step("Register app with RS256 public key").
                 Ref(refs.RFC7517).
                 Arrow("App", "AS", "POST /apps/register {domain, signing_alg: RS256, public_key}").
                 DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
                 Note("Unlike HS256 registration, no secret is returned. The auth server stores the public key and serves it via JWKS.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `PUB=$(cat your-public-key.pem)
+curl -s -X POST http://localhost:8081/apps/register \
+  -H 'Content-Type: application/json' \
+  -d "{\"client_domain\":\"myapp.example.com\",\"signing_alg\":\"RS256\",\"public_key\":$(jq -Rs . &lt;&lt;&lt;"$PUB")}"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         pubPEM, _ := utils.EncodePublicKeyPEM(&amp;privKey.PublicKey)
                         body, _ := json.Marshal(map[string]any{
                                 "client_domain": "myapp.example.com",
                                 "signing_alg":   "RS256",
                                 "public_key":    string(pubPEM),
                         })
-                        resp, _ := http.Post(authServer.URL+"/apps/register", "application/json",
+                        resp, err := http.Post(authServer.URL+"/apps/register", "application/json",
                                 bytes.NewReader(body))
-                        var reg map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("register: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;reg)
                         resp.Body.Close()
 
                         clientID = reg["client_id"].(string)
                         fmt.Printf("    client_id:     %s\n", clientID)
                         fmt.Printf("    client_secret: (none — RS256 uses key pair)\n")
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Verify JWKS ---
         <span class="cov0" title="0">demo.Step("Verify the public key appears in JWKS").
                 Ref(refs.RFC7517).
                 Ref(refs.RFC7638).
                 Arrow("App", "AS", "GET /.well-known/jwks.json").
                 DashedArrow("AS", "App", "{keys: [{kty: RSA, alg: RS256, kid: ..., n: ..., e: ...}]}").
                 Note("The JWKS endpoint serves only public keys — HS256 secrets are never exposed. Each key includes a kid (Key ID) computed from the key thumbprint (RFC 7638).").
-                Run(func() </span><span class="cov0" title="0">{
-                        resp, _ := http.Get(authServer.URL + "/.well-known/jwks.json")
-                        body, _ := io.ReadAll(resp.Body)
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8081/.well-known/jwks.json | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        resp, err := http.Get(authServer.URL + "/.well-known/jwks.json")
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("jwks: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(resp.Body)
                         resp.Body.Close()
 
                         var jwkSet map[string]any
@@ -8141,7 +10318,6 @@ func main() <span class="cov0" title="0">{
                                 fmt.Printf("    kid: %s\n", key["kid"])
                                 fmt.Printf("    key_ops: %v\n", key["key_ops"])
 
-                                // Verify no private key fields
                                 for _, field := range []string{"d", "p", "q", "dp", "dq", "qi"} </span><span class="cov0" title="0">{
                                         if key[field] != nil </span><span class="cov0" title="0">{
                                                 fmt.Printf("    WARNING: private field %q leaked!\n", field)
@@ -8149,6 +10325,7 @@ func main() <span class="cov0" title="0">{
                                 }
                                 <span class="cov0" title="0">fmt.Printf("    private fields: (absent — only public components served)\n")</span>
                         }
+                        <span class="cov0" title="0">return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("How JWKS discovery works",
@@ -8162,37 +10339,7 @@ func main() <span class="cov0" title="0">{
                 "This is the same mechanism Keycloak, Auth0, and other IdPs use.",
         )
 
-        // --- Start resource server with JWKS discovery ---
-        demo.Step("Start resource server with JWKS-based key discovery").
-                Ref(refs.RFC7517).
-                Note("The resource server points its JWKSKeyStore at the auth server's JWKS URL. It automatically fetches and caches the public keys.").
-                Run(func() </span><span class="cov0" title="0">{
-                        jwksKS := keys.NewJWKSKeyStore(
-                                authServer.URL+"/.well-known/jwks.json",
-                                keys.WithMinRefreshGap(0),
-                        )
-                        jwksKS.Start()
-
-                        middleware := &amp;apiauth.APIMiddleware{KeyStore: jwksKS}
-                        resMux := http.NewServeMux()
-                        resMux.Handle("GET /resource", middleware.ValidateToken(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        ctx := r.Context()
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "user":   apiauth.GetUserIDFromAPIContext(ctx),
-                                                "scopes": apiauth.GetScopesFromAPIContext(ctx),
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
-
-                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)
-                        fmt.Printf("    JWKS source:     %s/.well-known/jwks.json\n", authServer.URL)</span>
-                })
-
-        // --- Mint and validate ---
-        <span class="cov0" title="0">demo.Step("Mint a token with the private key and validate via JWKS").
+        demo.Step("Mint a token with the private key and validate via JWKS").
                 Ref(refs.RFC7519).
                 Ref(refs.RFC7515).
                 Ref(refs.RFC7638).
@@ -8202,17 +10349,26 @@ func main() <span class="cov0" title="0">{
                 Arrow("RS", "RS", "Verify RS256 signature with public key from JWKS").
                 DashedArrow("RS", "App", "200 {user: alice}").
                 Note("The token's kid header tells the resource server which key to use. The signature is verified with the public key — the private key was never shared.").
-                Run(func() </span><span class="cov0" title="0">{
-                        aliceToken, _ = admin.MintResourceTokenWithKey(
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;RS256 token&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        tok, err := admin.MintResourceTokenWithKey(
                                 "alice", clientID, privKey,
                                 admin.AppQuota{}, []string{"read", "write"}, nil,
                         )
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("mint: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">aliceToken = tok
                         fmt.Printf("    token: %s...\n", aliceToken[:40])
 
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+aliceToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("get: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         fmt.Printf("    status: %d\n", res.StatusCode)
@@ -8220,17 +10376,19 @@ func main() <span class="cov0" title="0">{
                         json.Unmarshal(body, &amp;data)
                         pretty, _ := json.MarshalIndent(data, "    ", "  ")
                         fmt.Printf("    response: %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Wrong key ---
         <span class="cov0" title="0">demo.Step("Token signed with a different private key is rejected").
                 Ref(refs.RFC7515).
                 Arrow("App", "App", "MintResourceTokenWithKey(eve, differentPrivKey)").
                 Arrow("App", "RS", "GET /resource (Bearer: bad token)").
                 DashedArrow("RS", "App", "401 Unauthorized").
                 Note("Even though the token is a valid JWT, its kid doesn't match any key in JWKS, or the signature doesn't verify with the registered public key.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Generate a completely different key pair
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -o /dev/null -w '%{http_code}\n' \
+  http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;token signed with a different RSA key&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         otherPrivPEM, _, _ := utils.GenerateRSAKeyPair(2048)
                         otherPrivKey, _ := utils.ParsePrivateKeyPEM(otherPrivPEM)
 
@@ -8240,10 +10398,14 @@ func main() <span class="cov0" title="0">{
                         )
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+badToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        res.Body.Close()
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("get: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">res.Body.Close()
                         fmt.Printf("    status: %d (correctly rejected — wrong private key)\n", res.StatusCode)
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("HS256 vs RS256 — when to use which",
                 "| | HS256 (Example 02) | RS256 (this example) |",
@@ -8266,28 +10428,142 @@ func main() <span class="cov0" title="0">{
                 "with external IdPs like Keycloak and Auth0.",
         )
 
-        demo.Execute()
-
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
-        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
-                resourceServer.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 </pre>
 		
-		<pre class="file" id="file40" style="display: none">// Example 04: AS Metadata Discovery (RFC 8414)
+		<pre class="file" id="file48" style="display: none">// Example 04: AS Metadata Discovery (RFC 8414).
 //
-// In Examples 01-03, we hardcoded URLs like authServer.URL+"/api/token".
+// In Examples 01-03 we hardcoded URLs like authServer.URL+"/api/token".
 // In production, clients discover endpoints automatically from a single
-// well-known URL. This is how Keycloak, Auth0, and OneAuth all work.
+// well-known URL — same mechanism Keycloak / Auth0 / Authlete use.
 //
-// Run:   go run ./examples/04-discovery/
-// Docs:  Run with --readme to regenerate README.md
+// Two-process architecture:
+//
+//        make serve   # auth :8081 (full discovery surface), resource :8082
+//        make demo    # walkthrough that drives both
 //
 // See: https://www.rfc-editor.org/rfc/rfc8414
 package main
+
+import (
+        "encoding/json"
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+const jwtSecret = "discovery-example-secret-32chars!"
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "resource server listen address")
+        asPublicURL := flag.String("as-url", "", "external URL of the AS (used as issuer; default http://localhost&lt;as-addr&gt;)")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        issuer := *asPublicURL
+        if issuer == "" </span><span class="cov0" title="0">{
+                issuer = fmt.Sprintf("http://localhost%s", *asAddr)
+        }</span>
+
+        <span class="cov0" title="0">ks := keys.NewInMemoryKeyStore()
+        asMux := newAuthServer(ks, issuer)
+        rsMux := newResourceServer(issuer)
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-04] resource server listening on %s", *rsAddr)
+                if err := http.ListenAndServe(*rsAddr, rsMux); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-04] auth server listening on %s (issuer=%s)", *asAddr, issuer)
+        log.Printf("[example-04] discovery: curl %s/.well-known/openid-configuration", issuer)
+        if err := http.ListenAndServe(*asAddr, asMux); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer wires the full discovery surface: registration, token
+// endpoint, JWKS, introspection, and the discovery document itself.
+// `issuer` is the canonical public URL — token `iss` claims and the
+// metadata `issuer` field both use it, and the RS's `JWTIssuer` must
+// match.
+func newAuthServer(ks keys.KeyStorage, issuer string) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+        apiAuth := &amp;apiauth.APIAuth{
+                JWTSecretKey:   jwtSecret,
+                JWTIssuer:      issuer,
+                ClientKeyStore: ks,
+        }
+        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+        mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+        mux.Handle("POST /oauth/introspect", introspection)
+        mux.Handle("GET /.well-known/openid-configuration",
+                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                        Issuer:                        issuer,
+                        TokenEndpoint:                 issuer + "/api/token",
+                        JWKSURI:                       issuer + "/.well-known/jwks.json",
+                        IntrospectionEndpoint:         issuer + "/oauth/introspect",
+                        RegistrationEndpoint:          issuer + "/apps/register",
+                        ScopesSupported:               []string{"read", "write", "admin"},
+                        GrantTypesSupported:           []string{"client_credentials"},
+                        ResponseTypesSupported:        []string{"token"},
+                        TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
+                        CodeChallengeMethodsSupported: []string{"S256"},
+                }))
+        return mux
+}</span>
+
+func newResourceServer(issuer string) http.Handler <span class="cov0" title="0">{
+        middleware := &amp;apiauth.APIMiddleware{
+                JWTSecretKey: jwtSecret,
+                JWTIssuer:    issuer,
+        }
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+                                "scopes": apiauth.GetScopesFromAPIContext(r.Context()),
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file49" style="display: none">package main
 
 import (
         "encoding/json"
@@ -8299,10 +10575,9 @@ import (
         "strings"
         "time"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/client"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
@@ -8310,9 +10585,22 @@ import (
 const kcExamplesURL = "http://localhost:8280"
 const kcExamplesRealm = "oneauth-examples"
 
-func main() <span class="cov0" title="0">{
-        var authServer, resourceServer *httptest.Server
-        var ks keys.KeyStorage
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+
+        // We need the AS to know its own public URL for issuer / metadata.
+        // httptest.NewUnstartedServer + Start gives us the URL before the
+        // handler is fully wired so we can pass it as `issuer`.
+        authServer := httptest.NewUnstartedServer(http.NewServeMux())
+        authServer.Config.Handler = newAuthServer(ks, "")
+        authServer.Start()
+        defer authServer.Close()
+        // Replace handler with one wired to the real URL as issuer.
+        authServer.Config.Handler = newAuthServer(ks, authServer.URL)
+
+        resourceServer := httptest.NewServer(newResourceServer(authServer.URL))
+        defer resourceServer.Close()
+
         var discoveredMeta *client.ASMetadata
         var clientID, clientSecret, accessToken string
 
@@ -8344,84 +10632,26 @@ func main() <span class="cov0" title="0">{
                 "Clients fetch this once and use the discovered URLs for everything.",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server with discovery, token, JWKS, and introspection endpoints").
-                Ref(refs.RFC8414).
-                Note("This is the most complete auth server we've built so far — it serves discovery, tokens, JWKS, introspection, and registration.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
-
-                        apiAuth := &amp;apiauth.APIAuth{
-                                JWTSecretKey:   "discovery-example-secret-32chars!",
-                                ClientKeyStore: ks,
-                        }
-
-                        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
-
-                        mux := http.NewServeMux()
-                        mux.Handle("/apps/", registrar.Handler())
-                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
-                        mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
-                        mux.Handle("POST /oauth/introspect", introspection)
-                        authServer = httptest.NewServer(mux)
-
-                        // Set issuer to actual URL (must match tokens)
-                        apiAuth.JWTIssuer = authServer.URL
-
-                        // Register discovery endpoint with all the server's capabilities
-                        mux.Handle("GET /.well-known/openid-configuration",
-                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
-                                        Issuer:                        authServer.URL,
-                                        TokenEndpoint:                 authServer.URL + "/api/token",
-                                        JWKSURI:                       authServer.URL + "/.well-known/jwks.json",
-                                        IntrospectionEndpoint:         authServer.URL + "/oauth/introspect",
-                                        RegistrationEndpoint:          authServer.URL + "/apps/register",
-                                        ScopesSupported:               []string{"read", "write", "admin"},
-                                        GrantTypesSupported:           []string{"client_credentials"},
-                                        ResponseTypesSupported:        []string{"token"},
-                                        TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
-                                        CodeChallengeMethodsSupported: []string{"S256"},
-                                }))
-
-                        // Resource server
-                        middleware := &amp;apiauth.APIMiddleware{
-                                JWTSecretKey: "discovery-example-secret-32chars!",
-                                JWTIssuer:    authServer.URL,
-                        }
-                        resMux := http.NewServeMux()
-                        resMux.Handle("GET /resource", middleware.ValidateToken(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "user":   apiauth.GetUserIDFromAPIContext(r.Context()),
-                                                "scopes": apiauth.GetScopesFromAPIContext(r.Context()),
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
-
-                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
-                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)</span>
-                })
-
-        // --- Fetch raw metadata ---
-        <span class="cov0" title="0">demo.Step("Fetch the discovery document (raw HTTP)").
+        demo.Step("Fetch the discovery document (raw HTTP)").
                 Ref(refs.RFC8414).
                 Arrow("App", "AS", "GET /.well-known/openid-configuration").
                 DashedArrow("AS", "App", "JSON {issuer, token_endpoint, jwks_uri, ...}").
                 Note("The discovery document is a JSON object listing every endpoint the server supports. This is the same format Keycloak, Auth0, and Google use.").
-                Run(func() </span><span class="cov0" title="0">{
-                        resp, _ := http.Get(authServer.URL + "/.well-known/openid-configuration")
-                        body, _ := io.ReadAll(resp.Body)
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8081/.well-known/openid-configuration | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        resp, err := http.Get(authServer.URL + "/.well-known/openid-configuration")
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("discovery: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(resp.Body)
                         resp.Body.Close()
 
                         var meta map[string]any
                         json.Unmarshal(body, &amp;meta)
                         pretty, _ := json.MarshalIndent(meta, "    ", "  ")
                         fmt.Printf("    %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("What's in the metadata?",
                 "| Field | What it tells the client |",
@@ -8439,42 +10669,48 @@ func main() <span class="cov0" title="0">{
                 "A client only needs to know the server's base URL. Everything else is discovered.",
         )
 
-        // --- Use client.DiscoverAS ---
         demo.Step("Discover using the client SDK (client.DiscoverAS)").
                 Ref(refs.RFC8414).
                 Arrow("App", "AS", "client.DiscoverAS(serverURL)").
                 DashedArrow("AS", "App", "typed ASMetadata struct").
                 Note("client.DiscoverAS() fetches and parses the metadata into a typed Go struct. Production code should use this — no manual JSON parsing needed.").
-                Run(func() </span><span class="cov0" title="0">{
-                        var err error
-                        discoveredMeta, err = client.DiscoverAS(authServer.URL)
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        meta, err := client.DiscoverAS(authServer.URL)
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("discover: %v", err)
                         }</span>
+                        <span class="cov0" title="0">discoveredMeta = meta
 
-                        <span class="cov0" title="0">fmt.Printf("    issuer:                  %s\n", discoveredMeta.Issuer)
+                        fmt.Printf("    issuer:                  %s\n", discoveredMeta.Issuer)
                         fmt.Printf("    token_endpoint:          %s\n", discoveredMeta.TokenEndpoint)
                         fmt.Printf("    jwks_uri:                %s\n", discoveredMeta.JWKSURI)
                         fmt.Printf("    introspection_endpoint:  %s\n", discoveredMeta.IntrospectionEndpoint)
                         fmt.Printf("    scopes_supported:        %v\n", discoveredMeta.ScopesSupported)
                         fmt.Printf("    grant_types_supported:   %v\n", discoveredMeta.GrantTypesSupported)
-                        fmt.Printf("    auth_methods:            %v\n", discoveredMeta.TokenEndpointAuthMethods)</span>
+                        fmt.Printf("    auth_methods:            %v\n", discoveredMeta.TokenEndpointAuthMethods)
+                        return nil</span>
                 })
 
-        // --- Register using discovered endpoint ---
         <span class="cov0" title="0">demo.Step("Register a client (using discovered URL)").
                 Arrow("App", "AS", "POST {discovered_registration_endpoint}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
                 Note("Instead of hardcoding /apps/register, we use the registration_endpoint from discovery. The same code works against OneAuth, Keycloak, or any RFC 8414-compliant server.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `# Discover the registration endpoint, then use it
+REG=$(curl -s http://localhost:8081/.well-known/openid-configuration | jq -r .registration_endpoint)
+curl -s -X POST "$REG" \
+  -H 'Content-Type: application/json' \
+  -d '{"client_domain":"discovery-demo.example.com","signing_alg":"HS256"}' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         body, _ := json.Marshal(map[string]any{
                                 "client_domain": "discovery-demo.example.com",
                                 "signing_alg":   "HS256",
                         })
-                        resp, _ := http.Post(authServer.URL+"/apps/register",
+                        resp, err := http.Post(authServer.URL+"/apps/register",
                                 "application/json", strings.NewReader(string(body)))
-                        var reg map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("register: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;reg)
                         resp.Body.Close()
 
@@ -8482,22 +10718,31 @@ func main() <span class="cov0" title="0">{
                         clientSecret = reg["client_secret"].(string)
                         fmt.Printf("    client_id:     %s\n", clientID)
                         fmt.Printf("    client_secret: %s...\n", clientSecret[:16])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Get token using discovered endpoint ---
         <span class="cov0" title="0">demo.Step("Get a token (using discovered token endpoint)").
                 Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "POST {discovered_token_endpoint}").
                 DashedArrow("AS", "App", "{access_token, token_type, expires_in}").
                 Note("We use discoveredMeta.TokenEndpoint instead of hardcoding /api/token. This is the key benefit — the same client code works against any compliant AS.").
-                Run(func() </span><span class="cov0" title="0">{
-                        resp, _ := http.PostForm(discoveredMeta.TokenEndpoint, url.Values{
+                VerbatimLang("Reproduce on the wire", "bash", `TOK=$(curl -s http://localhost:8081/.well-known/openid-configuration | jq -r .token_endpoint)
+curl -s -X POST "$TOK" \
+  -d 'grant_type=client_credentials' \
+  -d 'client_id=&lt;from previous step&gt;' \
+  -d 'client_secret=&lt;from previous step&gt;' \
+  -d 'scope=read write' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        resp, err := http.PostForm(discoveredMeta.TokenEndpoint, url.Values{
                                 "grant_type":    {"client_credentials"},
                                 "client_id":     {clientID},
                                 "client_secret": {clientSecret},
                                 "scope":         {"read write"},
                         })
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;tokenData)
                         resp.Body.Close()
 
@@ -8506,19 +10751,24 @@ func main() <span class="cov0" title="0">{
                         fmt.Printf("    token_type:          %s\n", tokenData["token_type"])
                         fmt.Printf("    scope:               %s\n", tokenData["scope"])
                         fmt.Printf("    access_token:        %s...\n", accessToken[:40])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Use the token ---
         <span class="cov0" title="0">demo.Step("Use the token on a resource server").
                 Ref(refs.RFC6750).
                 Arrow("App", "RS", "GET /resource (Bearer token)").
                 DashedArrow("RS", "App", "200 {data}").
                 Note("The resource server validates the token as in previous examples. Discovery doesn't change how tokens work — it only changes how the client finds the endpoints.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8082/resource \
+  -H "Authorization: Bearer &lt;access_token from previous step&gt;" | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+accessToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("resource: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         fmt.Printf("    status: %d\n", res.StatusCode)
@@ -8526,30 +10776,29 @@ func main() <span class="cov0" title="0">{
                         json.Unmarshal(body, &amp;data)
                         pretty, _ := json.MarshalIndent(data, "    ", "  ")
                         fmt.Printf("    response: %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Optional: Keycloak comparison ---
         <span class="cov0" title="0">demo.Step("Discover Keycloak endpoints (optional)").
                 Ref(refs.RFC8414).
                 Arrow("App", "AS", "client.DiscoverAS(keycloakRealmURL)").
                 DashedArrow("AS", "App", "{issuer, token_endpoint, jwks_uri, ...}").
                 Note("Same DiscoverAS() call, completely different server. If Keycloak isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Check if KC is reachable
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
                         httpClient := &amp;http.Client{Timeout: 2 * time.Second}
                         resp, err := httpClient.Get(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
                                 fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
-                                return
+                                return nil
                         }</span>
                         <span class="cov0" title="0">resp.Body.Close()
 
                         kcMeta, err := client.DiscoverAS(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
-                                return
+                                return nil
                         }</span>
 
                         <span class="cov0" title="0">fmt.Printf("    Keycloak discovered at %s:\n", kcRealmURL)
@@ -8566,7 +10815,8 @@ func main() <span class="cov0" title="0">{
                         fmt.Printf("      %-25s %-45s %s\n", "jwks_uri",
                                 discoveredMeta.JWKSURI, kcMeta.JWKSURI)
                         fmt.Printf("      %-25s %-45s %s\n", "introspection_endpoint",
-                                discoveredMeta.IntrospectionEndpoint, kcMeta.IntrospectionEndpoint)</span>
+                                discoveredMeta.IntrospectionEndpoint, kcMeta.IntrospectionEndpoint)
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("Why discovery matters",
@@ -8591,32 +10841,102 @@ func main() <span class="cov0" title="0">{
                 "for opaque tokens.",
         )
 
-        demo.Execute()
-
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
-        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
-                resourceServer.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 </pre>
 		
-		<pre class="file" id="file41" style="display: none">// Example 05: Token Introspection (RFC 7662)
+		<pre class="file" id="file50" style="display: none">// Example 05: Token Introspection (RFC 7662).
 //
-// In Examples 01-04, the resource server validated tokens locally by checking
-// the JWT signature. That's fast but has a gap: if a token is revoked, the RS
-// won't know until the token expires.
+// In examples 01-04 the resource server validated tokens locally by
+// checking the JWT signature. That's fast, but if a token is revoked,
+// the RS won't know until expiry. Introspection is the alternative: the
+// RS asks the AS "is this token still valid?" — the AS checks its
+// blacklist and returns the token's claims (or `{active: false}`).
 //
-// Introspection is the alternative: the RS asks the auth server "is this token
-// still valid?" on every request (or with caching). The AS checks its blacklist
-// and returns the token's claims.
+// Two-process architecture:
 //
-// Run:   go run ./examples/05-introspection/
-// Docs:  Run with --readme to regenerate README.md
+//        make serve   # auth :8081 with token + introspection + blacklist
+//        make demo    # walkthrough that drives it
 //
 // See: https://www.rfc-editor.org/rfc/rfc7662
 package main
+
+import (
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/core"
+        "github.com/panyam/oneauth/keys"
+)
+
+const jwtSecret = "introspection-example-secret-32c!"
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        asPublicURL := flag.String("as-url", "", "external URL of the AS (issuer); default http://localhost&lt;as-addr&gt;")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        issuer := *asPublicURL
+        if issuer == "" </span><span class="cov0" title="0">{
+                issuer = fmt.Sprintf("http://localhost%s", *asAddr)
+        }</span>
+
+        <span class="cov0" title="0">ks := keys.NewInMemoryKeyStore()
+        blacklist := core.NewInMemoryBlacklist()
+
+        log.Printf("[example-05] auth server listening on %s (issuer=%s)", *asAddr, issuer)
+        log.Printf("[example-05] introspection: POST http://localhost%s/oauth/introspect", *asAddr)
+        if err := http.ListenAndServe(*asAddr, newAuthServer(ks, blacklist, issuer)); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer wires registration, token issuance, and introspection.
+// The shared blacklist is what makes introspection-based revocation
+// work — `RevocationHandler` (or any admin tool) can call
+// `blacklist.Revoke(jti, exp)` to invalidate a token immediately.
+func newAuthServer(ks keys.KeyStorage, blacklist core.TokenBlacklist, issuer string) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        apiAuth := &amp;apiauth.APIAuth{
+                JWTSecretKey:   jwtSecret,
+                JWTIssuer:      issuer,
+                ClientKeyStore: ks,
+                Blacklist:      blacklist,
+        }
+        introspectionHandler := apiauth.NewIntrospectionHandler(apiAuth, ks)
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+        mux.Handle("POST /oauth/introspect", introspectionHandler)
+        return mux
+}</span>
+</pre>
+		
+		<pre class="file" id="file51" style="display: none">package main
 
 import (
         "encoding/base64"
@@ -8629,11 +10949,10 @@ import (
         "strings"
         "time"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/demokit"
         "github.com/panyam/oneauth/client"
         "github.com/panyam/oneauth/core"
-        "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
@@ -8643,10 +10962,19 @@ const kcExamplesRealm = "oneauth-examples"
 const kcExampleClientID = "example-app"
 const kcExampleClientSecret = "example-app-secret"
 
-func main() <span class="cov0" title="0">{
-        var authServer *httptest.Server
-        var ks keys.KeyStorage
-        var blacklist *core.InMemoryBlacklist
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+        blacklist := core.NewInMemoryBlacklist()
+
+        // Two-pass start: get the test server's URL, rebuild handler with
+        // it as the issuer (the issuer claim has to match the discovery /
+        // metadata identity for tokens to validate).
+        authServer := httptest.NewUnstartedServer(http.NewServeMux())
+        authServer.Config.Handler = newAuthServer(ks, blacklist, "")
+        authServer.Start()
+        defer authServer.Close()
+        authServer.Config.Handler = newAuthServer(ks, blacklist, authServer.URL)
+
         var clientID, clientSecret, accessToken string
         var tokenJTI string
 
@@ -8679,77 +11007,50 @@ func main() <span class="cov0" title="0">{
                 "| Both (hybrid) | Best of both | Immediate | Validate locally, introspect on failure or for critical ops |",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server with token endpoint, introspection, and blacklist").
-                Ref(refs.RFC7662).
-                Note("The auth server now has a blacklist for token revocation. The introspection endpoint checks it before responding.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        blacklist = core.NewInMemoryBlacklist()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-
-                        apiAuth := &amp;apiauth.APIAuth{
-                                JWTSecretKey:   "introspection-example-secret-32c!",
-                                JWTIssuer:      "will-be-set-after-start",
-                                ClientKeyStore: ks,
-                                Blacklist:      blacklist,
-                        }
-
-                        introspectionHandler := apiauth.NewIntrospectionHandler(apiAuth, ks)
-
-                        mux := http.NewServeMux()
-                        mux.Handle("/apps/", registrar.Handler())
-                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
-                        mux.Handle("POST /oauth/introspect", introspectionHandler)
-                        authServer = httptest.NewServer(mux)
-                        apiAuth.JWTIssuer = authServer.URL
-
-                        fmt.Printf("    Auth server:            %s\n", authServer.URL)
-                        fmt.Printf("    Token endpoint:         %s/api/token\n", authServer.URL)
-                        fmt.Printf("    Introspection endpoint: %s/oauth/introspect\n", authServer.URL)
-                }</span>)
-
-        // --- Register + get token ---
-        <span class="cov0" title="0">demo.Step("Register a client and get an access token").
+        demo.Step("Register a client and get an access token").
                 Ref(refs.RFC6749_ClientCredentials).
                 Ref(refs.RFC7519).
                 Arrow("App", "AS", "POST /apps/register → POST /api/token").
                 DashedArrow("AS", "App", "{client_id, client_secret, access_token}").
                 Note("Same as Example 01 — register, then client_credentials grant. The token includes a jti (JWT ID) claim used for revocation.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Register
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         body, _ := json.Marshal(map[string]any{
                                 "client_domain": "introspect-demo.example.com",
                                 "signing_alg":   "HS256",
                         })
-                        regResp, _ := http.Post(authServer.URL+"/apps/register",
+                        regResp, err := http.Post(authServer.URL+"/apps/register",
                                 "application/json", strings.NewReader(string(body)))
-                        var reg map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("register: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
                         json.NewDecoder(regResp.Body).Decode(&amp;reg)
                         regResp.Body.Close()
                         clientID = reg["client_id"].(string)
                         clientSecret = reg["client_secret"].(string)
 
-                        // Get token
-                        tokenResp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+                        tokenResp, err := http.PostForm(authServer.URL+"/api/token", url.Values{
                                 "grant_type":    {"client_credentials"},
                                 "client_id":     {clientID},
                                 "client_secret": {clientSecret},
                                 "scope":         {"read write"},
                         })
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(tokenResp.Body).Decode(&amp;tokenData)
                         tokenResp.Body.Close()
                         accessToken = tokenData["access_token"].(string)
 
-                        // Parse jti from the token for later revocation
                         claims := parseJWTClaims(accessToken)
                         tokenJTI = claims["jti"].(string)
 
                         fmt.Printf("    client_id:    %s\n", clientID)
                         fmt.Printf("    access_token: %s...\n", accessToken[:40])
                         fmt.Printf("    jti:          %s...\n", tokenJTI[:16])
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("How introspection works",
                 "The resource server POSTs the token to `/oauth/introspect` and authenticates",
@@ -8765,118 +11066,128 @@ func main() <span class="cov0" title="0">{
                 "information leakage to potentially malicious callers.",
         )
 
-        // --- Introspect valid token ---
         demo.Step("Introspect a valid token").
                 Ref(refs.RFC7662).
                 Arrow("RS", "AS", "POST /oauth/introspect {token} (Basic auth)").
                 DashedArrow("AS", "RS", "{active: true, sub, scope, exp, iss, jti}").
                 Note("The RS authenticates with its own credentials (same client in this example). The response includes the token's claims — the RS doesn't need to decode the JWT itself.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -u "&lt;client_id&gt;:&lt;client_secret&gt;" \
+  -d "token=&lt;access_token&gt;" \
+  http://localhost:8081/oauth/introspect | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         result := introspect(authServer.URL+"/oauth/introspect", accessToken, clientID, clientSecret)
                         pretty, _ := json.MarshalIndent(result, "    ", "  ")
                         fmt.Printf("    %s\n", string(pretty))
+                        return nil
                 }</span>)
 
-        // --- Introspect garbage ---
         <span class="cov0" title="0">demo.Step("Introspect a garbage token").
                 Ref(refs.RFC7662).
                 Arrow("RS", "AS", "POST /oauth/introspect {token: not-a-real-token}").
                 DashedArrow("AS", "RS", "{active: false}").
                 Note("Invalid tokens always return {active: false} — the AS never reveals why. This is a security requirement of RFC 7662.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -u "&lt;client_id&gt;:&lt;client_secret&gt;" \
+  -d "token=not-a-real-token" \
+  http://localhost:8081/oauth/introspect | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         result := introspect(authServer.URL+"/oauth/introspect", "not-a-real-token", clientID, clientSecret)
                         pretty, _ := json.MarshalIndent(result, "    ", "  ")
                         fmt.Printf("    %s\n", string(pretty))
+                        return nil
                 }</span>)
 
-        // --- Revoke and re-introspect ---
         <span class="cov0" title="0">demo.Step("Revoke the token, then introspect again").
                 Ref(refs.RFC7662).
                 Arrow("Admin", "AS", "blacklist.Revoke(jti)").
                 Arrow("RS", "AS", "POST /oauth/introspect {same token as step 3}").
                 DashedArrow("AS", "RS", "{active: false}").
                 Note("After revocation, the same token that was valid in step 3 now returns active=false. This is the key advantage over local JWT validation — revocation takes effect immediately.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Revoke via blacklist
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         claims := parseJWTClaims(accessToken)
                         expFloat := claims["exp"].(float64)
                         blacklist.Revoke(tokenJTI, time.Unix(int64(expFloat), 0))
                         fmt.Printf("    Revoked jti=%s...\n\n", tokenJTI[:16])
 
-                        // Introspect again
                         result := introspect(authServer.URL+"/oauth/introspect", accessToken, clientID, clientSecret)
                         pretty, _ := json.MarshalIndent(result, "    ", "  ")
                         fmt.Printf("    %s\n", string(pretty))
+                        return nil
                 }</span>)
 
-        // --- Unauthenticated caller ---
         <span class="cov0" title="0">demo.Step("Introspect without authentication (rejected)").
                 Ref(refs.RFC7662).
                 Arrow("Attacker", "AS", "POST /oauth/introspect {token} (no Basic auth)").
                 DashedArrow("AS", "Attacker", "401 Unauthorized").
                 Note("The introspection endpoint requires the caller to authenticate. An unauthenticated request is rejected — you can't fish for valid tokens.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `# No -u — caller is unauthenticated
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -d "token=&lt;access_token&gt;" \
+  http://localhost:8081/oauth/introspect`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         form := url.Values{"token": {accessToken}}
                         req, _ := http.NewRequest("POST", authServer.URL+"/oauth/introspect",
                                 strings.NewReader(form.Encode()))
                         req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-                        // No Basic auth!
-                        resp, _ := http.DefaultClient.Do(req)
-                        resp.Body.Close()
+                        resp, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("post: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">resp.Body.Close()
                         fmt.Printf("    status: %d (correctly rejected — no authentication)\n", resp.StatusCode)
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Optional: Keycloak introspection ---
         <span class="cov0" title="0">demo.Step("Introspect via Keycloak (optional)").
                 Ref(refs.RFC7662).
                 Arrow("App", "AS", "POST {KC token_endpoint} → get KC token").
                 Arrow("RS", "AS", "POST {KC introspection_endpoint} {token}").
                 DashedArrow("AS", "RS", "{active: true, sub, scope, ...}").
                 Note("Same introspection flow against Keycloak. If KC isn't running, this step is skipped — run 'make upkcl' in examples/ to start it.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Check if KC is reachable
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
                         httpClient := &amp;http.Client{Timeout: 2 * time.Second}
                         resp, err := httpClient.Get(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
                                 fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
-                                return
+                                return nil
                         }</span>
                         <span class="cov0" title="0">resp.Body.Close()
 
-                        // Discover KC endpoints
                         kcMeta, err := client.DiscoverAS(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
-                                return
+                                return nil
                         }</span>
                         <span class="cov0" title="0">fmt.Printf("    Keycloak introspection endpoint: %s\n\n", kcMeta.IntrospectionEndpoint)
 
-                        // Get a token from KC
-                        kcTokenResp, _ := http.PostForm(kcMeta.TokenEndpoint, url.Values{
+                        kcTokenResp, err := http.PostForm(kcMeta.TokenEndpoint, url.Values{
                                 "grant_type":    {"client_credentials"},
                                 "client_id":     {kcExampleClientID},
                                 "client_secret": {kcExampleClientSecret},
                                 "scope":         {"openid"},
                         })
-                        var kcToken map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR getting KC token: %v\n", err)
+                                return nil
+                        }</span>
+                        <span class="cov0" title="0">var kcToken map[string]any
                         json.NewDecoder(kcTokenResp.Body).Decode(&amp;kcToken)
                         kcTokenResp.Body.Close()
 
                         if kcToken["error"] != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    ERROR getting KC token: %v\n", kcToken["error_description"])
-                                return
+                                return nil
                         }</span>
 
                         <span class="cov0" title="0">kcAccessToken := kcToken["access_token"].(string)
                         fmt.Printf("    KC access_token: %s...\n\n", kcAccessToken[:40])
 
-                        // Introspect via KC
                         kcResult := introspect(kcMeta.IntrospectionEndpoint,
                                 kcAccessToken, kcExampleClientID, kcExampleClientSecret)
                         pretty, _ := json.MarshalIndent(kcResult, "    ", "  ")
-                        fmt.Printf("    KC introspection response:\n    %s\n", string(pretty))</span>
+                        fmt.Printf("    KC introspection response:\n    %s\n", string(pretty))
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("Introspection vs local validation — the tradeoff",
@@ -8908,17 +11219,12 @@ func main() <span class="cov0" title="0">{
                 "no admin dashboard needed. This is how third-party integrations onboard.",
         )
 
-        demo.Execute()
-
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 
-// --- Helpers ---
-
-// introspect calls an introspection endpoint and returns the parsed response.
-// endpointURL is the full introspection URL (e.g., "http://localhost:8080/oauth/introspect").
+// introspect calls an introspection endpoint and returns the parsed
+// response. endpointURL is the full introspection URL.
 func introspect(endpointURL, token, callerID, callerSecret string) map[string]any <span class="cov0" title="0">{
         form := url.Values{"token": {token}}
         req, _ := http.NewRequest("POST", endpointURL,
@@ -8935,13 +11241,12 @@ func introspect(endpointURL, token, callerID, callerSecret string) map[string]an
         return result
 }</span>
 
-// parseJWTClaims decodes JWT payload without verification (for display only).
+// parseJWTClaims decodes a JWT payload without verification (display only).
 func parseJWTClaims(tokenStr string) map[string]any <span class="cov0" title="0">{
         parts := strings.Split(tokenStr, ".")
         if len(parts) != 3 </span><span class="cov0" title="0">{
                 return nil
         }</span>
-        // JWT uses base64url (no padding)
         <span class="cov0" title="0">payload, err := base64.RawURLEncoding.DecodeString(parts[1])
         if err != nil </span><span class="cov0" title="0">{
                 return nil
@@ -8952,22 +11257,107 @@ func parseJWTClaims(tokenStr string) map[string]any <span class="cov0" title="0"
 }
 </pre>
 		
-		<pre class="file" id="file42" style="display: none">// Example 06: Dynamic Client Registration (RFC 7591)
+		<pre class="file" id="file52" style="display: none">// Example 06: Dynamic Client Registration (RFC 7591).
 //
-// In Examples 01-05, we registered apps via OneAuth's proprietary /apps/register
-// endpoint. That works but is OneAuth-specific. RFC 7591 defines a standard way
-// for clients to register themselves — the same API works across OneAuth,
-// Keycloak, Auth0, and any compliant provider.
+// Self-service client onboarding via the standard DCR endpoint
+// (`/apps/dcr`) — same request shape works against OneAuth, Keycloak,
+// Auth0, and any compliant AS. Supports both client_secret_post and
+// private_key_jwt registrations.
 //
-// Run:   go run ./examples/06-dynamic-client-registration/
-// Docs:  Run with --readme to regenerate README.md
+// Two-process architecture:
+//
+//        make serve   # auth :8081 with /apps/dcr + token + JWKS + discovery
+//        make demo    # walkthrough that drives both
 //
 // See: https://www.rfc-editor.org/rfc/rfc7591
 package main
 
 import (
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+const jwtSecret = "dcr-example-secret-at-least-32ch!"
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        asPublicURL := flag.String("as-url", "", "external URL of the AS (issuer); default http://localhost&lt;as-addr&gt;")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        issuer := *asPublicURL
+        if issuer == "" </span><span class="cov0" title="0">{
+                issuer = fmt.Sprintf("http://localhost%s", *asAddr)
+        }</span>
+
+        <span class="cov0" title="0">ks := keys.NewInMemoryKeyStore()
+        log.Printf("[example-06] auth server listening on %s (issuer=%s)", *asAddr, issuer)
+        log.Printf("[example-06] DCR: POST %s/apps/dcr", issuer)
+        if err := http.ListenAndServe(*asAddr, newAuthServer(ks, issuer)); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer wires the DCR endpoint (under /apps/) plus token, JWKS,
+// and discovery so a freshly-registered client can immediately fetch
+// the AS metadata, mint a token, and verify signatures.
+func newAuthServer(ks keys.KeyStorage, issuer string) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+        apiAuth := &amp;apiauth.APIAuth{
+                JWTSecretKey:   jwtSecret,
+                JWTIssuer:      issuer,
+                ClientKeyStore: ks,
+        }
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+        mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
+        mux.Handle("GET /.well-known/openid-configuration",
+                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                        Issuer:                   issuer,
+                        TokenEndpoint:            issuer + "/api/token",
+                        JWKSURI:                  issuer + "/.well-known/jwks.json",
+                        RegistrationEndpoint:     issuer + "/apps/dcr",
+                        GrantTypesSupported:      []string{"client_credentials"},
+                        TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},
+                }))
+        return mux
+}</span>
+</pre>
+		
+		<pre class="file" id="file53" style="display: none">package main
+
+import (
         "bytes"
+        "context"
         "encoding/json"
+        "errors"
         "fmt"
         "io"
         "net/http"
@@ -8975,10 +11365,9 @@ import (
         "net/url"
         "time"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/client"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
@@ -8987,10 +11376,18 @@ import (
 const kcExamplesURL = "http://localhost:8280"
 const kcExamplesRealm = "oneauth-examples"
 
-func main() <span class="cov0" title="0">{
-        var authServer *httptest.Server
-        var ks keys.KeyStorage
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+
+        authServer := httptest.NewUnstartedServer(http.NewServeMux())
+        authServer.Config.Handler = newAuthServer(ks, "")
+        authServer.Start()
+        defer authServer.Close()
+        authServer.Config.Handler = newAuthServer(ks, authServer.URL)
+
         var symClientID, symClientSecret string
+        var symRegToken, symRegURI string
+        var symRegTokenPrevious string // captured before PUT rotation so the next step can demo rejection
         var asymClientID string
 
         demo := demokit.New("06: Dynamic Client Registration").
@@ -9018,43 +11415,7 @@ func main() <span class="cov0" title="0">{
                 "grant types, auth method). The AS creates the client and returns credentials.",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server with DCR endpoint").
-                Ref(refs.RFC7591).
-                Ref(refs.RFC8414).
-                Note("The auth server serves /apps/dcr (RFC 7591) alongside the proprietary /apps/register. Both create clients in the same KeyStore.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
-
-                        apiAuth := &amp;apiauth.APIAuth{
-                                JWTSecretKey:   "dcr-example-secret-at-least-32ch!",
-                                ClientKeyStore: ks,
-                        }
-
-                        mux := http.NewServeMux()
-                        mux.Handle("/apps/", registrar.Handler()) // includes /apps/dcr
-                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
-                        mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler.ServeHTTP)
-                        authServer = httptest.NewServer(mux)
-                        apiAuth.JWTIssuer = authServer.URL
-
-                        mux.Handle("GET /.well-known/openid-configuration",
-                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
-                                        Issuer:                   authServer.URL,
-                                        TokenEndpoint:            authServer.URL + "/api/token",
-                                        JWKSURI:                  authServer.URL + "/.well-known/jwks.json",
-                                        RegistrationEndpoint:     authServer.URL + "/apps/dcr",
-                                        GrantTypesSupported:      []string{"client_credentials"},
-                                        TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},
-                                }))
-
-                        fmt.Printf("    Auth server:    %s\n", authServer.URL)
-                        fmt.Printf("    DCR endpoint:   %s/apps/dcr\n", authServer.URL)
-                }</span>)
-
-        <span class="cov0" title="0">demo.Section("DCR request format (RFC 7591 §2)",
+        demo.Section("DCR request format (RFC 7591 §2)",
                 "A DCR request is a JSON object with client metadata:",
                 "```json",
                 "{",
@@ -9078,13 +11439,21 @@ func main() <span class="cov0" title="0">{
                 "```",
         )
 
-        // --- Symmetric registration ---
         demo.Step("Register a symmetric client (client_secret_post)").
                 Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, auth_method}").
                 DashedArrow("AS", "App", "{client_id, client_secret, client_id_issued_at}").
                 Note("The simplest DCR: the AS generates both a client_id and client_secret. The client uses client_secret_post to authenticate at the token endpoint.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/apps/dcr \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_name":"My Example Bot",
+    "client_uri":"https://bot.example.com",
+    "grant_types":["client_credentials"],
+    "token_endpoint_auth_method":"client_secret_post",
+    "scope":"read write"
+  }' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         dcrReq := map[string]any{
                                 "client_name":                "My Example Bot",
                                 "client_uri":                 "https://bot.example.com",
@@ -9094,9 +11463,12 @@ func main() <span class="cov0" title="0">{
                         }
                         body, _ := json.Marshal(dcrReq)
 
-                        resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+                        resp, err := http.Post(authServer.URL+"/apps/dcr", "application/json",
                                 bytes.NewReader(body))
-                        respBody, _ := io.ReadAll(resp.Body)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("dcr: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">respBody, _ := io.ReadAll(resp.Body)
                         resp.Body.Close()
 
                         fmt.Printf("    HTTP status: %d\n\n", resp.StatusCode)
@@ -9108,38 +11480,207 @@ func main() <span class="cov0" title="0">{
 
                         symClientID = dcrResp["client_id"].(string)
                         symClientSecret = dcrResp["client_secret"].(string)
-                }</span>)
+                        symRegToken, _ = dcrResp["registration_access_token"].(string)
+                        symRegURI, _ = dcrResp["registration_client_uri"].(string)
+                        return nil</span>
+                })
 
-        // --- Use the registered client ---
+        <span class="cov0" title="0">demo.Section("RFC 7592: managing your own registration",
+                "Notice the response above includes two extra fields:",
+                "",
+                "- `registration_access_token` — a Bearer token tied to **this specific client_id**",
+                "- `registration_client_uri` — the management endpoint for this registration",
+                "",
+                "These come from RFC 7592 (Dynamic Client Registration *Management*). Once a client",
+                "is registered, holding the access token lets the client read, update, or delete",
+                "its own registration without going through an admin — a self-service lifecycle.",
+                "",
+                "OneAuth issue 168 ships GET (read); 169 / 170 will add PUT (update) and DELETE.",
+        )
+
+        demo.Step("Fetch your own registration (RFC 7592 §2.1)").
+                Ref(refs.RFC7592).
+                Arrow("App", "AS", "GET {registration_client_uri}  Authorization: Bearer {registration_access_token}").
+                DashedArrow("AS", "App", "{registration metadata — without client_secret}").
+                Note("client.GetRegistration is a thin SDK wrapper. Note the response intentionally omits client_secret on read — re-emitting symmetric credentials on every fetch enlarges disclosure if the access token leaks. Clients that lose the secret will rotate via PUT (#169).").
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X GET '&lt;registration_client_uri&gt;' \
+  -H 'Authorization: Bearer &lt;registration_access_token&gt;' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        if symRegToken == "" || symRegURI == "" </span><span class="cov0" title="0">{
+                                return demokit.Errf("symmetric registration didn't issue management credentials")
+                        }</span>
+                        <span class="cov0" title="0">resp, err := client.GetRegistration(context.Background(), &amp;client.GetRegistrationRequest{
+                                RegistrationClientURI:   symRegURI,
+                                RegistrationAccessToken: symRegToken,
+                        })
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("GetRegistration: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">got := resp.Registration
+                        fmt.Printf("    client_id:                 %s\n", got.ClientID)
+                        fmt.Printf("    client_name:               %s\n", got.ClientName)
+                        fmt.Printf("    scope:                     %s\n", got.Scope)
+                        fmt.Printf("    grant_types:               %v\n", got.GrantTypes)
+                        fmt.Printf("    registration_client_uri:   %s\n", got.RegistrationClientURI)
+                        fmt.Printf("    client_secret in response: %v (intentionally omitted)\n", got.ClientSecret != "")
+                        return nil</span>
+                })
+
+        <span class="cov0" title="0">demo.Step("Update your scope (RFC 7592 §2.2)").
+                Ref(refs.RFC7592).
+                Arrow("App", "AS", "PUT {registration_client_uri}  Authorization: Bearer {registration_access_token}").
+                DashedArrow("AS", "App", "{registration metadata + NEW registration_access_token}").
+                Note("PUT is a full replacement (not PATCH-style merge): any field omitted from the body is cleared. The AS rotates the registration_access_token on success — the response includes a NEW token that supersedes the one passed in. The OneAuth server also rejects token_endpoint_auth_method changes (those require re-keying; clients DELETE + re-register instead).").
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X PUT '&lt;registration_client_uri&gt;' \
+  -H 'Authorization: Bearer &lt;registration_access_token&gt;' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_id":"&lt;from registration&gt;",
+    "client_name":"My Example Bot",
+    "client_uri":"https://bot.example.com",
+    "grant_types":["client_credentials"],
+    "token_endpoint_auth_method":"client_secret_post",
+    "scope":"read write admin"
+  }' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        if symRegToken == "" || symRegURI == "" </span><span class="cov0" title="0">{
+                                return demokit.Errf("symmetric registration didn't issue management credentials")
+                        }</span>
+                        <span class="cov0" title="0">resp, err := client.UpdateRegistration(context.Background(), &amp;client.UpdateRegistrationRequest{
+                                RegistrationClientURI:   symRegURI,
+                                RegistrationAccessToken: symRegToken,
+                                ClientID:                symClientID,
+                                Metadata: client.ClientRegistrationRequest{
+                                        ClientName:              "My Example Bot",
+                                        ClientURI:               "https://bot.example.com",
+                                        GrantTypes:              []string{"client_credentials"},
+                                        TokenEndpointAuthMethod: "client_secret_post",
+                                        Scope:                   "read write admin",
+                                },
+                        })
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("UpdateRegistration: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">updated := resp.Registration
+                        fmt.Printf("    client_id:        %s\n", updated.ClientID)
+                        fmt.Printf("    new scope:        %s\n", updated.Scope)
+                        fmt.Printf("    token rotated:    %v (old != new)\n", updated.RegistrationAccessToken != symRegToken)
+                        fmt.Printf("    new token (4):    %s...\n", updated.RegistrationAccessToken[:4])
+
+                        // Persist the rotated token; remember the old one so the next step
+                        // can demonstrate that it is now rejected.
+                        symRegTokenPrevious = symRegToken
+                        symRegToken = updated.RegistrationAccessToken
+                        return nil</span>
+                })
+
+        <span class="cov0" title="0">demo.Step("Old token is rejected after rotation").
+                Ref(refs.RFC7592).
+                Arrow("App", "AS", "GET {registration_client_uri}  Authorization: Bearer {OLD token}").
+                DashedArrow("AS", "App", "401 Unauthorized").
+                Note("After PUT rotates the token, attempting to reuse the *previous* registration_access_token must fail with 401 — even though the client_id is still valid. This is the security guarantee of rotation: a leaked-then-rotated token cannot be replayed.").
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        if symRegTokenPrevious == "" </span><span class="cov0" title="0">{
+                                return demokit.Errf("previous step didn't capture the old token")
+                        }</span>
+                        <span class="cov0" title="0">_, err := client.GetRegistration(context.Background(), &amp;client.GetRegistrationRequest{
+                                RegistrationClientURI:   symRegURI,
+                                RegistrationAccessToken: symRegTokenPrevious,
+                        })
+                        if err == nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("expected old token to be rejected; it succeeded instead")
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    old token (4): %s...\n", symRegTokenPrevious[:4])
+                        fmt.Printf("    new token (4): %s...\n", symRegToken[:4])
+                        fmt.Printf("    error from AS: %v\n", err)
+                        fmt.Printf("    is ErrRegistrationUnauthorized: %v\n",
+                                errors.Is(err, client.ErrRegistrationUnauthorized))
+                        return nil</span>
+                })
+
         <span class="cov0" title="0">demo.Step("Get a token with the DCR-registered client").
                 Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "POST /api/token {client_id, client_secret from DCR}").
                 DashedArrow("AS", "App", "{access_token}").
                 Note("The dynamically registered client works exactly like a manually registered one — the AS doesn't distinguish between registration methods.").
-                Run(func() </span><span class="cov0" title="0">{
-                        tokenResp, _ := http.PostForm(authServer.URL+"/api/token", url.Values{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/api/token \
+  -d 'grant_type=client_credentials' \
+  -d 'client_id=&lt;from DCR&gt;' \
+  -d 'client_secret=&lt;from DCR&gt;' \
+  -d 'scope=read' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        tokenResp, err := http.PostForm(authServer.URL+"/api/token", url.Values{
                                 "grant_type":    {"client_credentials"},
                                 "client_id":     {symClientID},
                                 "client_secret": {symClientSecret},
                                 "scope":         {"read"},
                         })
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(tokenResp.Body).Decode(&amp;tokenData)
                         tokenResp.Body.Close()
 
                         fmt.Printf("    token_type:    %s\n", tokenData["token_type"])
                         fmt.Printf("    scope:         %s\n", tokenData["scope"])
                         fmt.Printf("    access_token:  %s...\n", tokenData["access_token"].(string)[:40])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Asymmetric registration ---
+        <span class="cov0" title="0">demo.Step("Delete the registration (RFC 7592 §2.3)").
+                Ref(refs.RFC7592).
+                Arrow("App", "AS", "DELETE {registration_client_uri}  Authorization: Bearer {registration_access_token}").
+                DashedArrow("AS", "App", "204 No Content").
+                Note("DELETE removes the registration AND invalidates the signing credentials. After this, the client_secret captured at registration can no longer mint access tokens — the AS has dropped the signing key. RFC 7592 §2.3 requires the AS to MUST invalidate already-issued tokens; OneAuth does this by deleting the KeyStore entry so the JWT signature check fails.").
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X DELETE '&lt;registration_client_uri&gt;' \
+  -H 'Authorization: Bearer &lt;registration_access_token&gt;' -i`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        if symRegToken == "" || symRegURI == "" </span><span class="cov0" title="0">{
+                                return demokit.Errf("symmetric registration didn't issue management credentials")
+                        }</span>
+                        <span class="cov0" title="0">_, err := client.DeleteRegistration(context.Background(), &amp;client.DeleteRegistrationRequest{
+                                RegistrationClientURI:   symRegURI,
+                                RegistrationAccessToken: symRegToken,
+                        })
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("DeleteRegistration: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">fmt.Printf("    DELETE: 204 No Content (registration removed)\n\n")
+
+                        // Demonstrate that the credentials are dead — client_credentials
+                        // with the now-invalidated secret fails.
+                        tokenResp, err := http.PostForm(authServer.URL+"/api/token", url.Values{
+                                "grant_type":    {"client_credentials"},
+                                "client_id":     {symClientID},
+                                "client_secret": {symClientSecret},
+                                "scope":         {"read"},
+                        })
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token check: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">tokenResp.Body.Close()
+                        fmt.Printf("    POST /api/token with old secret → HTTP %d (deleted client cannot mint tokens)\n", tokenResp.StatusCode)
+                        return nil</span>
+                })
+
         <span class="cov0" title="0">demo.Step("Register an asymmetric client (private_key_jwt with JWKS)").
                 Ref(refs.RFC7591).
                 Ref(refs.RFC7517).
                 Arrow("App", "AS", "POST /apps/dcr {auth_method: private_key_jwt, jwks: {keys: [...]}}").
                 DashedArrow("AS", "App", "{client_id} (no client_secret — asymmetric!)").
                 Note("For asymmetric auth, the client sends its public key as a JWK set. No secret is returned — the client authenticates with signed JWTs using its private key.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `# Replace JWK_JSON with a single JWK for your public key (kty/n/e for RSA, kty/x/y for EC)
+JWK_JSON='{"kty":"RSA","alg":"RS256","kid":"...","n":"...","e":"AQAB"}'
+curl -s -X POST http://localhost:8081/apps/dcr \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"client_name\":\"My Secure Service\",
+    \"grant_types\":[\"client_credentials\"],
+    \"token_endpoint_auth_method\":\"private_key_jwt\",
+    \"jwks\":{\"keys\":[$JWK_JSON]}
+  }" | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         _, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
                         pubKey, _ := utils.ParsePublicKeyPEM(pubPEM)
                         kid, _ := utils.ComputeKid(pubKey, "RS256")
@@ -9153,9 +11694,12 @@ func main() <span class="cov0" title="0">{
                         }
                         body, _ := json.Marshal(dcrReq)
 
-                        resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+                        resp, err := http.Post(authServer.URL+"/apps/dcr", "application/json",
                                 bytes.NewReader(body))
-                        respBody, _ := io.ReadAll(resp.Body)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("dcr: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">respBody, _ := io.ReadAll(resp.Body)
                         resp.Body.Close()
 
                         fmt.Printf("    HTTP status: %d\n\n", resp.StatusCode)
@@ -9169,7 +11713,8 @@ func main() <span class="cov0" title="0">{
                         hasSecret := dcrResp["client_secret"] != nil &amp;&amp; dcrResp["client_secret"] != ""
                         fmt.Printf("\n    client_id:     %s\n", asymClientID)
                         fmt.Printf("    client_secret: %v (asymmetric — no secret needed)\n", hasSecret)
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("Symmetric vs asymmetric DCR",
                 "| | client_secret_post / basic | private_key_jwt |",
@@ -9181,34 +11726,32 @@ func main() <span class="cov0" title="0">{
                 "| **Best for** | Simple integrations | High-security, multi-service |",
         )
 
-        // --- Optional: Keycloak DCR ---
         demo.Step("Register via Keycloak DCR (optional)").
                 Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST {KC registration_endpoint} {client_name, grant_types}").
                 DashedArrow("AS", "App", "{client_id, client_secret, registration_access_token}").
                 Note("Same DCR request format against Keycloak. KC returns additional fields like registration_access_token for client management. If KC isn't running, this step is skipped.").
-                Run(func() </span><span class="cov0" title="0">{
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
                         httpClient := &amp;http.Client{Timeout: 2 * time.Second}
                         resp, err := httpClient.Get(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
                                 fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
-                                return
+                                return nil
                         }</span>
                         <span class="cov0" title="0">resp.Body.Close()
 
-                        // Discover KC registration endpoint
                         kcMeta, err := client.DiscoverAS(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    ERROR discovering Keycloak: %v\n", err)
-                                return
+                                return nil
                         }</span>
 
                         <span class="cov0" title="0">if kcMeta.RegistrationEndpoint == "" </span><span class="cov0" title="0">{
                                 fmt.Printf("    SKIPPED: Keycloak does not advertise a registration_endpoint\n")
                                 fmt.Printf("    (KC may need 'registrationAllowed' enabled on the realm)\n")
-                                return
+                                return nil
                         }</span>
 
                         <span class="cov0" title="0">fmt.Printf("    KC registration endpoint: %s\n\n", kcMeta.RegistrationEndpoint)
@@ -9219,16 +11762,21 @@ func main() <span class="cov0" title="0">{
                         }
                         body, _ := json.Marshal(dcrReq)
 
-                        dcrResp, _ := http.Post(kcMeta.RegistrationEndpoint, "application/json",
+                        dcrResp, err := http.Post(kcMeta.RegistrationEndpoint, "application/json",
                                 bytes.NewReader(body))
-                        dcrBody, _ := io.ReadAll(dcrResp.Body)
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return nil
+                        }</span>
+                        <span class="cov0" title="0">dcrBody, _ := io.ReadAll(dcrResp.Body)
                         dcrResp.Body.Close()
 
                         fmt.Printf("    HTTP status: %d\n", dcrResp.StatusCode)
                         var kcDCR map[string]any
                         json.Unmarshal(dcrBody, &amp;kcDCR)
                         pretty, _ := json.MarshalIndent(kcDCR, "    ", "  ")
-                        fmt.Printf("    %s\n", string(pretty))</span>
+                        fmt.Printf("    %s\n", string(pretty))
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("What's next?",
@@ -9237,25 +11785,123 @@ func main() <span class="cov0" title="0">{
                 "configuration — all wrapped in a simple `TokenSource` interface.",
         )
 
-        demo.Execute()
-
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 </pre>
 		
-		<pre class="file" id="file43" style="display: none">// Example 07: Client SDK — Production Patterns
+		<pre class="file" id="file54" style="display: none">// Example 07: Client SDK — Production Patterns.
 //
-// Examples 01-06 showed the server side and raw HTTP calls. This example shows
-// how production client code works: discovery-driven configuration, automatic
-// token caching/refresh, and scope step-up — all via OneAuth's client SDK.
+// Examples 01-06 made raw `http.Post` calls. This one shows how
+// production client code uses OneAuth's SDK: discovery-driven
+// configuration, automatic token caching, scope step-up, all behind
+// the `TokenSource` interface.
 //
-// Run:   go run ./examples/07-client-sdk/
-// Docs:  Run with --readme to regenerate README.md
+// Two-process architecture:
+//
+//        make serve   # auth :8081 with token + discovery, resource :8082
+//        make demo    # walkthrough that drives both
 //
 // See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
 package main
+
+import (
+        "encoding/json"
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+const jwtSecret = "sdk-example-secret-at-least-32ch!"
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "resource server listen address")
+        asPublicURL := flag.String("as-url", "", "external URL of the AS (issuer); default http://localhost&lt;as-addr&gt;")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        issuer := *asPublicURL
+        if issuer == "" </span><span class="cov0" title="0">{
+                issuer = fmt.Sprintf("http://localhost%s", *asAddr)
+        }</span>
+
+        <span class="cov0" title="0">ks := keys.NewInMemoryKeyStore()
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-07] resource server listening on %s", *rsAddr)
+                if err := http.ListenAndServe(*rsAddr, newResourceServer(issuer)); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-07] auth server listening on %s (issuer=%s)", *asAddr, issuer)
+        if err := http.ListenAndServe(*asAddr, newAuthServer(ks, issuer)); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+func newAuthServer(ks keys.KeyStorage, issuer string) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        apiAuth := &amp;apiauth.APIAuth{
+                JWTSecretKey:   jwtSecret,
+                JWTIssuer:      issuer,
+                ClientKeyStore: ks,
+        }
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+        mux.Handle("GET /.well-known/openid-configuration",
+                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                        Issuer:                   issuer,
+                        TokenEndpoint:            issuer + "/api/token",
+                        GrantTypesSupported:      []string{"client_credentials"},
+                        TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic"},
+                }))
+        return mux
+}</span>
+
+func newResourceServer(issuer string) http.Handler <span class="cov0" title="0">{
+        middleware := &amp;apiauth.APIMiddleware{
+                JWTSecretKey: jwtSecret,
+                JWTIssuer:    issuer,
+        }
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+                                "scopes": apiauth.GetScopesFromAPIContext(r.Context()),
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file55" style="display: none">package main
 
 import (
         "bytes"
@@ -9266,10 +11912,9 @@ import (
         "net/http/httptest"
         "time"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/client"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
@@ -9279,9 +11924,27 @@ const kcExamplesRealm = "oneauth-examples"
 const kcExampleClientID = "example-app"
 const kcExampleClientSecret = "example-app-secret"
 
-func main() <span class="cov0" title="0">{
-        var authServer, resourceServer *httptest.Server
-        var registeredClientID, registeredSecret string
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+
+        authServer := httptest.NewUnstartedServer(http.NewServeMux())
+        authServer.Config.Handler = newAuthServer(ks, "")
+        authServer.Start()
+        defer authServer.Close()
+        authServer.Config.Handler = newAuthServer(ks, authServer.URL)
+
+        resourceServer := httptest.NewServer(newResourceServer(authServer.URL))
+        defer resourceServer.Close()
+
+        // Pre-register a client — the SDK is about token acquisition, not
+        // registration (covered in Example 06).
+        regResp := postJSON(authServer.URL+"/apps/register", map[string]any{
+                "client_domain": "sdk-demo.example.com",
+                "signing_alg":   "HS256",
+        })
+        registeredClientID := regResp["client_id"].(string)
+        registeredSecret := regResp["client_secret"].(string)
+
         var tokenSource *client.ClientCredentialsSource
 
         demo := demokit.New("07: Client SDK — Production Patterns").
@@ -9311,86 +11974,33 @@ func main() <span class="cov0" title="0">{
                 "```",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server and resource server").
-                Note("Same auth server as previous examples. We also pre-register a client since the SDK focuses on token acquisition, not registration.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks := keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        fmt.Printf("    Pre-registered client: %s\n\n", registeredClientID)
 
-                        apiAuth := &amp;apiauth.APIAuth{
-                                JWTSecretKey:   "sdk-example-secret-at-least-32ch!",
-                                ClientKeyStore: ks,
-                        }
-
-                        mux := http.NewServeMux()
-                        mux.Handle("/apps/", registrar.Handler())
-                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
-                        authServer = httptest.NewServer(mux)
-                        apiAuth.JWTIssuer = authServer.URL
-
-                        mux.Handle("GET /.well-known/openid-configuration",
-                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
-                                        Issuer:                   authServer.URL,
-                                        TokenEndpoint:            authServer.URL + "/api/token",
-                                        GrantTypesSupported:      []string{"client_credentials"},
-                                        TokenEndpointAuthMethods: []string{"client_secret_post", "client_secret_basic"},
-                                }))
-
-                        // Resource server
-                        middleware := &amp;apiauth.APIMiddleware{
-                                JWTSecretKey: "sdk-example-secret-at-least-32ch!",
-                                JWTIssuer:    authServer.URL,
-                        }
-                        resMux := http.NewServeMux()
-                        resMux.Handle("GET /resource", middleware.ValidateToken(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "user":   apiauth.GetUserIDFromAPIContext(r.Context()),
-                                                "scopes": apiauth.GetScopesFromAPIContext(r.Context()),
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">resourceServer = httptest.NewServer(resMux)
-
-                        // Pre-register a client
-                        resp := postJSON(authServer.URL+"/apps/register", map[string]any{
-                                "client_domain": "sdk-demo.example.com",
-                                "signing_alg":   "HS256",
-                        })
-                        registeredClientID = resp["client_id"].(string)
-                        registeredSecret = resp["client_secret"].(string)
-
-                        fmt.Printf("    Auth server:     %s\n", authServer.URL)
-                        fmt.Printf("    Resource server: %s\n", resourceServer.URL)
-                        fmt.Printf("    Client ID:       %s\n", registeredClientID)</span>
-                })
-
-        // --- One-shot token ---
-        <span class="cov0" title="0">demo.Step("One-shot token with AuthClient").
+        demo.Step("One-shot token with AuthClient").
                 Ref(refs.RFC6749_ClientCredentials).
                 Ref(refs.RFC8414).
                 Arrow("App", "AS", "client.DiscoverAS(serverURL)").
                 Arrow("App", "AS", "authClient.ClientCredentialsToken(id, secret, scopes)").
                 DashedArrow("AS", "App", "ServerCredential{AccessToken, ExpiresAt, Scope}").
                 Note("AuthClient is the low-level SDK: discover endpoints, then make a single token request. Good for one-off calls. Uses discovery to find the token endpoint automatically.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Discover + create client
-                        meta, _ := client.DiscoverAS(authServer.URL)
-                        authClient := client.NewAuthClient(authServer.URL, nil,
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        meta, err := client.DiscoverAS(authServer.URL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("discover: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">authClient := client.NewAuthClient(authServer.URL, nil,
                                 client.WithASMetadata(meta))
 
                         cred, err := authClient.ClientCredentialsToken(
                                 registeredClientID, registeredSecret, []string{"read"})
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("token: %v", err)
                         }</span>
 
                         <span class="cov0" title="0">fmt.Printf("    access_token: %s...\n", cred.AccessToken[:40])
                         fmt.Printf("    scope:        %s\n", cred.Scope)
-                        fmt.Printf("    expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))</span>
+                        fmt.Printf("    expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("AuthClient vs ClientCredentialsSource",
@@ -9403,14 +12013,18 @@ func main() <span class="cov0" title="0">{
                 "| **Scope step-up** | Manual | `TokenForScopes()` |",
         )
 
-        // --- TokenSource with caching ---
         demo.Step("Cached token with ClientCredentialsSource").
                 Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "App", "tokenSource.Token() → cached or fetched").
                 Arrow("App", "RS", "GET /resource (Bearer: cached token)").
                 DashedArrow("RS", "App", "200 {data}").
                 Note("ClientCredentialsSource implements TokenSource: Token() returns a cached token if still valid, or fetches a new one. Multiple goroutines can safely call Token() concurrently.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Equivalent on the wire", "bash", `# What the SDK does under the hood (first call only — subsequent calls reuse the cached token):
+TOKEN=$(curl -s -X POST http://localhost:8081/api/token \
+  -d 'grant_type=client_credentials' \
+  -d 'client_id=&lt;id&gt;' -d 'client_secret=&lt;secret&gt;' -d 'scope=read' | jq -r .access_token)
+curl -s http://localhost:8082/resource -H "Authorization: Bearer $TOKEN" | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         tokenSource = &amp;client.ClientCredentialsSource{
                                 TokenEndpoint: authServer.URL + "/api/token",
                                 ClientID:      registeredClientID,
@@ -9418,48 +12032,44 @@ func main() <span class="cov0" title="0">{
                                 Scopes:        []string{"read"},
                         }
 
-                        // First call: fetches a new token
                         token1, err := tokenSource.Token()
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("token: %v", err)
                         }</span>
                         <span class="cov0" title="0">fmt.Printf("    First call:  %s... (fetched)\n", token1[:40])
 
-                        // Second call: returns cached token (no HTTP call)
                         token2, _ := tokenSource.Token()
                         fmt.Printf("    Second call: %s... (cached)\n", token2[:40])
                         fmt.Printf("    Same token:  %v\n", token1 == token2)
 
-                        // Use the token on a resource server
                         req, _ := http.NewRequest("GET", resourceServer.URL+"/resource", nil)
                         req.Header.Set("Authorization", "Bearer "+token1)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("resource: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
-
-                        fmt.Printf("    Resource:    %d %s\n", res.StatusCode, string(body))</span>
+                        fmt.Printf("    Resource:    %d %s\n", res.StatusCode, string(body))
+                        return nil</span>
                 })
 
-        // --- Scope step-up ---
         <span class="cov0" title="0">demo.Step("Scope step-up with TokenForScopes").
                 Arrow("App", "App", "tokenSource.TokenForScopes([\"write\"])").
                 Arrow("App", "AS", "POST /api/token {scope: read write} (merged)").
                 DashedArrow("AS", "App", "new token with expanded scopes").
                 Note("When your app needs additional permissions, TokenForScopes merges the new scopes with existing ones, invalidates the cache, and fetches a fresh token.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Original token has "read" only
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         oldToken, _ := tokenSource.Token()
                         fmt.Printf("    Before step-up: %s...\n", oldToken[:40])
 
-                        // Step up to include "write"
                         newToken, err := tokenSource.TokenForScopes([]string{"write"})
                         if err != nil </span><span class="cov0" title="0">{
-                                fmt.Printf("    ERROR: %v\n", err)
-                                return
+                                return demokit.Errf("step-up: %v", err)
                         }</span>
                         <span class="cov0" title="0">fmt.Printf("    After step-up:  %s...\n", newToken[:40])
-                        fmt.Printf("    Different token: %v (cache was invalidated)\n", oldToken != newToken)</span>
+                        fmt.Printf("    Different token: %v (cache was invalidated)\n", oldToken != newToken)
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("TokenSource in practice",
@@ -9484,7 +12094,6 @@ func main() <span class="cov0" title="0">{
                 "no cross-module import needed.",
         )
 
-        // --- Optional: Keycloak ---
         demo.Step("Use the SDK against Keycloak (optional)").
                 Ref(refs.RFC8414).
                 Ref(refs.RFC6749_ClientCredentials).
@@ -9492,38 +12101,37 @@ func main() <span class="cov0" title="0">{
                 Arrow("App", "AS", "authClient.ClientCredentialsToken(...)").
                 DashedArrow("AS", "App", "ServerCredential from Keycloak").
                 Note("Same SDK code, pointed at Keycloak. DiscoverAS finds the KC token endpoint automatically. If KC isn't running, this step is skipped.").
-                Run(func() </span><span class="cov0" title="0">{
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         kcRealmURL := kcExamplesURL + "/realms/" + kcExamplesRealm
                         httpClient := &amp;http.Client{Timeout: 2 * time.Second}
                         resp, err := httpClient.Get(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    SKIPPED: Keycloak not running at %s\n", kcExamplesURL)
                                 fmt.Printf("    To enable: cd examples &amp;&amp; make upkcl\n")
-                                return
+                                return nil
                         }</span>
                         <span class="cov0" title="0">resp.Body.Close()
 
-                        // Discover KC
                         kcMeta, err := client.DiscoverAS(kcRealmURL)
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    ERROR discovering KC: %v\n", err)
-                                return
+                                return nil
                         }</span>
 
-                        // Use AuthClient against KC
                         <span class="cov0" title="0">kcClient := client.NewAuthClient(kcRealmURL, nil,
                                 client.WithASMetadata(kcMeta))
                         cred, err := kcClient.ClientCredentialsToken(
                                 kcExampleClientID, kcExampleClientSecret, []string{"openid"})
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    ERROR getting KC token: %v\n", err)
-                                return
+                                return nil
                         }</span>
 
                         <span class="cov0" title="0">fmt.Printf("    KC access_token: %s...\n", cred.AccessToken[:40])
                         fmt.Printf("    KC scope:        %s\n", cred.Scope)
                         fmt.Printf("    KC expires_at:   %s\n", cred.ExpiresAt.Format(time.RFC3339))
-                        fmt.Printf("\n    Same SDK code — different server. That's the point.\n")</span>
+                        fmt.Printf("\n    Same SDK code — different server. That's the point.\n")
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("What's next?",
@@ -9532,20 +12140,15 @@ func main() <span class="cov0" title="0">{
                 "like \"transfer 45 EUR to Merchant A\" using RFC 9396.",
         )
 
+        common.SetupRenderer(demo)
         demo.Execute()
 
         if tokenSource != nil </span><span class="cov0" title="0">{
                 tokenSource.Close()
         }</span>
-        <span class="cov0" title="0">if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
-        <span class="cov0" title="0">if resourceServer != nil </span><span class="cov0" title="0">{
-                resourceServer.Close()
-        }</span>
 }
 
-// postJSON is a helper that POSTs JSON and returns the decoded response.
+// postJSON POSTs JSON and returns the decoded response.
 func postJSON(url string, body any) map[string]any <span class="cov0" title="0">{
         data, _ := json.Marshal(body)
         resp, _ := http.Post(url, "application/json", bytes.NewReader(data))
@@ -9556,20 +12159,146 @@ func postJSON(url string, body any) map[string]any <span class="cov0" title="0">
 }</span>
 </pre>
 		
-		<pre class="file" id="file44" style="display: none">// Example 08: Rich Authorization Requests (RFC 9396)
+		<pre class="file" id="file56" style="display: none">// Example 08: Rich Authorization Requests (RFC 9396).
 //
-// This is the culmination of Examples 01-07. Flat scopes like "read" and "write"
-// can't express "transfer 45 EUR to Merchant A". RFC 9396 adds structured
-// authorization_details to OAuth — fine-grained, typed, with API-specific fields.
+// Flat scopes can't express "transfer 45 EUR to Merchant A". RAR adds
+// structured `authorization_details` to the token endpoint, JWT claim,
+// introspection response, and middleware enforcement.
 //
-// This is the feature that motivated this entire PR — driven by a banking client
-// evaluating OneAuth for transaction-level authorization.
+// Three-server architecture:
 //
-// Run:   go run ./examples/08-rich-authorization-requests/
-// Docs:  Run with --readme to regenerate README.md
+//        make serve    # auth :8081, payments :8082, accounts :8083
+//        make demo     # walkthrough that drives all three
 //
 // See: https://www.rfc-editor.org/rfc/rfc9396
 package main
+
+import (
+        "encoding/json"
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+const jwtSecret = "rar-example-secret-at-least-32ch!"
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        payAddr := flag.String("payments-addr", ":8082", "payments RS listen address")
+        acctAddr := flag.String("accounts-addr", ":8083", "accounts RS listen address")
+        asPublicURL := flag.String("as-url", "", "external URL of the AS (issuer); default http://localhost&lt;as-addr&gt;")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        issuer := *asPublicURL
+        if issuer == "" </span><span class="cov0" title="0">{
+                issuer = fmt.Sprintf("http://localhost%s", *asAddr)
+        }</span>
+
+        <span class="cov0" title="0">ks := keys.NewInMemoryKeyStore()
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-08] payments RS listening on %s", *payAddr)
+                if err := http.ListenAndServe(*payAddr, newPaymentsServer(issuer)); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("payments server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-08] accounts RS listening on %s", *acctAddr)
+                if err := http.ListenAndServe(*acctAddr, newAccountsServer(issuer)); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("accounts server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-08] auth server listening on %s (issuer=%s)", *asAddr, issuer)
+        if err := http.ListenAndServe(*asAddr, newAuthServer(ks, issuer)); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+func newAuthServer(ks keys.KeyStorage, issuer string) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        apiAuth := &amp;apiauth.APIAuth{
+                JWTSecretKey:   jwtSecret,
+                JWTIssuer:      issuer,
+                ClientKeyStore: ks,
+        }
+        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
+        mux.Handle("POST /oauth/introspect", introspection)
+        mux.Handle("GET /.well-known/openid-configuration",
+                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+                        Issuer:                             issuer,
+                        TokenEndpoint:                      issuer + "/api/token",
+                        IntrospectionEndpoint:              issuer + "/oauth/introspect",
+                        GrantTypesSupported:                []string{"client_credentials"},
+                        TokenEndpointAuthMethods:           []string{"client_secret_post", "client_secret_basic"},
+                        AuthorizationDetailsTypesSupported: []string{"payment_initiation", "account_information"},
+                }))
+        return mux
+}</span>
+
+// newPaymentsServer enforces `payment_initiation` authorization_details.
+// A token without that type — even with the right scopes — is rejected.
+func newPaymentsServer(issuer string) http.Handler <span class="cov0" title="0">{
+        mw := &amp;apiauth.APIMiddleware{JWTSecretKey: jwtSecret, JWTIssuer: issuer}
+        mux := http.NewServeMux()
+        mux.Handle("POST /payments", mw.RequireAuthorizationDetails("payment_initiation")(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "status":  "payment_accepted",
+                                "details": details,
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+
+// newAccountsServer enforces `account_information` authorization_details.
+func newAccountsServer(issuer string) http.Handler <span class="cov0" title="0">{
+        mw := &amp;apiauth.APIMiddleware{JWTSecretKey: jwtSecret, JWTIssuer: issuer}
+        mux := http.NewServeMux()
+        mux.Handle("GET /accounts", mw.RequireAuthorizationDetails("account_information")(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
+                        w.Header().Set("Content-Type", "application/json")
+                        json.NewEncoder(w).Encode(map[string]any{
+                                "status":  "accounts_listed",
+                                "details": details,
+                        })
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file57" style="display: none">package main
 
 import (
         "bytes"
@@ -9582,19 +12311,29 @@ import (
         "strings"
         "time"
 
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
-        "github.com/panyam/oneauth/client"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/client"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
 const rarIssuerURL = "http://localhost:8181"
 
-func main() <span class="cov0" title="0">{
-        var authServer, paymentsRS, accountsRS *httptest.Server
-        var ks keys.KeyStorage
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+
+        authServer := httptest.NewUnstartedServer(http.NewServeMux())
+        authServer.Config.Handler = newAuthServer(ks, "")
+        authServer.Start()
+        defer authServer.Close()
+        authServer.Config.Handler = newAuthServer(ks, authServer.URL)
+
+        paymentsRS := httptest.NewServer(newPaymentsServer(authServer.URL))
+        defer paymentsRS.Close()
+        accountsRS := httptest.NewServer(newAccountsServer(authServer.URL))
+        defer accountsRS.Close()
+
         var clientID, clientSecret string
         var paymentToken string
 
@@ -9634,91 +12373,28 @@ func main() <span class="cov0" title="0">{
                 "fintechs, and any regulated industry needs.",
         )
 
-        // --- Setup ---
-        demo.Step("Start auth server with RAR support + two resource servers").
-                Ref(refs.RFC9396).
-                Ref(refs.RFC8414).
-                Note("The auth server advertises authorization_details_types_supported in its discovery document. Two resource servers enforce different authorization types.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        fmt.Printf("    Auth server:   %s\n", authServer.URL)
+        fmt.Printf("    Payments API:  %s\n", paymentsRS.URL)
+        fmt.Printf("    Accounts API:  %s\n\n", accountsRS.URL)
 
-                        apiAuth := &amp;apiauth.APIAuth{
-                                JWTSecretKey:   "rar-example-secret-at-least-32ch!",
-                                ClientKeyStore: ks,
-                        }
-
-                        introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
-
-                        mux := http.NewServeMux()
-                        mux.Handle("/apps/", registrar.Handler())
-                        mux.HandleFunc("POST /api/token", apiAuth.ServeHTTP)
-                        mux.Handle("POST /oauth/introspect", introspection)
-                        authServer = httptest.NewServer(mux)
-                        apiAuth.JWTIssuer = authServer.URL
-
-                        mux.Handle("GET /.well-known/openid-configuration",
-                                apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
-                                        Issuer:                             authServer.URL,
-                                        TokenEndpoint:                      authServer.URL + "/api/token",
-                                        IntrospectionEndpoint:              authServer.URL + "/oauth/introspect",
-                                        GrantTypesSupported:                []string{"client_credentials"},
-                                        TokenEndpointAuthMethods:           []string{"client_secret_post", "client_secret_basic"},
-                                        AuthorizationDetailsTypesSupported: []string{"payment_initiation", "account_information"},
-                                }))
-
-                        // Payments resource server — requires payment_initiation type
-                        payMW := &amp;apiauth.APIMiddleware{
-                                JWTSecretKey: "rar-example-secret-at-least-32ch!",
-                                JWTIssuer:    authServer.URL,
-                        }
-                        payMux := http.NewServeMux()
-                        payMux.Handle("POST /payments", payMW.RequireAuthorizationDetails("payment_initiation")(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "status":  "payment_accepted",
-                                                "details": details,
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">paymentsRS = httptest.NewServer(payMux)
-
-                        // Accounts resource server — requires account_information type
-                        acctMW := &amp;apiauth.APIMiddleware{
-                                JWTSecretKey: "rar-example-secret-at-least-32ch!",
-                                JWTIssuer:    authServer.URL,
-                        }
-                        acctMux := http.NewServeMux()
-                        acctMux.Handle("GET /accounts", acctMW.RequireAuthorizationDetails("account_information")(
-                                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                        details := apiauth.GetAuthorizationDetailsFromContext(r.Context())
-                                        w.Header().Set("Content-Type", "application/json")
-                                        json.NewEncoder(w).Encode(map[string]any{
-                                                "status":  "accounts_listed",
-                                                "details": details,
-                                        })
-                                }</span>),
-                        ))
-                        <span class="cov0" title="0">accountsRS = httptest.NewServer(acctMux)
-
-                        fmt.Printf("    Auth server:   %s\n", authServer.URL)
-                        fmt.Printf("    Payments API:  %s\n", paymentsRS.URL)
-                        fmt.Printf("    Accounts API:  %s\n", accountsRS.URL)</span>
-                })
-
-        // --- Discovery ---
-        <span class="cov0" title="0">demo.Step("Discover supported authorization_details types").
+        demo.Step("Discover supported authorization_details types").
                 Ref(refs.RFC9396).
                 Ref(refs.RFC8414).
                 Arrow("App", "AS", "GET /.well-known/openid-configuration").
                 DashedArrow("AS", "App", "{..., authorization_details_types_supported: [...]}").
                 Note("RFC 9396 §10: the AS advertises which authorization_details types it supports. Clients check this before requesting.").
-                Run(func() </span><span class="cov0" title="0">{
-                        meta, _ := client.DiscoverAS(authServer.URL)
-                        resp, _ := http.Get(authServer.URL + "/.well-known/openid-configuration")
-                        body, _ := io.ReadAll(resp.Body)
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8081/.well-known/openid-configuration \
+  | jq '.authorization_details_types_supported'`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        meta, err := client.DiscoverAS(authServer.URL)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("discover: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">resp, err := http.Get(authServer.URL + "/.well-known/openid-configuration")
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("metadata: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(resp.Body)
                         resp.Body.Close()
                         var raw map[string]any
                         json.Unmarshal(body, &amp;raw)
@@ -9726,40 +12402,65 @@ func main() <span class="cov0" title="0">{
                         types := raw["authorization_details_types_supported"]
                         fmt.Printf("    authorization_details_types_supported: %v\n", types)
                         fmt.Printf("    token_endpoint: %s\n", meta.TokenEndpoint)
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Register via DCR ---
         <span class="cov0" title="0">demo.Step("Register a banking app via DCR (RFC 7591)").
                 Ref(refs.RFC7591).
                 Arrow("App", "AS", "POST /apps/dcr {client_name, grant_types, scope}").
                 DashedArrow("AS", "App", "{client_id, client_secret}").
                 Note("Using standards-compliant DCR (Example 06) instead of the proprietary endpoint. A banking app should be fully standards-based.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/apps/dcr \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_name":"Fintech Payment App",
+    "grant_types":["client_credentials"],
+    "token_endpoint_auth_method":"client_secret_post",
+    "scope":"payments accounts"
+  }' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         body, _ := json.Marshal(map[string]any{
                                 "client_name":                "Fintech Payment App",
                                 "grant_types":                []string{"client_credentials"},
                                 "token_endpoint_auth_method": "client_secret_post",
                                 "scope":                      "payments accounts",
                         })
-                        resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json",
+                        resp, err := http.Post(authServer.URL+"/apps/dcr", "application/json",
                                 bytes.NewReader(body))
-                        var reg map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("dcr: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;reg)
                         resp.Body.Close()
                         clientID = reg["client_id"].(string)
                         clientSecret = reg["client_secret"].(string)
                         fmt.Printf("    client_id:   %s\n", clientID)
                         fmt.Printf("    client_name: %s\n", reg["client_name"])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Payment token ---
         <span class="cov0" title="0">demo.Step("Request a token with payment authorization_details").
                 Ref(refs.RFC9396).
                 Ref(refs.RFC6749_ClientCredentials).
                 Arrow("App", "AS", "POST /api/token {authorization_details: [{type: payment_initiation, ...}]}").
                 DashedArrow("AS", "App", "{access_token, authorization_details: [{type: payment_initiation, ...}]}").
                 Note("The token request includes structured authorization_details — not just 'scope=payments' but the exact payment to initiate. The AS validates, embeds in the JWT, and echoes in the response.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/api/token \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "grant_type":"client_credentials",
+    "client_id":"&lt;from previous step&gt;",
+    "client_secret":"&lt;from previous step&gt;",
+    "authorization_details":[{
+      "type":"payment_initiation",
+      "actions":["initiate"],
+      "locations":["http://localhost:8082/payments"],
+      "instructedAmount":{"currency":"EUR","amount":"45.00"},
+      "creditorName":"Merchant A"
+    }]
+  }' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         reqBody := map[string]any{
                                 "grant_type":    "client_credentials",
                                 "client_id":     clientID,
@@ -9779,20 +12480,23 @@ func main() <span class="cov0" title="0">{
                         }
                         body, _ := json.Marshal(reqBody)
 
-                        resp, _ := http.Post(authServer.URL+"/api/token", "application/json",
+                        resp, err := http.Post(authServer.URL+"/api/token", "application/json",
                                 bytes.NewReader(body))
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;tokenData)
                         resp.Body.Close()
 
                         paymentToken = tokenData["access_token"].(string)
 
-                        // Show the authorization_details in the response
                         ad := tokenData["authorization_details"].([]any)
                         adPretty, _ := json.MarshalIndent(ad, "    ", "  ")
                         fmt.Printf("    authorization_details in response:\n    %s\n\n", string(adPretty))
                         fmt.Printf("    access_token: %s...\n", paymentToken[:40])
-                }</span>)
+                        return nil</span>
+                })
 
         <span class="cov0" title="0">demo.Section("What's in the JWT?",
                 "The access token now carries `authorization_details` as a JWT claim:",
@@ -9813,18 +12517,22 @@ func main() <span class="cov0" title="0">{
                 "The resource server reads this claim to enforce fine-grained access.",
         )
 
-        // --- Use on payments RS ---
         demo.Step("Access the Payments API (authorized)").
                 Ref(refs.RFC9396).
                 Arrow("App", "Pay", "POST /payments (Bearer: payment token)").
                 Arrow("Pay", "Pay", "RequireAuthorizationDetails(\"payment_initiation\") ✓").
                 DashedArrow("Pay", "App", "200 {status: payment_accepted, details: [...]}").
                 Note("The Payments API uses RequireAuthorizationDetails middleware — it checks that the token has a payment_initiation authorization_details entry. The details are available in the request context.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8082/payments \
+  -H "Authorization: Bearer &lt;payment token&gt;" | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("POST", paymentsRS.URL+"/payments", nil)
                         req.Header.Set("Authorization", "Bearer "+paymentToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("payments: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         fmt.Printf("    status: %d\n", res.StatusCode)
@@ -9832,54 +12540,72 @@ func main() <span class="cov0" title="0">{
                         json.Unmarshal(body, &amp;data)
                         pretty, _ := json.MarshalIndent(data, "    ", "  ")
                         fmt.Printf("    response: %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Use on accounts RS (should fail) ---
         <span class="cov0" title="0">demo.Step("Access the Accounts API with a payment token (rejected)").
                 Ref(refs.RFC9396).
                 Arrow("App", "Acct", "GET /accounts (Bearer: payment token)").
                 Arrow("Acct", "Acct", "RequireAuthorizationDetails(\"account_information\") ✗").
                 DashedArrow("Acct", "App", "401 Unauthorized").
                 Note("The payment token has type=payment_initiation but the Accounts API requires type=account_information. Fine-grained enforcement: a payment token can't read account data.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8083/accounts \
+  -H "Authorization: Bearer &lt;payment token&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         req, _ := http.NewRequest("GET", accountsRS.URL+"/accounts", nil)
                         req.Header.Set("Authorization", "Bearer "+paymentToken)
-                        res, _ := http.DefaultClient.Do(req)
-                        res.Body.Close()
-
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("accounts: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">res.Body.Close()
                         fmt.Printf("    status: %d (correctly rejected — wrong authorization type)\n", res.StatusCode)
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Introspect ---
         <span class="cov0" title="0">demo.Step("Introspect the payment token").
                 Ref(refs.RFC9396).
                 Ref(refs.RFC7662).
                 Arrow("RS", "AS", "POST /oauth/introspect {token}").
                 DashedArrow("AS", "RS", "{active: true, authorization_details: [...]}").
                 Note("Introspection returns the authorization_details alongside the standard claims. Resource servers that use introspection (instead of local JWT validation) get the same fine-grained information.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -u "&lt;client_id&gt;:&lt;client_secret&gt;" \
+  -d "token=&lt;payment token&gt;" \
+  http://localhost:8081/oauth/introspect | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         form := url.Values{"token": {paymentToken}}
                         req, _ := http.NewRequest("POST", authServer.URL+"/oauth/introspect",
                                 strings.NewReader(form.Encode()))
                         req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
                         req.SetBasicAuth(clientID, clientSecret)
-                        res, _ := http.DefaultClient.Do(req)
-                        body, _ := io.ReadAll(res.Body)
+                        res, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("introspect: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(res.Body)
                         res.Body.Close()
 
                         var result map[string]any
                         json.Unmarshal(body, &amp;result)
                         pretty, _ := json.MarshalIndent(result, "    ", "  ")
                         fmt.Printf("    %s\n", string(pretty))
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Scope coexistence ---
         <span class="cov0" title="0">demo.Step("RAR coexists with scopes").
                 Ref(refs.RFC9396).
                 Arrow("App", "AS", "POST /api/token {scope: read, authorization_details: [...]}").
                 DashedArrow("AS", "App", "{scope: read, authorization_details: [...]}").
                 Note("Scopes and authorization_details are independent — you can use both in the same request. Scopes for coarse-grained access, RAR for fine-grained.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/api/token \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "grant_type":"client_credentials",
+    "client_id":"&lt;id&gt;","client_secret":"&lt;secret&gt;",
+    "scope":"read write",
+    "authorization_details":[{"type":"account_information","actions":["list_accounts"]}]
+  }' | jq '{scope, authorization_details}'`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         reqBody := map[string]any{
                                 "grant_type":    "client_credentials",
                                 "client_id":     clientID,
@@ -9890,9 +12616,12 @@ func main() <span class="cov0" title="0">{
                                 },
                         }
                         body, _ := json.Marshal(reqBody)
-                        resp, _ := http.Post(authServer.URL+"/api/token", "application/json",
+                        resp, err := http.Post(authServer.URL+"/api/token", "application/json",
                                 bytes.NewReader(body))
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("token: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(resp.Body).Decode(&amp;tokenData)
                         resp.Body.Close()
 
@@ -9900,25 +12629,24 @@ func main() <span class="cov0" title="0">{
                         ad := tokenData["authorization_details"].([]any)
                         fmt.Printf("    authorization_details: %d entries\n", len(ad))
                         fmt.Printf("    Both present — independent, composable.\n")
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Optional: RAR test issuer ---
         <span class="cov0" title="0">demo.Step("Cross-server RAR validation (optional — RAR test issuer)").
                 Ref(refs.RFC9396).
                 Arrow("App", "AS", "POST {RAR issuer}/api/token {authorization_details}").
                 Arrow("App", "RS", "Bearer token → validate via JWKS from RAR issuer").
                 Note("No open-source IdP supports RFC 9396 on standard OAuth flows yet. We built a RAR test issuer (cmd/rar-test-issuer) for interop testing. Run 'make uprar' to start it. When Keycloak adds RAR support, this step will migrate to KC.").
-                Run(func() </span><span class="cov0" title="0">{
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         httpClient := &amp;http.Client{Timeout: 2 * time.Second}
                         resp, err := httpClient.Get(rarIssuerURL + "/_ah/health")
                         if err != nil </span><span class="cov0" title="0">{
                                 fmt.Printf("    SKIPPED: RAR test issuer not running at %s\n", rarIssuerURL)
                                 fmt.Printf("    To enable: make uprar (from repo root)\n")
-                                return
+                                return nil
                         }</span>
                         <span class="cov0" title="0">resp.Body.Close()
 
-                        // Get a RAR token from the external issuer
                         reqBody := map[string]any{
                                 "grant_type":    "client_credentials",
                                 "client_id":     "rar-test-client",
@@ -9928,17 +12656,21 @@ func main() <span class="cov0" title="0">{
                                 },
                         }
                         body, _ := json.Marshal(reqBody)
-                        tokenResp, _ := http.Post(rarIssuerURL+"/api/token", "application/json",
+                        tokenResp, err := http.Post(rarIssuerURL+"/api/token", "application/json",
                                 bytes.NewReader(body))
-                        var tokenData map[string]any
+                        if err != nil </span><span class="cov0" title="0">{
+                                fmt.Printf("    ERROR: %v\n", err)
+                                return nil
+                        }</span>
+                        <span class="cov0" title="0">var tokenData map[string]any
                         json.NewDecoder(tokenResp.Body).Decode(&amp;tokenData)
                         tokenResp.Body.Close()
 
                         fmt.Printf("    Token from RAR test issuer: %s...\n", tokenData["access_token"].(string)[:40])
-
                         ad := tokenData["authorization_details"].([]any)
                         fmt.Printf("    authorization_details: %v\n", ad[0].(map[string]any)["type"])
-                        fmt.Printf("\n    Same RFC 9396 format — issued by a different server.\n")</span>
+                        fmt.Printf("\n    Same RFC 9396 format — issued by a different server.\n")
+                        return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("RFC 9396 in OneAuth — what we built",
@@ -9961,32 +12693,126 @@ func main() <span class="cov0" title="0">{
                 "transition, then fail after the grace window closes.",
         )
 
-        demo.Execute()
-
-        if authServer != nil </span><span class="cov0" title="0">{
-                authServer.Close()
-        }</span>
-        <span class="cov0" title="0">if paymentsRS != nil </span><span class="cov0" title="0">{
-                paymentsRS.Close()
-        }</span>
-        <span class="cov0" title="0">if accountsRS != nil </span><span class="cov0" title="0">{
-                accountsRS.Close()
-        }</span>
+        common.SetupRenderer(demo)
+        demo.Execute()</span>
 }
 </pre>
 		
-		<pre class="file" id="file45" style="display: none">// Example 09: Key Rotation with Grace Periods
+		<pre class="file" id="file58" style="display: none">// Example 09: Key Rotation with Grace Periods.
 //
-// In production, signing keys need to be rotated periodically. But you can't
-// just swap keys — existing tokens signed with the old key would break. OneAuth
-// solves this with a grace period: old keys stay valid for a window after
-// rotation, then expire.
+// In production, signing keys must be rotated periodically without
+// breaking tokens that were issued with the old key. OneAuth uses
+// `KidStore` + `CompositeKeyLookup` to keep the old key valid for a
+// grace window after rotation.
 //
-// Run:   go run ./examples/09-key-rotation/
-// Docs:  Run with --readme to regenerate README.md
+// Two-process architecture:
+//
+//        make serve   # auth :8081 (registration + rotation), resource :8082
+//        make demo    # walkthrough that drives rotation in-process
+//
+// In --serve mode an admin can drive rotation by hand:
+//
+//        POST /apps/register            → returns client_id + client_secret (kv1)
+//        POST /apps/{id}/rotate         → returns new client_secret (kv2),
+//                                         old key sticks in KidStore for grace period
+//        GET  /resource (Bearer token)  → validates against KeyStore + KidStore
 //
 // See: https://www.rfc-editor.org/rfc/rfc7517 (JWK)
 package main
+
+import (
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+        "time"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+)
+
+// gracePeriod is short for demo purposes — production would be hours
+// or days, long enough that any in-flight tokens roll over to the new
+// key before old ones are invalidated.
+const gracePeriod = 100 * time.Millisecond
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "resource server listen address")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        ks := keys.NewInMemoryKeyStore()
+        kidStore := keys.NewKidStore()
+        asMux := newAuthServer(ks, kidStore)
+        rsMux := newResourceServer(ks, kidStore)
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-09] resource server listening on %s", *rsAddr)
+                if err := http.ListenAndServe(*rsAddr, rsMux); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-09] auth server listening on %s", *asAddr)
+        log.Printf("[example-09] rotate: curl -X POST http://localhost%s/apps/&lt;client_id&gt;/rotate", *asAddr)
+        if err := http.ListenAndServe(*asAddr, asMux); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+// newAuthServer wires AppRegistrar with a configured KidStore and grace
+// period. Rotation moves the old key into KidStore with the grace TTL.
+func newAuthServer(ks keys.KeyStorage, kidStore *keys.KidStore) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        registrar.KidStore = kidStore
+        registrar.DefaultGracePeriod = gracePeriod
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        return mux
+}</span>
+
+// newResourceServer uses CompositeKeyLookup so the middleware checks the
+// current KeyStore first, then falls back to KidStore for grace-period
+// keys.
+func newResourceServer(ks keys.KeyStorage, kidStore *keys.KidStore) http.Handler <span class="cov0" title="0">{
+        composite := &amp;keys.CompositeKeyLookup{
+                Lookups: []keys.KeyLookup{ks, kidStore},
+        }
+        middleware := &amp;apiauth.APIMiddleware{KeyStore: composite}
+
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        w.Header().Set("Content-Type", "application/json")
+                        fmt.Fprintf(w, `{"user":%q,"scopes":%q}`,
+                                apiauth.GetUserIDFromAPIContext(r.Context()),
+                                apiauth.GetScopesFromAPIContext(r.Context()))
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file59" style="display: none">package main
 
 import (
         "bytes"
@@ -9997,18 +12823,22 @@ import (
         "time"
 
         "github.com/golang-jwt/jwt/v5"
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
 )
 
-func main() <span class="cov0" title="0">{
-        var regHandler http.Handler
-        var ks keys.KeyStorage
-        var kidStore *keys.KidStore
-        var middleware *apiauth.APIMiddleware
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+        kidStore := keys.NewKidStore()
+
+        authServer := httptest.NewServer(newAuthServer(ks, kidStore))
+        defer authServer.Close()
+        resourceServer := httptest.NewServer(newResourceServer(ks, kidStore))
+        defer resourceServer.Close()
+
         var clientID, oldSecret, newSecret string
         var oldToken, newToken string
 
@@ -10044,47 +12874,29 @@ func main() <span class="cov0" title="0">{
                 "```",
         )
 
-        // --- Setup ---
-        demo.Step("Set up auth server with key rotation support").
-                Ref(refs.RFC7517).
-                Ref(refs.RFC7638).
-                Note("The auth server uses a KidStore alongside the main KeyStore. On rotation, the old key moves to KidStore with a grace period TTL. The CompositeKeyLookup checks both.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
-                        kidStore = keys.NewKidStore()
+        fmt.Printf("    Auth server:     %s\n", authServer.URL)
+        fmt.Printf("    Resource server: %s\n", resourceServer.URL)
+        fmt.Printf("    Grace period:    %s (short for demo)\n\n", gracePeriod)
 
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-                        registrar.KidStore = kidStore
-                        registrar.DefaultGracePeriod = 100 * time.Millisecond // short for demo
-                        regHandler = registrar.Handler()
-
-                        // CompositeKeyLookup: check current keys first, then grace period keys
-                        composite := &amp;keys.CompositeKeyLookup{
-                                Lookups: []keys.KeyLookup{ks, kidStore},
-                        }
-                        middleware = &amp;apiauth.APIMiddleware{KeyStore: composite}
-
-                        fmt.Printf("    KeyStore:     in-memory (current keys)\n")
-                        fmt.Printf("    KidStore:     in-memory (grace period keys)\n")
-                        fmt.Printf("    Grace period: 100ms (short for demo)\n")
-                }</span>)
-
-        // --- Register and mint ---
-        <span class="cov0" title="0">demo.Step("Register an app and mint a token with the original key").
+        demo.Step("Register an app and mint a token with the original key").
                 Ref(refs.RFC7519).
                 Arrow("Admin", "AS", "POST /apps/register").
                 DashedArrow("AS", "Admin", "{client_id, client_secret}").
                 Arrow("Admin", "Admin", "MintResourceToken(alice, oldSecret)").
                 Note("The app gets a client_secret (HS256). We mint a token for Alice — this token's kid header is derived from the old key.").
-                Run(func() </span><span class="cov0" title="0">{
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/apps/register \
+  -H 'Content-Type: application/json' \
+  -d '{"client_domain":"rotate.example.com"}' | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         body, _ := json.Marshal(map[string]any{"client_domain": "rotate.example.com"})
-                        req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
-                        req.Header.Set("Content-Type", "application/json")
-                        rr := httptest.NewRecorder()
-                        regHandler.ServeHTTP(rr, req)
-
-                        var reg map[string]any
-                        json.NewDecoder(rr.Body).Decode(&amp;reg)
+                        resp, err := http.Post(authServer.URL+"/apps/register", "application/json",
+                                bytes.NewReader(body))
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("register: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var reg map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;reg)
+                        resp.Body.Close()
                         clientID = reg["client_id"].(string)
                         oldSecret = reg["client_secret"].(string)
 
@@ -10092,27 +12904,29 @@ func main() <span class="cov0" title="0">{
                                 "alice", clientID, oldSecret,
                                 admin.AppQuota{}, []string{"read"}, nil)
 
-                        // Show the kid
                         parser := jwt.NewParser()
                         parsed, _, _ := parser.ParseUnverified(oldToken, jwt.MapClaims{})
-                        fmt.Printf("    client_id:   %s\n", clientID)
-                        fmt.Printf("    old secret:  %s...\n", oldSecret[:16])
+                        fmt.Printf("    client_id:     %s\n", clientID)
+                        fmt.Printf("    old secret:    %s...\n", oldSecret[:16])
                         fmt.Printf("    old token kid: %s\n", parsed.Header["kid"])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- Rotate ---
         <span class="cov0" title="0">demo.Step("Rotate the key").
                 Ref(refs.RFC7517).
                 Arrow("Admin", "AS", "POST /apps/{id}/rotate").
                 DashedArrow("AS", "Admin", "{client_secret: newSecret}").
                 Note("Rotation replaces the key in the main KeyStore and moves the old key to KidStore with a grace period TTL. Both keys are now valid.").
-                Run(func() </span><span class="cov0" title="0">{
-                        req := httptest.NewRequest("POST", "/apps/"+clientID+"/rotate", nil)
-                        rr := httptest.NewRecorder()
-                        regHandler.ServeHTTP(rr, req)
-
-                        var rot map[string]any
-                        json.NewDecoder(rr.Body).Decode(&amp;rot)
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s -X POST http://localhost:8081/apps/&lt;client_id&gt;/rotate | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        req, _ := http.NewRequest("POST", authServer.URL+"/apps/"+clientID+"/rotate", nil)
+                        resp, err := http.DefaultClient.Do(req)
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("rotate: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">var rot map[string]any
+                        json.NewDecoder(resp.Body).Decode(&amp;rot)
+                        resp.Body.Close()
                         newSecret = rot["client_secret"].(string)
 
                         newToken, _ = admin.MintResourceToken(
@@ -10125,45 +12939,41 @@ func main() <span class="cov0" title="0">{
                         parser := jwt.NewParser()
                         parsed, _, _ := parser.ParseUnverified(newToken, jwt.MapClaims{})
                         fmt.Printf("    new token kid: %s\n", parsed.Header["kid"])
-                }</span>)
+                        return nil</span>
+                })
 
-        // --- During grace period ---
         <span class="cov0" title="0">demo.Step("During grace period — both tokens work").
                 Ref(refs.RFC7638).
                 Arrow("RS", "RS", "Validate old token → kid found in KidStore (grace) ✓").
                 Arrow("RS", "RS", "Validate new token → kid found in KeyStore (current) ✓").
                 Note("The CompositeKeyLookup checks the main KeyStore first, then falls back to KidStore. Old tokens find their key in the grace store; new tokens find theirs in the main store.").
-                Run(func() </span><span class="cov0" title="0">{
-                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                w.WriteHeader(http.StatusOK)
-                        }</span>))
+                VerbatimLang("Reproduce on the wire", "bash", `# Both should return 200 during the grace window
+curl -s -o /dev/null -w 'old: %{http_code}\n' http://localhost:8082/resource -H "Authorization: Bearer &lt;old token&gt;"
+curl -s -o /dev/null -w 'new: %{http_code}\n' http://localhost:8082/resource -H "Authorization: Bearer &lt;new token&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        oldStatus := callResource(resourceServer.URL, oldToken)
+                        newStatus := callResource(resourceServer.URL, newToken)
+                        fmt.Printf("    old token (during grace): %d ✓\n", oldStatus)
+                        fmt.Printf("    new token:                %d ✓\n", newStatus)
+                        return nil
+                }</span>)
 
-                        <span class="cov0" title="0">oldResult := validateToken(handler, oldToken)
-                        newResult := validateToken(handler, newToken)
-
-                        fmt.Printf("    old token (during grace): %d ✓\n", oldResult)
-                        fmt.Printf("    new token:                %d ✓\n", newResult)</span>
-                })
-
-        // --- After grace period ---
         <span class="cov0" title="0">demo.Step("After grace period — old token rejected").
                 Arrow("RS", "RS", "Validate old token → kid not found anywhere ✗").
                 Arrow("RS", "RS", "Validate new token → kid found in KeyStore ✓").
                 Note("After the grace period expires (100ms in this demo), the old key is removed from KidStore. Tokens signed with it are now rejected.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Wait for grace period to expire
-                        time.Sleep(120 * time.Millisecond)
-
-                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                w.WriteHeader(http.StatusOK)
-                        }</span>))
-
-                        <span class="cov0" title="0">oldResult := validateToken(handler, oldToken)
-                        newResult := validateToken(handler, newToken)
-
-                        fmt.Printf("    old token (after grace):  %d ✗ (correctly rejected)\n", oldResult)
-                        fmt.Printf("    new token:                %d ✓\n", newResult)</span>
-                })
+                VerbatimLang("Reproduce on the wire", "bash", `# After grace expires: old → 401, new → 200
+sleep 1   # wait past production grace period
+curl -s -o /dev/null -w 'old: %{http_code}\n' http://localhost:8082/resource -H "Authorization: Bearer &lt;old token&gt;"
+curl -s -o /dev/null -w 'new: %{http_code}\n' http://localhost:8082/resource -H "Authorization: Bearer &lt;new token&gt;"`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        time.Sleep(gracePeriod + 20*time.Millisecond)
+                        oldStatus := callResource(resourceServer.URL, oldToken)
+                        newStatus := callResource(resourceServer.URL, newToken)
+                        fmt.Printf("    old token (after grace):  %d ✗ (correctly rejected)\n", oldStatus)
+                        fmt.Printf("    new token:                %d ✓\n", newStatus)
+                        return nil
+                }</span>)
 
         <span class="cov0" title="0">demo.Section("How it works under the hood",
                 "```",
@@ -10188,35 +12998,141 @@ func main() <span class="cov0" title="0">{
                 "JWKS security properties.",
         )
 
+        common.SetupRenderer(demo)
         demo.Execute()</span>
 }
 
-// validateToken runs a token through the middleware and returns the HTTP status.
-func validateToken(handler http.Handler, token string) int <span class="cov0" title="0">{
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest("GET", "/resource", nil)
+// callResource hits the resource endpoint with a Bearer token and
+// returns the HTTP status.
+func callResource(rsURL, token string) int <span class="cov0" title="0">{
+        req, _ := http.NewRequest("GET", rsURL+"/resource", nil)
         req.Header.Set("Authorization", "Bearer "+token)
-        handler.ServeHTTP(rr, req)
-        return rr.Code
-}</span>
+        res, err := http.DefaultClient.Do(req)
+        if err != nil </span><span class="cov0" title="0">{
+                return 0
+        }</span>
+        <span class="cov0" title="0">defer res.Body.Close()
+        return res.StatusCode</span>
+}
 </pre>
 		
-		<pre class="file" id="file46" style="display: none">// Example 10: Security — Attack Prevention
+		<pre class="file" id="file60" style="display: none">// Example 10: Security — Attack Prevention.
 //
-// This example demonstrates real attacks against JWT-based auth systems and
-// how OneAuth prevents them. Each step shows the attack, why it works against
-// naive implementations, and how OneAuth's defenses block it.
+// Demonstrates real attacks against JWT-based auth and OneAuth's
+// defenses: algorithm confusion (CVE-2015-9235), alg:none, cross-app
+// forgery, and JWKS leak prevention.
 //
-// Run:   go run ./examples/10-security/
-// Docs:  Run with --readme to regenerate README.md
+// Two-process architecture:
 //
-// See: https://nvd.nist.gov/vuln/detail/CVE-2015-9235 (algorithm confusion)
+//        make serve   # auth + JWKS :8081, protected resource :8082
+//        make demo    # walkthrough that drives both
+//
+// In --serve mode you can fuzz the resource endpoint with crafted
+// tokens to verify the middleware blocks them in your environment too:
+//
+//        curl http://localhost:8082/resource -H "Authorization: Bearer &lt;crafted-token&gt;"
+//
+// See: https://nvd.nist.gov/vuln/detail/CVE-2015-9235
 package main
 
 import (
-        "bytes"
         "crypto/rand"
         "crypto/rsa"
+        "flag"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "strings"
+
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/apiauth"
+        "github.com/panyam/oneauth/keys"
+        "github.com/panyam/oneauth/utils"
+)
+
+// servePreseededApps wires the two demo apps that the walkthrough
+// references — `app-rsa` (RS256) and `app-hmac` (HS256). main and
+// walkthrough both call this so the KeyStore is identical between
+// modes.
+func servePreseededApps(ks *keys.InMemoryKeyStore) (*rsa.PrivateKey, []byte) <span class="cov0" title="0">{
+        rsaPrivKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+        pubPEM, _ := utils.EncodePublicKeyPEM(&amp;rsaPrivKey.PublicKey)
+        ks.RegisterKey("app-rsa", pubPEM, "RS256")
+        ks.RegisterKey("app-hmac", []byte("shared-secret-for-hs256-app"), "HS256")
+        return rsaPrivKey, pubPEM
+}</span>
+
+func main() <span class="cov0" title="0">{
+        for _, arg := range os.Args[1:] </span><span class="cov0" title="0">{
+                if strings.TrimSpace(arg) == "--serve" </span><span class="cov0" title="0">{
+                        serve()
+                        return
+                }</span>
+        }
+        <span class="cov0" title="0">runDemo()</span>
+}
+
+func serve() <span class="cov0" title="0">{
+        asAddr := flag.String("as-addr", ":8081", "auth/JWKS server listen address")
+        rsAddr := flag.String("rs-addr", ":8082", "protected resource listen address")
+        args := make([]string, 0, len(os.Args)-1)
+        for _, a := range os.Args[1:] </span><span class="cov0" title="0">{
+                if a != "--serve" </span><span class="cov0" title="0">{
+                        args = append(args, a)
+                }</span>
+        }
+        <span class="cov0" title="0">flag.CommandLine.Parse(args)
+
+        ks := keys.NewInMemoryKeyStore()
+        servePreseededApps(ks)
+
+        go func() </span><span class="cov0" title="0">{
+                log.Printf("[example-10] resource server listening on %s", *rsAddr)
+                if err := http.ListenAndServe(*rsAddr, newResourceServer(ks)); err != nil </span><span class="cov0" title="0">{
+                        log.Fatalf("resource server: %v", err)
+                }</span>
+        }()
+        <span class="cov0" title="0">log.Printf("[example-10] auth/JWKS server listening on %s", *asAddr)
+        log.Printf("[example-10] try crafting tokens and POSTing them at %s/resource", *rsAddr)
+        if err := http.ListenAndServe(*asAddr, newAuthServer(ks)); err != nil </span><span class="cov0" title="0">{
+                log.Fatalf("auth server: %v", err)
+        }</span>
+}
+
+func newAuthServer(ks *keys.InMemoryKeyStore) http.Handler <span class="cov0" title="0">{
+        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
+
+        mux := http.NewServeMux()
+        mux.Handle("/apps/", registrar.Handler())
+        mux.Handle("GET /.well-known/jwks.json", jwksHandler)
+        return mux
+}</span>
+
+// newResourceServer is the strict-validation endpoint — middleware
+// checks alg-vs-stored-key match, kid-owns-client_id, and rejects
+// alg:none. This is what the walkthrough fires forged tokens against.
+func newResourceServer(ks keys.KeyStorage) http.Handler <span class="cov0" title="0">{
+        middleware := &amp;apiauth.APIMiddleware{KeyStore: ks}
+        mux := http.NewServeMux()
+        mux.Handle("GET /resource", middleware.ValidateToken(
+                http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
+                        w.Header().Set("Content-Type", "application/json")
+                        custom := apiauth.GetCustomClaimsFromContext(r.Context())
+                        fmt.Fprintf(w, `{"user":%q,"client_id":%q}`,
+                                apiauth.GetUserIDFromAPIContext(r.Context()),
+                                custom["client_id"])
+                }</span>),
+        ))
+        <span class="cov0" title="0">return mux</span>
+}
+</pre>
+		
+		<pre class="file" id="file61" style="display: none">package main
+
+import (
+        "bytes"
         "encoding/json"
         "fmt"
         "io"
@@ -10225,19 +13141,22 @@ import (
         "time"
 
         "github.com/golang-jwt/jwt/v5"
-        "github.com/panyam/oneauth/admin"
-        "github.com/panyam/oneauth/apiauth"
         "github.com/panyam/demokit"
+        "github.com/panyam/oneauth/admin"
+        "github.com/panyam/oneauth/examples/common"
         "github.com/panyam/oneauth/examples/refs"
         "github.com/panyam/oneauth/keys"
         "github.com/panyam/oneauth/utils"
 )
 
-func main() <span class="cov0" title="0">{
-        var ks *keys.InMemoryKeyStore
-        var middleware *apiauth.APIMiddleware
-        var rsaPrivKey *rsa.PrivateKey
-        var pubPEM []byte
+func runDemo() <span class="cov0" title="0">{
+        ks := keys.NewInMemoryKeyStore()
+        rsaPrivKey, pubPEM := servePreseededApps(ks)
+
+        authServer := httptest.NewServer(newAuthServer(ks))
+        defer authServer.Close()
+        resourceServer := httptest.NewServer(newResourceServer(ks))
+        defer resourceServer.Close()
 
         demo := demokit.New("10: Security — Attack Prevention").
                 Dir("10-security").
@@ -10259,42 +13178,20 @@ func main() <span class="cov0" title="0">{
                 "4. JWKS private key leakage — checking that secrets stay secret",
         )
 
-        // --- Setup ---
-        demo.Step("Set up KeyStore with an RS256 app and an HS256 app").
-                Ref(refs.RFC7517).
-                Note("Two apps coexist: one with an RSA key pair (RS256), one with a shared secret (HS256). The resource server validates tokens from both.").
-                Run(func() </span><span class="cov0" title="0">{
-                        ks = keys.NewInMemoryKeyStore()
+        fmt.Printf("    KeyStore pre-seeded with two apps:\n")
+        fmt.Printf("      app-rsa  — RS256 (public key registered)\n")
+        fmt.Printf("      app-hmac — HS256 (shared secret registered)\n")
+        fmt.Printf("    Resource server: %s\n\n", resourceServer.URL)
 
-                        // RS256 app
-                        rsaPrivKey, _ = rsa.GenerateKey(rand.Reader, 2048)
-                        pubPEM, _ = utils.EncodePublicKeyPEM(&amp;rsaPrivKey.PublicKey)
-                        ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
-                        // HS256 app
-                        ks.RegisterKey("app-hmac", []byte("shared-secret-for-hs256-app"), "HS256")
-
-                        middleware = &amp;apiauth.APIMiddleware{KeyStore: ks}
-
-                        fmt.Printf("    app-rsa:  RS256 (public key registered)\n")
-                        fmt.Printf("    app-hmac: HS256 (shared secret registered)\n")
-                }</span>)
-
-        // --- Attack 1: Algorithm confusion ---
-        <span class="cov0" title="0">demo.Step("Attack 1: Algorithm confusion (CVE-2015-9235)").
+        demo.Step("Attack 1: Algorithm confusion (CVE-2015-9235)").
                 Ref(refs.CVE_2015_9235).
                 Ref(refs.RFC7515).
                 Arrow("Attacker", "Attacker", "Craft JWT: alg=HS256, sign with RSA public key").
                 Arrow("Attacker", "RS", "Bearer: confused token").
                 DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
                 Note("The attack: The attacker knows the RSA public key (it's public, served via JWKS). They craft a JWT with alg:HS256 and sign it using the public key bytes as the HMAC secret. A naive server reads alg:HS256, grabs the stored key bytes, and verifies — which passes because the attacker used those same bytes.\n\nOneAuth's defense: The middleware checks that the token's alg header matches the KeyRecord.Algorithm. Store says RS256, token says HS256 → mismatch → rejected before any signature check.").
-                Run(func() </span><span class="cov0" title="0">{
-                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                w.WriteHeader(http.StatusOK)
-                        }</span>))
-
-                        // Legitimate RS256 token
-                        <span class="cov0" title="0">legit := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        legit := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
                                 "sub": "alice", "client_id": "app-rsa", "type": "access",
                                 "scopes": []string{"read"}, "exp": time.Now().Add(time.Hour).Unix(),
                                 "iat": time.Now().Unix(),
@@ -10303,102 +13200,89 @@ func main() <span class="cov0" title="0">{
                                 legit.Header["kid"] = kid
                         }</span>
                         <span class="cov0" title="0">legitToken, _ := legit.SignedString(rsaPrivKey)
-                        fmt.Printf("    Legitimate RS256 token: %d\n", validateToken(handler, legitToken))
+                        fmt.Printf("    Legitimate RS256 token: %d\n", callRS(resourceServer.URL, legitToken))
 
-                        // Algorithm confusion: sign with public key as HMAC secret
                         attack := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
                                 "sub": "attacker", "client_id": "app-rsa", "type": "access",
                                 "scopes": []string{"admin"}, "exp": time.Now().Add(time.Hour).Unix(),
                                 "iat": time.Now().Unix(),
                         })
-                        attackToken, _ := attack.SignedString(pubPEM) // public key as HMAC secret!
-                        fmt.Printf("    Algorithm confusion:    %d (blocked — alg mismatch)\n", validateToken(handler, attackToken))</span>
+                        attackToken, _ := attack.SignedString(pubPEM)
+                        fmt.Printf("    Algorithm confusion:    %d (blocked — alg mismatch)\n", callRS(resourceServer.URL, attackToken))
+                        return nil</span>
                 })
 
-        // --- Attack 2: alg:none ---
         <span class="cov0" title="0">demo.Step("Attack 2: alg:none — no signature at all").
                 Ref(refs.CVE_2015_9235).
                 Arrow("Attacker", "Attacker", "Craft JWT: alg=none, no signature").
                 Arrow("Attacker", "RS", "Bearer: unsigned token").
                 DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
                 Note("The attack: The attacker sends a JWT with alg:none — no signature at all. Some JWT libraries accept this as valid.\n\nOneAuth uses golang-jwt/v5 which rejects alg:none by default unless explicitly opted in with UnsafeAllowNoneSignatureType.").
-                Run(func() </span><span class="cov0" title="0">{
-                        handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                w.WriteHeader(http.StatusOK)
-                        }</span>))
-
-                        <span class="cov0" title="0">none := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        none := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
                                 "sub": "attacker", "client_id": "app-rsa", "type": "access",
                                 "scopes": []string{"admin"}, "exp": time.Now().Add(time.Hour).Unix(),
                                 "iat": time.Now().Unix(),
                         })
                         noneToken, _ := none.SignedString(jwt.UnsafeAllowNoneSignatureType)
-                        fmt.Printf("    alg:none token: %d (blocked)\n", validateToken(handler, noneToken))</span>
-                })
+                        fmt.Printf("    alg:none token: %d (blocked)\n", callRS(resourceServer.URL, noneToken))
+                        return nil
+                }</span>)
 
-        // --- Attack 3: Cross-app forgery ---
         <span class="cov0" title="0">demo.Step("Attack 3: Cross-app token forgery").
                 Arrow("Attacker", "Attacker", "Sign JWT with app-A's key but claim client_id=app-B").
                 Arrow("Attacker", "RS", "Bearer: cross-app token").
                 DashedArrow("RS", "Attacker", "401 Unauthorized (blocked)").
                 Note("The attack: App A's key is compromised. The attacker signs a token claiming to be App B (client_id=app-B) using App A's key. If the resource server only checks the signature and not which app owns the key, the token validates.\n\nOneAuth's defense: The middleware checks that the kid's owning client matches the client_id claim. App A's key → kid owned by app-A → client_id claim says app-B → mismatch → rejected.").
-                Run(func() </span><span class="cov0" title="0">{
-                        // Register two apps
-                        registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-                        regHandler := registrar.Handler()
-
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
                         var clientIDs [2]string
                         var secrets [2]string
                         for i, domain := range []string{"app-a.com", "app-b.com"} </span><span class="cov0" title="0">{
                                 body, _ := json.Marshal(map[string]any{"client_domain": domain})
-                                req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
-                                req.Header.Set("Content-Type", "application/json")
-                                rr := httptest.NewRecorder()
-                                regHandler.ServeHTTP(rr, req)
-                                var resp map[string]any
-                                json.NewDecoder(rr.Body).Decode(&amp;resp)
-                                clientIDs[i] = resp["client_id"].(string)
-                                secrets[i] = resp["client_secret"].(string)
-                        }</span>
+                                resp, err := http.Post(authServer.URL+"/apps/register", "application/json",
+                                        bytes.NewReader(body))
+                                if err != nil </span><span class="cov0" title="0">{
+                                        return demokit.Errf("register: %v", err)
+                                }</span>
+                                <span class="cov0" title="0">var reg map[string]any
+                                json.NewDecoder(resp.Body).Decode(&amp;reg)
+                                resp.Body.Close()
+                                clientIDs[i] = reg["client_id"].(string)
+                                secrets[i] = reg["client_secret"].(string)</span>
+                        }
 
-                        <span class="cov0" title="0">handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) </span><span class="cov0" title="0">{
-                                w.WriteHeader(http.StatusOK)
-                        }</span>))
-
-                        // Cross-app: sign with app A's secret, claim app B's client_id
                         <span class="cov0" title="0">crossToken, _ := admin.MintResourceToken(
                                 "eve", clientIDs[1], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
                         fmt.Printf("    Cross-app token (A's key, B's id): %d (blocked — kid/client_id mismatch)\n",
-                                validateToken(handler, crossToken))
+                                callRS(resourceServer.URL, crossToken))
 
-                        // Correct: app A's secret with app A's client_id
                         correctToken, _ := admin.MintResourceToken(
                                 "alice", clientIDs[0], secrets[0], admin.AppQuota{}, []string{"read"}, nil)
                         fmt.Printf("    Correct token (A's key, A's id):   %d ✓\n",
-                                validateToken(handler, correctToken))</span>
+                                callRS(resourceServer.URL, correctToken))
+                        return nil</span>
                 })
 
-        // --- JWKS security ---
         <span class="cov0" title="0">demo.Step("JWKS security: only public keys, never secrets").
                 Ref(refs.RFC7517).
                 Arrow("Anyone", "AS", "GET /.well-known/jwks.json").
                 DashedArrow("AS", "Anyone", "{keys: [RSA public key only]}").
                 Note("JWKS serves only asymmetric public keys. HS256 secrets are excluded entirely. RSA keys include only public components (n, e) — private fields (d, p, q) are structurally absent from the JWK type.").
-                Run(func() </span><span class="cov0" title="0">{
-                        jwksHandler := &amp;keys.JWKSHandler{KeyStore: ks}
-                        srv := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))
-                        defer srv.Close()
-
-                        resp, _ := http.Get(srv.URL)
-                        body, _ := io.ReadAll(resp.Body)
+                VerbatimLang("Reproduce on the wire", "bash", `curl -s http://localhost:8081/.well-known/jwks.json | jq`).
+                Run(func(ctx demokit.StepContext) *demokit.StepResult </span><span class="cov0" title="0">{
+                        resp, err := http.Get(authServer.URL + "/.well-known/jwks.json")
+                        if err != nil </span><span class="cov0" title="0">{
+                                return demokit.Errf("jwks: %v", err)
+                        }</span>
+                        <span class="cov0" title="0">body, _ := io.ReadAll(resp.Body)
                         resp.Body.Close()
 
                         var raw map[string]any
                         json.Unmarshal(body, &amp;raw)
                         jwksKeys := raw["keys"].([]any)
 
-                        fmt.Printf("    Total apps in KeyStore: 2 (RSA + HMAC)\n")
-                        fmt.Printf("    Keys in JWKS:           %d (only RSA — HMAC secret excluded)\n", len(jwksKeys))
+                        fmt.Printf("    Total apps in KeyStore: 4 (2 preseeded + 2 from forgery step, RSA + HMAC mix)\n")
+                        fmt.Printf("    Keys in JWKS:           %d (only RSA — HMAC secrets excluded)\n", len(jwksKeys))
 
                         if len(jwksKeys) &gt; 0 </span><span class="cov0" title="0">{
                                 key := jwksKeys[0].(map[string]any)
@@ -10415,6 +13299,7 @@ func main() <span class="cov0" title="0">{
                                         fmt.Printf("    Private fields (d, p, q, dp, dq, qi): absent ✓\n")
                                 }</span>
                         }
+                        <span class="cov0" title="0">return nil</span>
                 })
 
         <span class="cov0" title="0">demo.Section("Summary of defenses",
@@ -10448,19 +13333,83 @@ func main() <span class="cov0" title="0">{
                 "| 10 | Security — attack prevention | CVE-2015-9235 |",
         )
 
+        common.SetupRenderer(demo)
         demo.Execute()</span>
 }
 
-func validateToken(handler http.Handler, token string) int <span class="cov0" title="0">{
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest("GET", "/resource", nil)
+// callRS hits the protected endpoint with a Bearer token and returns
+// the HTTP status. Used by the walkthrough to score each attack.
+func callRS(rsURL, token string) int <span class="cov0" title="0">{
+        req, _ := http.NewRequest("GET", rsURL+"/resource", nil)
         req.Header.Set("Authorization", "Bearer "+token)
-        handler.ServeHTTP(rr, req)
-        return rr.Code
+        res, err := http.DefaultClient.Do(req)
+        if err != nil </span><span class="cov0" title="0">{
+                return 0
+        }</span>
+        <span class="cov0" title="0">defer res.Body.Close()
+        return res.StatusCode</span>
+}
+</pre>
+		
+		<pre class="file" id="file62" style="display: none">// Package common holds helpers shared across oneauth examples — the seam
+// where "every example needs this now" updates land in one place instead
+// of N copy-paste edits.
+//
+// Each example follows the same shape:
+//
+//        main.go         — boots the auth server and resource server. With
+//                          --serve, binds them on real ports and blocks so any
+//                          external client can drive them. Default behavior
+//                          spins them up in-process and runs the walkthrough.
+//        walkthrough.go  — defines the demokit demo (the "client") that drives
+//                          the servers and prints the protocol exchange.
+//
+// SetupRenderer wires the TUI renderer when --tui is passed; the default
+// PlainRenderer stays in place otherwise. Examples should call this
+// before demo.Execute().
+package common
+
+import (
+        "log"
+
+        "github.com/panyam/demokit"
+        "github.com/panyam/demokit/tui"
+)
+
+// SetupRenderer enables the TUI renderer when the user passes --tui.
+// No-op otherwise so the default plain renderer keeps working in CI and
+// piped environments.
+func SetupRenderer(demo *demokit.Demo) <span class="cov0" title="0">{
+        if demokit.IsTUI() </span><span class="cov0" title="0">{
+                demo.WithRenderer(tui.New())
+        }</span>
+}
+
+// NewOneAuthLogger returns the canonical demokit ColorLogger used across
+// oneauth examples. The baseline rules tint:
+//
+//   - error= and ERROR markers (red)
+//   - [http] → outbound HTTP requests (gray / dim blue)
+//   - [http] ← inbound HTTP responses (cyan / blue)
+//   - "minted" / "issued" token-mint events (bright green / green)
+//
+// extraRules append to the baseline so callers can tint
+// example-specific lines without losing the shared set.
+func NewOneAuthLogger(prefix string, extraRules ...demokit.ColorRule) *log.Logger <span class="cov0" title="0">{
+        rules := []demokit.ColorRule{
+                {Contains: "error=", DarkColor: demokit.ANSIRed},
+                {Contains: "ERROR", DarkColor: demokit.ANSIRed},
+                {Contains: "[http] →", DarkColor: demokit.ANSIGray, LightColor: demokit.ANSIDimBlue},
+                {Contains: "[http] ←", DarkColor: demokit.ANSICyan, LightColor: demokit.ANSIBlue},
+                {Contains: "minted", DarkColor: demokit.ANSIBrightGreen, LightColor: demokit.ANSIGreen},
+                {Contains: "issued", DarkColor: demokit.ANSIBrightGreen, LightColor: demokit.ANSIGreen},
+        }
+        rules = append(rules, extraRules...)
+        return demokit.NewColorLogger(prefix, rules)
 }</span>
 </pre>
 		
-		<pre class="file" id="file47" style="display: none">package httpauth
+		<pre class="file" id="file63" style="display: none">package httpauth
 
 import (
         "io"
@@ -10520,7 +13469,7 @@ func IsBodyTooLargeError(err error) bool <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file48" style="display: none">package httpauth
+		<pre class="file" id="file64" style="display: none">package httpauth
 
 import (
         "context"
@@ -10727,7 +13676,7 @@ func CSRFTemplateField(r *http.Request) template.HTML <span class="cov8" title="
 }</span>
 </pre>
 		
-		<pre class="file" id="file49" style="display: none">package httpauth
+		<pre class="file" id="file65" style="display: none">package httpauth
 
 import (
         "context"
@@ -10887,7 +13836,7 @@ func (a *Middleware) setLoggedInUserId(userId string, r *http.Request) *http.Req
 }</span>
 </pre>
 		
-		<pre class="file" id="file50" style="display: none">package httpauth
+		<pre class="file" id="file66" style="display: none">package httpauth
 
 import (
         "fmt"
@@ -11426,7 +14375,7 @@ func (a *OneAuth) GetLinkingUserID(r *http.Request) string <span class="cov0" ti
 }</span>
 </pre>
 		
-		<pre class="file" id="file51" style="display: none">package httpauth
+		<pre class="file" id="file67" style="display: none">package httpauth
 
 import "net/http"
 
@@ -11550,7 +14499,7 @@ func itoa(n int) string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file52" style="display: none">package keys
+		<pre class="file" id="file68" style="display: none">package keys
 
 import (
         "crypto/aes"
@@ -11759,7 +14708,7 @@ func isHMACAlgorithm(alg string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file53" style="display: none">package keys
+		<pre class="file" id="file69" style="display: none">package keys
 
 import (
         "crypto/sha256"
@@ -11874,7 +14823,7 @@ func (h *JWKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) <span cl
 }
 </pre>
 		
-		<pre class="file" id="file54" style="display: none">package keys
+		<pre class="file" id="file70" style="display: none">package keys
 
 import (
         "crypto"
@@ -12095,7 +15044,7 @@ func (s *JWKSKeyStore) GetExpectedAlg(clientID string) (string, error) <span cla
 }
 </pre>
 		
-		<pre class="file" id="file55" style="display: none">package keys
+		<pre class="file" id="file71" style="display: none">package keys
 
 import (
         "fmt"
@@ -12311,7 +15260,7 @@ func (s *InMemoryKeyStore) GetCurrentKid(clientID string) (string, error) <span 
 }
 </pre>
 		
-		<pre class="file" id="file56" style="display: none">package keys
+		<pre class="file" id="file72" style="display: none">package keys
 
 import (
         "sync"
@@ -12441,7 +15390,7 @@ func (c *CompositeKeyLookup) GetKeyByKid(kid string) (*KeyRecord, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file57" style="display: none">// Package keystoretest provides shared test suites for all KeyStore implementations.
+		<pre class="file" id="file73" style="display: none">// Package keystoretest provides shared test suites for all KeyStore implementations.
 // Each backend (inmem, gorm, fs, gae) calls these tests with its own factory function.
 package keystoretest
 
@@ -12811,7 +15760,7 @@ func TestRegisterAndGetAsymmetricKey(t *testing.T, factory Factory) <span class=
 }
 </pre>
 		
-		<pre class="file" id="file58" style="display: none">package localauth
+		<pre class="file" id="file74" style="display: none">package localauth
 
 import (
         "crypto/rand"
@@ -13501,7 +16450,7 @@ func parseIdentityKey(key string) []string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file59" style="display: none">package localauth
+		<pre class="file" id="file75" style="display: none">package localauth
 
 import (
         "encoding/json"
@@ -14188,7 +17137,7 @@ func (a *LocalAuth) HandleLinkCredentials(config LinkCredentialsConfig, getUser 
 }
 </pre>
 		
-		<pre class="file" id="file60" style="display: none">package localauth
+		<pre class="file" id="file76" style="display: none">package localauth
 
 import (
         "encoding/json"
@@ -14448,7 +17397,7 @@ func (a *LocalAuth) parseSignupForm(r *http.Request) (*core.Credentials, *core.A
 }
 </pre>
 		
-		<pre class="file" id="file61" style="display: none">package fs
+		<pre class="file" id="file77" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14698,7 +17647,169 @@ func (s *FSAPIKeyStore) UpdateAPIKeyLastUsed(keyID string) error <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file62" style="display: none">package fs
+		<pre class="file" id="file78" style="display: none">package fs
+
+import (
+        "encoding/json"
+        "fmt"
+        "os"
+        "path/filepath"
+        "strings"
+        "sync"
+
+        "github.com/panyam/oneauth/admin"
+)
+
+// FSAppStore implements admin.AppRegistrationStore by persisting each
+// registration as a JSON file under {basePath}/apps/{client_id}.json.
+//
+// Mirrors the FSKeyStore design: file-per-record (so concurrent ops don't
+// serialize on a single mutex outside this process), atomic writes via
+// temp-file + rename (so a crash mid-write leaves either the old file or
+// the new file intact, never a half-written one), and safeName guarding
+// path-traversal in client_ids.
+//
+// In-process concurrency is mediated by sync.RWMutex. Multi-process
+// deployments need a backend with real transaction semantics — see
+// GORMAppStore (#167).
+type FSAppStore struct {
+        StoragePath string
+        mu          sync.RWMutex
+}
+
+// NewFSAppStore creates a filesystem-backed AppRegistrationStore. The
+// {basePath}/apps/ directory is created lazily on first write.
+func NewFSAppStore(storagePath string) *FSAppStore <span class="cov8" title="1">{
+        return &amp;FSAppStore{StoragePath: storagePath}
+}</span>
+
+func (s *FSAppStore) appsDir() string <span class="cov8" title="1">{
+        return filepath.Join(s.StoragePath, "apps")
+}</span>
+
+func (s *FSAppStore) appPath(clientID string) (string, error) <span class="cov8" title="1">{
+        safeID, err := safeName(clientID)
+        if err != nil </span><span class="cov8" title="1">{
+                return "", fmt.Errorf("invalid clientID: %w", err)
+        }</span>
+        <span class="cov8" title="1">return filepath.Join(s.appsDir(), safeID+".json"), nil</span>
+}
+
+// SaveApp persists app to disk. Overwrites any existing registration with
+// the same client_id. Empty client_id is rejected.
+func (s *FSAppStore) SaveApp(app *admin.AppRegistration) error <span class="cov8" title="1">{
+        if app == nil || app.ClientID == "" </span><span class="cov0" title="0">{
+                return fmt.Errorf("AppRegistration.ClientID required")
+        }</span>
+
+        <span class="cov8" title="1">path, err := s.appPath(app.ClientID)
+        if err != nil </span><span class="cov8" title="1">{
+                return err
+        }</span>
+
+        <span class="cov8" title="1">s.mu.Lock()
+        defer s.mu.Unlock()
+
+        if err := os.MkdirAll(s.appsDir(), 0700); err != nil </span><span class="cov0" title="0">{
+                return fmt.Errorf("create apps dir: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">data, err := json.MarshalIndent(app, "", "  ")
+        if err != nil </span><span class="cov0" title="0">{
+                return fmt.Errorf("marshal AppRegistration: %w", err)
+        }</span>
+        <span class="cov8" title="1">return writeAtomicFile(path, data)</span>
+}
+
+// GetApp returns the registration for clientID, or admin.ErrAppNotFound if
+// no such file exists. A corrupt JSON file surfaces as a parse error rather
+// than ErrAppNotFound — callers should distinguish "registration absent"
+// from "registration unreadable" so an unexpected on-disk corruption isn't
+// silently treated as a missing client.
+func (s *FSAppStore) GetApp(clientID string) (*admin.AppRegistration, error) <span class="cov8" title="1">{
+        path, err := s.appPath(clientID)
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, err
+        }</span>
+
+        <span class="cov8" title="1">s.mu.RLock()
+        defer s.mu.RUnlock()
+
+        data, err := os.ReadFile(path)
+        if err != nil </span><span class="cov8" title="1">{
+                if os.IsNotExist(err) </span><span class="cov8" title="1">{
+                        return nil, admin.ErrAppNotFound
+                }</span>
+                <span class="cov0" title="0">return nil, err</span>
+        }
+        <span class="cov8" title="1">var app admin.AppRegistration
+        if err := json.Unmarshal(data, &amp;app); err != nil </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+        }</span>
+        <span class="cov8" title="1">return &amp;app, nil</span>
+}
+
+// ListApps returns every registration in the store. Files that fail to
+// parse are skipped (with no error returned) so a single hand-corrupted
+// file does not lock out admin tooling — partial recovery beats total
+// failure here. Callers needing strict integrity should validate at the
+// store level (e.g., periodic fsck) rather than relying on ListApps.
+//
+// Returns an empty slice (not an error) when the apps dir does not yet
+// exist, matching the InMemory backend's "fresh store has no apps" shape.
+func (s *FSAppStore) ListApps() ([]*admin.AppRegistration, error) <span class="cov8" title="1">{
+        s.mu.RLock()
+        defer s.mu.RUnlock()
+
+        dir := s.appsDir()
+        entries, err := os.ReadDir(dir)
+        if err != nil </span><span class="cov8" title="1">{
+                if os.IsNotExist(err) </span><span class="cov8" title="1">{
+                        return []*admin.AppRegistration{}, nil
+                }</span>
+                <span class="cov0" title="0">return nil, err</span>
+        }
+
+        <span class="cov8" title="1">out := make([]*admin.AppRegistration, 0, len(entries))
+        for _, e := range entries </span><span class="cov8" title="1">{
+                if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") </span><span class="cov0" title="0">{
+                        continue</span>
+                }
+                <span class="cov8" title="1">data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+                if err != nil </span><span class="cov0" title="0">{
+                        continue</span>
+                }
+                <span class="cov8" title="1">var app admin.AppRegistration
+                if err := json.Unmarshal(data, &amp;app); err != nil </span><span class="cov8" title="1">{
+                        // Skip corrupt files — see godoc for rationale.
+                        continue</span>
+                }
+                // Take address of a fresh copy; ranging by value re-uses the loop var.
+                <span class="cov8" title="1">clone := app
+                out = append(out, &amp;clone)</span>
+        }
+        <span class="cov8" title="1">return out, nil</span>
+}
+
+// DeleteApp removes the registration for clientID. Returns admin.ErrAppNotFound
+// if no such registration exists, matching InMemoryAppStore semantics.
+func (s *FSAppStore) DeleteApp(clientID string) error <span class="cov8" title="1">{
+        path, err := s.appPath(clientID)
+        if err != nil </span><span class="cov8" title="1">{
+                return err
+        }</span>
+
+        <span class="cov8" title="1">s.mu.Lock()
+        defer s.mu.Unlock()
+
+        if _, err := os.Stat(path); os.IsNotExist(err) </span><span class="cov8" title="1">{
+                return admin.ErrAppNotFound
+        }</span>
+        <span class="cov8" title="1">return os.Remove(path)</span>
+}
+</pre>
+		
+		<pre class="file" id="file79" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14829,7 +17940,7 @@ func (s *FSChannelStore) GetChannelsByIdentity(identityKey string) ([]*core.Chan
 }
 </pre>
 		
-		<pre class="file" id="file63" style="display: none">package fs
+		<pre class="file" id="file80" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -14964,7 +18075,7 @@ func (s *FSIdentityStore) GetUserIdentities(userId string) ([]*core.Identity, er
 }
 </pre>
 		
-		<pre class="file" id="file64" style="display: none">package fs
+		<pre class="file" id="file81" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -15197,7 +18308,7 @@ func (s *FSKeyStore) GetCurrentKid(clientID string) (string, error) <span class=
 }
 </pre>
 		
-		<pre class="file" id="file65" style="display: none">package fs
+		<pre class="file" id="file82" style="display: none">package fs
 
 import (
         "crypto/sha256"
@@ -15536,7 +18647,7 @@ func (s *FSRefreshTokenStore) forEachToken(fn func(token *core.RefreshToken, pat
 }
 </pre>
 		
-		<pre class="file" id="file66" style="display: none">package fs
+		<pre class="file" id="file83" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -15674,7 +18785,7 @@ func (s *FSTokenStore) DeleteUserTokens(userID string, tokenType core.TokenType)
 }
 </pre>
 		
-		<pre class="file" id="file67" style="display: none">package fs
+		<pre class="file" id="file84" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -15782,7 +18893,7 @@ func (s *FSUserStore) SaveUser(user core.User) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file68" style="display: none">package fs
+		<pre class="file" id="file85" style="display: none">package fs
 
 import (
         "encoding/json"
@@ -16074,7 +19185,7 @@ func (s *FSUsernameStore) ChangeUsername(oldUsername, newUsername, userID string
 }
 </pre>
 		
-		<pre class="file" id="file69" style="display: none">package fs
+		<pre class="file" id="file86" style="display: none">package fs
 
 import (
         "fmt"
@@ -16161,7 +19272,7 @@ func writeAtomicFile(path string, data []byte) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file70" style="display: none">// Package testutil provides reusable test infrastructure for oneauth
+		<pre class="file" id="file87" style="display: none">// Package testutil provides reusable test infrastructure for oneauth
 // integration tests. It is intended to be imported by downstream projects
 // (mcpkit, relay, etc.) as well as oneauth's own test suites.
 //
@@ -16353,7 +19464,7 @@ func ParseJWTHeader(t *testing.T, tokenStr string) map[string]any <span class="c
 }
 </pre>
 		
-		<pre class="file" id="file71" style="display: none">package testutil
+		<pre class="file" id="file88" style="display: none">package testutil
 
 import (
         "crypto/rand"
@@ -16412,10 +19523,13 @@ type TestAuthServer struct {
 
 // config holds TestAuthServer configuration set via functional options.
 type config struct {
-        adminKey string
-        issuer   string
-        audience string
-        scopes   []string
+        adminKey                string
+        issuer                  string
+        audience                string
+        scopes                  []string
+        grantTypesSupported     []string                         // overrides default when non-nil
+        issParameterSupported   *bool                            // RFC 9207 advertisement (nil = omit)
+        trustedAssertionIssuers []apiauth.TrustedAssertionIssuer // RFC 7523 §2.1 + RFC 8693
 }
 
 // Option configures a TestAuthServer.
@@ -16443,6 +19557,67 @@ func WithAudience(aud string) Option <span class="cov8" title="1">{
 // Default: ["read", "write", "admin"].
 func WithScopes(scopes []string) Option <span class="cov8" title="1">{
         return func(c *config) </span><span class="cov8" title="1">{ c.scopes = scopes }</span>
+}
+
+// WithGrantTypesSupported overrides the `grant_types_supported` field
+// advertised in AS metadata (RFC 8414). Use this when enabling a grant
+// beyond the default (`client_credentials`) — e.g., advertising the
+// jwt-bearer (RFC 7523 §2.1) or token-exchange (RFC 8693) grants
+// alongside the default.
+//
+// The values supplied REPLACE the default. Callers that want to keep
+// `client_credentials` and add more must include it in the slice.
+//
+// Note: advertising a grant in metadata does NOT enable its handler at
+// the token endpoint. Pair this with WithTrustedAssertionIssuers to
+// actually serve jwt-bearer / token-exchange requests.
+func WithGrantTypesSupported(grants []string) Option <span class="cov8" title="1">{
+        return func(c *config) </span><span class="cov8" title="1">{ c.grantTypesSupported = grants }</span>
+}
+
+// WithIssParameterSupported sets the
+// `authorization_response_iss_parameter_supported` field in AS metadata
+// (RFC 9207 §3). Mitigates mix-up attacks against clients that interact
+// with multiple ASes by signaling that the AS includes an `iss`
+// parameter on every authorization response.
+//
+// Note: TestAuthServer does NOT currently implement an authorization
+// endpoint, so the *behavior* RFC 9207 §2 mandates (`iss=` in redirects)
+// is not yet driven by this flag — the flag affects only the metadata
+// advertisement. Setting it true on a real AS that does NOT actually
+// emit `iss` in authorization responses is a spec violation.
+func WithIssParameterSupported(supported bool) Option <span class="cov8" title="1">{
+        return func(c *config) </span><span class="cov8" title="1">{ c.issParameterSupported = &amp;supported }</span>
+}
+
+// WithTrustedAssertionIssuers configures the AS to accept
+// jwt-bearer (RFC 7523 §2.1) and token-exchange (RFC 8693) grants from
+// the listed upstream IdPs. Each entry binds an issuer URL to a public
+// key (or KeyFunc) so the AS can verify assertion signatures.
+//
+// When the supplied slice is non-empty, this Option AUTOMATICALLY
+// extends the advertised `grant_types_supported` to include the two new
+// grant URIs (so callers don't need to remember the pair). Callers can
+// still pass WithGrantTypesSupported AFTER this option to fully replace
+// the advertised list — last-option-wins for the slice.
+//
+// See:
+//   - RFC 7523 §2.1: https://www.rfc-editor.org/rfc/rfc7523#section-2.1
+//   - RFC 8693:      https://www.rfc-editor.org/rfc/rfc8693
+func WithTrustedAssertionIssuers(issuers []apiauth.TrustedAssertionIssuer) Option <span class="cov8" title="1">{
+        return func(c *config) </span><span class="cov8" title="1">{
+                c.trustedAssertionIssuers = issuers
+                // Extend the advertised grants unless the caller already pinned
+                // a specific list. Append-don't-replace keeps client_credentials
+                // alongside the new grants by default.
+                if c.grantTypesSupported == nil </span><span class="cov8" title="1">{
+                        c.grantTypesSupported = []string{
+                                "client_credentials",
+                                apiauth.JwtBearerGrantType,
+                                apiauth.TokenExchangeGrantType,
+                        }
+                }</span>
+        }
 }
 
 // NewTestAuthServer creates and starts an in-process authorization server
@@ -16493,12 +19668,13 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) <span class="cov8" t
         <span class="cov8" title="1">registrar := admin.NewAppRegistrar(ks, admin.NewAPIKeyAuth(cfg.adminKey))
 
         apiAuth := &amp;apiauth.APIAuth{
-                JWTSigningAlg:  "RS256",
-                JWTSigningKey:  privKey,
-                JWTVerifyKey:   &amp;privKey.PublicKey,
-                JWTIssuer:      cfg.issuer,
-                JWTAudience:    cfg.audience,
-                ClientKeyStore: ks,
+                JWTSigningAlg:           "RS256",
+                JWTSigningKey:           privKey,
+                JWTVerifyKey:            &amp;privKey.PublicKey,
+                JWTIssuer:               cfg.issuer,
+                JWTAudience:             cfg.audience,
+                ClientKeyStore:          ks,
+                TrustedAssertionIssuers: cfg.trustedAssertionIssuers,
         }
 
         introspection := apiauth.NewIntrospectionHandler(apiAuth, ks)
@@ -16523,19 +19699,23 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) <span class="cov8" t
                 issuer = baseURL
                 apiAuth.JWTIssuer = issuer
         }</span>
-        <span class="cov8" title="1">asMetaHandler := apiauth.NewASMetadataHandler(&amp;apiauth.ASServerMetadata{
+        <span class="cov8" title="1">grants := cfg.grantTypesSupported
+        if grants == nil </span><span class="cov8" title="1">{
+                grants = []string{"client_credentials"}
+        }</span>
+        <span class="cov8" title="1">apiauth.MountASMetadata(mux, &amp;apiauth.ASServerMetadata{
                 Issuer:                        issuer,
                 TokenEndpoint:                 baseURL + "/api/token",
                 JWKSURI:                       baseURL + "/.well-known/jwks.json",
                 IntrospectionEndpoint:         baseURL + "/oauth/introspect",
                 RegistrationEndpoint:          baseURL + "/apps/register",
                 ScopesSupported:               cfg.scopes,
-                GrantTypesSupported:           []string{"client_credentials"},
+                GrantTypesSupported:           grants,
                 ResponseTypesSupported:        []string{"token"},
                 TokenEndpointAuthMethods:      []string{"client_secret_post", "client_secret_basic"},
                 CodeChallengeMethodsSupported: []string{"S256"},
+                AuthorizationResponseIssParameterSupported: cfg.issParameterSupported,
         })
-        mux.Handle("GET /.well-known/openid-configuration", asMetaHandler)
 
         return &amp;TestAuthServer{
                 Server:     server,
@@ -16613,7 +19793,7 @@ func (s *TestAuthServer) MintTokenForSubject(subject string, scopes []string) (s
 }
 </pre>
 		
-		<pre class="file" id="file72" style="display: none">package testutil
+		<pre class="file" id="file89" style="display: none">package testutil
 
 import (
         "time"
@@ -16692,7 +19872,7 @@ func (s *TestAuthServer) signToken(claims jwt.MapClaims) (string, error) <span c
 }
 </pre>
 		
-		<pre class="file" id="file73" style="display: none">package utils
+		<pre class="file" id="file90" style="display: none">package utils
 
 import (
         "crypto"
@@ -16874,7 +20054,7 @@ func SigningMethodForAlg(alg string) (jwt.SigningMethod, error) <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file74" style="display: none">package utils
+		<pre class="file" id="file91" style="display: none">package utils
 
 import (
         "bytes"
@@ -17042,7 +20222,7 @@ func excelDecode(encoded string, alpha string, revmap map[rune]uint) uint64 <spa
 }
 </pre>
 		
-		<pre class="file" id="file75" style="display: none">package utils
+		<pre class="file" id="file92" style="display: none">package utils
 
 import (
         "crypto"
@@ -17187,7 +20367,7 @@ func ecJWKToPublicKey(jwk JWK) (crypto.PublicKey, string, error) <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file76" style="display: none">package utils
+		<pre class="file" id="file93" style="display: none">package utils
 
 import (
         "crypto/ecdsa"

--- a/test-reports/report.html
+++ b/test-reports/report.html
@@ -16,7 +16,7 @@ th { background: #f5f5f5; font-weight: 600; }
 pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 13px; max-height: 400px; overflow-y: auto; }
 </style></head><body>
 <h1>OneAuth Test Report</h1>
-<div class='meta'>Branch: <strong>feat/server-memory-mode</strong> | Commit: <code>7810428</code> | Date: 2026-04-27 16:27:28</div>
+<div class='meta'>Branch: <strong>feat/issue-184-rs256-issuer-mode</strong> | Commit: <code>f97c6e1</code> | Date: 2026-05-08 09:39:56</div>
 <table><tr><th>Stage</th><th>Result</th></tr>
 <tr><td>lint</td><td class='pass'>PASS</td></tr>
 <tr><td>unit+coverage</td><td class='pass'>PASS</td></tr>
@@ -31,11 +31,11 @@ pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; 
 <div class='summary-pass'>All 9 stages passed</div>
 <h2>Full Log</h2><pre>
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 16:25:56 PDT 2026
+Started: Fri May  8 09:38:22 PDT 2026
 Starting PostgreSQL...
-7c5f700e02fae78459598ea16090442ac74a297faccb80825813d70b9b3ab466
+afc619f298520cd9b5eb3b0cb4fd1b8f16e482d503e864a3ed12f858fa3b906e
 Starting Keycloak...
-72d6da1785f346a1ef9bd06c90489b17aa688d37d84569fec959df7565c92225
+24ae02b51fbc0f84e44498920f0549b4e327aa9f2dd151ec968d85192dd19fda
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -44,12 +44,13 @@ Starting Keycloak...
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.606s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	4.487s	coverage: 75.2% of statements
-ok  	github.com/panyam/oneauth/client	6.175s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.981s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	1.086s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	1.946s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	1.543s	coverage: 81.1% of statements
+ok  	github.com/panyam/oneauth/apiauth	6.772s	coverage: 75.6% of statements
+	github.com/panyam/oneauth/appstoretest		coverage: 0.0% of statements
+ok  	github.com/panyam/oneauth/client	6.845s	coverage: 82.5% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.267s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	1.641s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	2.726s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -60,27 +61,28 @@ ok  	github.com/panyam/oneauth/examples	1.946s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/08-rich-authorization-requests		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/common		coverage: 0.0% of statements
 ?   	github.com/panyam/oneauth/examples/refs	[no test files]
-ok  	github.com/panyam/oneauth/httpauth	1.418s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	2.858s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/httpauth	1.555s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	3.807s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	8.898s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	2.320s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	5.347s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	4.015s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	4.236s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	9.309s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	2.732s	coverage: 32.8% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	5.103s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	4.261s	coverage: 80.4% of statements
+ok  	github.com/panyam/oneauth/utils	4.072s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	20.996s
+ok  	github.com/panyam/oneauth/tests/e2e	21.036s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	1.186s
+ok  	github.com/panyam/oneauth/stores/gorm	1.436s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -91,7 +93,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.340s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.525s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -103,10 +105,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.340s
     ○ ░
     ░    gitleaks
 
-[90m4:26PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m4:26PM[0m [32mINF[0m [1m205 commits scanned.[0m
-[90m4:26PM[0m [32mINF[0m [1mscanned ~3640316 bytes (3.64 MB) in 778ms[0m
-[90m4:26PM[0m [32mINF[0m [1mno leaks found[0m
+[90m9:39AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m9:39AM[0m [32mINF[0m [1m232 commits scanned.[0m
+[90m9:39AM[0m [32mINF[0m [1mscanned ~4312566 bytes (4.31 MB) in 1.01s[0m
+[90m9:39AM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -117,17 +119,18 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 16:26:44 Using in-memory KeyStore (not persistent)
-2026/04/27 16:26:44 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 16:26:44 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 16:26:44 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 16:27:17 
+2026/05/08 09:39:14 Using in-memory KeyStore (not persistent)
+2026/05/08 09:39:14 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/05/08 09:39:14 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/05/08 09:39:14 Using in-memory AppStore (registrations lost on restart)
+2026/05/08 09:39:14 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/05/08 09:39:45 
 === EMAIL: Password Reset ===
-2026/04/27 16:27:17 To: zaproxy@example.com
-2026/04/27 16:27:17 Subject: Reset your password
-2026/04/27 16:27:17 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=259bdd9edef61d438a27156d2376b7acef3a886ff2f276d94cb7684004c9544d
-2026/04/27 16:27:17 ==============================
-2026/04/27 16:27:17 error validating user:  invalid credentials
+2026/05/08 09:39:45 To: zaproxy@example.com
+2026/05/08 09:39:45 Subject: Reset your password
+2026/05/08 09:39:45 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=36c0c3b1a8b1401caa32a57fb4d602bbc02838d2ea8ffd0e5aebc9a3c417801a
+2026/05/08 09:39:45 ==============================
+2026/05/08 09:39:45 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -194,25 +197,25 @@ PASS: Loosely Scoped Cookie [90033]
 IGNORE: Cookie No HttpOnly Flag [10010] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
-	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
-	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
@@ -220,11 +223,11 @@ IGNORE: Session Management Response Identified [10112] x 2
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
-	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
@@ -235,7 +238,7 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 16:27:27 PDT 2026
+Finished: Fri May  8 09:39:54 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak
 </pre>

--- a/test-reports/run.log
+++ b/test-reports/run.log
@@ -1,9 +1,9 @@
 === OneAuth Comprehensive Test Suite ===
-Started: Mon Apr 27 16:25:56 PDT 2026
+Started: Fri May  8 09:38:22 PDT 2026
 Starting PostgreSQL...
-7c5f700e02fae78459598ea16090442ac74a297faccb80825813d70b9b3ab466
+afc619f298520cd9b5eb3b0cb4fd1b8f16e482d503e864a3ed12f858fa3b906e
 Starting Keycloak...
-72d6da1785f346a1ef9bd06c90489b17aa688d37d84569fec959df7565c92225
+24ae02b51fbc0f84e44498920f0549b4e327aa9f2dd151ec968d85192dd19fda
 
 --- [1/9] Lint (staticcheck) ---
 [lint] Running staticcheck...
@@ -12,12 +12,13 @@ Starting Keycloak...
 --- [2/9] Unit tests + coverage (core + sub-modules) ---
 go test -buildvcs=false -coverprofile=test-reports/coverage.out ./... -count=1 -timeout 60s
 ?   	github.com/panyam/oneauth	[no test files]
-ok  	github.com/panyam/oneauth/admin	0.606s	coverage: 75.6% of statements
-ok  	github.com/panyam/oneauth/apiauth	4.487s	coverage: 75.2% of statements
-ok  	github.com/panyam/oneauth/client	6.175s	coverage: 82.4% of statements
-ok  	github.com/panyam/oneauth/client/stores/fs	1.981s	coverage: 77.9% of statements
-ok  	github.com/panyam/oneauth/core	1.086s	coverage: 20.1% of statements
-ok  	github.com/panyam/oneauth/examples	1.946s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/admin	1.543s	coverage: 81.1% of statements
+ok  	github.com/panyam/oneauth/apiauth	6.772s	coverage: 75.6% of statements
+	github.com/panyam/oneauth/appstoretest		coverage: 0.0% of statements
+ok  	github.com/panyam/oneauth/client	6.845s	coverage: 82.5% of statements
+ok  	github.com/panyam/oneauth/client/stores/fs	1.267s	coverage: 77.9% of statements
+ok  	github.com/panyam/oneauth/core	1.641s	coverage: 20.1% of statements
+ok  	github.com/panyam/oneauth/examples	2.726s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/01-client-credentials		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/02-resource-token-hs256		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/03-resource-token-rs256-jwks		coverage: 0.0% of statements
@@ -28,27 +29,28 @@ ok  	github.com/panyam/oneauth/examples	1.946s	coverage: [no statements]
 	github.com/panyam/oneauth/examples/08-rich-authorization-requests		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/09-key-rotation		coverage: 0.0% of statements
 	github.com/panyam/oneauth/examples/10-security		coverage: 0.0% of statements
+	github.com/panyam/oneauth/examples/common		coverage: 0.0% of statements
 ?   	github.com/panyam/oneauth/examples/refs	[no test files]
-ok  	github.com/panyam/oneauth/httpauth	1.418s	coverage: 29.4% of statements
-ok  	github.com/panyam/oneauth/keys	2.858s	coverage: 75.6% of statements
+ok  	github.com/panyam/oneauth/httpauth	1.555s	coverage: 29.4% of statements
+ok  	github.com/panyam/oneauth/keys	3.807s	coverage: 75.6% of statements
 	github.com/panyam/oneauth/keystoretest		coverage: 0.0% of statements
-ok  	github.com/panyam/oneauth/localauth	8.898s	coverage: 65.1% of statements
-ok  	github.com/panyam/oneauth/stores/fs	2.320s	coverage: 27.9% of statements
-ok  	github.com/panyam/oneauth/tests/e2e	5.347s	coverage: [no statements]
-ok  	github.com/panyam/oneauth/testutil	4.015s	coverage: 79.1% of statements
-ok  	github.com/panyam/oneauth/utils	4.236s	coverage: 54.7% of statements
+ok  	github.com/panyam/oneauth/localauth	9.309s	coverage: 65.1% of statements
+ok  	github.com/panyam/oneauth/stores/fs	2.732s	coverage: 32.8% of statements
+ok  	github.com/panyam/oneauth/tests/e2e	5.103s	coverage: [no statements]
+ok  	github.com/panyam/oneauth/testutil	4.261s	coverage: 80.4% of statements
+ok  	github.com/panyam/oneauth/utils	4.072s	coverage: 54.7% of statements
 go tool cover -html=test-reports/coverage.out -o test-reports/coverage.html
 Coverage report: test-reports/coverage.html
   PASS: unit+coverage
 
 --- [3/9] E2E tests (in-process race detector) ---
 [e2e] Running in-process e2e tests (race detector)...
-ok  	github.com/panyam/oneauth/tests/e2e	20.996s
+ok  	github.com/panyam/oneauth/tests/e2e	21.036s
   PASS: e2e
 
 --- [4/9] PostgreSQL / GORM tests ---
 [postgres] Running GORM tests against PostgreSQL on port 5433...
-ok  	github.com/panyam/oneauth/stores/gorm	1.186s
+ok  	github.com/panyam/oneauth/stores/gorm	1.436s
   PASS: postgres
 
 --- [5/9] Datastore tests ---
@@ -59,7 +61,7 @@ SKIP: no credentials at ~/dev-app-data/secrets/gappeng/gappeng-7bb71377bfa2.json
 --- [6/9] Keycloak interop tests ---
 [keycloak] Waiting for Keycloak on port 8180...
 [keycloak] Running interop tests...
-ok  	github.com/panyam/oneauth/tests/keycloak	2.340s
+ok  	github.com/panyam/oneauth/tests/keycloak	2.525s
   PASS: keycloak
 
 --- [7/9] Secret scanning ---
@@ -71,10 +73,10 @@ ok  	github.com/panyam/oneauth/tests/keycloak	2.340s
     ○ ░
     ░    gitleaks
 
-[90m4:26PM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
-[90m4:26PM[0m [32mINF[0m [1m205 commits scanned.[0m
-[90m4:26PM[0m [32mINF[0m [1mscanned ~3640316 bytes (3.64 MB) in 778ms[0m
-[90m4:26PM[0m [32mINF[0m [1mno leaks found[0m
+[90m9:39AM[0m [32mINF[0m [1mUnknown SCM platform. Use --platform to include links in findings.[0m [36mhost=[0mpanyam-github
+[90m9:39AM[0m [32mINF[0m [1m232 commits scanned.[0m
+[90m9:39AM[0m [32mINF[0m [1mscanned ~4312566 bytes (4.31 MB) in 1.01s[0m
+[90m9:39AM[0m [32mINF[0m [1mno leaks found[0m
   PASS: secrets
 
 --- [8/9] Vulnerability check ---
@@ -85,17 +87,18 @@ No vulnerabilities found.
 --- [9/9] ZAP baseline scan ---
 [zap] Building server...
 [zap] Starting server on :19876...
-2026/04/27 16:26:44 Using in-memory KeyStore (not persistent)
-2026/04/27 16:26:44 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
-2026/04/27 16:26:44 Using filesystem user stores at /tmp/oneauth-zap-test-all
-2026/04/27 16:26:44 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
-2026/04/27 16:27:17 
+2026/05/08 09:39:14 Using in-memory KeyStore (not persistent)
+2026/05/08 09:39:14 WARNING: ONEAUTH_MASTER_KEY not set — HS256 secrets stored in plaintext
+2026/05/08 09:39:14 Using filesystem user stores at /tmp/oneauth-zap-test-all
+2026/05/08 09:39:14 Using in-memory AppStore (registrations lost on restart)
+2026/05/08 09:39:14 oneauth-server listening on 0.0.0.0:19876 (keystore=memory, user_stores=fs, auth=api-key)
+2026/05/08 09:39:45 
 === EMAIL: Password Reset ===
-2026/04/27 16:27:17 To: zaproxy@example.com
-2026/04/27 16:27:17 Subject: Reset your password
-2026/04/27 16:27:17 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=259bdd9edef61d438a27156d2376b7acef3a886ff2f276d94cb7684004c9544d
-2026/04/27 16:27:17 ==============================
-2026/04/27 16:27:17 error validating user:  invalid credentials
+2026/05/08 09:39:45 To: zaproxy@example.com
+2026/05/08 09:39:45 Subject: Reset your password
+2026/05/08 09:39:45 Body: Reset your password by clicking: http://localhost:19876/auth/reset-password?token=36c0c3b1a8b1401caa32a57fb4d602bbc02838d2ea8ffd0e5aebc9a3c417801a
+2026/05/08 09:39:45 ==============================
+2026/05/08 09:39:45 error validating user:  invalid credentials
 Using the Automation Framework
 Total of 9 URLs
 PASS: Vulnerable JS Library (Powered by Retire.js) [10003]
@@ -162,25 +165,25 @@ PASS: Loosely Scoped Cookie [90033]
 IGNORE: Cookie No HttpOnly Flag [10010] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Cross-Domain JavaScript Source File Inclusion [10017] x 5 
-	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: User Controllable HTML Element Attribute (Potential XSS) [10031] x 2 
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Non-Storable Content [10049] x 6 
 	http://host.docker.internal:19876/auth/forgot-password (303 See Other)
-	http://host.docker.internal:19876 (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
-	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
+	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
 IGNORE: CSP: style-src unsafe-inline [10055] x 5 
-	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Authentication Request Identified [10111] x 1 
 	http://host.docker.internal:19876/auth/login (200 OK)
@@ -188,11 +191,11 @@ IGNORE: Session Management Response Identified [10112] x 2
 	http://host.docker.internal:19876/auth/login (200 OK)
 	http://host.docker.internal:19876/auth/login (200 OK)
 IGNORE: Sub Resource Integrity Attribute Missing [90003] x 5 
-	http://host.docker.internal:19876 (200 OK)
+	http://host.docker.internal:19876/ (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password (200 OK)
 	http://host.docker.internal:19876/auth/forgot-password?sent=true (200 OK)
 	http://host.docker.internal:19876/auth/signup (200 OK)
-	http://host.docker.internal:19876/auth/login (200 OK)
+	http://host.docker.internal:19876/auth/signup (200 OK)
 IGNORE: Sec-Fetch-Dest Header is Missing [90005] x 12 
 	http://host.docker.internal:19876/robots.txt (404 Not Found)
 	http://host.docker.internal:19876/sitemap.xml (404 Not Found)
@@ -203,6 +206,6 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 0	WARN-INPROG: 0	INFO: 0	IGNORE: 9	PASS: 61
   PASS: zap
 
 === Summary: 9 passed, 0 failed ===
-Finished: Mon Apr 27 16:27:27 PDT 2026
+Finished: Fri May  8 09:39:54 PDT 2026
 oneauth-test-pg
 oneauth-test-keycloak


### PR DESCRIPTION
## Summary
- Closes the second half of 184. The previous PR fixed the iss-claim leak; this one fixes the underlying reason `TestRAR_JWKS_ValidateToken` and `TestRAR_JWKS_RequireAuthorizationDetails` were failing — the rar-test issuer minted HS256 tokens, and HS256 secrets are correctly omitted from JWKS by design (keys/jwks_handler.go filters to asymmetric only).
- New `jwt.signing_alg` config (default HS256). When RS256/ES256, the public half of the keypair is registered in the keystore so the existing JWKS handler exposes it.
- Production path: set `jwt.private_key_path` to a stable PEM file. Test/dev path: set `jwt.ephemeral_signing_key: true` (explicit opt-in — generates a fresh RSA-2048 keypair on each startup with a prominent warning).
- Misconfiguration (alg=RS256 + neither field set) fails loudly. Production deployments can't accidentally end up with ephemeral keys.
- `rar-test.yaml` flips to RS256 + ephemeral (the config is explicitly described as "ephemeral in-memory server").

## Test plan
- [x] `make testkcl KC_PORT=8281` — full suite green (was failing 2 tests before this branch). Both `TestRAR_JWKS_ValidateToken` and `TestRAR_JWKS_RequireAuthorizationDetails` now PASS.
- [x] `make test` — clean.
- [x] `make e2e` — clean (21s, race detector).

## Filed as a follow-up
- 194 (meta): promote `cmd/oneauth-server` from POC to production-grade reference deployment. The "explicit ephemeral_signing_key opt-in" choice in this PR is the first concrete POC-grade fix in that direction; 194 catalogs the broader gaps (admin UI, MFA, full /authorize, etc.) and what's *intentionally* not on the roadmap.