### PR TITLE
feat(keys): persistent KidStorage interface + FS/GORM/GAE backends

### DIFF
--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -59,7 +59,10 @@ type AppRegistrar struct {
 	// KidStore retains old keys during rotation grace periods so that
 	// in-flight tokens signed with the previous key remain verifiable.
 	// If nil, rotation replaces the key immediately with no grace period.
-	KidStore *keys.KidStore
+	// Typed as the KidStorage interface so deployments can plug in a
+	// persistent backend (FS/GORM/GAE) without losing in-memory KidStore
+	// compatibility (*KidStore satisfies KidStorage).
+	KidStore keys.KidStorage
 
 	// DefaultGracePeriod is the default grace period for key rotation
 	// when not specified in the request. Defaults to 24h.
@@ -434,7 +437,12 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 	}
 
 	if h.KidStore != nil && oldKey != nil && oldKid != "" {
-		h.KidStore.Add(oldKid, oldKey, oldAlg, req.ClientID, time.Now().Add(gracePeriod))
+		// Surface persistence failures: silently dropping the old kid
+		// would advertise a grace period that didn't actually persist,
+		// rejecting in-flight tokens. Fail the rotation instead.
+		if err := h.KidStore.Add(oldKid, oldKey, oldAlg, req.ClientID, time.Now().Add(gracePeriod)); err != nil {
+			return nil, fmt.Errorf("retain previous key: %w", err)
+		}
 		resp.PreviousKid = oldKid
 		resp.GracePeriod = gracePeriod
 	}

--- a/keys/SUMMARY.md
+++ b/keys/SUMMARY.md
@@ -5,7 +5,7 @@ JWT signing key management: storage interfaces, in-memory and encrypted backends
 ## Contents
 - **keystore.go** — `KeyRecord`, `KeyLookup`, `KeyStorage` interfaces, `InMemoryKeyStore`, error vars
 - **encrypted.go** — `EncryptedKeyStorage` decorator (AES-256-GCM at rest for HMAC secrets)
-- **kid.go** — `KidStore` (grace-period key retention), `CompositeKeyLookup`
+- **kid.go** — `KidStorage` interface, `KidStore` (in-memory grace-period key retention), `CompositeKeyLookup`. Persistent `KidStorage` backends live in `stores/{fs,gorm,gae}`.
 - **jwks_handler.go** — `JWKSHandler` (serves `/.well-known/jwks.json`)
 - **jwks_keystore.go** — `JWKSKeyStore` (fetches remote JWKS), option functions
 

--- a/keys/kid.go
+++ b/keys/kid.go
@@ -19,7 +19,28 @@ func (r *kidRecord) isExpired() bool {
 	return !r.ExpiresAt.IsZero() && time.Now().After(r.ExpiresAt)
 }
 
-// KidStore is an in-memory KeyLookup that tracks kid→key mappings,
+// KidStorage is the write side of a kid-indexed key store. It extends the
+// read-only KeyLookup with the grace-period operations KidStore provides,
+// so retired keys can be persisted across process restarts by backends in
+// stores/ (FS, GORM, GAE) rather than living only in process memory.
+//
+// Unlike KeyStorage, KidStorage is keyed by kid (not clientID): GetKey by
+// clientID always returns ErrKeyNotFound — only GetKeyByKid is meaningful.
+type KidStorage interface {
+	KeyLookup
+
+	// Add registers a kid→key mapping. If expiresAt is zero, the key has
+	// no expiry. Re-adding an existing kid overwrites it.
+	Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error
+
+	// Remove deletes a kid entry. Removing an absent kid is not an error.
+	Remove(kid string) error
+
+	// CleanExpired removes all entries whose expiry has passed.
+	CleanExpired() error
+}
+
+// KidStore is an in-memory KidStorage that tracks kid→key mappings,
 // including grace-period entries retained during key rotation.
 //
 // Usage during rotation:
@@ -31,6 +52,8 @@ type KidStore struct {
 	records map[string]*kidRecord // kid -> record
 }
 
+var _ KidStorage = (*KidStore)(nil)
+
 // NewKidStore creates a new empty KidStore.
 func NewKidStore() *KidStore {
 	return &KidStore{
@@ -39,7 +62,7 @@ func NewKidStore() *KidStore {
 }
 
 // Add registers a kid→key mapping. If expiresAt is zero, the key has no expiry.
-func (s *KidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) {
+func (s *KidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.records[kid] = &kidRecord{
@@ -48,13 +71,15 @@ func (s *KidStore) Add(kid string, key any, algorithm string, clientID string, e
 		ClientID:  clientID,
 		ExpiresAt: expiresAt,
 	}
+	return nil
 }
 
-// Remove deletes a kid entry.
-func (s *KidStore) Remove(kid string) {
+// Remove deletes a kid entry. Removing an absent kid is not an error.
+func (s *KidStore) Remove(kid string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.records, kid)
+	return nil
 }
 
 // GetKey always returns ErrKeyNotFound — KidStore only supports kid-based lookup.
@@ -81,7 +106,7 @@ func (s *KidStore) GetKeyByKid(kid string) (*KeyRecord, error) {
 }
 
 // CleanExpired removes all expired entries.
-func (s *KidStore) CleanExpired() {
+func (s *KidStore) CleanExpired() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for kid, rec := range s.records {
@@ -89,6 +114,7 @@ func (s *KidStore) CleanExpired() {
 			delete(s.records, kid)
 		}
 	}
+	return nil
 }
 
 // Len returns the number of entries (including expired ones not yet cleaned).

--- a/keys/kidstore_conformance_test.go
+++ b/keys/kidstore_conformance_test.go
@@ -1,0 +1,18 @@
+package keys_test
+
+// Runs the shared KidStorage conformance suite against the in-memory
+// KidStore. The same suite also runs against the FS, GORM, and GAE
+// backends in their respective test files.
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/kidstoretest"
+)
+
+func TestInMemoryKidStoreConformance(t *testing.T) {
+	kidstoretest.RunAll(t, func(t *testing.T) keys.KidStorage {
+		return keys.NewKidStore()
+	})
+}

--- a/kidstoretest/kidstoretest.go
+++ b/kidstoretest/kidstoretest.go
@@ -1,0 +1,257 @@
+// Package kidstoretest provides shared test suites for all KidStorage
+// implementations. Each backend (in-memory KidStore, FS, GORM, GAE) calls
+// these tests with its own factory function, mirroring keystoretest.
+package kidstoretest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/utils"
+)
+
+// Factory creates a fresh KidStorage for each test.
+type Factory func(t *testing.T) keys.KidStorage
+
+// RunAll runs the complete KidStorage test suite against the provided factory.
+func RunAll(t *testing.T, factory Factory) {
+	t.Run("AddAndGetByKid", func(t *testing.T) { TestAddAndGetByKid(t, factory) })
+	t.Run("GetByUnknownKid", func(t *testing.T) { TestGetByUnknownKid(t, factory) })
+	t.Run("GetKeyByClientIDAlwaysNotFound", func(t *testing.T) { TestGetKeyByClientIDAlwaysNotFound(t, factory) })
+	t.Run("OverwriteSameKid", func(t *testing.T) { TestOverwriteSameKid(t, factory) })
+	t.Run("RemoveIdempotent", func(t *testing.T) { TestRemoveIdempotent(t, factory) })
+	t.Run("ExpiredKidNotReturned", func(t *testing.T) { TestExpiredKidNotReturned(t, factory) })
+	t.Run("ZeroExpiryNeverExpires", func(t *testing.T) { TestZeroExpiryNeverExpires(t, factory) })
+	t.Run("CleanExpired", func(t *testing.T) { TestCleanExpired(t, factory) })
+	t.Run("AsymmetricKeyRoundTrip", func(t *testing.T) { TestAsymmetricKeyRoundTrip(t, factory) })
+	t.Run("Persistence", func(t *testing.T) { TestPersistence(t, factory) })
+}
+
+func TestAddAndGetByKid(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	secret := []byte("kid-secret")
+	if err := ks.Add("kid-1", secret, "HS256", "app-1", time.Time{}); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	rec, err := ks.GetKeyByKid("kid-1")
+	if err != nil {
+		t.Fatalf("GetKeyByKid failed: %v", err)
+	}
+	keyBytes, ok := rec.Key.([]byte)
+	if !ok {
+		t.Fatalf("Expected []byte, got %T", rec.Key)
+	}
+	if string(keyBytes) != string(secret) {
+		t.Errorf("key mismatch: got %q, want %q", keyBytes, secret)
+	}
+	if rec.Algorithm != "HS256" {
+		t.Errorf("alg=%s, want HS256", rec.Algorithm)
+	}
+	if rec.ClientID != "app-1" {
+		t.Errorf("clientID=%s, want app-1", rec.ClientID)
+	}
+	if rec.Kid != "kid-1" {
+		t.Errorf("kid=%s, want kid-1", rec.Kid)
+	}
+}
+
+func TestGetByUnknownKid(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	_, err := ks.GetKeyByKid("does-not-exist")
+	if err != keys.ErrKidNotFound {
+		t.Errorf("Expected ErrKidNotFound, got %v", err)
+	}
+}
+
+// TestGetKeyByClientIDAlwaysNotFound enforces the documented KidStorage
+// semantic: lookup by clientID is meaningless for a kid-indexed store and
+// must always return ErrKeyNotFound, regardless of whether the client has
+// any kids registered.
+func TestGetKeyByClientIDAlwaysNotFound(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	if err := ks.Add("kid-1", []byte("s"), "HS256", "app-1", time.Time{}); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	_, err := ks.GetKey("app-1")
+	if err != keys.ErrKeyNotFound {
+		t.Errorf("GetKey by clientID must always return ErrKeyNotFound, got %v", err)
+	}
+}
+
+func TestOverwriteSameKid(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	if err := ks.Add("kid-1", []byte("old"), "HS256", "app-1", time.Time{}); err != nil {
+		t.Fatalf("first Add failed: %v", err)
+	}
+	if err := ks.Add("kid-1", []byte("new"), "HS512", "app-2", time.Time{}); err != nil {
+		t.Fatalf("overwrite Add failed: %v", err)
+	}
+
+	rec, err := ks.GetKeyByKid("kid-1")
+	if err != nil {
+		t.Fatalf("GetKeyByKid failed: %v", err)
+	}
+	if string(rec.Key.([]byte)) != "new" {
+		t.Errorf("expected overwritten key, got %q", rec.Key)
+	}
+	if rec.Algorithm != "HS512" {
+		t.Errorf("expected overwritten alg HS512, got %s", rec.Algorithm)
+	}
+	if rec.ClientID != "app-2" {
+		t.Errorf("expected overwritten clientID app-2, got %s", rec.ClientID)
+	}
+}
+
+// TestRemoveIdempotent enforces that Remove on an absent kid is not an
+// error — KidStorage Remove is intentionally idempotent (differs from
+// KeyStorage.DeleteKey which returns ErrKeyNotFound).
+func TestRemoveIdempotent(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	if err := ks.Remove("never-existed"); err != nil {
+		t.Errorf("Remove of absent kid should be nil, got %v", err)
+	}
+
+	if err := ks.Add("kid-1", []byte("s"), "HS256", "app-1", time.Time{}); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	if err := ks.Remove("kid-1"); err != nil {
+		t.Errorf("Remove of present kid failed: %v", err)
+	}
+	if _, err := ks.GetKeyByKid("kid-1"); err != keys.ErrKidNotFound {
+		t.Errorf("kid should be gone after Remove, got %v", err)
+	}
+	if err := ks.Remove("kid-1"); err != nil {
+		t.Errorf("second Remove (now absent) should be nil, got %v", err)
+	}
+}
+
+func TestExpiredKidNotReturned(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	past := time.Now().Add(-1 * time.Hour)
+	if err := ks.Add("kid-old", []byte("s"), "HS256", "app-1", past); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	_, err := ks.GetKeyByKid("kid-old")
+	if err != keys.ErrKidNotFound {
+		t.Errorf("expired kid should return ErrKidNotFound, got %v", err)
+	}
+}
+
+func TestZeroExpiryNeverExpires(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	// Zero time.Time = no expiry. A check far in the future must still find it.
+	if err := ks.Add("kid-forever", []byte("s"), "HS256", "app-1", time.Time{}); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	rec, err := ks.GetKeyByKid("kid-forever")
+	if err != nil {
+		t.Fatalf("zero-expiry kid must be returned: %v", err)
+	}
+	if rec.Kid != "kid-forever" {
+		t.Errorf("kid=%s, want kid-forever", rec.Kid)
+	}
+}
+
+func TestCleanExpired(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	if err := ks.Add("kid-alive", []byte("a"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("Add kid-alive failed: %v", err)
+	}
+	if err := ks.Add("kid-dead", []byte("b"), "HS256", "app-2", time.Now().Add(-1*time.Hour)); err != nil {
+		t.Fatalf("Add kid-dead failed: %v", err)
+	}
+	if err := ks.Add("kid-forever", []byte("c"), "HS256", "app-3", time.Time{}); err != nil {
+		t.Fatalf("Add kid-forever failed: %v", err)
+	}
+
+	if err := ks.CleanExpired(); err != nil {
+		t.Fatalf("CleanExpired failed: %v", err)
+	}
+
+	if _, err := ks.GetKeyByKid("kid-alive"); err != nil {
+		t.Errorf("live kid was swept: %v", err)
+	}
+	if _, err := ks.GetKeyByKid("kid-forever"); err != nil {
+		t.Errorf("non-expiring kid was swept: %v", err)
+	}
+	// Re-add kid-dead and confirm it's gone from the backing store
+	// (GetKeyByKid already filters expired entries even before CleanExpired,
+	// so this also confirms CleanExpired physically removed the row/file
+	// — re-adding with a future expiry must not collide with stale state).
+	if err := ks.Add("kid-dead", []byte("b2"), "HS256", "app-2", time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("re-Add kid-dead failed: %v", err)
+	}
+	rec, err := ks.GetKeyByKid("kid-dead")
+	if err != nil {
+		t.Fatalf("re-added kid-dead missing: %v", err)
+	}
+	if string(rec.Key.([]byte)) != "b2" {
+		t.Errorf("expected fresh value b2 after re-Add, got %q", rec.Key)
+	}
+}
+
+func TestAsymmetricKeyRoundTrip(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	_, pubPEM, err := utils.GenerateRSAKeyPair(2048)
+	if err != nil {
+		t.Fatalf("GenerateRSAKeyPair failed: %v", err)
+	}
+
+	kid, err := utils.ComputeKid(pubPEM, "RS256")
+	if err != nil {
+		t.Fatalf("ComputeKid failed: %v", err)
+	}
+
+	if err := ks.Add(kid, pubPEM, "RS256", "app-rsa", time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	rec, err := ks.GetKeyByKid(kid)
+	if err != nil {
+		t.Fatalf("GetKeyByKid failed: %v", err)
+	}
+	if rec.Algorithm != "RS256" {
+		t.Errorf("alg=%s, want RS256", rec.Algorithm)
+	}
+	keyBytes, ok := rec.Key.([]byte)
+	if !ok {
+		t.Fatalf("Expected []byte, got %T", rec.Key)
+	}
+	if string(keyBytes) != string(pubPEM) {
+		t.Error("PEM round-trip mismatch")
+	}
+}
+
+// TestPersistence verifies the store reads back what it wrote. For
+// persistent backends (FS, GORM, GAE) this exercises the actual storage
+// layer; for in-memory it is trivially true. Cross-instance restart proof
+// is handled in backend-specific tests where reopening makes sense.
+func TestPersistence(t *testing.T, factory Factory) {
+	ks := factory(t)
+
+	if err := ks.Add("kid-1", []byte("persistent"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	rec, err := ks.GetKeyByKid("kid-1")
+	if err != nil {
+		t.Fatalf("GetKeyByKid failed: %v", err)
+	}
+	if string(rec.Key.([]byte)) != "persistent" {
+		t.Error("persisted key material mismatch")
+	}
+}

--- a/stores/fs/fskidstore.go
+++ b/stores/fs/fskidstore.go
@@ -1,0 +1,174 @@
+package fs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/panyam/oneauth/keys"
+)
+
+// fsKidEntry is the on-disk JSON representation of a kid→key grace entry.
+// Mirrors fsKeyEntry but keyed by kid (not clientID) and carries an expiry
+// — the grace-period TTL set when a key is retired during rotation.
+type fsKidEntry struct {
+	Kid       string    `json:"kid"`
+	Key       []byte    `json:"key"`
+	Algorithm string    `json:"algorithm"`
+	ClientID  string    `json:"client_id"`
+	ExpiresAt time.Time `json:"expires_at"` // zero value = no expiry
+}
+
+// FSKidStore implements keys.KidStorage using filesystem storage.
+// One file per kid under {StoragePath}/kid_keys/, mirroring FSKeyStore's
+// file-per-record layout.
+type FSKidStore struct {
+	StoragePath string
+	mu          sync.RWMutex
+}
+
+var _ keys.KidStorage = (*FSKidStore)(nil)
+
+// NewFSKidStore creates a new filesystem-backed KidStorage.
+func NewFSKidStore(storagePath string) *FSKidStore {
+	return &FSKidStore{StoragePath: storagePath}
+}
+
+func (s *FSKidStore) getKidDir() string {
+	return filepath.Join(s.StoragePath, "kid_keys")
+}
+
+func (s *FSKidStore) getKidPath(kid string) (string, error) {
+	safeKid, err := safeName(kid)
+	if err != nil {
+		return "", fmt.Errorf("invalid kid: %w", err)
+	}
+	return filepath.Join(s.getKidDir(), safeKid+".json"), nil
+}
+
+// isExpired matches keys.kidRecord.isExpired: zero time = never expires.
+func isExpired(t time.Time) bool {
+	return !t.IsZero() && time.Now().After(t)
+}
+
+func (s *FSKidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
+	keyBytes, ok := key.([]byte)
+	if !ok {
+		return keys.ErrAlgorithmMismatch
+	}
+
+	path, err := s.getKidPath(kid)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(s.getKidDir(), 0700); err != nil {
+		return err
+	}
+
+	entry := &fsKidEntry{
+		Kid:       kid,
+		Key:       keyBytes,
+		Algorithm: algorithm,
+		ClientID:  clientID,
+		ExpiresAt: expiresAt,
+	}
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomicFile(path, data)
+}
+
+// Remove is idempotent — deleting an absent kid is not an error.
+func (s *FSKidStore) Remove(kid string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path, err := s.getKidPath(kid)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// GetKey always returns ErrKeyNotFound — KidStorage is kid-indexed and
+// has no clientID→key lookup. Matches the in-memory KidStore.
+func (s *FSKidStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+	return nil, keys.ErrKeyNotFound
+}
+
+func (s *FSKidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path, err := s.getKidPath(kid)
+	if err != nil {
+		return nil, keys.ErrKidNotFound
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, keys.ErrKidNotFound
+		}
+		return nil, err
+	}
+	var entry fsKidEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, err
+	}
+	if isExpired(entry.ExpiresAt) {
+		return nil, keys.ErrKidNotFound
+	}
+	return &keys.KeyRecord{
+		ClientID:  entry.ClientID,
+		Key:       entry.Key,
+		Algorithm: entry.Algorithm,
+		Kid:       entry.Kid,
+	}, nil
+}
+
+func (s *FSKidStore) CleanExpired() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dir := s.getKidDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var entry fsKidEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			continue
+		}
+		if isExpired(entry.ExpiresAt) {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/stores/fs/fskidstore_test.go
+++ b/stores/fs/fskidstore_test.go
@@ -1,0 +1,46 @@
+package fs
+
+// Tests for the filesystem-based KidStorage implementation. The shared
+// conformance suite is in kidstoretest; the cross-instance restart test
+// below is FS-specific — it's the headline proof that grace-period kids
+// survive a process restart.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/kidstoretest"
+)
+
+func TestFSKidStore(t *testing.T) {
+	kidstoretest.RunAll(t, func(t *testing.T) keys.KidStorage {
+		return NewFSKidStore(t.TempDir())
+	})
+}
+
+// TestFSKidStorePersistsAcrossInstances exercises the actual gap this
+// backend closes: a second store instance opened over the same directory
+// must see kids written by the first. Without this, "survives a process
+// restart" is only an interface-level claim, not a verified behavior.
+func TestFSKidStorePersistsAcrossInstances(t *testing.T) {
+	dir := t.TempDir()
+
+	writer := NewFSKidStore(dir)
+	if err := writer.Add("kid-grace", []byte("retired-secret"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("writer.Add failed: %v", err)
+	}
+
+	// Fresh instance over the same backing directory — simulates a process restart.
+	reader := NewFSKidStore(dir)
+	rec, err := reader.GetKeyByKid("kid-grace")
+	if err != nil {
+		t.Fatalf("reader.GetKeyByKid failed after restart: %v", err)
+	}
+	if string(rec.Key.([]byte)) != "retired-secret" {
+		t.Errorf("key material did not survive restart: got %q", rec.Key)
+	}
+	if rec.ClientID != "app-1" {
+		t.Errorf("clientID did not survive restart: got %s", rec.ClientID)
+	}
+}

--- a/stores/gae/kidstore.go
+++ b/stores/gae/kidstore.go
@@ -1,0 +1,131 @@
+//go:build !wasm
+// +build !wasm
+
+package gae
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/datastore"
+	"github.com/panyam/oneauth/keys"
+)
+
+const KindKidKey = "KidKey"
+
+// KidKeyEntity is the Datastore entity for kid→key grace entries.
+// The Datastore key name is the kid itself.
+type KidKeyEntity struct {
+	Key       *datastore.Key `datastore:"__key__"`
+	KeyBytes  []byte         `datastore:"key_bytes,noindex"`
+	Algorithm string         `datastore:"algorithm"`
+	ClientID  string         `datastore:"client_id"`
+	// ExpiresAt is unindexed: CleanExpired scans + filters in Go (kid
+	// stores are small, and we'd need a not-equal-zero filter combined
+	// with a less-than filter which Datastore doesn't support natively).
+	ExpiresAt time.Time `datastore:"expires_at,noindex"`
+}
+
+// GAEKidStore implements keys.KidStorage using Google Cloud Datastore.
+type GAEKidStore struct {
+	client    *datastore.Client
+	namespace string
+	ctx       context.Context
+}
+
+var _ keys.KidStorage = (*GAEKidStore)(nil)
+
+// NewKidStore creates a new Datastore-backed KidStorage.
+func NewKidStore(client *datastore.Client, namespace string) *GAEKidStore {
+	return &GAEKidStore{
+		client:    client,
+		namespace: namespace,
+		ctx:       context.Background(),
+	}
+}
+
+// WithContext returns a copy of the store with the given context, matching
+// the GAEKeyStore.WithContext pattern (see issue 110 / 175 for the planned
+// ctx-as-parameter migration).
+func (s *GAEKidStore) WithContext(ctx context.Context) *GAEKidStore {
+	return &GAEKidStore{
+		client:    s.client,
+		namespace: s.namespace,
+		ctx:       ctx,
+	}
+}
+
+func (s *GAEKidStore) namespacedKey(name string) *datastore.Key {
+	key := datastore.NameKey(KindKidKey, name, nil)
+	key.Namespace = s.namespace
+	return key
+}
+
+func (s *GAEKidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
+	keyBytes, ok := key.([]byte)
+	if !ok {
+		return keys.ErrAlgorithmMismatch
+	}
+
+	entity := &KidKeyEntity{
+		Key:       s.namespacedKey(kid),
+		KeyBytes:  keyBytes,
+		Algorithm: algorithm,
+		ClientID:  clientID,
+		ExpiresAt: expiresAt,
+	}
+	_, err := s.client.Put(s.ctx, entity.Key, entity)
+	return err
+}
+
+// Remove is idempotent — Datastore Delete on a missing key returns nil.
+func (s *GAEKidStore) Remove(kid string) error {
+	return s.client.Delete(s.ctx, s.namespacedKey(kid))
+}
+
+// GetKey always returns ErrKeyNotFound — KidStorage is kid-indexed.
+func (s *GAEKidStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+	return nil, keys.ErrKeyNotFound
+}
+
+func (s *GAEKidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+	var entity KidKeyEntity
+	if err := s.client.Get(s.ctx, s.namespacedKey(kid), &entity); err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, keys.ErrKidNotFound
+		}
+		return nil, err
+	}
+	if !entity.ExpiresAt.IsZero() && time.Now().After(entity.ExpiresAt) {
+		return nil, keys.ErrKidNotFound
+	}
+	return &keys.KeyRecord{
+		ClientID:  entity.ClientID,
+		Key:       entity.KeyBytes,
+		Algorithm: entity.Algorithm,
+		Kid:       kid,
+	}, nil
+}
+
+func (s *GAEKidStore) CleanExpired() error {
+	q := datastore.NewQuery(KindKidKey)
+	if s.namespace != "" {
+		q = q.Namespace(s.namespace)
+	}
+	var entities []KidKeyEntity
+	dsKeys, err := s.client.GetAll(s.ctx, q, &entities)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	var toDelete []*datastore.Key
+	for i, e := range entities {
+		if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+			toDelete = append(toDelete, dsKeys[i])
+		}
+	}
+	if len(toDelete) == 0 {
+		return nil
+	}
+	return s.client.DeleteMulti(s.ctx, toDelete)
+}

--- a/stores/gae/kidstore_test.go
+++ b/stores/gae/kidstore_test.go
@@ -1,0 +1,70 @@
+//go:build !wasm
+// +build !wasm
+
+// Tests for the Google App Engine Datastore-based KidStorage implementation.
+
+package gae
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/kidstoretest"
+	"google.golang.org/api/option" //nolint:staticcheck // WithCredentialsFile is simpler for test use
+)
+
+// TestGAEKidStore runs the shared KidStorage conformance suite against
+// Google Cloud Datastore. Skips unless DATASTORE_PROJECT_ID is set —
+// same env contract as TestGAEKeyStore.
+//
+// To run against the Datastore emulator:
+//
+//	export DATASTORE_EMULATOR_HOST=localhost:8081
+//	export DATASTORE_PROJECT_ID=test-project
+//	go test -v ./stores/gae/...
+func TestGAEKidStore(t *testing.T) {
+	projectID := os.Getenv("DATASTORE_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("DATASTORE_PROJECT_ID not set, skipping GAE KidStore tests")
+	}
+
+	namespace := os.Getenv("DATASTORE_TEST_NAMESPACE")
+	if namespace == "" {
+		namespace = "oneauth-kidstore-test"
+	}
+
+	ctx := context.Background()
+	var opts []option.ClientOption
+	if credsFile := os.Getenv("DATASTORE_CREDENTIALS_FILE"); credsFile != "" {
+		opts = append(opts, option.WithCredentialsFile(credsFile))
+	}
+
+	client, err := datastore.NewClient(ctx, projectID, opts...)
+	if err != nil {
+		t.Fatalf("Failed to create Datastore client: %v", err)
+	}
+	defer client.Close()
+
+	cleanup := func() {
+		q := datastore.NewQuery(KindKidKey).KeysOnly().Namespace(namespace)
+		dsKeys, err := client.GetAll(ctx, q, nil)
+		if err != nil {
+			t.Logf("Cleanup warning: failed to query kid keys: %v", err)
+			return
+		}
+		if len(dsKeys) > 0 {
+			if err := client.DeleteMulti(ctx, dsKeys); err != nil {
+				t.Logf("Cleanup warning: failed to delete kid keys: %v", err)
+			}
+		}
+	}
+	t.Cleanup(cleanup)
+
+	kidstoretest.RunAll(t, func(t *testing.T) keys.KidStorage {
+		cleanup() // fresh state per sub-test
+		return NewKidStore(client, namespace)
+	})
+}

--- a/stores/gorm/kidstore.go
+++ b/stores/gorm/kidstore.go
@@ -1,0 +1,97 @@
+//go:build !wasm
+// +build !wasm
+
+package gorm
+
+import (
+	"time"
+
+	"github.com/panyam/oneauth/keys"
+	"gorm.io/gorm"
+)
+
+// KidKeyModel is the GORM model for kid→key grace entries. Mirrors the
+// fields the in-memory KidStore tracks per kid. ExpiresAt is nullable;
+// nil means "no expiry" (matches zero time.Time in the in-memory store)
+// — avoiding the messy 0001-01-01 zero-date some SQL dialects produce.
+type KidKeyModel struct {
+	Kid       string     `gorm:"primaryKey;size:128"`
+	Key       []byte     `gorm:"not null"`
+	Algorithm string     `gorm:"size:16;not null"`
+	ClientID  string     `gorm:"size:128;index"`
+	ExpiresAt *time.Time `gorm:"index:idx_kid_expires_at"`
+	CreatedAt time.Time  `gorm:"autoCreateTime"`
+}
+
+func (KidKeyModel) TableName() string {
+	return "kid_keys"
+}
+
+// KidStore implements keys.KidStorage using GORM.
+type KidStore struct {
+	db *gorm.DB
+}
+
+var _ keys.KidStorage = (*KidStore)(nil)
+
+// NewKidStore creates a new GORM-backed KidStorage.
+func NewKidStore(db *gorm.DB) *KidStore {
+	return &KidStore{db: db}
+}
+
+func (s *KidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
+	keyBytes, ok := key.([]byte)
+	if !ok {
+		return keys.ErrAlgorithmMismatch
+	}
+	model := &KidKeyModel{
+		Kid:       kid,
+		Key:       keyBytes,
+		Algorithm: algorithm,
+		ClientID:  clientID,
+	}
+	if !expiresAt.IsZero() {
+		t := expiresAt
+		model.ExpiresAt = &t
+	}
+	// Save = upsert by primary key (kid), matching KidStore.Add's
+	// "re-adding an existing kid overwrites it" contract.
+	return s.db.Save(model).Error
+}
+
+// Remove is idempotent — deleting an absent kid is not an error.
+func (s *KidStore) Remove(kid string) error {
+	return s.db.Delete(&KidKeyModel{}, "kid = ?", kid).Error
+}
+
+// GetKey always returns ErrKeyNotFound — KidStorage is kid-indexed.
+func (s *KidStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+	return nil, keys.ErrKeyNotFound
+}
+
+func (s *KidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+	var model KidKeyModel
+	if err := s.db.First(&model, "kid = ?", kid).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, keys.ErrKidNotFound
+		}
+		return nil, err
+	}
+	// Expired entries are filtered at read time (CleanExpired physically
+	// removes them); mirrors the in-memory KidStore semantics.
+	if model.ExpiresAt != nil && time.Now().After(*model.ExpiresAt) {
+		return nil, keys.ErrKidNotFound
+	}
+	return &keys.KeyRecord{
+		ClientID:  model.ClientID,
+		Key:       model.Key,
+		Algorithm: model.Algorithm,
+		Kid:       model.Kid,
+	}, nil
+}
+
+func (s *KidStore) CleanExpired() error {
+	// expires_at IS NOT NULL excludes zero-expiry (never-expiring) rows.
+	return s.db.Where("expires_at IS NOT NULL AND expires_at < ?", time.Now()).
+		Delete(&KidKeyModel{}).Error
+}

--- a/stores/gorm/kidstore_test.go
+++ b/stores/gorm/kidstore_test.go
@@ -1,0 +1,45 @@
+//go:build !wasm
+// +build !wasm
+
+// Tests for the GORM SQL-based KidStorage implementation (SQLite and PostgreSQL).
+
+package gorm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/kidstoretest"
+)
+
+// TestGORMKidStore runs the shared KidStorage conformance suite against
+// the GORM-backed implementation (SQLite by default, PostgreSQL when
+// ONEAUTH_TEST_PGDB is set — same env contract as TestGORMKeyStore).
+func TestGORMKidStore(t *testing.T) {
+	kidstoretest.RunAll(t, func(t *testing.T) keys.KidStorage {
+		return NewKidStore(setupTestDB(t))
+	})
+}
+
+// TestGORMKidStorePersistsAcrossInstances mirrors the FS cross-instance
+// restart test: two KidStore values over the same *gorm.DB see each
+// other's writes, proving the substrate (not just the in-memory handle)
+// holds the grace entry.
+func TestGORMKidStorePersistsAcrossInstances(t *testing.T) {
+	db := setupTestDB(t)
+
+	writer := NewKidStore(db)
+	if err := writer.Add("kid-grace", []byte("retired-secret"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("writer.Add failed: %v", err)
+	}
+
+	reader := NewKidStore(db)
+	rec, err := reader.GetKeyByKid("kid-grace")
+	if err != nil {
+		t.Fatalf("reader.GetKeyByKid failed: %v", err)
+	}
+	if string(rec.Key.([]byte)) != "retired-secret" {
+		t.Errorf("key material mismatch across instances: got %q", rec.Key)
+	}
+}

--- a/stores/gorm/stores.go
+++ b/stores/gorm/stores.go
@@ -27,6 +27,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&APIKeyModel{},
 		&UsernameModel{},
 		&SigningKeyModel{},
+		&KidKeyModel{},
 		&AppRegistrationModel{},
 	)
 }


### PR DESCRIPTION
## What changes

Extracts a `keys.KidStorage` interface from the in-memory `KidStore` and adds FS, GORM, and GAE backends so grace-period `kid → verify-key` mappings survive a process restart. Without this, a server restart mid-rotation drops the retired key from in-memory state and tokens signed with it (still inside the grace window) fail verification.

Behavior of the in-memory `KidStore` is unchanged for callers that don't migrate — `*KidStore` satisfies the new interface, the example flow at `examples/09-key-rotation` is unaffected.

## Reviewer's guide

Read in this order:

1. [keys/kid.go](https://github.com/panyam/oneauth/pull/205/files#diff-fc78fe28fa55ca6e80dea9bd4a799d24392feec8b29cf4a3a9622319c5f47dbd) — start here. The `KidStorage` interface definition + the `Add` / `Remove` / `CleanExpired` signature change (now returning `error`). The interface deliberately mirrors the existing `keys.KidStore` shape rather than going full gRPC-shape — see Decision log below.
2. [kidstoretest/kidstoretest.go](https://github.com/panyam/oneauth/pull/205/files#diff-0d564c776e4e52acb66fb93c4e5b9afbf4af116ba58992e5645d42f56ac9028b) — the shared conformance suite. The 10 sub-tests are the spec each backend must satisfy. Notably `RemoveIdempotent` (KidStorage diverges from `KeyStorage.DeleteKey` here, deliberately) and `ZeroExpiryNeverExpires` (zero `time.Time` = no expiry, matching in-memory).
3. [stores/fs/fskidstore.go](https://github.com/panyam/oneauth/pull/205/files#diff-b5e007ce3134d1cf7cf1c94ff86421d973d0c4c914bc64db73618fbc31886c2c) — first backend. Mirrors `FSKeyStore`'s file-per-record + atomic-write pattern. `kid` is the filename via the existing `safeName` helper, so `GetKeyByKid` is O(1) (unlike `FSKeyStore.GetKeyByKid` which scans).
4. [stores/fs/fskidstore_test.go](https://github.com/panyam/oneauth/pull/205/files#diff-da5198a390b99b00f7b70bc3a235bd99023128e7a10b28cf78a6c63eca090c6c) — `TestFSKidStorePersistsAcrossInstances` is the headline acceptance for the whole PR: write with one store, read from a fresh instance over the same dir, key survives.
5. [stores/gorm/kidstore.go](https://github.com/panyam/oneauth/pull/205/files#diff-05773e44cf2e059e2dd197f1eaf579e884abefc8223ffbdf36a84ad430375790) — second backend. `ExpiresAt *time.Time` is nullable on purpose (zero-time in SQL is messy); `CleanExpired` filters `expires_at IS NOT NULL AND expires_at < now` so non-expiring entries are correctly retained.
6. [stores/gorm/stores.go](https://github.com/panyam/oneauth/pull/205/files#diff-5d5be43f743443a5ac5f918767adb86363183249ed0f7b51a096cd0b2ff9d60e) — `KidKeyModel` registered in `AutoMigrate`. One-line change but easy to miss.
7. [stores/gae/kidstore.go](https://github.com/panyam/oneauth/pull/205/files#diff-243e141f1eed9c4b45505e5a2071e39920641deb5223632209ba000611d52ba9) — third backend. `CleanExpired` does `GetAll` + filter-in-Go + `DeleteMulti` since Datastore can't express "not-zero AND less-than" in a single query; fine because kid stores are small.
8. [admin/registrar.go](https://github.com/panyam/oneauth/pull/205/files#diff-357a2ab591dde1d22068c00e675d315f4bbc15d7c36f0e89b29a4dd0b1ff953e) — type widening of `AppRegistrar.KidStore` from `*keys.KidStore` to `keys.KidStorage`, plus error handling for `Add`. The only production-code call site of the changed signatures.
9. [keys/kidstore_conformance_test.go](https://github.com/panyam/oneauth/pull/205/files#diff-b5c99932660a9907db8c20e0633a0baf264885ee261867578c4c4969d055e923) — proves in-memory `KidStore` satisfies the new interface via the same conformance suite.

Skim or skip: backwards-compat alias methods (none added in this PR), [keys/SUMMARY.md](https://github.com/panyam/oneauth/pull/205/files#diff-d4b8b6122f8a469fcdc59e013e3f9f1f1b8345257d90a5b5853b17523461cfc7) (doc-only).

## Decision log

- **`Add` keeps 5 positional params** rather than going full gRPC-shape (`ctx`, Request/Response). The convention in CLAUDE.md is scoped to `apiauth/` and `admin/` service interfaces; the `keys/` and `stores/` layer is currently *half*-modernized (`PutKey(*KeyRecord)` already, but `GetKey(clientID string)` and no `ctx` anywhere). Going full gRPC-shape on `KidStorage` alone would create a third shape, different from both `KeyStorage` and the apiauth/admin services. The whole store-layer modernization is now tracked separately as a follow-up to 110/175 — see "Out of scope" below.
- **Interface methods return `error`**. The in-memory `KidStore.Add/Remove/CleanExpired` were `void`; persistent backends genuinely can fail (disk full, DB unreachable). The blast radius is one production call site (`admin/registrar.go`) plus test files where statements work either way.
- **`Remove` is idempotent** — returns `nil` for an absent kid, diverging from `KeyStorage.DeleteKey` (which returns `ErrKeyNotFound`). Matches the in-memory `KidStore.Remove` semantics and is the more useful default during rotation: a sweep retry shouldn't fail because the row was already gone.
- **`JWKSHandler` stays on the concrete `*keys.KidStore`** (it reaches into private `.records` to enumerate). Migrating JWKS to the interface requires an enumeration method the scope deliberately didn't include — separate follow-up.
- **`AppRegistrar.KidStore` widens to the interface**. Without this, the new backends are unreachable from the one existing caller (`RotateSecret`). `*KidStore` still satisfies the interface, so no example or test that currently assigns a `*KidStore` breaks.

## Risk / blast radius

- Affects: anything that constructs an `AppRegistrar` and assigns `KidStore`. All such call sites pass `*keys.KidStore`, which still satisfies the widened interface — no source-level break.
- Tests covering this: shared conformance suite (10 sub-tests × 4 backends = 40 acceptances), plus the cross-instance restart tests for FS and GORM. All passing locally (`make test`, `cd stores/gorm && go test ./...`, `cd stores/gae && go test ./...`).
- Be paranoid about: the `time.Time` zero-value handling. Three backends, three storage substrates — FS round-trips via JSON RFC3339, GORM uses `*time.Time` nullable, GAE stores `time.Time` directly. `TestZeroExpiryNeverExpires` is the cross-backend acceptance for this.
- No new external dependencies in any module.

## Out of scope (deliberately deferred)

- **Rotation orchestration** in `admin/` (key generation + `PutKey` + `Add`-old-kid). The substrate is here; the operation that drives it is the next PR.
- **`JWKSHandler` over persistent `KidStorage`** (needs an enumeration method the scope didn't include).
- **`EncryptedKidStorage`** wrapper (grace-period HMAC secrets at rest, parity with `EncryptedKeyStorage`).
- **Store-layer gRPC-shape migration** (`ctx` + Request/Response across all store interfaces) — filed as a separate follow-up to issues 110 / 175, tracked at issue 204.
- **Background sweeper goroutine** that periodically calls `CleanExpired` — without rotation orchestration populating expiring entries, there's nothing to sweep.

## Candidates for the rotation follow-up PR

The reviewer might ask "where are the e2e tests / Keycloak / example updates?" — flagging these explicitly so the conversation isn't lost:

- **E2E** (`tests/e2e`): valuable once rotation orchestration exists — "rotate → grace → verify a token signed with the retired key after a server restart". Can't happen now: in-process e2e can't cross a process boundary, and nothing in the current API drives `Add` from a user-facing flow.
- **Keycloak interop** (`tests/keycloak`): not applicable. KidStore is internal storage with no wire format — Keycloak only observes our JWKS output.
- **Examples**: `examples/09-key-rotation` currently uses in-memory `KidStore`. Switching it to `FSKidStore` is a one-line swap that adds no narrative; the valuable example is "rotate, restart the server, old token still verifies during the grace window" — needs rotation orchestration *and* `cmd/oneauth-server` to grow `kidstore` config plumbing (it has none today; the reference server doesn't configure a `KidStore` at all).
