### PR TITLE
chore: checkpoint — sync learnings from the convention/persistence/RS256 session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,7 @@ Each subpackage has a `SUMMARY.md` with detailed contents.
 | `stores/` | FS, GORM, GAE backend implementations | `stores/*/SUMMARY.md` |
 | `examples/` | 10 progressive interactive examples with demokit | [examples/README.md](examples/README.md) |
 | `tests/keycloak/` | Keycloak interop + RAR conformance tests | [tests/keycloak/README.md](tests/keycloak/README.md) |
-| `cmd/oneauth-server/` | Config-driven reference server | `cmd/oneauth-server/config.go` |
-| `cmd/rar-test-issuer/` | Minimal RAR-capable AS for interop testing | `cmd/rar-test-issuer/main.go` header |
+| `cmd/oneauth-server/` | Config-driven reference server (#194 tracks POC→production-grade ambition) | `cmd/oneauth-server/config.go` |
 
 ## Multi-Module Structure
 
@@ -42,35 +41,48 @@ Full command reference: see `Makefile` header comments and `make help` (if avail
 
 ## Key Architecture Decisions
 
-- **Client library, not a proxy** — embeddable, no extra service to operate
-- **Transport-independent core** — `OneAuth` struct with `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker` interfaces. HTTP handlers are thin wrappers. See [#110](https://github.com/panyam/oneauth/issues/110).
-- **Storage-agnostic** — interface-based, three backends (FS, GORM, GAE)
-- **Composed interfaces** — no god objects. Each implementation takes only the deps it needs.
+- **Client library, not a proxy** — embeddable. `cmd/oneauth-server/` is a reference deployment, not the product.
+- **gRPC-shape convention everywhere** — every transport-agnostic interface follows `MethodName(ctx context.Context, req *XRequest) (*XResponse, error)`. Applies to `apiauth/` (`TokenIssuer` / `Validator` / `Introspector` / `Revoker` / `ClientAuthenticator`) and `admin/` (`ClientRegistrationManager` / `ClientRegistrar`). HTTP handlers are thin wrappers. Issue #110 / #175.
+- **Storage-agnostic** — interface-based, three backends (FS, GORM, GAE) for KeyStore + UserStore + AppRegistrationStore.
+- **Composed interfaces, no god objects** — each impl takes only the deps it needs.
 - **Grouped hooks** — `TokenHooks`, `AuthHooks`, `ClientHooks`, `SecurityHooks`. See `apiauth/hooks.go`.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for rationale and [docs/ROADMAP.md](docs/ROADMAP.md) for what's shipped vs in flight.
 
 ## Standards Compliance
 
 | Endpoint | Handler | RFC |
 |----------|---------|-----|
-| `POST /api/token` | `APIAuth.ServeHTTP` | RFC 6749 |
+| `POST /api/token` (password / refresh / client_credentials / jwt-bearer / token-exchange) | `APIAuth.ServeHTTP` | RFC 6749, 7523, 8693 |
 | `POST /oauth/introspect` | `IntrospectionHandler` | RFC 7662 |
 | `POST /oauth/revoke` | `RevocationHandler` | RFC 7009 |
 | `GET /.well-known/openid-configuration` | `NewASMetadataHandler` | RFC 8414 |
 | `GET /.well-known/jwks.json` | `JWKSHandler` | RFC 7517 |
 | `GET /.well-known/oauth-protected-resource` | `NewProtectedResourceHandler` | RFC 9728 |
 | `POST /apps/dcr` | `DCRHandler` | RFC 7591 |
+| `GET / PUT / DELETE /apps/dcr/{client_id}` | `DCRManagementHandler` | RFC 7592 |
+| Authorize-redirect `?iss=` query param | (issuer URL on redirects) | RFC 9207 |
 
-RFC 9396 (Rich Authorization Requests) supported on token endpoint, introspection, and middleware. See `core/authorization_details.go`.
+RFC 9396 (Rich Authorization Requests) supported on token endpoint, introspection, and middleware. See `core/authorization_details.go`. Full Authlete-superset gap analysis: [docs/gaps/AUTHLETE_GAP_ANALYSIS.md](docs/gaps/AUTHLETE_GAP_ANALYSIS.md), tracked under #163.
 
 ## Conventions
 
-- Each subpackage has a `SUMMARY.md` for LLM discoverability
-- Security tests must include `// See:` links to RFC/CVE/CWE references
-- Use `GH_TOKEN="$GH_PERSONAL_TOKEN"` for gh CLI
-- Keycloak: `quay.io/keycloak/keycloak:26.6` on port 8180
-- RAR test issuer: port 8181. See `cmd/rar-test-issuer/main.go` for details.
-- Sub-modules need `GOWORK=off` when running outside workspace
-- Examples split into `main.go` (server, supports `--serve` to bind real ports) + `walkthrough.go` (demokit client demo). Each ships slim `README.md` + generated `WALKTHROUGH.md` (`make walkthrough`). Default `make demo` uses TUI renderer.
+- Each subpackage has a `SUMMARY.md` for LLM discoverability.
+- Security tests must include `// See:` links to RFC/CVE/CWE references.
+- Use `GH_TOKEN="$GH_PERSONAL_TOKEN"` for gh CLI.
+- Keep new test groups in separate `_test.go` files (don't bloat existing ones).
+- Sub-modules need `GOWORK=off` when running outside workspace.
+- Examples split into `main.go` (server, `--serve` for real ports) + `walkthrough.go` (demokit client demo). Slim `README.md` + generated `WALKTHROUGH.md` via `make walkthrough`.
+
+## Gotchas
+
+- **Keycloak port collision**: Default `KC_PORT=8180`, default `RAR_PORT=8181`. `mcpkit-keycloak` (other project) often holds 8180; pass `make upkcl KC_PORT=8281 && make testkcl KC_PORT=8281` to avoid both that and the RAR_PORT clash.
+- **RAR test issuer**: lives at `cmd/oneauth-server/deploy-examples/rar-test.yaml`, started inside `make testkcl`. Old `cmd/rar-test-issuer/` is retired.
+- **JWKS only exposes asymmetric keys.** HS256 secrets are *correctly* omitted (`keys/jwks_handler.go`). Tests/services that validate via `JWKSKeyStore` must mint RS256/ES256 tokens — set `jwt.signing_alg: RS256` + `jwt.private_key_path` (or `ephemeral_signing_key: true` for tests).
+- **Asymmetric signing in cmd/oneauth-server**: `jwt.signing_alg=RS256` requires either `jwt.private_key_path` or `jwt.ephemeral_signing_key: true` — neither set fails loudly. Auto-generated ephemeral keys invalidate tokens on restart.
+- **Local main can be locked by another worktree**. When working in a stacked branch, cut new branches from `origin/main` directly (`git checkout -b feat/X origin/main`) — don't try to `git checkout main` if the `conformance/` or `rfc-extensions/` worktrees own it.
+- **`go.work` Go directive**: stdlib CVEs require keeping the `go` directive across all 9 modules in lock-step (root + workspace + 7 sub-modules). `make vulncheck` is the gate.
+- **Backlinks via `#N`**: only when the cross-reference is genuinely the audit trail you want. For background-only references, use plain text (`"issue 123"` not `#123`) — see global `~/.claude/CLAUDE.md` for the full rule.
 
 ## Gap analyses
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -176,21 +176,19 @@ Pure-OAuth code pushed down from mcpkit/ext/auth (mcpkit#158) into oneauth for b
 
 ---
 
-## App Registrar Persistence
+## App Registrar Persistence ✅ COMPLETE
 
-Splits issue 20 (Persist AppRegistrar state) into shippable backend chunks. The schema additions for issue 157 (RFC 7592 management) are baked in upfront so subsequent tickets do not churn the table layout.
+Closed parent issue 20 (Persist AppRegistrar state) via three shippable chunks. Schema additions for the RFC 7592 management track were baked in upfront so subsequent tickets did not churn the table layout.
 
 | # | Scope | Status |
 |---|-------|--------|
 | 165 | `AppRegistrationStore` interface + `InMemoryAppStore` + AppRegistrar refactor (cache + write-through) + `appstoretest` contract suite + e2e simulated-restart test | Merged |
 | 166 | `FSAppStore` (filesystem backend) — file-per-app, atomic writes, safeName traversal defense, partial recovery on corrupt files | Merged |
-| 167 | `GORMAppStore` (multi-node persistence — Postgres/MySQL/SQLite) + `app_store` config block in `cmd/oneauth-server`. Closes parent issue 20. | In progress |
+| 167 | `GORMAppStore` (multi-node — Postgres/MySQL/SQLite) + `app_store` config block in `cmd/oneauth-server`. **Closed parent #20.** | Merged |
 
-After 167 lands, parent issue 20 can close. The chain unblocks the entire RFC 7592 track (issues 168 / 169 / 170 / 171) tracked under issue 157.
+## RFC 7592 — DCR Management ✅ COMPLETE
 
-## RFC 7592 — DCR Management
-
-Splits issue 157 (parent) into vertical verb-by-verb slices. Each ticket ships a server handler, a client SDK helper, tests, and a walkthrough step in `examples/06-dynamic-client-registration/`. The `ClientRegistrationManager` interface introduced in 168 is also the blueprint for issue 172 (transport-agnostic refactor of legacy admin/ surface).
+Closed parent issue 157 via four vertical verb-by-verb slices. Each ticket shipped a server handler, a client SDK helper, tests, and a walkthrough step in `examples/06-dynamic-client-registration/`. The `ClientRegistrationManager` interface introduced in 168 is the blueprint for the convention-port track below.
 
 | # | Slice | Status |
 |---|-------|--------|
@@ -199,15 +197,22 @@ Splits issue 157 (parent) into vertical verb-by-verb slices. Each ticket ships a
 | 170 | DELETE — registration removal + KeyStore credential invalidation + `client.DeleteRegistration` + walkthrough step. Closes the verb trio. | Merged |
 | 171 | Keycloak interop — full lifecycle test against Keycloak's RFC 7592 endpoints; validates the wire format of 168/169/170 against a real-world AS | Merged |
 
-## Convention Ports
+## Convention Ports ✅ COMPLETE
 
-The `(ctx, *Req) → (*Resp, error)` convention adopted in 169 propagates to the rest of the library:
+The `(ctx context.Context, *XRequest) → (*XResponse, error)` convention adopted in 169 has propagated through the library. Every transport-agnostic interface in `apiauth/` and `admin/` now follows the gRPC-shape signature.
 
 | # | Surface | Status |
 |---|---------|--------|
-| 172 | Legacy `admin/` — `ClientRegistrar` interface for `DCRHandler.ServeHTTP` + legacy `/apps/register` + admin CRUD + secret rotation. HTTP handlers reduced to thin wrappers. Wire format unchanged. | In progress |
-| 175 | `apiauth/` — `TokenIssuer` / `TokenValidator` / `TokenIntrospector` / `TokenRevoker` / `ClientAuthenticator` adopt the same shape; HTTP handlers (auth.go, introspection.go, revocation.go) reduced to thin wrappers; wire format unchanged | In progress |
-| 189 | Follow-up: remove `/apps/register` once a quota story for `MaxRooms` / `MaxMsgRate` is decided | Pending |
+| 172 | Legacy `admin/` — `ClientRegistrar` interface for register / list / get / delete / rotate. HTTP handlers reduced to thin wrappers. Wire format unchanged. | Merged |
+| 175 | `apiauth/` — `TokenIssuer` / `TokenValidator` / `TokenIntrospector` / `TokenRevoker` / `ClientAuthenticator`. HTTP handlers (auth.go, introspection.go, revocation.go) reduced to thin wrappers. Wire format unchanged. | Merged |
+| 189 | **Pending** — remove `/apps/register` once a quota story for `MaxRooms` / `MaxMsgRate` is decided. Blocked on the design call, not implementation. | Pending |
+
+## Reference Server (cmd/oneauth-server)
+
+| # | Item | Status |
+|---|------|--------|
+| 184 | Issuer URL fix (drop iss=0.0.0.0 leak) + RS256 token signing mode (`jwt.signing_alg: RS256`) so JWKS-based remote validation works. Test/dev opts into ephemeral keys via explicit `jwt.ephemeral_signing_key: true`; production sets `jwt.private_key_path`. | Merged |
+| 194 | **Meta-tracker** — promote `cmd/oneauth-server` from POC to production-grade reference deployment. Catalogs feature gaps (admin UI, MFA, full /authorize, multi-tenant, WebAuthn, etc.) and what's *intentionally* not on the roadmap. Living document; not a single PR. | Open |
 
 ---
 

--- a/memories/MEMORY.md
+++ b/memories/MEMORY.md
@@ -5,3 +5,5 @@
 - [feedback_pr_docs.md](feedback_pr_docs.md) — Always update docs as part of every PR commit, not as afterthought. Close GitHub issue, update SUMMARY, ROADMAP, guide docs, subpackage SUMMARYs.
 - [feedback_test_file_organization.md](feedback_test_file_organization.md) — Keep new test groups in separate _test.go files to prevent bloat in existing test files.
 - [feedback_review_cadences.md](feedback_review_cadences.md) — Prefer ad-hoc `make X-report` targets over cron/calendar review cadences; advisory metadata (e.g., `expires:`) shouldn't gate.
+- [feedback_stacked_branches_in_worktrees.md](feedback_stacked_branches_in_worktrees.md) — When local main is held by another worktree, cut new feature branches from `origin/main` directly. Don't try to `git checkout main`.
+- [feedback_explicit_opt_in_for_dev_hacks.md](feedback_explicit_opt_in_for_dev_hacks.md) — Gate dev/test-only conveniences behind explicit opt-in flags; never make them silent fallbacks. Production misconfiguration should fail loudly.

--- a/memories/feedback_explicit_opt_in_for_dev_hacks.md
+++ b/memories/feedback_explicit_opt_in_for_dev_hacks.md
@@ -1,0 +1,20 @@
+---
+name: feedback_explicit_opt_in_for_dev_hacks
+description: When a feature has both a production-correct path and a dev/test-only convenience, gate the convenience behind an explicit opt-in flag — never make it the silent fallback.
+type: feedback
+---
+
+When designing config knobs that have a "production correct" form and a "test/dev convenient" shortcut (e.g., persistent signing key vs. ephemeral keypair, real DB vs. in-memory store, real secret vs. auto-generated), **gate the shortcut behind an explicit opt-in flag**. Don't make it the silent fallback when the production field is unset.
+
+**Why:** validated during the #184 / #194 discussion. I initially proposed: "if `jwt.signing_alg=RS256` and no `private_key_path` is set, auto-generate a fresh keypair on startup." User pushed back on this being a "POC dumping ground hack" — silent fallbacks turn config typos into deployments that look like they're working but emit ephemeral tokens that break across restarts. The shape that landed:
+
+- `jwt.signing_alg=RS256` requires either `jwt.private_key_path` (production path) or `jwt.ephemeral_signing_key: true` (explicit opt-in for tests).
+- Neither set → fail loudly with a clear error: "set jwt.private_key_path or jwt.ephemeral_signing_key=true".
+
+**How to apply:**
+- Look for places where I'm about to add a "default to convenient behavior" branch. Reframe as "default to error; require explicit opt-in for the convenience."
+- The opt-in flag name should make intent obvious: `ephemeral_signing_key`, `dev_auto_generate`, `test_only_*`. Avoid bare booleans like `auto: true`.
+- Production deployments should never silently get the test-friendly behavior. Misconfiguration in prod must be a loud failure, not a working-but-broken state.
+- This is part of the broader "reference deployment, not POC" framing in #194 — the reference server (`cmd/oneauth-server`) should fail loudly, not paper over gaps.
+
+**Why this is a memory and not just a code review note:** the temptation to add silent-fallback "convenience" defaults recurs every time a new config knob lands. Codifying the pattern means the next config addition starts from explicit-opt-in instead of defaulting to convenience-fallback and getting pushback after the fact.

--- a/memories/feedback_stacked_branches_in_worktrees.md
+++ b/memories/feedback_stacked_branches_in_worktrees.md
@@ -1,0 +1,18 @@
+---
+name: feedback_stacked_branches_in_worktrees
+description: When local main is held by another worktree, cut new feature branches from origin/main directly instead of trying to git checkout main locally.
+type: feedback
+---
+
+This repo is a bare repo at `/Users/dzshrh/newstack/oneauth` with multiple worktrees: `main/` (where most work happens), `conformance/`, `rfc-extensions/`. Worktrees can each hold one branch; `main` is often checked out in a sibling worktree (e.g., `conformance/`) for parallel work.
+
+**The trap:** doing `git checkout main` from a feature branch in `main/` fails with "fatal: 'main' is already used by worktree at ...". Same issue with `git branch -f main origin/main` to fast-forward — branch is locked elsewhere. This bit me mid-flight several times when I tried to "switch back to main and cut a fresh branch".
+
+**The pattern that works:**
+- Cut new feature branches directly from `origin/main`: `git checkout -b feat/issue-N origin/main`. This switches you off the current branch and creates the new one tracking origin/main, no `git checkout main` needed.
+- Sync via `git fetch origin --prune` to pull in remote-deleted branches and refresh `origin/main`. The local `main` ref staying behind is fine — `origin/main` is what you cut from.
+- Delete the previous (merged) feature branch with `git branch -D <branch>` after cutting the new one — you can't delete the branch you're currently on.
+
+**Why this matters:** when an in-flight session involves 3-5 stacked PRs in a row, each merging and triggering "cut next from updated main", the local `main` ref isn't the source of truth — `origin/main` is. Treating it that way makes the cadence reliable.
+
+**Don't:** discard local changes via `git checkout` to recover. If a `checkout -b` fails partway and leaves stray modifications, `git stash push --include-untracked -m "<descriptive name>"` is the safe move — the user can recover the stash later in whichever worktree the changes belong to. (This bit us in the #166 → #167 transition where in-progress RFC-9207 work from another worktree leaked into the main worktree's index.)


### PR DESCRIPTION
## Summary
Captures session learnings into checked-in docs after a multi-PR run that closed parent issues #20 (App Registrar persistence) and #157 (RFC 7592 management) plus the convention port (#172, #175) and the RS256 issuer mode (#184).

### CLAUDE.md
- Drop retired `cmd/rar-test-issuer/` reference (it's now `cmd/oneauth-server/deploy-examples/rar-test.yaml`).
- Standards Compliance table gets the RFC 7592 management routes, RFC 9207 iss query param, RFC 7523 jwt-bearer + RFC 8693 token-exchange grants.
- Architecture Decisions section calls out the gRPC-shape convention (`MethodName(ctx, *XReq) → (*XResp, error)`) as a library-wide invariant, not just OneAuth-struct-specific.
- New **Gotchas** section: KC port collision, JWKS skips HS256, asymmetric signing failure mode, worktree-locked main branch, lock-step Go directive across modules, backlink hygiene reminder.

### docs/ROADMAP.md
- App Registrar Persistence chain marked ✅ COMPLETE (closes #20).
- RFC 7592 — DCR Management chain marked ✅ COMPLETE.
- Convention Ports chain marked ✅ COMPLETE.
- New Reference Server section tracking #184 (merged) and #194 (open meta-tracker for POC→production-grade).

### memories/
- `feedback_stacked_branches_in_worktrees.md` — when local main is held by a sibling worktree, cut new branches from `origin/main` directly.
- `feedback_explicit_opt_in_for_dev_hacks.md` — gate dev/test conveniences behind explicit opt-in flags; never silent fallbacks. Validated by the #184 / #194 discussion.

## Test plan
Doc-only — no code changes. Sanity-check the rendered Markdown looks reasonable.