### PR TITLE
feat(apiauth): advertise scopes_supported + claims_supported in AS metadata (#200)

### DIFF
--- a/apiauth/SUMMARY.md
+++ b/apiauth/SUMMARY.md
@@ -25,6 +25,7 @@ The `OneAuth` struct composes focused interfaces for all auth operations without
 HTTP handlers (`IntrospectionHandler`, `RevocationHandler`) delegate to core interfaces. `APIMiddleware` delegates to `TokenValidator` when `KeyStore` is set.
 
 ## Recent Changes
+- **AS metadata `claims_supported` (issue 200)** — `ASServerMetadata` exposes a new `ClaimsSupported []string` field (OIDC Discovery 1.0 §3). The reference deployments (`cmd/oneauth-server`, `testutil`) now populate `scopes_supported` + `claims_supported` by default, clearing two warnings from the OIDF discovery test (`oidcc-discovery-endpoint-verification`).
 - **`private_key_jwt` client auth (#158)** — `ClientAuthenticator` now accepts RFC 7523 §2.2 / OIDC Core §9 signed-JWT client authentication. Token + introspection + revocation handlers all route through a shared `extractClientCredentials` helper covering `client_secret_basic` / `client_secret_post` / `private_key_jwt`. AS metadata advertises `private_key_jwt` and the new `token_endpoint_auth_signing_alg_values_supported` field. Closes the previously expected-fail `introspection/post_auth_accepted` ratchet entry as a side effect.
 - **Token revocation** — `RevocationHandler` at `POST /oauth/revoke` (RFC 7009). Always returns 200. Supports `token_type_hint`.
 - **RFC 9396 Rich Authorization Requests** — `authorization_details` on token requests, JWT claims, introspection, middleware enforcement via `RequireAuthorizationDetails`.

--- a/apiauth/as_metadata.go
+++ b/apiauth/as_metadata.go
@@ -35,6 +35,17 @@ type ASServerMetadata struct {
 	// Supported features
 	AuthorizationDetailsTypesSupported []string `json:"authorization_details_types_supported,omitempty"` // RFC 9396
 	ScopesSupported                    []string `json:"scopes_supported,omitempty"`
+
+	// ClaimsSupported lists the claim names this AS may include in
+	// issued tokens (and, once a userinfo endpoint exists, the userinfo
+	// response). OIDC Discovery 1.0 §3 declares this RECOMMENDED; the
+	// OpenID Foundation conformance suite emits a warning when the list
+	// is absent. Advertise only claims the AS actually emits — listing
+	// claims the AS does not produce misleads relying parties.
+	//
+	// See: OpenID Connect Discovery 1.0 §3
+	ClaimsSupported []string `json:"claims_supported,omitempty"`
+
 	ResponseTypesSupported        []string `json:"response_types_supported,omitempty"`
 	GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
 	TokenEndpointAuthMethods      []string `json:"token_endpoint_auth_methods_supported,omitempty"`

--- a/apiauth/as_metadata_test.go
+++ b/apiauth/as_metadata_test.go
@@ -94,6 +94,31 @@ func TestASMetadata_OmitsEmptyFields(t *testing.T) {
 	assert.NotContains(t, body, "introspection_endpoint")
 	assert.NotContains(t, body, "registration_endpoint")
 	assert.NotContains(t, body, "scopes_supported")
+	assert.NotContains(t, body, "claims_supported")
+}
+
+// TestASMetadata_ClaimsSupported verifies that claims_supported is
+// serialized when set. OIDC Discovery 1.0 §3 declares this RECOMMENDED
+// and the OpenID Foundation conformance suite emits a warning when the
+// field is absent (oidcc-discovery-endpoint-verification —
+// CheckDiscEndpointClaimsSupported).
+//
+// See: OpenID Connect Discovery 1.0 §3
+func TestASMetadata_ClaimsSupported(t *testing.T) {
+	meta := &apiauth.ASServerMetadata{
+		Issuer:          "https://auth.example.com",
+		TokenEndpoint:   "https://auth.example.com/api/token",
+		ClaimsSupported: []string{"sub", "iss", "aud", "exp", "iat", "jti"},
+	}
+
+	handler := apiauth.NewASMetadataHandler(meta)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, []any{"sub", "iss", "aud", "exp", "iat", "jti"}, body["claims_supported"])
 }
 
 // TestASMetadata_CacheControl verifies that the response includes

--- a/cmd/oneauth-server/config.go
+++ b/cmd/oneauth-server/config.go
@@ -42,6 +42,17 @@ type JWTConfig struct {
 	Issuer                    string   `yaml:"issuer"`                      // JWT issuer claim
 	AuthorizationDetailsTypes []string `yaml:"authorization_details_types"` // RFC 9396 supported types (advertised in AS metadata)
 
+	// ScopesSupported populates the `scopes_supported` field in AS
+	// metadata (RFC 8414 §2 / OIDC Discovery 1.0 §3). Empty falls back
+	// to a default that satisfies the OIDF discovery check
+	// CheckDiscEndpointScopesSupportedContainsOpenId.
+	ScopesSupported []string `yaml:"scopes_supported"`
+
+	// ClaimsSupported populates the `claims_supported` field in AS
+	// metadata (OIDC Discovery 1.0 §3). Empty falls back to the
+	// claims this AS actually emits in bearer tokens.
+	ClaimsSupported []string `yaml:"claims_supported"`
+
 	// SigningAlg controls how access tokens are signed. Defaults to HS256
 	// (uses SecretKey). Set to "RS256" / "ES256" for asymmetric signing —
 	// the public half is exposed via JWKS so remote resource servers can
@@ -175,8 +186,30 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.JWT.Issuer == "" {
 		cfg.JWT.Issuer = "oneauth"
 	}
+	if len(cfg.JWT.ScopesSupported) == 0 {
+		cfg.JWT.ScopesSupported = defaultScopesSupported()
+	}
+	if len(cfg.JWT.ClaimsSupported) == 0 {
+		cfg.JWT.ClaimsSupported = defaultClaimsSupported()
+	}
 
 	return &cfg, nil
+}
+
+// defaultScopesSupported returns the default `scopes_supported` advertised
+// in AS metadata when the deployment does not override the list. Includes
+// `openid` so the OIDF discovery check
+// CheckDiscEndpointScopesSupportedContainsOpenId passes; the rest are the
+// scopes the reference deployment exercises in examples and tests.
+func defaultScopesSupported() []string {
+	return []string{"openid", "profile", "email", "read", "write", "offline"}
+}
+
+// defaultClaimsSupported returns the default `claims_supported` advertised
+// in AS metadata. Conservative — only the claims OneAuth's bearer tokens
+// already emit. Expand once a userinfo endpoint lands (issue 116).
+func defaultClaimsSupported() []string {
+	return []string{"sub", "iss", "aud", "exp", "iat", "jti", "scope", "client_id"}
 }
 
 // configFromEnv builds a Config purely from environment variables.

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -329,6 +329,8 @@ func main() {
 		TokenEndpointAuthSigningAlgValuesSupported: []string{"RS256", "ES256"},
 		CodeChallengeMethodsSupported:              []string{"S256"},
 		SubjectTypesSupported:              []string{"public"},
+		ScopesSupported:                    cfg.JWT.ScopesSupported,
+		ClaimsSupported:                    cfg.JWT.ClaimsSupported,
 		AuthorizationDetailsTypesSupported: cfg.JWT.AuthorizationDetailsTypes,
 	})
 

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -38,6 +38,7 @@ type OIDCConfig struct {
 	IntrospectionEndpoint                      string   `json:"introspection_endpoint,omitempty"`
 	RegistrationEndpoint                       string   `json:"registration_endpoint,omitempty"`
 	ScopesSupported                            []string `json:"scopes_supported,omitempty"`
+	ClaimsSupported                            []string `json:"claims_supported,omitempty"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported,omitempty"`
 	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported,omitempty"`
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -61,6 +61,7 @@ type config struct {
 	issuer                  string
 	audience                string
 	scopes                  []string
+	claimsSupported         []string                         // OIDC Discovery 1.0 §3 advertisement
 	grantTypesSupported     []string                         // overrides default when non-nil
 	issParameterSupported   *bool                            // RFC 9207 advertisement (nil = omit)
 	trustedAssertionIssuers []apiauth.TrustedAssertionIssuer // RFC 7523 §2.1 + RFC 8693
@@ -91,6 +92,13 @@ func WithAudience(aud string) Option {
 // Default: ["read", "write", "admin"].
 func WithScopes(scopes []string) Option {
 	return func(c *config) { c.scopes = scopes }
+}
+
+// WithClaimsSupported sets the `claims_supported` field in AS metadata
+// (OIDC Discovery 1.0 §3). Default: the claims OneAuth's bearer tokens
+// already emit (sub, iss, aud, exp, iat, jti, scope, client_id).
+func WithClaimsSupported(claims []string) Option {
+	return func(c *config) { c.claimsSupported = claims }
 }
 
 // WithGrantTypesSupported overrides the `grant_types_supported` field
@@ -168,9 +176,10 @@ func WithTrustedAssertionIssuers(issuers []apiauth.TrustedAssertionIssuer) Optio
 // For test code, prefer NewTestAuthServer which auto-registers cleanup.
 func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 	cfg := config{
-		adminKey: defaultAdminKey,
-		issuer:   defaultIssuer,
-		scopes:   []string{"read", "write", "admin"},
+		adminKey:        defaultAdminKey,
+		issuer:          defaultIssuer,
+		scopes:          []string{"read", "write", "admin"},
+		claimsSupported: []string{"sub", "iss", "aud", "exp", "iat", "jti", "scope", "client_id"},
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -244,6 +253,7 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		IntrospectionEndpoint:         baseURL + "/oauth/introspect",
 		RegistrationEndpoint:          baseURL + "/apps/register",
 		ScopesSupported:               cfg.scopes,
+		ClaimsSupported:               cfg.claimsSupported,
 		GrantTypesSupported:           grants,
 		ResponseTypesSupported:        []string{"token"},
 		TokenEndpointAuthMethods:                   []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},

--- a/testutil/server_test.go
+++ b/testutil/server_test.go
@@ -312,6 +312,53 @@ func TestWithScopes_Option(t *testing.T) {
 	assert.Equal(t, "email", scopes[2])
 }
 
+// TestDiscoveryAdvertisesScopesAndClaims verifies the issue 200 acceptance
+// criterion: the default TestAuthServer's discovery document advertises
+// non-empty scopes_supported AND claims_supported. Both fields are required
+// by the OpenID Foundation conformance suite (oidcc-discovery-endpoint-
+// verification — CheckDiscEndpointScopesSupportedContainsOpenId,
+// CheckDiscEndpointClaimsSupported).
+//
+// See: OpenID Connect Discovery 1.0 §3
+func TestDiscoveryAdvertisesScopesAndClaims(t *testing.T) {
+	srv := testutil.NewTestAuthServer(t)
+
+	resp, err := http.Get(srv.URL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	scopes, ok := meta["scopes_supported"].([]any)
+	require.True(t, ok, "scopes_supported must be present")
+	assert.NotEmpty(t, scopes)
+
+	claims, ok := meta["claims_supported"].([]any)
+	require.True(t, ok, "claims_supported must be present")
+	assert.NotEmpty(t, claims)
+	assert.Contains(t, claims, "sub", "claims_supported should include sub")
+}
+
+// TestWithClaimsSupported_Option verifies that WithClaimsSupported overrides
+// the default `claims_supported` advertised in AS discovery metadata.
+//
+// See: OpenID Connect Discovery 1.0 §3
+func TestWithClaimsSupported_Option(t *testing.T) {
+	srv := testutil.NewTestAuthServer(t, testutil.WithClaimsSupported([]string{"sub", "email"}))
+
+	resp, err := http.Get(srv.URL() + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+
+	claims, ok := meta["claims_supported"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"sub", "email"}, claims)
+}
+
 // TestWithAdminKey_Option verifies that WithAdminKey configures the admin
 // API key required for app registration. Requests with the wrong key
 // should be rejected.


### PR DESCRIPTION
## What changes

`apiauth.ASServerMetadata` gains a new `ClaimsSupported []string` field (OIDC Discovery 1.0 §3), and the two reference deployments — `cmd/oneauth-server` and `testutil.TestAuthServer` — now populate both `scopes_supported` and `claims_supported` by default. Closes the two metadata-only warnings flagged by `oidcc-discovery-endpoint-verification` in the issue 197 phase-1 baseline (`CheckDiscEndpointScopesSupportedContainsOpenId`, `CheckDiscEndpointClaimsSupported`), independent of issue 116.

## Reviewer's guide

Read in this order:

1. [apiauth/as_metadata.go](https://github.com/panyam/oneauth/pull/203/files#diff-271d63776b88f1a5e791d54f0e5f2763fb32b5295d5f85d278bbebd7f3ca6456) — start here. Pure additive struct field; check the doc comment cites OIDC Discovery 1.0 §3 correctly.
2. [apiauth/as_metadata_test.go](https://github.com/panyam/oneauth/pull/203/files#diff-3309652f9c4f4368c1d1e0e1de964fcaf84a5ec2c58dcd9097d8ec73c0716453) — `TestASMetadata_ClaimsSupported` (new) and the extension to `TestASMetadata_OmitsEmptyFields` confirm round-trip + omit-when-nil.
3. [cmd/oneauth-server/config.go](https://github.com/panyam/oneauth/pull/203/files#diff-356728f980c9546d1ae9802ac863c4ccc97a7df25253e12e3ed019d559653f30) — new `jwt.scopes_supported` / `jwt.claims_supported` YAML keys plus `defaultScopesSupported()` / `defaultClaimsSupported()` helpers. The defaults are the contentious decision — see Decision log.
4. [cmd/oneauth-server/main.go](https://github.com/panyam/oneauth/pull/203/files#diff-e10cea20e37f1e5e5e61786642a3b5a2da9fa5b930d457555ca11400927e495a) — wires the two config fields into the existing `MountASMetadata` call.
5. [testutil/server.go](https://github.com/panyam/oneauth/pull/203/files#diff-99024381707d0f5eb1ec0cae31d4cfb27ae17fa491994eb366083e03640fda7f) — new `WithClaimsSupported` Option (mirrors existing `WithScopes`), default claim list set in `NewAuthServer`.
6. [testutil/server_test.go](https://github.com/panyam/oneauth/pull/203/files#diff-0a457326e0d5b0013418f3d108e759041fc91045b93bdf7ea9dd9954caf957ee) — `TestDiscoveryAdvertisesScopesAndClaims` is the issue-acceptance assertion ("non-empty for the default testutil server").

Skim or skip: [apiauth/SUMMARY.md](https://github.com/panyam/oneauth/pull/203/files#diff-f3bbacfca08d00c3458076319ba481fec63aa40f5488dd2adf1254e38b90986e), [testutil/helpers.go](https://github.com/panyam/oneauth/pull/203/files#diff-a115a6071a0b0b27cf71a7ddcd0e90c6a7923bf58cbb7a5cbdb0fb74949f9317) (one-line struct field).

## Decision log

- **`openid` is in the default scope list.** The OIDF check that drives this issue is literally `CheckDiscEndpointScopesSupportedContainsOpenId`, so spec compliance requires it. We don't yet issue id_tokens (gated on issue 116), but the metadata advertisement is a soft promise — `response_types_supported` still excludes `id_token`-bearing types, so a strict client will not be misled.
- **Defaults live in `LoadConfig`, not hardcoded inline in `main.go`.** Lets deployments override per-tenant via YAML, matches how `AuthorizationDetailsTypes` already lives on `JWTConfig`.
- **`ScopesSupported` / `ClaimsSupported` parked on `JWTConfig`.** Slightly weird semantically (scopes aren't a JWT concept), but keeps a single config surface for now. If the metadata-config surface grows, refactor to a `MetadataConfig` block in a follow-up.
- **Conservative claims list.** Only the claims OneAuth's bearer tokens already emit (`sub`, `iss`, `aud`, `exp`, `iat`, `jti`, `scope`, `client_id`). Listing claims the AS does not produce would mislead relying parties. Expand once a userinfo source lands.

## Risk / blast radius

- **Affects:** `cmd/oneauth-server` discovery metadata + `testutil.TestAuthServer` discovery metadata. No behavioral change to token issuance, validation, introspection, or revocation.
- **Tests covering this:** `apiauth/as_metadata_test.go`, `testutil/server_test.go` (added 6 new positive assertions, 0 weakened or removed).
- **Be paranoid about:** downstream consumers that decode AS metadata into a strict struct may now see an unexpected `claims_supported` field — mitigated by `omitempty` and JSON's default ignore-unknown behavior in Go decoders.

## Before / after

```
$ curl -s http://localhost:8080/.well-known/openid-configuration | jq '.scopes_supported, .claims_supported'

# Before:
null
null

# After:
[
  "openid",
  "profile",
  "email",
  "read",
  "write",
  "offline"
]
[
  "sub",
  "iss",
  "aud",
  "exp",
  "iat",
  "jti",
  "scope",
  "client_id"
]
```

`make test` and `make e2e` both green.

## Out of scope (deliberately deferred)

- `id_token_signing_alg_values_supported` and `userinfo_endpoint` — gated on issue 116 (`/authorize` + id_tokens).
- HTTPS deployment-mode failures from the same baseline — covered by issue 201.
- Re-running the OIDF harness end-to-end — covered by issue 202 (Phase 2 ratchet wiring).

Closes 200. Related to 197, 163.