### PR TITLE
refactor(core): rename token Subject fields (PR 2a — phase 1 of Subject vocab)

### DIFF
--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -333,7 +333,7 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	}
 
 	// Create new access token (carry forward authorization_details from original grant)
-	accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.UserID, refreshToken.Scopes, refreshToken.AuthorizationDetails)
+	accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.Subject, refreshToken.Scopes, refreshToken.AuthorizationDetails)
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -493,7 +493,7 @@ func (a *APIAuth) HandleLogoutAll(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Revoke all user tokens
-	if err := a.RefreshTokenStore.RevokeUserTokens(userID); err != nil {
+	if err := a.RefreshTokenStore.RevokeSubjectTokens(userID); err != nil {
 		log.Printf("Error revoking user tokens: %v", err)
 		a.errorResponse(w, "server_error", "Failed to revoke sessions", http.StatusInternalServerError)
 		return
@@ -518,7 +518,7 @@ func (a *APIAuth) HandleListSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get user's active tokens
-	tokens, err := a.RefreshTokenStore.GetUserTokens(userID)
+	tokens, err := a.RefreshTokenStore.GetSubjectTokens(userID)
 	if err != nil {
 		log.Printf("Error getting user tokens: %v", err)
 		a.errorResponse(w, "server_error", "Failed to get sessions", http.StatusInternalServerError)
@@ -880,7 +880,7 @@ func (a *APIAuth) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get user's API keys
-	keys, err := a.APIKeyStore.ListUserAPIKeys(userID)
+	keys, err := a.APIKeyStore.ListSubjectAPIKeys(userID)
 	if err != nil {
 		log.Printf("Error listing API keys: %v", err)
 		a.errorResponse(w, "server_error", "Failed to list API keys", http.StatusInternalServerError)
@@ -1030,7 +1030,7 @@ func (a *APIAuth) HandleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if apiKey.UserID != userID {
+	if apiKey.Subject != userID {
 		a.errorResponse(w, "forbidden", "Not authorized to revoke this key", http.StatusForbidden)
 		return
 	}
@@ -1458,7 +1458,7 @@ func (m *APIMiddleware) validateAPIKey(fullKey string) (userID string, scopes []
 		}
 	}()
 
-	return apiKey.UserID, apiKey.Scopes, "api_key", nil
+	return apiKey.Subject, apiKey.Scopes, "api_key", nil
 }
 
 // handleAuthError handles authentication errors

--- a/apiauth/auth_test.go
+++ b/apiauth/auth_test.go
@@ -503,8 +503,8 @@ func TestAPIKeyAuthentication(t *testing.T) {
 
 		var response map[string]any
 		json.NewDecoder(rr.Body).Decode(&response)
-		if response["user_id"] != apiKey.UserID {
-			t.Errorf("Expected user_id %s, got %v", apiKey.UserID, response["user_id"])
+		if response["user_id"] != apiKey.Subject {
+			t.Errorf("Expected user_id %s, got %v", apiKey.Subject, response["user_id"])
 		}
 		if response["auth_type"] != "api_key" {
 			t.Errorf("Expected auth_type api_key, got %v", response["auth_type"])

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -224,12 +224,12 @@ func newInMemoryRefreshStore() *inMemoryRefreshStore {
 	return &inMemoryRefreshStore{tokens: make(map[string]*core.RefreshToken)}
 }
 
-func (s *inMemoryRefreshStore) CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
+func (s *inMemoryRefreshStore) CreateRefreshToken(subject, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
 	token, _ := core.GenerateSecureToken()
 	family, _ := core.GenerateSecureToken()
 	rt := &core.RefreshToken{
 		Token:     token,
-		UserID:    userID,
+		Subject:   subject,
 		ClientID:  clientID,
 		Scopes:    scopes,
 		Family:    family[:16],
@@ -270,7 +270,7 @@ func (s *inMemoryRefreshStore) RotateRefreshToken(old string) (*core.RefreshToke
 	newToken, _ := core.GenerateSecureToken()
 	newRT := &core.RefreshToken{
 		Token:                newToken,
-		UserID:               rt.UserID,
+		Subject:              rt.Subject,
 		ClientID:             rt.ClientID,
 		Scopes:               rt.Scopes,
 		AuthorizationDetails: rt.AuthorizationDetails,
@@ -281,9 +281,9 @@ func (s *inMemoryRefreshStore) RotateRefreshToken(old string) (*core.RefreshToke
 	return newRT, nil
 }
 
-func (s *inMemoryRefreshStore) RevokeUserTokens(userID string) error { return nil }
-func (s *inMemoryRefreshStore) RevokeTokenFamily(family string) error { return nil }
-func (s *inMemoryRefreshStore) GetUserTokens(userID string) ([]*core.RefreshToken, error) {
+func (s *inMemoryRefreshStore) RevokeSubjectTokens(subject string) error { return nil }
+func (s *inMemoryRefreshStore) RevokeTokenFamily(family string) error    { return nil }
+func (s *inMemoryRefreshStore) GetSubjectTokens(subject string) ([]*core.RefreshToken, error) {
 	return nil, nil
 }
 func (s *inMemoryRefreshStore) CleanupExpiredTokens() error { return nil }

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -418,7 +418,7 @@ func (i *jwtIssuer) RefreshGrant(ctx context.Context, req *RefreshGrantRequest) 
 
 	// Create new access token (carry forward scopes + authorization_details)
 	tok, err := i.CreateAccessToken(ctx, &CreateAccessTokenRequest{
-		Subject:              rt.UserID,
+		Subject:              rt.Subject,
 		Scopes:               rt.Scopes,
 		AuthorizationDetails: rt.AuthorizationDetails,
 	})
@@ -426,7 +426,7 @@ func (i *jwtIssuer) RefreshGrant(ctx context.Context, req *RefreshGrantRequest) 
 		return nil, fmt.Errorf("server_error: %w", err)
 	}
 
-	i.hooks.fireOnIssued(rt.UserID, "refresh_token")
+	i.hooks.fireOnIssued(rt.Subject, "refresh_token")
 
 	return &RefreshGrantResponse{Tokens: &core.TokenPair{
 		AccessToken:          tok.Token,

--- a/core/stores.go
+++ b/core/stores.go
@@ -4,8 +4,10 @@ import "time"
 
 // RefreshTokenStore manages refresh tokens for API access.
 type RefreshTokenStore interface {
-	// CreateRefreshToken creates a new refresh token for a user.
-	CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*RefreshToken, error)
+	// CreateRefreshToken creates a new refresh token for the given subject
+	// (RFC 7519 sub) — a user ID for user-bound tokens, a client_id for
+	// client_credentials.
+	CreateRefreshToken(subject, clientID string, deviceInfo map[string]any, scopes []string) (*RefreshToken, error)
 
 	// GetRefreshToken retrieves a refresh token by its value.
 	GetRefreshToken(token string) (*RefreshToken, error)
@@ -17,14 +19,15 @@ type RefreshTokenStore interface {
 	// RevokeRefreshToken marks a token as revoked.
 	RevokeRefreshToken(token string) error
 
-	// RevokeUserTokens revokes all refresh tokens for a user.
-	RevokeUserTokens(userID string) error
+	// RevokeSubjectTokens revokes all refresh tokens belonging to a subject.
+	RevokeSubjectTokens(subject string) error
 
 	// RevokeTokenFamily revokes all tokens in a family (theft detection).
 	RevokeTokenFamily(family string) error
 
-	// GetUserTokens lists all active (non-revoked, non-expired) refresh tokens for a user.
-	GetUserTokens(userID string) ([]*RefreshToken, error)
+	// GetSubjectTokens lists all active (non-revoked, non-expired) refresh
+	// tokens for a subject.
+	GetSubjectTokens(subject string) ([]*RefreshToken, error)
 
 	// CleanupExpiredTokens removes expired tokens (for maintenance).
 	CleanupExpiredTokens() error
@@ -32,9 +35,9 @@ type RefreshTokenStore interface {
 
 // APIKeyStore manages API keys for programmatic access.
 type APIKeyStore interface {
-	// CreateAPIKey creates a new API key and returns the full key (only shown once).
-	// The key format is: keyID + "_" + secret.
-	CreateAPIKey(userID, name string, scopes []string, expiresAt *time.Time) (fullKey string, apiKey *APIKey, err error)
+	// CreateAPIKey creates a new API key for the given subject and returns
+	// the full key (only shown once). The key format is keyID + "_" + secret.
+	CreateAPIKey(subject, name string, scopes []string, expiresAt *time.Time) (fullKey string, apiKey *APIKey, err error)
 
 	// GetAPIKeyByID retrieves an API key by its public ID.
 	GetAPIKeyByID(keyID string) (*APIKey, error)
@@ -46,8 +49,8 @@ type APIKeyStore interface {
 	// RevokeAPIKey marks an API key as revoked.
 	RevokeAPIKey(keyID string) error
 
-	// ListUserAPIKeys returns all API keys for a user (without secrets).
-	ListUserAPIKeys(userID string) ([]*APIKey, error)
+	// ListSubjectAPIKeys returns all API keys owned by a subject (without secrets).
+	ListSubjectAPIKeys(subject string) ([]*APIKey, error)
 
 	// UpdateAPIKeyLastUsed updates the last used timestamp.
 	UpdateAPIKeyLastUsed(keyID string) error

--- a/core/tokens.go
+++ b/core/tokens.go
@@ -37,7 +37,7 @@ func GenerateSecureToken() (string, error) {
 type RefreshToken struct {
 	Token                string                `json:"token"`       // 64-char hex token value
 	TokenHash            string                `json:"token_hash"`  // SHA256 hash for storage (optional)
-	UserID               string                `json:"user_id"`     // Associated user
+	Subject              string                `json:"subject"`     // Principal the token represents (RFC 7519 sub) — user ID for user-bound tokens, client_id for client_credentials
 	ClientID             string                `json:"client_id"`   // Optional client/app identifier
 	DeviceInfo           map[string]any        `json:"device_info"` // User agent, IP, etc.
 	Family               string                `json:"family"`      // Token family for rotation tracking
@@ -65,7 +65,7 @@ func (t *RefreshToken) IsValid() bool {
 type APIKey struct {
 	KeyID      string     `json:"key_id"`      // Public identifier (e.g., "oa_abc123...")
 	KeyHash    string     `json:"key_hash"`    // bcrypt hash of the secret portion
-	UserID     string     `json:"user_id"`     // Owner of this key
+	Subject    string     `json:"subject"`     // Principal the key represents (RFC 7519 sub) — user ID for user-bound keys, client_id for service accounts
 	Name       string     `json:"name"`        // User-defined label
 	Scopes     []string   `json:"scopes"`      // Allowed scopes
 	CreatedAt  time.Time  `json:"created_at"`

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,3 +1,69 @@
+# Migration Guide
+
+## v0.1.2 → v0.1.3 — Subject vocab (phase 1: token-bearing types)
+
+The principal field on token-bearing types renames from `UserID` to `Subject` to match RFC 7519 / RFC 8693 vocabulary. Affects `core.RefreshToken`, `core.APIKey`, `localauth.VerificationToken`, and the storage interface methods on `RefreshTokenStore`, `APIKeyStore`, and `VerificationTokenStore`.
+
+### Code changes (consumers)
+
+Search-and-replace on your consumer:
+
+```
+.UserID                         →  .Subject     (only on RefreshToken / APIKey / VerificationToken instances)
+GetUserTokens(                  →  GetSubjectTokens(
+RevokeUserTokens(               →  RevokeSubjectTokens(
+ListUserAPIKeys(                →  ListSubjectAPIKeys(
+DeleteUserTokens(               →  DeleteSubjectTokens(
+```
+
+`accounts.Identity.UserID`, `accounts.Username.UserID`, `UserStore`, and the `httpauth` public surface all stay unchanged.
+
+### Stored data migration
+
+#### GORM (Postgres / MySQL / SQLite)
+
+```sql
+ALTER TABLE refresh_tokens RENAME COLUMN user_id TO subject;
+ALTER TABLE api_keys       RENAME COLUMN user_id TO subject;
+ALTER TABLE auth_tokens    RENAME COLUMN user_id TO subject;
+-- indexes on user_id are auto-renamed by Postgres/MySQL. On SQLite,
+-- drop and recreate the index after the rename.
+```
+
+#### Filesystem store
+
+`stores/fs` persists JSON files with a `user_id` field on three token kinds:
+`refresh_tokens/*.json`, `api_keys/*.json`, `tokens/*.json`. Rewrite the
+field name in place, or **reset the store** (re-issue all tokens / API
+keys; users re-verify email).
+
+```bash
+# In each affected directory:
+for f in refresh_tokens api_keys tokens; do
+  find "$f" -name '*.json' -exec sed -i.bak 's/"user_id":/"subject":/g' {} \;
+done
+```
+
+#### GAE / Datastore
+
+`subject` becomes the new Datastore property name on
+`RefreshToken`, `APIKey`, and `AuthToken` kinds. Either run a Datastore
+update job to copy `user_id` → `subject` and drop `user_id`, or reset
+those kinds. Active filter queries on those kinds also need updating
+(they used `FilterField("user_id", ...)` — the library now filters by
+`subject`).
+
+If you have no production data on these stores (dev / staging), the
+simplest path is to delete those kinds and let the library recreate
+them with the new property.
+
+### Easier alternative
+
+If you have no production data persisted yet, just reset the three
+token stores and re-issue everything on next login. No SQL needed.
+
+---
+
 # Migration Guide: Sub-Module Split (v0.0.x → v0.0.40)
 
 ## What Changed

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,42 @@
 # OneAuth Release Notes
 
+## Version 0.1.3 (PR 2a — token Subject foundation)
+
+### Subject vocabulary — phase 1: token-bearing types
+
+**Breaking.** The token-bearing types in `core/` and `localauth/` now use **Subject** (RFC 7519 `sub`) for the principal field, replacing **UserID**. Motivation: in `client_credentials` flows the principal is a service account, not a human user — `UserID` was misleading. `Subject` is what the JWT `sub` claim, RFC 7662 introspection, RFC 8693 token exchange, and Spring Security / JWT / X.509 idiom all call this concept. Account-model types (`accounts.User`, `accounts.Identity.UserID`, `accounts.Username.UserID`) stay as **UserID** — those are application user records, not OAuth subjects.
+
+**Go API renames:**
+
+| Before | After |
+|---|---|
+| `core.RefreshToken.UserID` (`json:"user_id"`) | `core.RefreshToken.Subject` (`json:"subject"`) |
+| `core.APIKey.UserID` (`json:"user_id"`) | `core.APIKey.Subject` (`json:"subject"`) |
+| `localauth.VerificationToken.UserID` (`json:"user_id"`) | `localauth.VerificationToken.Subject` (`json:"subject"`) |
+| `RefreshTokenStore.CreateRefreshToken(userID, ...)` | `CreateRefreshToken(subject, ...)` |
+| `RefreshTokenStore.RevokeUserTokens(userID)` | `RevokeSubjectTokens(subject)` |
+| `RefreshTokenStore.GetUserTokens(userID)` | `GetSubjectTokens(subject)` |
+| `APIKeyStore.CreateAPIKey(userID, ...)` | `CreateAPIKey(subject, ...)` |
+| `APIKeyStore.ListUserAPIKeys(userID)` | `ListSubjectAPIKeys(subject)` |
+| `VerificationTokenStore.CreateToken(userID, ...)` | `CreateToken(subject, ...)` |
+| `VerificationTokenStore.DeleteUserTokens(userID, ...)` | `DeleteSubjectTokens(subject, ...)` |
+
+All three backends (`stores/fs`, `stores/gorm`, `stores/gae`) updated. Models renamed in lock-step.
+
+**Storage migration required.** GORM column renames: `refresh_tokens.user_id` → `subject`, `api_keys.user_id` → `subject`, `auth_tokens.user_id` → `subject`. FS JSON storage: `user_id` → `subject` on the three token kinds. GAE Datastore: same field renames. Existing data must be migrated or the affected stores reset — see `docs/MIGRATION.md`.
+
+**Out of scope (deferred to PR 2b):**
+- `core.GetUserIDFromContext` / `SetUserIDInContext` / `DefaultUserParamName="loggedInUserId"`
+- `core.GetUserScopesFunc`
+- `apiauth.PasswordGrantResponse.UserID` / `TokenInfo.UserID` / `GetUserIDFromAPIContext`
+- `httpauth.Middleware.GetLoggedInUserId` / `OneAuth.SetLoggedInUserID` (public surface stays — internals flip in PR 2b)
+- `grpc.UserIDFromContext` / `DefaultMetadataKeyUserID="x-user-id"`
+- Session cookie key `loggedInUserId` (PR 2b invalidates active sessions)
+
+See issue tracker for PR 2b.
+
+---
+
 ## Version 0.1.2
 
 ### Client SDK — gRPC-shape `ClientCredentials` + RFC 8707 / RFC 9396 plumbing

--- a/localauth/verification.go
+++ b/localauth/verification.go
@@ -30,7 +30,7 @@ const (
 type VerificationToken struct {
 	Token     string           `json:"token"`
 	Type      VerificationType `json:"type"`
-	UserID    string           `json:"user_id"`
+	Subject   string           `json:"subject"`
 	Email     string           `json:"email"`
 	CreatedAt time.Time        `json:"created_at"`
 	ExpiresAt time.Time        `json:"expires_at"`
@@ -49,8 +49,8 @@ func (t *VerificationToken) IsValid(expectedType VerificationType) bool {
 // VerificationTokenStore manages localauth verification tokens (signup
 // email-verify, password-reset). Renamed from core.TokenStore.
 type VerificationTokenStore interface {
-	CreateToken(userID, email string, tokenType VerificationType, expiryDuration time.Duration) (*VerificationToken, error)
+	CreateToken(subject, email string, tokenType VerificationType, expiryDuration time.Duration) (*VerificationToken, error)
 	GetToken(token string) (*VerificationToken, error)
 	DeleteToken(token string) error
-	DeleteUserTokens(userID string, tokenType VerificationType) error
+	DeleteSubjectTokens(subject string, tokenType VerificationType) error
 }

--- a/stores/fs/fsapikey_store.go
+++ b/stores/fs/fsapikey_store.go
@@ -39,9 +39,9 @@ func (s *FSAPIKeyStore) getKeyPath(keyID string) (string, error) {
 	return filepath.Join(s.getKeyDir(), safeID+".json"), nil
 }
 
-// CreateAPIKey creates a new API key and returns the full key (only shown once)
-// The key format is: keyID + "_" + secret
-func (s *FSAPIKeyStore) CreateAPIKey(userID, name string, scopes []string, expiresAt *time.Time) (fullKey string, apiKey *core.APIKey, err error) {
+// CreateAPIKey creates a new API key for the given subject and returns the full key (only shown once).
+// The key format is: keyID + "_" + secret.
+func (s *FSAPIKeyStore) CreateAPIKey(subject, name string, scopes []string, expiresAt *time.Time) (fullKey string, apiKey *core.APIKey, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -66,7 +66,7 @@ func (s *FSAPIKeyStore) CreateAPIKey(userID, name string, scopes []string, expir
 	apiKey = &core.APIKey{
 		KeyID:      keyID,
 		KeyHash:    string(keyHash),
-		UserID:     userID,
+		Subject:    subject,
 		Name:       name,
 		Scopes:     scopes,
 		CreatedAt:  now,
@@ -191,8 +191,8 @@ func (s *FSAPIKeyStore) RevokeAPIKey(keyID string) error {
 	return s.saveKey(apiKey)
 }
 
-// ListUserAPIKeys returns all API keys for a user (without secrets)
-func (s *FSAPIKeyStore) ListUserAPIKeys(userID string) ([]*core.APIKey, error) {
+// ListSubjectAPIKeys returns all API keys owned by a subject (without secrets).
+func (s *FSAPIKeyStore) ListSubjectAPIKeys(subject string) ([]*core.APIKey, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -223,7 +223,7 @@ func (s *FSAPIKeyStore) ListUserAPIKeys(userID string) ([]*core.APIKey, error) {
 			continue
 		}
 
-		if apiKey.UserID == userID {
+		if apiKey.Subject == subject {
 			// Clear the hash for security (not needed in listings)
 			apiKey.KeyHash = ""
 			keys = append(keys, &apiKey)

--- a/stores/fs/fsrefreshtoken_store.go
+++ b/stores/fs/fsrefreshtoken_store.go
@@ -35,8 +35,8 @@ func (s *FSRefreshTokenStore) getTokenPath(token string) string {
 	return filepath.Join(s.getTokenDir(), filename)
 }
 
-// CreateRefreshToken creates a new refresh token for a user
-func (s *FSRefreshTokenStore) CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
+// CreateRefreshToken creates a new refresh token for the given subject.
+func (s *FSRefreshTokenStore) CreateRefreshToken(subject, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -54,7 +54,7 @@ func (s *FSRefreshTokenStore) CreateRefreshToken(userID, clientID string, device
 	refreshToken := &core.RefreshToken{
 		Token:      token,
 		TokenHash:  s.hashToken(token),
-		UserID:     userID,
+		Subject:    subject,
 		ClientID:   clientID,
 		DeviceInfo: deviceInfo,
 		Family:     family[:16], // Use first 16 chars as family ID
@@ -160,7 +160,7 @@ func (s *FSRefreshTokenStore) RotateRefreshToken(oldToken string) (*core.Refresh
 	refreshToken := &core.RefreshToken{
 		Token:                newToken,
 		TokenHash:            s.hashToken(newToken),
-		UserID:               old.UserID,
+		Subject:              old.Subject,
 		ClientID:             old.ClientID,
 		DeviceInfo:           old.DeviceInfo,
 		Family:               old.Family,
@@ -203,13 +203,13 @@ func (s *FSRefreshTokenStore) RevokeRefreshToken(token string) error {
 	return s.saveToken(refreshToken)
 }
 
-// RevokeUserTokens revokes all refresh tokens for a user
-func (s *FSRefreshTokenStore) RevokeUserTokens(userID string) error {
+// RevokeSubjectTokens revokes all refresh tokens belonging to a subject.
+func (s *FSRefreshTokenStore) RevokeSubjectTokens(subject string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	return s.forEachToken(func(token *core.RefreshToken, path string) error {
-		if token.UserID == userID && !token.Revoked {
+		if token.Subject == subject && !token.Revoked {
 			now := time.Now()
 			token.Revoked = true
 			token.RevokedAt = &now
@@ -243,14 +243,15 @@ func (s *FSRefreshTokenStore) RevokeTokenFamily(family string) error {
 	})
 }
 
-// GetUserTokens lists all active (non-revoked, non-expired) refresh tokens for a user
-func (s *FSRefreshTokenStore) GetUserTokens(userID string) ([]*core.RefreshToken, error) {
+// GetSubjectTokens lists all active (non-revoked, non-expired) refresh
+// tokens belonging to a subject.
+func (s *FSRefreshTokenStore) GetSubjectTokens(subject string) ([]*core.RefreshToken, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var tokens []*core.RefreshToken
 	err := s.forEachToken(func(token *core.RefreshToken, path string) error {
-		if token.UserID == userID && token.IsValid() {
+		if token.Subject == subject && token.IsValid() {
 			// Don't include the actual token value for security
 			tokenCopy := *token
 			tokenCopy.Token = "" // Clear token value

--- a/stores/fs/fstoken_store.go
+++ b/stores/fs/fstoken_store.go
@@ -29,7 +29,7 @@ func (s *FSTokenStore) getTokenPath(token string) (string, error) {
 	return filepath.Join(s.StoragePath, "tokens", safeToken+".json"), nil
 }
 
-func (s *FSTokenStore) CreateToken(userID, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
+func (s *FSTokenStore) CreateToken(subject, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (s *FSTokenStore) CreateToken(userID, email string, tokenType localauth.Ver
 	verToken := &localauth.VerificationToken{
 		Token:     token,
 		Type:      tokenType,
-		UserID:    userID,
+		Subject:    subject,
 		Email:     email,
 		CreatedAt: time.Now(),
 		ExpiresAt: time.Now().Add(expiryDuration),
@@ -104,7 +104,7 @@ func (s *FSTokenStore) DeleteToken(token string) error {
 	return err
 }
 
-func (s *FSTokenStore) DeleteUserTokens(userID string, tokenType localauth.VerificationType) error {
+func (s *FSTokenStore) DeleteSubjectTokens(subject string, tokenType localauth.VerificationType) error {
 	tokensDir := filepath.Join(s.StoragePath, "tokens")
 	entries, err := os.ReadDir(tokensDir)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *FSTokenStore) DeleteUserTokens(userID string, tokenType localauth.Verif
 			continue
 		}
 
-		if verToken.UserID == userID && verToken.Type == tokenType {
+		if verToken.Subject == subject && verToken.Type == tokenType {
 			_ = os.Remove(filepath.Join(tokensDir, entry.Name()))
 		}
 	}

--- a/stores/gae/models.go
+++ b/stores/gae/models.go
@@ -77,7 +77,7 @@ type ChannelEntity struct {
 type VerificationTokenEntity struct {
 	Key       *datastore.Key            `datastore:"__key__"`
 	Type      localauth.VerificationType `datastore:"type"`
-	UserID    string                    `datastore:"user_id"`
+	Subject   string                    `datastore:"subject"`
 	Email     string                    `datastore:"email"`
 	CreatedAt time.Time                 `datastore:"created_at"`
 	ExpiresAt time.Time                 `datastore:"expires_at"`
@@ -87,7 +87,7 @@ func (e *VerificationTokenEntity) ToVerificationToken() *localauth.VerificationT
 	return &localauth.VerificationToken{
 		Token:     e.Key.Name,
 		Type:      e.Type,
-		UserID:    e.UserID,
+		Subject:   e.Subject,
 		Email:     e.Email,
 		CreatedAt: e.CreatedAt,
 		ExpiresAt: e.ExpiresAt,
@@ -98,7 +98,7 @@ func VerificationTokenToEntity(t *localauth.VerificationToken, key *datastore.Ke
 	return &VerificationTokenEntity{
 		Key:       key,
 		Type:      t.Type,
-		UserID:    t.UserID,
+		Subject:   t.Subject,
 		Email:     t.Email,
 		CreatedAt: t.CreatedAt,
 		ExpiresAt: t.ExpiresAt,
@@ -108,7 +108,7 @@ func VerificationTokenToEntity(t *localauth.VerificationToken, key *datastore.Ke
 // RefreshTokenEntity is the Datastore entity for refresh tokens
 type RefreshTokenEntity struct {
 	Key                  *datastore.Key `datastore:"__key__"` // Key is the token hash
-	UserID               string         `datastore:"user_id"`
+	Subject              string         `datastore:"subject"`
 	ClientID             string         `datastore:"client_id,omitempty"`
 	DeviceInfo           []byte         `datastore:"device_info,noindex"`            // JSON encoded
 	Family               string         `datastore:"family"`
@@ -126,7 +126,7 @@ type RefreshTokenEntity struct {
 type APIKeyEntity struct {
 	Key        *datastore.Key `datastore:"__key__"` // Key is the KeyID
 	KeyHash    string         `datastore:"key_hash,noindex"`
-	UserID     string         `datastore:"user_id"`
+	Subject    string         `datastore:"subject"`
 	Name       string         `datastore:"name"`
 	Scopes     []byte         `datastore:"scopes,noindex"` // JSON encoded
 	CreatedAt  time.Time      `datastore:"created_at"`

--- a/stores/gae/stores.go
+++ b/stores/gae/stores.go
@@ -513,7 +513,7 @@ func (s *TokenStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
-func (s *TokenStore) CreateToken(userID, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
+func (s *TokenStore) CreateToken(subject, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -524,7 +524,7 @@ func (s *TokenStore) CreateToken(userID, email string, tokenType localauth.Verif
 	entity := &VerificationTokenEntity{
 		Key:       key,
 		Type:      tokenType,
-		UserID:    userID,
+		Subject:   subject,
 		Email:     email,
 		CreatedAt: now,
 		ExpiresAt: now.Add(expiryDuration),
@@ -537,7 +537,7 @@ func (s *TokenStore) CreateToken(userID, email string, tokenType localauth.Verif
 	return &localauth.VerificationToken{
 		Token:     token,
 		Type:      tokenType,
-		UserID:    userID,
+		Subject:   subject,
 		Email:     email,
 		CreatedAt: now,
 		ExpiresAt: now.Add(expiryDuration),
@@ -568,9 +568,9 @@ func (s *TokenStore) DeleteToken(token string) error {
 	return s.client.Delete(s.ctx, key)
 }
 
-func (s *TokenStore) DeleteUserTokens(userID string, tokenType localauth.VerificationType) error {
+func (s *TokenStore) DeleteSubjectTokens(subject string, tokenType localauth.VerificationType) error {
 	query := datastore.NewQuery(KindAuthToken).
-		FilterField("user_id", "=", userID).
+		FilterField("subject", "=", subject).
 		FilterField("type", "=", string(tokenType)).
 		KeysOnly()
 	if s.namespace != "" {
@@ -628,7 +628,7 @@ func (s *RefreshTokenStore) hashToken(token string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-func (s *RefreshTokenStore) CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
+func (s *RefreshTokenStore) CreateRefreshToken(subject, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -653,7 +653,7 @@ func (s *RefreshTokenStore) CreateRefreshToken(userID, clientID string, deviceIn
 	key := s.namespacedKey(KindRefreshToken, tokenHash)
 	entity := &RefreshTokenEntity{
 		Key:        key,
-		UserID:     userID,
+		Subject:    subject,
 		ClientID:   clientID,
 		DeviceInfo: deviceBytes,
 		Family:     family[:16],
@@ -672,7 +672,7 @@ func (s *RefreshTokenStore) CreateRefreshToken(userID, clientID string, deviceIn
 	return &core.RefreshToken{
 		Token:      token,
 		TokenHash:  tokenHash,
-		UserID:     userID,
+		Subject:    subject,
 		ClientID:   clientID,
 		DeviceInfo: deviceInfo,
 		Family:     family[:16],
@@ -701,7 +701,7 @@ func (s *RefreshTokenStore) entityToToken(entity *RefreshTokenEntity) *core.Refr
 
 	rt := &core.RefreshToken{
 		TokenHash:            entity.Key.Name,
-		UserID:               entity.UserID,
+		Subject:              entity.Subject,
 		ClientID:             entity.ClientID,
 		DeviceInfo:           deviceInfo,
 		Family:               entity.Family,
@@ -794,7 +794,7 @@ func (s *RefreshTokenStore) RotateRefreshToken(oldToken string) (*core.RefreshTo
 
 		newEntity := &RefreshTokenEntity{
 			Key:                  newKey,
-			UserID:               oldRT.UserID,
+			Subject:              oldRT.Subject,
 			ClientID:             oldRT.ClientID,
 			DeviceInfo:           deviceBytes,
 			Family:               oldRT.Family,
@@ -814,7 +814,7 @@ func (s *RefreshTokenStore) RotateRefreshToken(oldToken string) (*core.RefreshTo
 		newRefreshToken = &core.RefreshToken{
 			Token:                newTokenStr,
 			TokenHash:            newHash,
-			UserID:               oldRT.UserID,
+			Subject:              oldRT.Subject,
 			ClientID:             oldRT.ClientID,
 			DeviceInfo:           oldRT.DeviceInfo,
 			Family:               oldRT.Family,
@@ -871,9 +871,9 @@ func (s *RefreshTokenStore) RevokeRefreshToken(token string) error {
 	return err
 }
 
-func (s *RefreshTokenStore) RevokeUserTokens(userID string) error {
+func (s *RefreshTokenStore) RevokeSubjectTokens(subject string) error {
 	query := datastore.NewQuery(KindRefreshToken).
-		FilterField("user_id", "=", userID).
+		FilterField("subject", "=", subject).
 		FilterField("revoked", "=", false)
 	if s.namespace != "" {
 		query = query.Namespace(s.namespace)
@@ -931,9 +931,9 @@ func (s *RefreshTokenStore) RevokeTokenFamily(family string) error {
 	return nil
 }
 
-func (s *RefreshTokenStore) GetUserTokens(userID string) ([]*core.RefreshToken, error) {
+func (s *RefreshTokenStore) GetSubjectTokens(subject string) ([]*core.RefreshToken, error) {
 	query := datastore.NewQuery(KindRefreshToken).
-		FilterField("user_id", "=", userID).
+		FilterField("subject", "=", subject).
 		FilterField("revoked", "=", false)
 	if s.namespace != "" {
 		query = query.Namespace(s.namespace)
@@ -1037,7 +1037,7 @@ func (s *APIKeyStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
-func (s *APIKeyStore) CreateAPIKey(userID, name string, scopes []string, expiresAt *time.Time) (string, *core.APIKey, error) {
+func (s *APIKeyStore) CreateAPIKey(subject, name string, scopes []string, expiresAt *time.Time) (string, *core.APIKey, error) {
 	keyID, err := core.GenerateAPIKeyID()
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to generate key ID: %w", err)
@@ -1064,7 +1064,7 @@ func (s *APIKeyStore) CreateAPIKey(userID, name string, scopes []string, expires
 	entity := &APIKeyEntity{
 		Key:        key,
 		KeyHash:    string(keyHash),
-		UserID:     userID,
+		Subject:    subject,
 		Name:       name,
 		Scopes:     scopeBytes,
 		CreatedAt:  now,
@@ -1084,7 +1084,7 @@ func (s *APIKeyStore) CreateAPIKey(userID, name string, scopes []string, expires
 	return fullKey, &core.APIKey{
 		KeyID:      keyID,
 		KeyHash:    string(keyHash),
-		UserID:     userID,
+		Subject:    subject,
 		Name:       name,
 		Scopes:     scopes,
 		CreatedAt:  now,
@@ -1103,7 +1103,7 @@ func (s *APIKeyStore) entityToAPIKey(entity *APIKeyEntity) *core.APIKey {
 	apiKey := &core.APIKey{
 		KeyID:      entity.Key.Name,
 		KeyHash:    entity.KeyHash,
-		UserID:     entity.UserID,
+		Subject:    entity.Subject,
 		Name:       entity.Name,
 		Scopes:     scopes,
 		CreatedAt:  entity.CreatedAt,
@@ -1187,9 +1187,9 @@ func (s *APIKeyStore) RevokeAPIKey(keyID string) error {
 	return err
 }
 
-func (s *APIKeyStore) ListUserAPIKeys(userID string) ([]*core.APIKey, error) {
+func (s *APIKeyStore) ListSubjectAPIKeys(subject string) ([]*core.APIKey, error) {
 	query := datastore.NewQuery(KindAPIKey).
-		FilterField("user_id", "=", userID)
+		FilterField("subject", "=", subject)
 	if s.namespace != "" {
 		query = query.Namespace(s.namespace)
 	}

--- a/stores/gorm/models.go
+++ b/stores/gorm/models.go
@@ -178,7 +178,7 @@ func ChannelToModel(c *accounts.Channel) *ChannelModel {
 type VerificationTokenModel struct {
 	Token     string                     `gorm:"primaryKey;size:128"`
 	Type      localauth.VerificationType `gorm:"size:32;index"`
-	UserID    string                     `gorm:"size:64;index"`
+	Subject   string                     `gorm:"size:64;index"`
 	Email     string                     `gorm:"size:255"`
 	CreatedAt time.Time                  `gorm:"autoCreateTime"`
 	ExpiresAt time.Time                  `gorm:"index"`
@@ -192,7 +192,7 @@ func (m *VerificationTokenModel) ToVerificationToken() *localauth.VerificationTo
 	return &localauth.VerificationToken{
 		Token:     m.Token,
 		Type:      m.Type,
-		UserID:    m.UserID,
+		Subject:   m.Subject,
 		Email:     m.Email,
 		CreatedAt: m.CreatedAt,
 		ExpiresAt: m.ExpiresAt,
@@ -203,7 +203,7 @@ func VerificationTokenToModel(t *localauth.VerificationToken) *VerificationToken
 	return &VerificationTokenModel{
 		Token:     t.Token,
 		Type:      t.Type,
-		UserID:    t.UserID,
+		Subject:   t.Subject,
 		Email:     t.Email,
 		CreatedAt: t.CreatedAt,
 		ExpiresAt: t.ExpiresAt,
@@ -214,7 +214,7 @@ func VerificationTokenToModel(t *localauth.VerificationToken) *VerificationToken
 type RefreshTokenModel struct {
 	TokenHash  string      `gorm:"primaryKey;size:64"`
 	Token      string      `gorm:"-"` // Not stored, only used in memory
-	UserID     string      `gorm:"size:64;index"`
+	Subject    string      `gorm:"size:64;index"`
 	ClientID   string      `gorm:"size:64"`
 	DeviceInfo JSONMap     `gorm:"type:jsonb"`
 	Family     string      `gorm:"size:32;index"`
@@ -236,7 +236,7 @@ func (m *RefreshTokenModel) ToRefreshToken() *core.RefreshToken {
 	return &core.RefreshToken{
 		Token:                m.Token,
 		TokenHash:            m.TokenHash,
-		UserID:               m.UserID,
+		Subject:              m.Subject,
 		ClientID:             m.ClientID,
 		DeviceInfo:           m.DeviceInfo,
 		Family:               m.Family,
@@ -255,7 +255,7 @@ func RefreshTokenToModel(t *core.RefreshToken) *RefreshTokenModel {
 	return &RefreshTokenModel{
 		Token:                t.Token,
 		TokenHash:            t.TokenHash,
-		UserID:               t.UserID,
+		Subject:              t.Subject,
 		ClientID:             t.ClientID,
 		DeviceInfo:           JSONMap(t.DeviceInfo),
 		Family:               t.Family,
@@ -274,7 +274,7 @@ func RefreshTokenToModel(t *core.RefreshToken) *RefreshTokenModel {
 type APIKeyModel struct {
 	KeyID      string      `gorm:"primaryKey;size:64"`
 	KeyHash    string      `gorm:"size:128"`
-	UserID     string      `gorm:"size:64;index"`
+	Subject    string      `gorm:"size:64;index"`
 	Name       string      `gorm:"size:255"`
 	Scopes     StringSlice `gorm:"type:jsonb"`
 	CreatedAt  time.Time   `gorm:"autoCreateTime"`
@@ -292,7 +292,7 @@ func (m *APIKeyModel) ToAPIKey() *core.APIKey {
 	return &core.APIKey{
 		KeyID:      m.KeyID,
 		KeyHash:    m.KeyHash,
-		UserID:     m.UserID,
+		Subject:    m.Subject,
 		Name:       m.Name,
 		Scopes:     m.Scopes,
 		CreatedAt:  m.CreatedAt,
@@ -307,7 +307,7 @@ func APIKeyToModel(k *core.APIKey) *APIKeyModel {
 	return &APIKeyModel{
 		KeyID:      k.KeyID,
 		KeyHash:    k.KeyHash,
-		UserID:     k.UserID,
+		Subject:    k.Subject,
 		Name:       k.Name,
 		Scopes:     StringSlice(k.Scopes),
 		CreatedAt:  k.CreatedAt,

--- a/stores/gorm/stores.go
+++ b/stores/gorm/stores.go
@@ -225,7 +225,7 @@ func NewTokenStore(db *gorm.DB) *TokenStore {
 	return &TokenStore{db: db}
 }
 
-func (s *TokenStore) CreateToken(userID, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
+func (s *TokenStore) CreateToken(subject, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -234,7 +234,7 @@ func (s *TokenStore) CreateToken(userID, email string, tokenType localauth.Verif
 	model := &VerificationTokenModel{
 		Token:     token,
 		Type:      tokenType,
-		UserID:    userID,
+		Subject:   subject,
 		Email:     email,
 		ExpiresAt: time.Now().Add(expiryDuration),
 	}
@@ -268,8 +268,8 @@ func (s *TokenStore) DeleteToken(token string) error {
 	return s.db.Delete(&VerificationTokenModel{}, "token = ?", token).Error
 }
 
-func (s *TokenStore) DeleteUserTokens(userID string, tokenType localauth.VerificationType) error {
-	return s.db.Delete(&VerificationTokenModel{}, "user_id = ? AND type = ?", userID, tokenType).Error
+func (s *TokenStore) DeleteSubjectTokens(subject string, tokenType localauth.VerificationType) error {
+	return s.db.Delete(&VerificationTokenModel{}, "subject = ? AND type = ?", subject, tokenType).Error
 }
 
 // =============================================================================
@@ -290,7 +290,7 @@ func (s *RefreshTokenStore) hashToken(token string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-func (s *RefreshTokenStore) CreateRefreshToken(userID, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
+func (s *RefreshTokenStore) CreateRefreshToken(subject, clientID string, deviceInfo map[string]any, scopes []string) (*core.RefreshToken, error) {
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -305,7 +305,7 @@ func (s *RefreshTokenStore) CreateRefreshToken(userID, clientID string, deviceIn
 	model := &RefreshTokenModel{
 		TokenHash:  s.hashToken(token),
 		Token:      token,
-		UserID:     userID,
+		Subject:    subject,
 		ClientID:   clientID,
 		DeviceInfo: deviceInfo,
 		Family:     family[:16],
@@ -381,7 +381,7 @@ func (s *RefreshTokenStore) RotateRefreshToken(oldToken string) (*core.RefreshTo
 
 		newModel := &RefreshTokenModel{
 			TokenHash:            s.hashToken(newToken),
-			UserID:               oldModel.UserID,
+			Subject:              oldModel.Subject,
 			ClientID:             oldModel.ClientID,
 			DeviceInfo:           oldModel.DeviceInfo,
 			Family:               oldModel.Family,
@@ -417,10 +417,10 @@ func (s *RefreshTokenStore) RevokeRefreshToken(token string) error {
 		Updates(map[string]any{"revoked": true, "revoked_at": now}).Error
 }
 
-func (s *RefreshTokenStore) RevokeUserTokens(userID string) error {
+func (s *RefreshTokenStore) RevokeSubjectTokens(subject string) error {
 	now := time.Now()
 	return s.db.Model(&RefreshTokenModel{}).
-		Where("user_id = ? AND revoked = ?", userID, false).
+		Where("subject = ? AND revoked = ?", subject, false).
 		Updates(map[string]any{"revoked": true, "revoked_at": now}).Error
 }
 
@@ -431,9 +431,9 @@ func (s *RefreshTokenStore) RevokeTokenFamily(family string) error {
 		Updates(map[string]any{"revoked": true, "revoked_at": now}).Error
 }
 
-func (s *RefreshTokenStore) GetUserTokens(userID string) ([]*core.RefreshToken, error) {
+func (s *RefreshTokenStore) GetSubjectTokens(subject string) ([]*core.RefreshToken, error) {
 	var models []RefreshTokenModel
-	if err := s.db.Where("user_id = ? AND revoked = ? AND expires_at > ?", userID, false, time.Now()).
+	if err := s.db.Where("subject = ? AND revoked = ? AND expires_at > ?", subject, false, time.Now()).
 		Find(&models).Error; err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func NewAPIKeyStore(db *gorm.DB) *APIKeyStore {
 	return &APIKeyStore{db: db}
 }
 
-func (s *APIKeyStore) CreateAPIKey(userID, name string, scopes []string, expiresAt *time.Time) (string, *core.APIKey, error) {
+func (s *APIKeyStore) CreateAPIKey(subject, name string, scopes []string, expiresAt *time.Time) (string, *core.APIKey, error) {
 	keyID, err := core.GenerateAPIKeyID()
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to generate key ID: %w", err)
@@ -486,7 +486,7 @@ func (s *APIKeyStore) CreateAPIKey(userID, name string, scopes []string, expires
 	model := &APIKeyModel{
 		KeyID:      keyID,
 		KeyHash:    string(keyHash),
-		UserID:     userID,
+		Subject:    subject,
 		Name:       name,
 		Scopes:     scopes,
 		ExpiresAt:  expiresAt,
@@ -563,9 +563,9 @@ func (s *APIKeyStore) RevokeAPIKey(keyID string) error {
 		Updates(map[string]any{"revoked": true, "revoked_at": now}).Error
 }
 
-func (s *APIKeyStore) ListUserAPIKeys(userID string) ([]*core.APIKey, error) {
+func (s *APIKeyStore) ListSubjectAPIKeys(subject string) ([]*core.APIKey, error) {
 	var models []APIKeyModel
-	if err := s.db.Where("user_id = ?", userID).Find(&models).Error; err != nil {
+	if err := s.db.Where("subject = ?", subject).Find(&models).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Phase 1 of the Subject vocab rename (PR 2). Foundation only — token-bearing types and their storage interfaces. Consumer-side helper / context / grpc / session-cookie renames land in PR 2b.

## What changes

The principal field on token-bearing types renames from `UserID` to `Subject` (RFC 7519 `sub`). The previous name was misleading in `client_credentials` flows where the principal is a service account, not a human user.

- `core.RefreshToken.Subject` (`json:"subject"`)
- `core.APIKey.Subject` (`json:"subject"`)
- `localauth.VerificationToken.Subject` (`json:"subject"`)
- `RefreshTokenStore.{CreateRefreshToken(subject,...), GetSubjectTokens, RevokeSubjectTokens}`
- `APIKeyStore.{CreateAPIKey(subject,...), ListSubjectAPIKeys}`
- `VerificationTokenStore.{CreateToken(subject,...), DeleteSubjectTokens}`

All three backends (`stores/fs`, `stores/gorm`, `stores/gae`) updated; models renamed in lock-step. GORM column names and GAE Datastore property names track the field renames — **storage migration required.**

`accounts.User`, `accounts.Identity.UserID`, `accounts.Username.UserID`, `UserStore`, and the `httpauth` public surface all stay unchanged.

## Reviewer's guide

1. [core/tokens.go](https://github.com/panyam/oneauth/pull/214/files#diff-1c38c2a4084104e416d9cb0ec24ada77c480eab0f6540fb77cf154bb3c1fd10c) — start here. Field + JSON tag renames on `RefreshToken` and `APIKey`. Compare against the migration doc — these JSON-tag changes are the cause of stored-data migration.
2. [core/stores.go](https://github.com/panyam/oneauth/pull/214/files#diff-b007670d758df4825ec0b9ef1f1da3029e2b41b85905770a6216e6b1c544cb84) — `RefreshTokenStore` and `APIKeyStore` interface method renames.
3. [localauth/verification.go](https://github.com/panyam/oneauth/pull/214/files#diff-c24ba625110c15425b59700cbe321421caf3543af33bbef801487ac45b053652) — `VerificationToken.Subject` field + `VerificationTokenStore` method renames. localauth verification is the third token-bearing type (and explicitly flipped per the design decision — see decision log).
4. [apiauth/auth.go](https://github.com/panyam/oneauth/pull/214/files#diff-6f548dbab24d0609200ec2c43738d8d522c8f3d3b5b288eae95c1dc06b239bf8), [apiauth/token_validator.go](https://github.com/panyam/oneauth/pull/214/files#diff-f9f7b35ad6cff7153c60ca3233a9dbd16b3c3dc4eb2f443916b6d6c9bb71e0e9) — internal consumers updated to the new field/method names. No public apiauth signature changes in this PR.
5. `stores/fs/`, `stores/gorm/`, `stores/gae/` — three backend implementations follow the new interfaces. Targeted edits — Identity / Username / User models stay untouched.
6. [docs/MIGRATION.md](https://github.com/panyam/oneauth/pull/214/files#diff-9069ee5e76909ff15e297f35234e161ce30629f025cd9072dddba403cc875c31) — start of the new v0.1.2 → v0.1.3 section. SQL + FS + Datastore migration recipes.
7. [docs/RELEASE_NOTES.md](https://github.com/panyam/oneauth/pull/214/files#diff-06470f44e11a4acf72ecac0f68c7438ff957181a677bbc006439d2532b9794b6) — v0.1.3 entry.

Skim / skip: test files (`apiauth/*_test.go` updates are mechanical field-name flips on existing fixtures).

## Decision log

- **Subject, not SubjectID.** RFC 7519 / Spring Security / JWT-libs / `crypto/x509.Subject` idiom all use `Subject` — the `ID` suffix would be "identifier of the identifier."
- **Storage-name flip too (full option A), not Go-API-only.** The repo is post-`v0.1.0` and pre-`v1.0`, no public production consumers yet — paying once is cheaper than living with `Go: Subject ↔ JSON: user_id` forever.
- **`accounts.*UserID` stays.** The `accounts.User`/`accounts.Identity`/`accounts.Username` model is the application's user-account model — always a human user, never a service account subject. Renaming it would obscure intent, not clarify it.
- **`localauth.VerificationToken.UserID` flipped.** Originally on the fence; uniformity won. Verification tokens are tokens too — same vocabulary applies.
- **Split foundation (PR 2a) from consumer signatures (PR 2b).** The full PR was 600+ LOC. Splitting at the token-type boundary makes each diff ~250 LOC and each PR independently bisectable.

## Risk / blast radius

- **Source-break for any caller** of `.UserID` on RefreshToken/APIKey/VerificationToken, or the renamed interface methods. Confirmed zero external callers (oneauth-private until first consumer bumps).
- **Wire format unchanged.** JWT `sub` claim, RFC 7662 introspection `sub` field, RFC 8693 token-exchange parameters — all already RFC-compliant. Only stored-data JSON tags and GORM/Datastore column/property names change.
- **Stored-data migration required.** GORM columns, FS JSON files, Datastore properties. Migration recipes in `docs/MIGRATION.md`. Affected consumers (notation) can use the recipes; others (no persisted state yet) can reset.
- **Tests covering this:** existing `apiauth/*_test.go`, `localauth/*_test.go`, `stores/fs/*_test.go`, `stores/gorm/*_test.go`, full `tests/e2e/`. All green.

## Out of scope (deferred to PR 2b)

- `core.GetUserIDFromContext` / `SetUserIDInContext` / `DefaultUserParamName="loggedInUserId"` constant
- `core.GetUserScopesFunc`
- `apiauth.PasswordGrantResponse.UserID`, `apiauth.TokenInfo.UserID`, `apiauth.GetUserIDFromAPIContext`
- `httpauth.Middleware.GetLoggedInUserId` internals (public surface stays — internals consume new core helpers in PR 2b)
- `grpc.UserIDFromContext` + `DefaultMetadataKeyUserID="x-user-id"` metadata header
- Session cookie key `loggedInUserId` (PR 2b invalidates active sessions)
- Tag v0.1.3 cut

PR 2b will be filed immediately after this merges.
