### PR TITLE
feat(client): assertion audience override + private_key_jwt on ClientCredentialsSource

### DIFF
--- a/client/client_credentials_source.go
+++ b/client/client_credentials_source.go
@@ -43,17 +43,19 @@ type ClientCredentialsSource struct {
 	// ClientID identifies this client to the authorization server.
 	ClientID string
 
-	// ClientSecret authenticates this client.
+	// ClientSecret authenticates this client when ClientAssertion is nil.
+	// Sent via the negotiated client_secret_basic or client_secret_post
+	// method (RFC 6749 §2.3.1).
 	ClientSecret string
+
+	// ClientAssertion, when non-nil, switches the source to the
+	// private_key_jwt client-authentication path (RFC 7521 §4.2 /
+	// RFC 7523 §2.2 / OIDC Core §9). ClientSecret is ignored. The same
+	// caching, OnToken, and ProactiveRefresher machinery applies.
+	ClientAssertion *ClientAssertionConfig
 
 	// Scopes to request.
 	Scopes []string
-
-	// AuthorizationDetails to request (RFC 9396). Sent alongside scopes.
-	AuthorizationDetails []core.AuthorizationDetail
-
-	// Audience is the resource server's canonical URI (RFC 8707 resource indicator).
-	Audience string
 
 	// Refresher enables proactive token refresh before expiry. When nil or
 	// Refresher.Buffer == 0, refresh is reactive — happens on the next
@@ -145,7 +147,15 @@ func (s *ClientCredentialsSource) fetchTokenLocked() (*ServerCredential, error) 
 			WithASMetadata(&ASMetadata{TokenEndpoint: s.TokenEndpoint}))
 	}
 
-	cred, err := s.client.ClientCredentialsToken(s.ClientID, s.ClientSecret, s.Scopes)
+	var (
+		cred *ServerCredential
+		err  error
+	)
+	if s.ClientAssertion != nil {
+		cred, err = s.client.ClientCredentialsTokenWithAssertion(s.ClientID, *s.ClientAssertion, s.Scopes)
+	} else {
+		cred, err = s.client.ClientCredentialsToken(s.ClientID, s.ClientSecret, s.Scopes)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("client credentials: %w", err)
 	}

--- a/client/client_credentials_source_jwt_test.go
+++ b/client/client_credentials_source_jwt_test.go
@@ -1,0 +1,139 @@
+package client
+
+// JWT-assertion (private_key_jwt) tests for ClientCredentialsSource.
+//
+// Exercises the path where the source authenticates to the token endpoint
+// with a signed `client_assertion` instead of a `client_secret`, while
+// still benefiting from the caching, OnToken, and proactive-refresh
+// machinery that the secret-based path already provides.
+//
+// References:
+//   - RFC 6749 §4.4   client_credentials grant
+//   - RFC 7521 §4.2   client authentication via assertion
+//   - RFC 7523 §2.2   JWT bearer client assertion
+//   - OIDC Core §9    private_key_jwt
+//   - Issue #211      ticket motivating this code path
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jwtTokenServer is the assertion-aware counterpart of tokenServer. It
+// asserts that every token request carries a `client_assertion_type` of
+// `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, parses the
+// assertion, and forwards the parsed claims to `onAssertion` so the
+// caller can make per-test assertions about the JWT shape.
+func jwtTokenServer(t *testing.T, expiry time.Duration, requestCount *atomic.Int32, onAssertion func(*testing.T, jwt.MapClaims)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		assert.Equal(t, "client_credentials", r.FormValue("grant_type"))
+		assert.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", r.FormValue("client_assertion_type"))
+
+		assertion := r.FormValue("client_assertion")
+		require.NotEmpty(t, assertion, "client_assertion form value must be present")
+
+		parsed, _, err := new(jwt.Parser).ParseUnverified(assertion, jwt.MapClaims{})
+		require.NoError(t, err)
+		claims, ok := parsed.Claims.(jwt.MapClaims)
+		require.True(t, ok)
+		if onAssertion != nil {
+			onAssertion(t, claims)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": fmt.Sprintf("tok-%d", n),
+			"token_type":   "Bearer",
+			"expires_in":   int(expiry.Seconds()),
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestClientCredentialsSource_JWT_TokenRoundtrip verifies that a source
+// configured with ClientAssertion uses the private_key_jwt path AND the
+// existing cache: the second Token() within the cached window returns
+// the same token without a new round-trip, and the third call after
+// induced expiry re-fetches.
+func TestClientCredentialsSource_JWT_TokenRoundtrip(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	var count atomic.Int32
+	srv := jwtTokenServer(t, 1*time.Hour, &count, nil)
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "demo-client",
+		ClientAssertion: &ClientAssertionConfig{
+			PrivateKey: priv,
+			SigningAlg: "RS256",
+		},
+	}
+
+	tok1, err := src.Token()
+	require.NoError(t, err)
+	assert.NotEmpty(t, tok1)
+	assert.Equal(t, int32(1), count.Load(), "first Token() must fetch")
+
+	tok2, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, tok1, tok2, "cached token returned unchanged")
+	assert.Equal(t, int32(1), count.Load(), "no extra fetch within cache window")
+
+	src.mu.Lock()
+	src.expiry = time.Now().Add(-1 * time.Minute)
+	src.mu.Unlock()
+
+	tok3, err := src.Token()
+	require.NoError(t, err)
+	assert.NotEqual(t, tok1, tok3, "post-expiry Token() must re-fetch")
+	assert.Equal(t, int32(2), count.Load())
+}
+
+// TestClientCredentialsSource_JWT_AudienceFlowsThrough confirms that
+// ClientAssertion.Audience reaches the AS — when set, the JWT's `aud`
+// claim equals the override (the AS issuer URL) rather than the token
+// endpoint URL that ClientCredentialsTokenWithAssertion would default
+// to.
+func TestClientCredentialsSource_JWT_AudienceFlowsThrough(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	const issuerAud = "https://issuer.example.com"
+
+	var count atomic.Int32
+	srv := jwtTokenServer(t, 1*time.Hour, &count, func(t *testing.T, claims jwt.MapClaims) {
+		assert.Equal(t, issuerAud, claims["aud"], "aud claim MUST be the configured override")
+	})
+	defer srv.Close()
+
+	src := &ClientCredentialsSource{
+		TokenEndpoint: srv.URL + "/token",
+		ClientID:      "demo-client",
+		ClientAssertion: &ClientAssertionConfig{
+			PrivateKey: priv,
+			SigningAlg: "RS256",
+			Audience:   issuerAud,
+		},
+	}
+
+	_, err = src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), count.Load())
+}

--- a/client/private_key_jwt.go
+++ b/client/private_key_jwt.go
@@ -44,6 +44,16 @@ type ClientAssertionConfig struct {
 	// 5min to satisfy OneAuth's server-side assertion lifetime cap;
 	// other AS implementations are typically stricter.
 	Lifetime time.Duration
+
+	// Audience, when non-empty, overrides the `aud` claim of the minted
+	// assertion. Empty falls back to the positional `audience` argument
+	// of MintClientAssertion (typically the token endpoint URL).
+	//
+	// RFC 7523bis (current OAuth WG draft) requires `aud` to be the AS
+	// issuer identifier; OIDC Core §9 historically permitted the token
+	// endpoint URL. ASes in the wild differ — set this when targeting a
+	// 7523bis-strict AS that rejects the token endpoint URL.
+	Audience string
 }
 
 // DefaultClientAssertionLifetime is the assertion lifetime applied when
@@ -55,17 +65,25 @@ const DefaultClientAssertionLifetime = 60 * time.Second
 // identity, suitable for use as the `client_assertion` form parameter
 // at the token / introspection / revocation endpoints.
 //
+// When cfg.Audience is non-empty it overrides the positional audience
+// argument — use the field to target RFC 7523bis ASes that require
+// `aud == issuer URL`; rely on the positional default (token endpoint
+// URL) for OIDC Core §9-compliant ASes.
+//
 // Claims set per RFC 7523 §3 + OIDC Core §9:
 //
 //	iss = clientID
 //	sub = clientID
-//	aud = audience  (token endpoint URL or AS issuer URL)
+//	aud = cfg.Audience if set, else `audience` argument
 //	jti = random 128-bit hex string
 //	iat = now
 //	exp = now + cfg.Lifetime  (or default)
 //
 // Returns the compact JWS string ready to drop into a form value.
 func MintClientAssertion(clientID, audience string, cfg ClientAssertionConfig) (string, error) {
+	if cfg.Audience != "" {
+		audience = cfg.Audience
+	}
 	if clientID == "" {
 		return "", fmt.Errorf("MintClientAssertion: clientID is required")
 	}

--- a/client/private_key_jwt_test.go
+++ b/client/private_key_jwt_test.go
@@ -109,6 +109,33 @@ func TestMintClientAssertion_FreshJTIPerCall(t *testing.T) {
 	assert.NotEqual(t, parseJTI(a), parseJTI(b), "jti MUST differ between assertions")
 }
 
+// TestMintClientAssertion_AudienceOverride — when ClientAssertionConfig.Audience
+// is set, it MUST become the `aud` claim and the positional `audience` argument
+// MUST be ignored. This lets callers target RFC 7523bis ASes (which require
+// `aud == issuer URL`) without bypassing the helper, while default behaviour
+// (positional argument = token endpoint URL per OIDC Core §9) is preserved
+// when the field is empty.
+//
+// See issue #211.
+func TestMintClientAssertion_AudienceOverride(t *testing.T) {
+	priv := newRSAKey(t)
+	const positionalAud = "https://as.example.com/token"
+	const overrideAud = "https://as.example.com" // RFC 7523bis issuer-identifier shape
+
+	signed, err := client.MintClientAssertion("c", positionalAud, client.ClientAssertionConfig{
+		PrivateKey: priv,
+		SigningAlg: "RS256",
+		Audience:   overrideAud,
+	})
+	require.NoError(t, err)
+
+	parsed, err := jwt.Parse(signed, func(t *jwt.Token) (any, error) { return &priv.PublicKey, nil })
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, overrideAud, claims["aud"], "cfg.Audience MUST win over the positional argument")
+}
+
 // TestMintClientAssertion_RequiresInputs — minimal-viable validation
 // that callers don't trigger nil-derefs on bad input. These are sanity
 // checks, not security boundaries.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # OneAuth Release Notes
 
+## Version 0.1.1
+
+### Client SDK — `private_key_jwt` ergonomics
+
+**`ClientAssertionConfig.Audience` (additive).** New field on `ClientAssertionConfig` overrides the `aud` claim of a minted assertion. When empty, behaviour is unchanged (positional argument — typically the token endpoint URL — per OIDC Core §9). Set the field when targeting an RFC 7523bis-strict AS that requires `aud` to be the issuer identifier. `MintClientAssertion` and `ClientCredentialsTokenWithAssertion` both honour the override.
+
+**`ClientCredentialsSource.ClientAssertion` (additive).** New `*ClientAssertionConfig` field on `ClientCredentialsSource`. When non-nil, the source routes through `ClientCredentialsTokenWithAssertion` instead of `ClientCredentialsToken`, applying the same caching, OnToken, and `ProactiveRefresher` machinery as the secret-based path. `ClientSecret` is ignored when `ClientAssertion` is set.
+
+**Cleanup — dead fields removed (breaking).** Removed `ClientCredentialsSource.Audience` (RFC 8707 resource indicator) and `ClientCredentialsSource.AuthorizationDetails` (RFC 9396). Both fields were declared on the struct but **never** wired into the underlying token request, making them silent no-ops. No internal caller and no downstream consumer (mcpkit, goapplib, projects/*) set these fields. Proper RFC 8707 / RFC 9396 plumbing for client_credentials is tracked as a follow-up — the right home is the token-request layer, not the cached source.
+
+Unblocks SEP-1046 conformance work in mcpkit issue 447 (umbrella 439).
+
+See: issue 211.
+
+---
+
 ## Version 0.0.32
 
 ### APIMiddleware Enhancements


### PR DESCRIPTION
Closes #211.

## What changes

Two additive features and one dead-code cleanup on the client SDK's `private_key_jwt` path.

1. **`ClientAssertionConfig.Audience`** — overrides the `aud` claim on a minted assertion. Empty falls back to the positional argument (token endpoint URL per OIDC Core §9). Set the field when targeting an RFC 7523bis-strict AS that requires `aud == issuer URL`.
2. **`ClientCredentialsSource.ClientAssertion`** — when non-nil, the source switches to `private_key_jwt` (RFC 7521 §4.2 / RFC 7523 §2.2). Same caching, OnToken, and proactive-refresher behaviour as the secret-based path.
3. **Cleanup (breaking).** Removed `ClientCredentialsSource.Audience` (RFC 8707) and `.AuthorizationDetails` (RFC 9396). Both fields were declared on the struct but never wired into the token request. Confirmed unused across oneauth + mcpkit (the most involved consumer) + goapplib + projects/*. Filed as a follow-up to land proper plumbing at the token-request layer.

Unblocks SEP-1046 conformance work in mcpkit issue 447 (umbrella 439). Tagged as v0.1.1 — see release notes entry.

## Reviewer's guide

Read in this order:

1. [client/private_key_jwt.go](https://github.com/panyam/oneauth/pull/212/files#diff-4e936cf2ad20681eb000e9f1b10cc5908d28372db82ce959bf631939ba185a92) — start here. New `Audience` field on `ClientAssertionConfig` + the override applied at the top of `MintClientAssertion`. Compatibility: empty field preserves the positional-argument default.
2. [client/client_credentials_source.go](https://github.com/panyam/oneauth/pull/212/files#diff-8d083e6b912efeb6b0a463ec40b00f3f8aa9ded5b43e1c36449781bfb5bc0f1f) — new `ClientAssertion *ClientAssertionConfig` field, two dead fields removed, branch in `fetchTokenLocked` selecting `ClientCredentialsTokenWithAssertion` vs `ClientCredentialsToken`.
3. [client/client_credentials_source_jwt_test.go](https://github.com/panyam/oneauth/pull/212/files#diff-b1ef9cf8fcc0bedfdc779d44ca11265a76a9253daf750430d59ff19e2b39e210) — acceptance for both source-level changes (cache reuse on JWT path + audience override flows through to the AS).
4. [client/private_key_jwt_test.go](https://github.com/panyam/oneauth/pull/212/files#diff-ce16a0f1ffa5cd92d3b0b9e6d7984019c9a546b3b88c8dd2e132c5d24ef31b68) — `TestMintClientAssertion_AudienceOverride` covers the helper-level override.
5. [docs/RELEASE_NOTES.md](https://github.com/panyam/oneauth/pull/212/files#diff-06470f44e11a4acf72ecac0f68c7438ff957181a677bbc006439d2532b9794b6) — v0.1.1 entry capturing the additive surface + dead-field removal rationale.

Skim or skip: nothing generated, no fixtures touched.

## Decision log

- **Override at the helper, not the caller.** Putting the override inside `MintClientAssertion` means every caller — `ClientCredentialsTokenWithAssertion`, `requestTokenFormWithAssertion`, `BrowserLogin` — gets the new behaviour for free, with no signature changes. Existing positional callers that don't set `cfg.Audience` keep their current `aud` value.
- **Why remove the dead fields instead of wiring them.** Audience-as-RFC-8707-resource and `authorization_details` both want to ride on the token request, not on the cached source. The current signatures of `ClientCredentialsToken*` don't accept them, so wiring them needs either a signature change or a `ClientCredentialsRequest` struct param (gRPC-shape convention). That's a separate, properly-tested change with its own interop story — out of scope here.
- **Pointer for `ClientAssertion`, not embedded struct.** A pointer lets `nil` cleanly mean "use ClientSecret"; an embedded struct would force every caller to use a sentinel value or split into two source types. The cost is one indirection on the rare-path token fetch.

## Risk / blast radius

- **Public API:** `ClientCredentialsSource` literal initializers that set `.Audience` or `.AuthorizationDetails` will fail to compile. Confirmed zero such call sites across oneauth, mcpkit, goapplib, lilbattle, notation, sdl. mcpkit only type-aliases the source — never struct-literals it.
- **Wire-level:** unchanged on the secret path; on the JWT path, identical to what `ClientCredentialsTokenWithAssertion` already produces today, plus an optional `aud` override.
- **Tests covering this:** existing `TestMintClientAssertion_ClaimShape`, `TestMintClientAssertion_DefaultLifetime`, `TestMintClientAssertion_FreshJTIPerCall`, `TestMintClientAssertion_RequiresInputs` plus the three new ones (`AudienceOverride`, `JWT_TokenRoundtrip`, `JWT_AudienceFlowsThrough`). e2e green.
- **Pressure-test:** the `requestTokenFormWithAssertion` path still passes the discovered token endpoint as the positional `audience` argument — confirm by reading that the override at the top of `MintClientAssertion` doesn't break the existing OIDC Core §9 default for callers that don't set `cfg.Audience`.

## Out of scope (deliberate)

- Wiring RFC 8707 `resource` and RFC 9396 `authorization_details` on `client_credentials` token requests. Will file as a follow-up issue with a Keycloak interop check, framing the right home (token-request layer, gRPC-shape param struct).
- `client_secret_jwt` (HMAC) client auth — that's #159.
