### PR TITLE
test(oidf-conformance): phase-1 baseline against cmd/oneauth-server (#197)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,46 @@ kcllogs:
 	@docker logs -f $(KC_CONTAINER_NAME)
 
 # =============================================================================
+# OIDF conformance harness (issue 197)
+# =============================================================================
+# Stands up the OpenID Foundation conformance suite (Java app + MongoDB +
+# nginx) against the local cmd/oneauth-server, captures baseline results.
+# This is *not* part of the conformance ratchet yet — Phase 1 is a
+# manually-run baseline so we can see, in concrete terms, which OIDF
+# certification tests pass against OneAuth today and which require
+# work (notably 116 — full OIDC /authorize endpoint).
+#
+# UI: https://localhost.emobix.co.uk:8443/  (hostname resolves publicly to 127.0.0.1)
+
+OIDF_COMPOSE := tests/oidf-conformance/docker-compose-prebuilt.yml
+OIDF_AS_CONFIG := tests/oidf-conformance/oneauth-server.yaml
+
+upoidf:
+	@echo "Starting OIDF conformance suite (mongo + nginx + server)..."
+	@docker compose -f $(OIDF_COMPOSE) up -d
+	@echo "Waiting for harness UI..."
+	@until curl -ksf -o /dev/null https://localhost.emobix.co.uk:8443/; do sleep 2; done
+	@echo ""
+	@echo "OIDF conformance suite is running!"
+	@echo "  UI:     https://localhost.emobix.co.uk:8443/"
+	@echo "  Stop:   make downoidf"
+	@echo ""
+	@echo "Next: in another shell, run 'make upoidf-as' to start oneauth-server"
+	@echo "      reachable at http://host.docker.internal:8888 from the harness."
+
+downoidf:
+	@echo "Stopping OIDF conformance stack..."
+	@docker compose -f $(OIDF_COMPOSE) down
+	@echo "MongoDB data persists in tests/oidf-conformance/mongo/ — delete that dir for a clean slate."
+
+upoidf-as:
+	@echo "Starting cmd/oneauth-server on :8888 with OIDF baseline config..."
+	@go run ./cmd/oneauth-server --config $(OIDF_AS_CONFIG)
+
+oidflogs:
+	@docker compose -f $(OIDF_COMPOSE) logs -f --tail=100 server
+
+# =============================================================================
 # Conformance ratchet — see docs/CONFORMANCE.md
 # =============================================================================
 # Runs every known conformance test (passing AND expected-fail) and diffs
@@ -688,7 +728,7 @@ audit: vulncheck secrets
 .PHONY: test test-hard testall test-report e2e audit \
 	unit postgres datastore keycloak zap lint secrets vulncheck \
 	updb downdb dblogs testpg upds downds dslogs testds testrealDS \
-	upkcl downkcl kcllogs testkcl uprar downrar deploygae gaelogs integ docs \
+	upkcl downkcl kcllogs testkcl uprar downrar upoidf downoidf upoidf-as oidflogs deploygae gaelogs integ docs \
 	setup-tools setup-hooks setup ball tallmods tidy tidy-all bump-root \
 	deps norep rep tag pushtag seccheck verify-submodule-deps \
 	cover cover-html cover-func cover-all

--- a/tests/oidf-conformance/.gitignore
+++ b/tests/oidf-conformance/.gitignore
@@ -1,0 +1,3 @@
+# MongoDB data dir created by docker-compose-prebuilt.yml at runtime.
+# Each fresh `docker compose up` repopulates it; not a build artifact.
+mongo/

--- a/tests/oidf-conformance/README.md
+++ b/tests/oidf-conformance/README.md
@@ -1,0 +1,97 @@
+# OIDF conformance harness
+
+This directory wires the [OpenID Foundation conformance suite](https://gitlab.com/openid/conformance-suite) against `cmd/oneauth-server` to produce a measured baseline of which OIDC certification tests OneAuth passes today.
+
+**Status:** Phase 1 — manually-run baseline. Not yet wired into the [`tests/conformance/` ratchet](../conformance/README.md). See issue 197 for the longer-term plan.
+
+## Quick start
+
+```bash
+# Terminal 1: start the harness (mongo + nginx + Java server)
+make upoidf
+
+# Terminal 2: start oneauth-server with the matching test config
+make upoidf-as
+```
+
+UI: https://localhost.emobix.co.uk:8443/  (the hostname resolves publicly to 127.0.0.1, no `/etc/hosts` edit required).
+
+OneAuth: `http://host.docker.internal:8888` (reachable from inside Docker on macOS).
+
+When done:
+
+```bash
+make downoidf
+# Ctrl-C the oneauth-server in Terminal 2.
+```
+
+## Running a baseline plan via the harness REST API
+
+The UI is the easy path; the API is reproducible. Both work with the same harness instance.
+
+```bash
+# The simplest plan: discovery-only (no /authorize required).
+cat > /tmp/oidf-config.json <<'EOF'
+{
+  "alias": "oneauth-config-baseline",
+  "server": {
+    "discoveryUrl": "http://host.docker.internal:8888/.well-known/openid-configuration"
+  }
+}
+EOF
+
+# Create plan instance
+PLAN=$(curl -ks -X POST \
+  "https://localhost.emobix.co.uk:8443/api/plan?planName=oidcc-config-certification-test-plan" \
+  -H "Content-Type: application/json" --data @/tmp/oidf-config.json \
+  | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")
+
+# Run the discovery test
+TEST=$(curl -ks -X POST \
+  "https://localhost.emobix.co.uk:8443/api/runner?test=oidcc-discovery-endpoint-verification&plan=${PLAN}&variant=%7B%22server_metadata%22%3A%22discovery%22%2C%22client_registration%22%3A%22static_client%22%7D" \
+  | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")
+
+# Pull the result
+sleep 5
+curl -ks "https://localhost.emobix.co.uk:8443/api/info/${TEST}" | python3 -m json.tool
+curl -ks "https://localhost.emobix.co.uk:8443/api/log/${TEST}" | python3 -m json.tool
+```
+
+## Layout
+
+```
+tests/oidf-conformance/
+├── README.md                        ← this file
+├── docker-compose-prebuilt.yml      ← upstream OIDF compose (vendored)
+├── oneauth-server.yaml              ← AS config the harness can target
+├── baselines/
+│   └── 2026-05-09/                  ← captured logs from the first baseline run
+│       ├── BASELINE.md              ← human-readable summary
+│       ├── config-cert-discovery.json
+│       ├── config-cert-discovery.failures.txt
+│       └── basic-op-oidcc-server.json
+└── .gitignore                        ← excludes mongo/ runtime dir
+```
+
+## Why a separate vendored compose file
+
+The upstream `docker-compose-prebuilt.yml` doesn't change frequently. Vendoring it (rather than `curl`-ing on every `make upoidf`) keeps the harness version pinnable per OneAuth release and lets `make upoidf` work offline once images are pulled.
+
+To refresh it:
+
+```bash
+curl -O https://gitlab.com/openid/conformance-suite/-/raw/master/docker-compose-prebuilt.yml \
+  -o tests/oidf-conformance/docker-compose-prebuilt.yml
+```
+
+## Networking notes
+
+The harness runs in Docker; OneAuth runs on the host. They communicate via `host.docker.internal` (resolvable from inside Mac/Windows Docker containers automatically; on Linux CI a `--add-host=host.docker.internal:host-gateway` may be needed if we ever wire this into CI).
+
+The harness expects HTTPS on the AS in production-mode plans. Phase 1 runs HTTP-only and accepts the resulting `Expected https protocol for ...` failures as known-deployment-mode warnings — they say nothing about spec compliance, only about how we're hosting locally. A follow-up will add a TLS-fronted variant for completeness.
+
+## What's next (Phase 2)
+
+- Wire results into `tests/conformance/`'s ratchet under the existing `suite + plan + test` external schema.
+- Add a CI job (manual-trigger, like `testkcl`).
+- Close the gaps catalogued in `baselines/<date>/BASELINE.md` one by one.

--- a/tests/oidf-conformance/baselines/2026-05-09/BASELINE.md
+++ b/tests/oidf-conformance/baselines/2026-05-09/BASELINE.md
@@ -1,0 +1,81 @@
+# OIDF conformance baseline — 2026-05-09
+
+First run of the [OpenID Foundation conformance suite](https://gitlab.com/openid/conformance-suite) against `cmd/oneauth-server`. Phase 1 of issue 197 — measure the gap, don't fix anything yet.
+
+**Setup:** prebuilt harness via `make upoidf`, AS via `make upoidf-as` (memory-mode config, RS256 ephemeral signing, `iss=http://host.docker.internal:8888`). Image tags as of run: `mongo:6.0.13` + harness `latest` from `registry.gitlab.com/openid/conformance-suite`.
+
+## Scoreboard
+
+| Plan | Modules | Verdict | Blocker |
+|---|---|---|---|
+| `oidcc-config-certification-test-plan` | 1 (`oidcc-discovery-endpoint-verification`) | **FAILED** with 8 failures + 3 warnings on the single discovery test | mostly metadata-shape gaps, fixable independently of `/authorize` |
+| `oidcc-basic-certification-test-plan` (1st test only — `oidcc-server`) | 35 modules total; only ran the first | **FAILED — interrupted at step 1** | `authorization_endpoint` missing → blocks the entire Basic / Hybrid / Implicit / Form-Post / Logout family. Tracked under issue 116 (full OIDC provider). |
+| `oidcc-dynamic-certification-test-plan` | 22+ modules | Same blocker as Basic — needs `authorization_endpoint`. Not run beyond plan creation. | issue 116 |
+
+## Discovery-test failure breakdown
+
+Test: `oidcc-discovery-endpoint-verification` against `http://host.docker.internal:8888/.well-known/openid-configuration`.
+
+### Substantive gaps (not deployment-mode noise)
+
+| Failure | Source check | Type | Fixable today? |
+|---|---|---|---|
+| `response_types_supported` lacks any OIDC type | `OIDCCCheckDiscEndpointResponseTypesSupported` | `/authorize`-flow related | **No** — tied to issue 116 (`code`, `id_token`, `code id_token`, etc. are response types of the auth endpoint we don't have) |
+| `id_token_signing_alg_values_supported`: not found | `OIDCCCheckDiscEndpointIdTokenSigningAlgValuesSupported` | metadata advertisement | **Partial** — we *could* advertise `["RS256","ES256"]` to mirror access-token signing, but the field is semantically about id_token signing, which is gated on issue 116 issuing id_tokens at all |
+| `authorization_endpoint`: URL not found | `CheckDiscEndpointAuthorizationEndpoint` | endpoint missing | **No** — issue 116 |
+| `claims_supported`: not found (warning) | `OIDCCCheckDiscEndpointClaimsSupported` | metadata advertisement | **Partial** — we can advertise the bearer-token claims we already issue (`sub`, `iss`, `aud`, `exp`, `iat`, `jti`); fuller list (`email`, `name`, `preferred_username`) is gated on a userinfo source |
+| `scopes_supported`: not advertised (warning skips dependent check) | `CheckDiscEndpointScopesSupportedContainsOpenId` | metadata advertisement | **Yes** — `apiauth.ASServerMetadata.ScopesSupported` is already a struct field; reference deployments just don't populate it. Single-line fix in `cmd/oneauth-server/main.go` and `testutil/server.go`. |
+| `userinfo_endpoint`: not present (warning) | `CheckDiscEndpointUserinfoEndpoint` | endpoint missing | **No** — issue 116 |
+
+### Deployment-mode failures (not spec-compliance signal)
+
+These all reduce to "the harness expects HTTPS in production mode". Running OneAuth on `http://` produces them; they say nothing about whether the AS is OIDC-compliant.
+
+- `Expected https protocol for server.discoveryUrl`
+- `Expected https protocol for token_endpoint`
+- `Expected https protocol for jwks_uri`
+- `Expected https protocol for registration_endpoint`
+- `Expected https protocol for token_endpoint` (twice — once via per-endpoint check, once via aggregate `CheckDiscEndpointAllEndpointsAreHttps`)
+
+Phase 2 will run the harness against a TLS-fronted AS to clear these and isolate the substantive gaps.
+
+## Basic OP failure breakdown
+
+Plan: `oidcc-basic-certification-test-plan`. Ran the canonical first test (`oidcc-server`) with variant `{response_type: "code", client_auth_type: "client_secret_basic"}`. Status: **INTERRUPTED**.
+
+Single failure, recorded by `CheckServerConfiguration`:
+
+```
+required: authorization_endpoint
+msg: Couldn't find required component
+```
+
+The check fails before any HTTP request is made — discovery doesn't expose `authorization_endpoint`, the test module aborts. This is the gating fact: **34 of the 35 Basic OP tests can't even start until issue 116 ships `/authorize`.** Once it lands, this plan becomes the right place to drive the next round of conformance work (id_token signing details, scope handling, prompt/display/max_age semantics, codereuse, etc.).
+
+## Headline finding
+
+**Resource-server interop is solid** (RFC 8414 / 9728 / 7517 / 7662 — discovery, JWKS, introspection, protected-resource metadata — all the validation-side endpoints work). **AS-side OIDC flows are blocked on a single missing piece** — `/authorize` (issue 116). Once that's in, most of the discovery-metadata gaps cascade fixable.
+
+For the "0-effort migration from a 3p IdP" pitch: today, that pitch holds for **resource servers** (you can swap your token validator for OneAuth's middleware/JWKSKeyStore against any RFC-8414-compliant AS) and **machine-to-machine clients**. It does **not** hold for **full IdP replacement** until issue 116.
+
+## Concrete follow-up issues to file
+
+1. **Quick win**: advertise `scopes_supported` in AS metadata defaults (cmd/oneauth-server, testutil). Closes one OIDF check standalone, no other dependencies.
+2. **Quick win**: advertise `claims_supported` for the claims OneAuth already emits in access tokens. Closes a warning standalone.
+3. **TLS deployment doc**: add a tested example of running `cmd/oneauth-server` behind TLS so the Phase 2 harness run can be apples-to-apples on protocols.
+4. **Phase 2 of issue 197**: ratchet wiring — `tests/conformance/cmd/runner` consumes the `suite + plan + test` external schema and turns the OIDF results into ratchet entries.
+5. **Issue 116** (already filed) gates the next big gap-closure wave.
+
+## Reproducing this run
+
+```bash
+make upoidf       # in one shell
+make upoidf-as    # in another
+# Then follow the API recipe in tests/oidf-conformance/README.md.
+```
+
+The captured logs in this directory:
+
+- `config-cert-discovery.json` — full harness log for the discovery test
+- `config-cert-discovery.failures.txt` — failure-only summary
+- `basic-op-oidcc-server.json` — full log for the Basic OP entry test

--- a/tests/oidf-conformance/baselines/2026-05-09/basic-op-oidcc-server.json
+++ b/tests/oidf-conformance/baselines/2026-05-09/basic-op-oidcc-server.json
@@ -1,0 +1,167 @@
+[
+    {
+        "_id": "hsVGs8saQrkgd9m-kNFeSi81rOSVQ8euCabzFLkQVA6zjKEj",
+        "msg": "Test instance hsVGs8saQrkgd9m created",
+        "result": "INFO",
+        "baseUrl": "https://localhost.emobix.co.uk:8443/test/a/oneauth-basic-baseline",
+        "variant": {
+            "client_auth_type": "client_secret_basic",
+            "response_type": "code",
+            "server_metadata": "discovery",
+            "client_registration": "static_client",
+            "response_mode": "default"
+        },
+        "alias": "oneauth-basic-baseline",
+        "description": "OneAuth basic OP baseline",
+        "planId": "1eFfMU3cEDisa",
+        "config": {
+            "alias": "oneauth-basic-baseline",
+            "description": "OneAuth basic OP baseline",
+            "server": {
+                "discoveryUrl": "http://host.docker.internal:8888/.well-known/openid-configuration"
+            },
+            "client": {
+                "client_id": "oneauth-test-client",
+                "client_secret": "oneauth-test-secret",
+                "scope": "openid profile email"
+            }
+        },
+        "baseMtlsUrl": "https://localhost:8444/test-mtls/a/oneauth-basic-baseline",
+        "testName": "oidcc-server",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "TEST-RUNNER",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356590
+    },
+    {
+        "_id": "hsVGs8saQrkgd9m-Le0xYhakFeInLC9SAXQ1OhmddfgwX24H",
+        "msg": "Created redirect URI",
+        "result": "SUCCESS",
+        "redirect_uri": "https://localhost.emobix.co.uk:8443/test/a/oneauth-basic-baseline/callback",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "CreateRedirectUri",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356597
+    },
+    {
+        "_id": "hsVGs8saQrkgd9m-parGfMxLlr7r5eGkJ6EYvzsRixQyHpJr",
+        "request_uri": "http://host.docker.internal:8888/.well-known/openid-configuration",
+        "request_method": "GET",
+        "request_headers": {
+            "Accept": "text/plain, application/json, application/yaml, application/*+json, */*",
+            "Content-Length": "0"
+        },
+        "request_body": "",
+        "msg": "HTTP request",
+        "http": "request",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "GetDynamicServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356616
+    },
+    {
+        "_id": "hsVGs8saQrkgd9m-VzGRrCKQYQgQq3Wko3AFnEOU5Upkbn3z",
+        "response_status_code": "200 OK",
+        "response_status_text": "OK",
+        "response_headers": {
+            "cache-control": "public, max-age=3600",
+            "content-security-policy": "default-src 'self'; script-src 'self' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'",
+            "content-type": "application/json",
+            "cross-origin-embedder-policy": "credentialless",
+            "cross-origin-opener-policy": "same-origin",
+            "cross-origin-resource-policy": "same-origin",
+            "permissions-policy": "camera=(), microphone=(), geolocation=()",
+            "referrer-policy": "strict-origin-when-cross-origin",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "x-content-type-options": "nosniff",
+            "x-frame-options": "DENY",
+            "date": "Sat, 09 May 2026 21:15:56 GMT",
+            "content-length": "759"
+        },
+        "response_body": "{\"issuer\":\"http://host.docker.internal:8888\",\"token_endpoint\":\"http://host.docker.internal:8888/api/token\",\"jwks_uri\":\"http://host.docker.internal:8888/.well-known/jwks.json\",\"introspection_endpoint\":\"http://host.docker.internal:8888/oauth/introspect\",\"revocation_endpoint\":\"http://host.docker.internal:8888/oauth/revoke\",\"registration_endpoint\":\"http://host.docker.internal:8888/apps/register\",\"response_types_supported\":[\"token\"],\"grant_types_supported\":[\"password\",\"refresh_token\",\"client_credentials\"],\"token_endpoint_auth_methods_supported\":[\"client_secret_post\",\"client_secret_basic\",\"private_key_jwt\"],\"token_endpoint_auth_signing_alg_values_supported\":[\"RS256\",\"ES256\"],\"code_challenge_methods_supported\":[\"S256\"],\"subject_types_supported\":[\"public\"]}",
+        "msg": "HTTP response",
+        "http": "response",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "GetDynamicServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356627
+    },
+    {
+        "_id": "hsVGs8saQrkgd9m-GfD7Uw762slkB2L7re86UFRvx67R66vQ",
+        "issuer": "http://host.docker.internal:8888",
+        "token_endpoint": "http://host.docker.internal:8888/api/token",
+        "jwks_uri": "http://host.docker.internal:8888/.well-known/jwks.json",
+        "introspection_endpoint": "http://host.docker.internal:8888/oauth/introspect",
+        "revocation_endpoint": "http://host.docker.internal:8888/oauth/revoke",
+        "registration_endpoint": "http://host.docker.internal:8888/apps/register",
+        "response_types_supported": [
+            "token"
+        ],
+        "grant_types_supported": [
+            "password",
+            "refresh_token",
+            "client_credentials"
+        ],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_post",
+            "client_secret_basic",
+            "private_key_jwt"
+        ],
+        "token_endpoint_auth_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+        ],
+        "code_challenge_methods_supported": [
+            "S256"
+        ],
+        "subject_types_supported": [
+            "public"
+        ],
+        "msg": "Successfully parsed server configuration",
+        "result": "SUCCESS",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "GetDynamicServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356633
+    },
+    {
+        "_id": "hsVGs8saQrkgd9m-Yl4Lkvp7vgM0K9VGFnCPPIsIQjtLsMTd",
+        "msg": "Couldn't find required component",
+        "result": "FAILURE",
+        "required": "authorization_endpoint",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "CheckServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356636
+    },
+    {
+        "_id": "hsVGs8saQrkgd9m-AxREVDRs4NntSldMegatvp1BKUKm5kUr",
+        "msg": "Test was interrupted before it could complete. The failure 'CheckServerConfiguration: Couldn't find required component' means the test cannot continue.",
+        "result": "INTERRUPTED",
+        "testId": "hsVGs8saQrkgd9m",
+        "src": "oidcc-server",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361356641
+    }
+]

--- a/tests/oidf-conformance/baselines/2026-05-09/config-cert-discovery.failures.txt
+++ b/tests/oidf-conformance/baselines/2026-05-09/config-cert-discovery.failures.txt
@@ -1,0 +1,11 @@
+[FAILURE] OIDCCCheckDiscEndpointResponseTypesSupported: The server must support at least one of the response types defined in OpenID Connect.
+[FAILURE] CheckDiscEndpointDiscoveryUrl: Expected https protocol for server.discoveryUrl
+[FAILURE] OIDCCCheckDiscEndpointIdTokenSigningAlgValuesSupported: id_token_signing_alg_values_supported: not found
+[FAILURE] CheckDiscEndpointAuthorizationEndpoint: authorization_endpoint: URL not found
+[FAILURE] CheckDiscEndpointTokenEndpoint: Expected https protocol for token_endpoint
+[WARNING] CheckDiscEndpointUserinfoEndpoint: Skipped evaluation due to missing required element: server userinfo_endpoint
+[FAILURE] CheckDiscEndpointRegistrationEndpoint: Expected https protocol for registration_endpoint
+[FAILURE] CheckJwksUri: Expected https protocol for jwks_uri
+[WARNING] OIDCCCheckDiscEndpointClaimsSupported: claims_supported: not found
+[WARNING] CheckDiscEndpointScopesSupportedContainsOpenId: Skipped evaluation due to missing required element: server scopes_supported
+[FAILURE] CheckDiscEndpointAllEndpointsAreHttps: Expected https protocol for token_endpoint

--- a/tests/oidf-conformance/baselines/2026-05-09/config-cert-discovery.json
+++ b/tests/oidf-conformance/baselines/2026-05-09/config-cert-discovery.json
@@ -1,0 +1,669 @@
+[
+    {
+        "_id": "OWBrfENvv6YAIJy-OkhAF4R9AdvN1DGZtXBtBFp5hoT7eNRN",
+        "msg": "Test instance OWBrfENvv6YAIJy created",
+        "result": "INFO",
+        "baseUrl": "https://localhost.emobix.co.uk:8443/test/a/oneauth-config-baseline",
+        "variant": {
+            "server_metadata": "discovery",
+            "client_registration": "static_client"
+        },
+        "alias": "oneauth-config-baseline",
+        "description": "OneAuth config certification baseline",
+        "planId": "kDlvvBbf3KYG2",
+        "config": {
+            "alias": "oneauth-config-baseline",
+            "description": "OneAuth config certification baseline",
+            "server": {
+                "discoveryUrl": "http://host.docker.internal:8888/.well-known/openid-configuration"
+            }
+        },
+        "baseMtlsUrl": "https://localhost:8444/test-mtls/a/oneauth-config-baseline",
+        "testName": "oidcc-discovery-endpoint-verification",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "TEST-RUNNER",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183251
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-DSJbp77xDhpRt5wNaS7HYmGDXgIbELAF",
+        "request_uri": "http://host.docker.internal:8888/.well-known/openid-configuration",
+        "request_method": "GET",
+        "request_headers": {
+            "Accept": "text/plain, application/json, application/yaml, application/*+json, */*",
+            "Content-Length": "0"
+        },
+        "request_body": "",
+        "msg": "HTTP request",
+        "http": "request",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "GetDynamicServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183570
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-RcDT5UeSqT8ykT1mdUav6AkdWefYJ3vf",
+        "response_status_code": "200 OK",
+        "response_status_text": "OK",
+        "response_headers": {
+            "cache-control": "public, max-age=3600",
+            "content-security-policy": "default-src 'self'; script-src 'self' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'",
+            "content-type": "application/json",
+            "cross-origin-embedder-policy": "credentialless",
+            "cross-origin-opener-policy": "same-origin",
+            "cross-origin-resource-policy": "same-origin",
+            "permissions-policy": "camera=(), microphone=(), geolocation=()",
+            "referrer-policy": "strict-origin-when-cross-origin",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "x-content-type-options": "nosniff",
+            "x-frame-options": "DENY",
+            "date": "Sat, 09 May 2026 21:13:03 GMT",
+            "content-length": "759"
+        },
+        "response_body": "{\"issuer\":\"http://host.docker.internal:8888\",\"token_endpoint\":\"http://host.docker.internal:8888/api/token\",\"jwks_uri\":\"http://host.docker.internal:8888/.well-known/jwks.json\",\"introspection_endpoint\":\"http://host.docker.internal:8888/oauth/introspect\",\"revocation_endpoint\":\"http://host.docker.internal:8888/oauth/revoke\",\"registration_endpoint\":\"http://host.docker.internal:8888/apps/register\",\"response_types_supported\":[\"token\"],\"grant_types_supported\":[\"password\",\"refresh_token\",\"client_credentials\"],\"token_endpoint_auth_methods_supported\":[\"client_secret_post\",\"client_secret_basic\",\"private_key_jwt\"],\"token_endpoint_auth_signing_alg_values_supported\":[\"RS256\",\"ES256\"],\"code_challenge_methods_supported\":[\"S256\"],\"subject_types_supported\":[\"public\"]}",
+        "msg": "HTTP response",
+        "http": "response",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "GetDynamicServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183722
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-1GBqbc40InguyLHvfccaLLGhZNmWPUSd",
+        "issuer": "http://host.docker.internal:8888",
+        "token_endpoint": "http://host.docker.internal:8888/api/token",
+        "jwks_uri": "http://host.docker.internal:8888/.well-known/jwks.json",
+        "introspection_endpoint": "http://host.docker.internal:8888/oauth/introspect",
+        "revocation_endpoint": "http://host.docker.internal:8888/oauth/revoke",
+        "registration_endpoint": "http://host.docker.internal:8888/apps/register",
+        "response_types_supported": [
+            "token"
+        ],
+        "grant_types_supported": [
+            "password",
+            "refresh_token",
+            "client_credentials"
+        ],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_post",
+            "client_secret_basic",
+            "private_key_jwt"
+        ],
+        "token_endpoint_auth_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+        ],
+        "code_challenge_methods_supported": [
+            "S256"
+        ],
+        "subject_types_supported": [
+            "public"
+        ],
+        "msg": "Successfully parsed server configuration",
+        "result": "SUCCESS",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "GetDynamicServerConfiguration",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183735
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-IJHBHy56giTb5LU871wA0HdMpFXCSIz5",
+        "msg": "discovery_endpoint_response returned http 200 as expected",
+        "result": "SUCCESS",
+        "requirements": [
+            "OIDCD-4"
+        ],
+        "http_status": 200,
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "EnsureDiscoveryEndpointResponseStatusCodeIs200",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183739
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-ehEw916hwiHf8Gocok0lHXxy1SXGSLHZ",
+        "msg": "discovery_endpoint_response Content-Type: header is application/json",
+        "result": "SUCCESS",
+        "requirements": [
+            "OIDCD-4"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscoveryEndpointReturnedJsonContentType",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183746
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-vLFNBUQh3TcddiqRW75yb0g4ctba7Wko",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "oidcc-discovery-endpoint-verification",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183751,
+        "msg": "Setup Done"
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-DajEbIj7cVr3v7arTjqWZc1gWEibo00g",
+        "discovery_metadata_key": "response_types_supported",
+        "expected_at_least_one_of": [
+            "code",
+            "code id_token",
+            "id_token",
+            "token id_token",
+            "code id_token token",
+            "code token"
+        ],
+        "msg": "The server must support at least one of the response types defined in OpenID Connect.",
+        "result": "FAILURE",
+        "actual": [
+            "token"
+        ],
+        "requirements": [
+            "OIDCD-3",
+            "OIDCC-3"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "OIDCCCheckDiscEndpointResponseTypesSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183763
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-e21maID5EaLRI3u27UqYYS6SsLbQYFpl",
+        "msg": "Expected https protocol for server.discoveryUrl",
+        "result": "FAILURE",
+        "actual": "http",
+        "expected": "https",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointDiscoveryUrl",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183772
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-yzSxGZXazj45Vf0TLEhR769B0Murf8E8",
+        "msg": "issuer is consistent with the discovery endpoint",
+        "result": "SUCCESS",
+        "requirements": [
+            "OIDCD-4.3",
+            "OIDCD-7.2"
+        ],
+        "issuer": "http://host.docker.internal:8888",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointIssuer",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183777
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-MTlkOUgD7nvubKpqnLH6c2eAIAtvkrDn",
+        "msg": "Contents of 'subject_types_supported' in discovery document matches expectations.",
+        "result": "SUCCESS",
+        "actual": [
+            "public"
+        ],
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "expected": [
+            "public",
+            "pairwise"
+        ],
+        "minimum_matches_required": 1,
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointSubjectTypesSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183781
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-5sw3zIj0r1BX6TzPkFLBmLZ39HL8L7Tx",
+        "discovery_metadata_key": "id_token_signing_alg_values_supported",
+        "expected_at_least_one_of": [
+            "RS256"
+        ],
+        "msg": "id_token_signing_alg_values_supported: not found",
+        "result": "FAILURE",
+        "actual": null,
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "OIDCCCheckDiscEndpointIdTokenSigningAlgValuesSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183784
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-dS52QdyQOKJ7slk1LfpCjraZHGqCChao",
+        "msg": "Skipped evaluation due to missing required element: server userinfo_signing_alg_values_supported",
+        "result": "INFO",
+        "path": "userinfo_signing_alg_values_supported",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "mapped": null,
+        "object": "server",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "OIDCCCheckDiscEndpointUserinfoSigningAlgValuesSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183790
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-4bX6ZXjGt98FDKgb3uF9NtVpvMg2CeXQ",
+        "msg": "authorization_endpoint: URL not found",
+        "result": "FAILURE",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointAuthorizationEndpoint",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183794
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-aK5GI4y5K7s8oK9djRH3mLkRa3J9ecDx",
+        "msg": "Expected https protocol for token_endpoint",
+        "result": "FAILURE",
+        "actual": "http://host.docker.internal:8888/api/token",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "required": "https",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointTokenEndpoint",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183801
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-ZEPQyff8o9cc1Sh8E7vpLTUqCnNCEwyZ",
+        "msg": "Skipped evaluation due to missing required element: server userinfo_endpoint",
+        "result": "WARNING",
+        "path": "userinfo_endpoint",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "mapped": null,
+        "object": "server",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointUserinfoEndpoint",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183807
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-Jw82eHHfEmjqnI1vBoTpSOJBUezLAwj1",
+        "msg": "Expected https protocol for registration_endpoint",
+        "result": "FAILURE",
+        "actual": "http://host.docker.internal:8888/apps/register",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "required": "https",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointRegistrationEndpoint",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183809
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-ZpAWgLn8oca5eo0fPEUKO8sKCSluPdHT",
+        "msg": "Expected https protocol for jwks_uri",
+        "result": "FAILURE",
+        "actual": "http://host.docker.internal:8888/.well-known/jwks.json",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "required": "https",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckJwksUri",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183814
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-Yu4kmTM6cd9BIF40zhDshb6s69iWcslx",
+        "msg": "Fetching server key",
+        "jwks_uri": "http://host.docker.internal:8888/.well-known/jwks.json",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "FetchServerKeys",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183821
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-gmwJdwazhT2p7layyvfoRHhsJphovaGH",
+        "request_uri": "http://host.docker.internal:8888/.well-known/jwks.json",
+        "request_method": "GET",
+        "request_headers": {
+            "Accept": "text/plain, application/json, application/yaml, application/*+json, */*",
+            "Content-Length": "0"
+        },
+        "request_body": "",
+        "msg": "HTTP request",
+        "http": "request",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "FetchServerKeys",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183841
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-eOkPdpJKesB8grvBPWyWwWO8Wf418KWf",
+        "response_status_code": "200 OK",
+        "response_status_text": "OK",
+        "response_headers": {
+            "cache-control": "public, max-age=3600",
+            "content-security-policy": "default-src 'self'; script-src 'self' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'",
+            "content-type": "application/json",
+            "cross-origin-embedder-policy": "credentialless",
+            "cross-origin-opener-policy": "same-origin",
+            "cross-origin-resource-policy": "same-origin",
+            "etag": "\"cfb524d55f6989e850b832942bc38542\"",
+            "permissions-policy": "camera=(), microphone=(), geolocation=()",
+            "referrer-policy": "strict-origin-when-cross-origin",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "x-content-type-options": "nosniff",
+            "x-frame-options": "DENY",
+            "date": "Sat, 09 May 2026 21:13:03 GMT",
+            "content-length": "483"
+        },
+        "response_body": "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"3x62sdJnu2lnpZND-hQAoe19s3Ku354stSTKH9d-hBA\",\"alg\":\"RS256\",\"use\":\"sig\",\"key_ops\":[\"verify\"],\"n\":\"v3nu1A2Nrf57gzacpOIOymbVLjWNPA2hQecFbCWIQURU67TupiCccyTZawGbPxhCp3vznHeGmefT3ZitA7cJJuutdAMTQFk55RggjqfJrmHaBy8DG1liXCtHSONWIOqwLOXTvnbCBXrFZs00Gy6NtJZ-dVeNT3pweE_QcZFWUX6A1SCMbtoicjuYo82cvsRgxsLrFAFOz8mEZoV5gZdDd4d3Sa7ZVYDuTbPpaE06lvfS6pQ8lZzZ3-meytWTylCnJFjAR23zz_CLE5OJq4UdC6Akc6CQFBKHnerJCPFMEKJltJhD1X2obCs3APwHjGq1bBR7HcoEngkasWzmyK3PCw\",\"e\":\"AQAB\"}]}",
+        "msg": "HTTP response",
+        "http": "response",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "FetchServerKeys",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183850
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-il48GV5yCVe1MymeV348ie7SHat3IOkW",
+        "msg": "Found JWK set string",
+        "jwk_string": "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"3x62sdJnu2lnpZND-hQAoe19s3Ku354stSTKH9d-hBA\",\"alg\":\"RS256\",\"use\":\"sig\",\"key_ops\":[\"verify\"],\"n\":\"v3nu1A2Nrf57gzacpOIOymbVLjWNPA2hQecFbCWIQURU67TupiCccyTZawGbPxhCp3vznHeGmefT3ZitA7cJJuutdAMTQFk55RggjqfJrmHaBy8DG1liXCtHSONWIOqwLOXTvnbCBXrFZs00Gy6NtJZ-dVeNT3pweE_QcZFWUX6A1SCMbtoicjuYo82cvsRgxsLrFAFOz8mEZoV5gZdDd4d3Sa7ZVYDuTbPpaE06lvfS6pQ8lZzZ3-meytWTylCnJFjAR23zz_CLE5OJq4UdC6Akc6CQFBKHnerJCPFMEKJltJhD1X2obCs3APwHjGq1bBR7HcoEngkasWzmyK3PCw\",\"e\":\"AQAB\"}]}",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "FetchServerKeys",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183853
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-qjQ8C8O8jVV76fSee0izl3BaciELUwQH",
+        "msg": "Found server JWK set",
+        "result": "SUCCESS",
+        "server_jwks": {
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "kid": "3x62sdJnu2lnpZND-hQAoe19s3Ku354stSTKH9d-hBA",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "key_ops": [
+                        "verify"
+                    ],
+                    "n": "v3nu1A2Nrf57gzacpOIOymbVLjWNPA2hQecFbCWIQURU67TupiCccyTZawGbPxhCp3vznHeGmefT3ZitA7cJJuutdAMTQFk55RggjqfJrmHaBy8DG1liXCtHSONWIOqwLOXTvnbCBXrFZs00Gy6NtJZ-dVeNT3pweE_QcZFWUX6A1SCMbtoicjuYo82cvsRgxsLrFAFOz8mEZoV5gZdDd4d3Sa7ZVYDuTbPpaE06lvfS6pQ8lZzZ3-meytWTylCnJFjAR23zz_CLE5OJq4UdC6Akc6CQFBKHnerJCPFMEKJltJhD1X2obCs3APwHjGq1bBR7HcoEngkasWzmyK3PCw",
+                    "e": "AQAB"
+                }
+            ]
+        },
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "FetchServerKeys",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183856
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-lE1lD2LEZICryKrO6a5eTsZez5suLq69",
+        "msg": "Valid server JWKs: keys are valid JSON, contain the required fields and are correctly encoded using unpadded base64url",
+        "result": "SUCCESS",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "ValidateServerJWKs",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183875
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-v08fB6AgRUGF9fESlaDr9VfxOLAy9quu",
+        "msg": "Jwks does not contain any private or symmetric keys",
+        "result": "SUCCESS",
+        "requirements": [
+            "RFC7518-6.3.2.1"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "EnsureServerJwksDoesNotContainPrivateOrSymmetricKeys",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183882
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-xbI0PzrRIePVhcfYdNuIQS7buJzpRi30",
+        "discovery_metadata_key": "request_parameter_supported",
+        "msg": "'request_parameter_supported' should be 'true', but is absent and the default value is 'false'.",
+        "result": "INFO",
+        "actual": null,
+        "expected": true,
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointRequestParameterSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183889
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-wF88iWpt8Kg3MiWxBvtNrILfP8BZ4VgO",
+        "msg": "request_uri_parameter_supported has correct value",
+        "result": "SUCCESS",
+        "request_uri_parameter_supported": null,
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointRequestUriParameterSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183894
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-exTcNGWYfBZoLqkQpiIttUM489OCfsN3",
+        "msg": "Skipped evaluation due to missing required element: server request_object_signing_alg_values_supported",
+        "result": "INFO",
+        "path": "request_object_signing_alg_values_supported",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "mapped": null,
+        "object": "server",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointRequestObjectSigningAlgValuesSupportedIncludesRS256",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183896
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-Nd5ZblIxmYsIIC1FgbpZcIr4kOCis5xQ",
+        "discovery_metadata_key": "claims_parameter_supported",
+        "msg": "'claims_parameter_supported' should be 'true', but is absent and the default value is 'false'.",
+        "result": "INFO",
+        "actual": null,
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "expected": true,
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointClaimsParameterSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183900
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-bHdnl7cqh6NT4bXDFPC1yMBlv5IO1qHC",
+        "discovery_metadata_key": "claims_supported",
+        "msg": "claims_supported: not found",
+        "result": "WARNING",
+        "actual": null,
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "expected": [],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "OIDCCCheckDiscEndpointClaimsSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183904
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-pmMWqUilxwMoiGpJkTi5jTO6SKOW2OjE",
+        "msg": "grant_types_supported is a non-empty array.",
+        "result": "SUCCESS",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "grant_types_supported": [
+            "password",
+            "refresh_token",
+            "client_credentials"
+        ],
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "OIDCCCheckDiscEndpointGrantTypesSupported",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183906
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-lW2S4Xprp9VHNf22ok8w5a6WaC2oBluT",
+        "msg": "Skipped evaluation due to missing required element: server scopes_supported",
+        "result": "WARNING",
+        "path": "scopes_supported",
+        "requirements": [
+            "OIDCD-3"
+        ],
+        "mapped": null,
+        "object": "server",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointScopesSupportedContainsOpenId",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183909
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-NB0QHZJ52LKREy56cFI0upDd0WbIBygc",
+        "msg": "Expected https protocol for token_endpoint",
+        "result": "FAILURE",
+        "actual": "http://host.docker.internal:8888/api/token",
+        "required": "https",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "CheckDiscEndpointAllEndpointsAreHttps",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183913
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-WFJwr6HAhPvLjPL3EDlQhhIsBIXINwjf",
+        "msg": "Contents of 'code_challenge_methods_supported' in discovery document matches expectations.",
+        "result": "SUCCESS",
+        "actual": [
+            "S256"
+        ],
+        "requirements": [
+            "RFC7636-4.3",
+            "RFC8414-2"
+        ],
+        "expected": [
+            "S256",
+            "plain"
+        ],
+        "minimum_matches_required": 1,
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "EnsureServerConfigurationCodeChallengeMethodsSupportedIsAnArray",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183918
+    },
+    {
+        "_id": "OWBrfENvv6YAIJy-YTKC5hS3JFv0oTXa9OxXtqOjFHb9ToSt",
+        "msg": "Test has run to completion",
+        "result": "FINISHED",
+        "testmodule_result": "FAILED",
+        "testId": "OWBrfENvv6YAIJy",
+        "src": "oidcc-discovery-endpoint-verification",
+        "testOwner": {
+            "sub": "developer",
+            "iss": "https://developer.com"
+        },
+        "time": 1778361183932
+    }
+]

--- a/tests/oidf-conformance/docker-compose-prebuilt.yml
+++ b/tests/oidf-conformance/docker-compose-prebuilt.yml
@@ -1,0 +1,38 @@
+services:
+  mongodb:
+    image: ${MONGODB_IMAGE:-mongo:6.0.13}
+    volumes:
+     - ./mongo/data:/data/db
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500k"
+        max-file: "5"
+  nginx:
+    image: registry.gitlab.com/openid/conformance-suite/nginx:${IMAGE_TAG:-latest}
+    ports:
+     - "8443:8443"
+    depends_on:
+     - server
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500k"
+        max-file: "5"
+  server:
+    image: registry.gitlab.com/openid/conformance-suite:${IMAGE_TAG:-latest}
+    environment:
+      BASE_URL: ${BASE_URL:-https://localhost.emobix.co.uk:8443}
+      MONGODB_HOST: mongodb
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+      OIDC_GOOGLE_CLIENTID: ${OIDC_GOOGLE_CLIENTID:-google-client}
+      OIDC_GOOGLE_SECRET: ${OIDC_GOOGLE_SECRET:-google-secret}
+      OIDC_GITLAB_CLIENTID: ${OIDC_GITLAB_CLIENTID:-gitlab-client}
+      OIDC_GITLAB_SECRET: ${OIDC_GITLAB_SECRET:-gitlab-secret}
+    depends_on:
+     - mongodb
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500k"
+        max-file: "5"

--- a/tests/oidf-conformance/oneauth-server.yaml
+++ b/tests/oidf-conformance/oneauth-server.yaml
@@ -1,0 +1,32 @@
+# cmd/oneauth-server config for the OIDF conformance harness baseline.
+#
+# The harness runs in Docker and reaches the host via host.docker.internal.
+# We bind to all interfaces and set both server.public_url and jwt.issuer
+# to the same host.docker.internal hostname so:
+#   - Discovery / JWKS / token URLs the harness *fetches* point at
+#     host.docker.internal (resolvable from inside the container).
+#   - Tokens we *issue* carry iss=host.docker.internal, which is what
+#     the harness expects to see when validating responses.
+#
+# RS256 with an ephemeral key so JWKS exposes the verifying half — the
+# harness must be able to validate tokens via JWKS to call any plan
+# successful (HS256 secrets are correctly omitted from JWKS).
+
+server:
+  port: 8888
+  host: 0.0.0.0
+  public_url: http://host.docker.internal:8888
+
+keystore:
+  type: memory
+
+user_stores:
+  type: memory
+
+jwt:
+  issuer: http://host.docker.internal:8888
+  signing_alg: RS256
+  ephemeral_signing_key: true
+
+admin_auth:
+  type: none


### PR DESCRIPTION
## Summary
Phase 1 of #197 — stands up the OpenID Foundation conformance suite locally and captures the first measured baseline of which OIDC certification tests OneAuth passes today. Manually-run, **not** wired into the `tests/conformance/` ratchet yet (that's Phase 2).

The deliverable is the baseline knowledge in [`tests/oidf-conformance/baselines/2026-05-09/BASELINE.md`](tests/oidf-conformance/baselines/2026-05-09/BASELINE.md), backed by raw harness JSON logs.

## Headline finding
- **Resource-server interop is solid** — discovery, JWKS, introspection, protected-resource metadata all pass shape checks.
- **AS-side OIDC flows are blocked on a single missing piece** — `/authorize` (#116). 34 of 35 Basic OP tests abort at step 1 (`CheckServerConfiguration` requires `authorization_endpoint`).
- **2 standalone quick wins** not gated on #116: advertise `scopes_supported` and `claims_supported` in AS metadata defaults.
- **5 deployment-mode "expected https" failures** isolate from spec-compliance signal — Phase 2 will run against a TLS-fronted AS to remove the noise.

The "0-effort migration from a 3p IdP" pitch holds today for **resource servers + M2M clients**. Full IdP replacement awaits #116.

## What's in the PR
- `make upoidf` / `make downoidf` / `make upoidf-as` / `make oidflogs` targets, mirroring `make upkcl` pattern.
- `tests/oidf-conformance/docker-compose-prebuilt.yml` — vendored upstream compose file (pinnable per OneAuth release).
- `tests/oidf-conformance/oneauth-server.yaml` — AS config tailored for the harness (`iss=http://host.docker.internal:8888`, RS256 ephemeral signing).
- `tests/oidf-conformance/README.md` — bring-up + REST-API recipe.
- `tests/oidf-conformance/baselines/2026-05-09/` — captured logs + human-readable summary.

## Test plan
- [x] `make upoidf` — harness comes up at https://localhost.emobix.co.uk:8443/
- [x] `make upoidf-as` — discovery + JWKS reachable from inside the harness container at `host.docker.internal:8888`
- [x] `oidcc-config-certification-test-plan` (discovery test) ran, captured 8 failures + 3 warnings — see `baselines/2026-05-09/config-cert-discovery.failures.txt`
- [x] `oidcc-basic-certification-test-plan` first module (`oidcc-server`) ran, captured the `authorization_endpoint`-missing block — see `baselines/2026-05-09/basic-op-oidcc-server.json`
- [x] `make downoidf` — clean teardown
- [ ] Phase 2 wiring (separate PR): ratchet runner consumes external `suite + plan + test` schema and asserts diff against `known-gaps.yaml`

## Follow-ups (will file once this is merged)
- Quick win: advertise `scopes_supported` + `claims_supported` in AS metadata defaults.
- Doc: TLS-fronted local deployment for clean Phase 2 runs.
- Phase 2 of #197: ratchet wiring.