### PR TITLE
refactor: complete Subject vocab rename (PR 2b — consumers, helpers, transports)

### DIFF
--- a/apiauth/asymmetric_jwt_test.go
+++ b/apiauth/asymmetric_jwt_test.go
@@ -267,7 +267,7 @@ func TestAPIMiddleware_RS256_MultiTenant(t *testing.T) {
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		if userID != "user-1" {
 			t.Errorf("userID = %s, want user-1", userID)
 		}

--- a/apiauth/audience_test.go
+++ b/apiauth/audience_test.go
@@ -313,7 +313,7 @@ func TestAudience_ArrayAud_Middleware_Accepted(t *testing.T) {
 	token := mintToken(t, secret, arrayAudClaims([]string{"service-a", "service-b"}))
 
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		assert.Equal(t, "user1", userID)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -65,7 +65,7 @@ type APIAuth struct {
 
 	// Callbacks
 	ValidateCredentials CredentialsValidator            // Validates username/password
-	GetUserScopes       core.GetUserScopesFunc          // Returns allowed scopes for a user
+	GetSubjectScopes    core.GetSubjectScopesFunc          // Returns allowed scopes for the subject (user ID or client_id)
 	OnLoginSuccess      func(userID string, r *http.Request) // Optional: for logging/analytics
 	OnLoginFailure      func(username string, r *http.Request, err error) // Optional: for logging/analytics
 
@@ -227,9 +227,9 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
 
 	// Get user's allowed scopes
 	allowedScopes := []string{core.ScopeRead, core.ScopeWrite, core.ScopeProfile, core.ScopeOffline}
-	if a.GetUserScopes != nil {
+	if a.GetSubjectScopes != nil {
 		var err error
-		allowedScopes, err = a.GetUserScopes(user.Id())
+		allowedScopes, err = a.GetSubjectScopes(user.Id())
 		if err != nil {
 			log.Printf("Error getting user scopes: %v", err)
 			a.errorResponse(w, "server_error", "Failed to get user permissions", http.StatusInternalServerError)
@@ -486,7 +486,7 @@ func (a *APIAuth) HandleLogoutAll(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get user ID from context (set by middleware)
-	userID := core.GetUserIDFromContext(r.Context())
+	userID := core.GetSubjectFromContext(r.Context())
 	if userID == "" {
 		a.errorResponse(w, "unauthorized", "Authentication required", http.StatusUnauthorized)
 		return
@@ -511,7 +511,7 @@ func (a *APIAuth) HandleListSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get user ID from context
-	userID := core.GetUserIDFromContext(r.Context())
+	userID := core.GetSubjectFromContext(r.Context())
 	if userID == "" {
 		a.errorResponse(w, "unauthorized", "Authentication required", http.StatusUnauthorized)
 		return
@@ -873,7 +873,7 @@ func (a *APIAuth) HandleAPIKeys(w http.ResponseWriter, r *http.Request) {
 // handleListAPIKeys handles GET /api/keys - lists user's API keys
 func (a *APIAuth) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 	// Get user ID from context
-	userID := core.GetUserIDFromContext(r.Context())
+	userID := core.GetSubjectFromContext(r.Context())
 	if userID == "" {
 		a.errorResponse(w, "unauthorized", "Authentication required", http.StatusUnauthorized)
 		return
@@ -920,7 +920,7 @@ func (a *APIAuth) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 // handleCreateAPIKey handles POST /api/keys - creates a new API key
 func (a *APIAuth) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	// Get user ID from context
-	userID := core.GetUserIDFromContext(r.Context())
+	userID := core.GetSubjectFromContext(r.Context())
 	if userID == "" {
 		a.errorResponse(w, "unauthorized", "Authentication required", http.StatusUnauthorized)
 		return
@@ -945,9 +945,9 @@ func (a *APIAuth) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 
 	// Validate and limit scopes
 	allowedScopes := []string{core.ScopeRead, core.ScopeWrite, core.ScopeProfile}
-	if a.GetUserScopes != nil {
+	if a.GetSubjectScopes != nil {
 		var err error
-		allowedScopes, err = a.GetUserScopes(userID)
+		allowedScopes, err = a.GetSubjectScopes(userID)
 		if err != nil {
 			log.Printf("Error getting user scopes: %v", err)
 			a.errorResponse(w, "server_error", "Failed to get user permissions", http.StatusInternalServerError)
@@ -999,7 +999,7 @@ func (a *APIAuth) HandleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get user ID from context
-	userID := core.GetUserIDFromContext(r.Context())
+	userID := core.GetSubjectFromContext(r.Context())
 	if userID == "" {
 		a.errorResponse(w, "unauthorized", "Authentication required", http.StatusUnauthorized)
 		return
@@ -1053,7 +1053,7 @@ func (a *APIAuth) HandleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 type apiContextKey string
 
 const (
-	contextKeyUserID               apiContextKey = "api_user_id"
+	contextKeySubject               apiContextKey = "api_user_id"
 	contextKeyScopes               apiContextKey = "api_scopes"
 	contextKeyAuthType             apiContextKey = "api_auth_type" // "jwt" or "api_key"
 	contextKeyCustomClaims         apiContextKey = "api_custom_claims"
@@ -1111,11 +1111,13 @@ type APIMiddleware struct {
 	lazyValidator TokenValidator
 }
 
-// GetUserIDFromAPIContext retrieves the user ID from the API middleware context
-func GetUserIDFromAPIContext(ctx context.Context) string {
-	if v := ctx.Value(contextKeyUserID); v != nil {
-		if userID, ok := v.(string); ok {
-			return userID
+// GetSubjectFromAPIContext retrieves the authenticated subject (RFC 7519
+// `sub` — user ID for human-driven flows, client_id for
+// client_credentials) from the API middleware context.
+func GetSubjectFromAPIContext(ctx context.Context) string {
+	if v := ctx.Value(contextKeySubject); v != nil {
+		if subject, ok := v.(string); ok {
+			return subject
 		}
 	}
 	return ""
@@ -1302,7 +1304,7 @@ func (m *APIMiddleware) validateJWT(tokenString string) (userID string, scopes [
 		if len(info.AuthorizationDetails) > 0 {
 			customClaims["__authz_details"] = info.AuthorizationDetails
 		}
-		return info.UserID, info.Scopes, info.AuthType, customClaims, nil
+		return info.Subject, info.Scopes, info.AuthType, customClaims, nil
 	}
 
 	// Fallback: single-tenant JWTSecretKey validation (no KeyStore configured)
@@ -1571,7 +1573,7 @@ func toStringSlice(raw []any) []string {
 
 // setAuthContext sets all standard auth context values on the request context.
 func setAuthContext(ctx context.Context, userID string, scopes []string, authType string, customClaims map[string]any) context.Context {
-	ctx = context.WithValue(ctx, contextKeyUserID, userID)
+	ctx = context.WithValue(ctx, contextKeySubject, userID)
 	ctx = context.WithValue(ctx, contextKeyScopes, scopes)
 	ctx = context.WithValue(ctx, contextKeyAuthType, authType)
 	if customClaims != nil {
@@ -1582,7 +1584,7 @@ func setAuthContext(ctx context.Context, userID string, scopes []string, authTyp
 		}
 		ctx = context.WithValue(ctx, contextKeyCustomClaims, customClaims)
 	}
-	ctx = core.SetUserIDInContext(ctx, userID)
+	ctx = core.SetSubjectInContext(ctx, userID)
 	return ctx
 }
 

--- a/apiauth/auth_test.go
+++ b/apiauth/auth_test.go
@@ -52,7 +52,7 @@ func setupAPIAuthTest(t *testing.T) (*apiauth.APIAuth, *fs.FSRefreshTokenStore, 
 		JWTSecretKey:        "test-secret-key-for-testing-only",
 		JWTIssuer:           "oneauth-test",
 		ValidateCredentials: localauth.NewCredentialsValidator(identityStore, channelStore, userStore),
-		GetUserScopes: func(userID string) ([]string, error) {
+		GetSubjectScopes: func(userID string) ([]string, error) {
 			return []string{core.ScopeRead, core.ScopeWrite, core.ScopeProfile, core.ScopeOffline}, nil
 		},
 	}
@@ -329,7 +329,7 @@ func TestJWTValidation(t *testing.T) {
 
 	// Test handler that returns user info
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		scopes := apiauth.GetScopesFromAPIContext(r.Context())
 		authType := apiauth.GetAuthTypeFromAPIContext(r.Context())
 		json.NewEncoder(w).Encode(map[string]any{
@@ -482,7 +482,7 @@ func TestAPIKeyAuthentication(t *testing.T) {
 	}
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		authType := apiauth.GetAuthTypeFromAPIContext(r.Context())
 		json.NewEncoder(w).Encode(map[string]any{
 			"user_id":   userID,
@@ -557,7 +557,7 @@ func TestAPIKeyManagement(t *testing.T) {
 		body, _ := json.Marshal(createBody)
 		req := httptest.NewRequest(http.MethodPost, "/api/keys", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(core.SetUserIDInContext(req.Context(), userID))
+		req = req.WithContext(core.SetSubjectInContext(req.Context(), userID))
 		rr := httptest.NewRecorder()
 
 		apiAuth.HandleAPIKeys(rr, req)
@@ -585,7 +585,7 @@ func TestAPIKeyManagement(t *testing.T) {
 
 	t.Run("list API keys", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/keys", nil)
-		req = req.WithContext(core.SetUserIDInContext(req.Context(), userID))
+		req = req.WithContext(core.SetSubjectInContext(req.Context(), userID))
 		rr := httptest.NewRecorder()
 
 		apiAuth.HandleAPIKeys(rr, req)
@@ -608,7 +608,7 @@ func TestAPIKeyManagement(t *testing.T) {
 		}
 
 		req := httptest.NewRequest(http.MethodDelete, "/api/keys/"+createdKeyID, nil)
-		req = req.WithContext(core.SetUserIDInContext(req.Context(), userID))
+		req = req.WithContext(core.SetSubjectInContext(req.Context(), userID))
 		rr := httptest.NewRecorder()
 
 		apiAuth.HandleRevokeAPIKey(rr, req)
@@ -637,7 +637,7 @@ func TestOptionalMiddleware(t *testing.T) {
 	}
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		json.NewEncoder(w).Encode(map[string]any{
 			"user_id": userID,
 		})
@@ -726,7 +726,7 @@ func TestQueryParamToken(t *testing.T) {
 	}
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		json.NewEncoder(w).Encode(map[string]any{
 			"user_id": userID,
 		})
@@ -812,7 +812,7 @@ func TestCustomClaimsInContext(t *testing.T) {
 		JWTSecretKey:        "test-secret-custom-claims",
 		JWTIssuer:           "oneauth-test",
 		ValidateCredentials: localauth.NewCredentialsValidator(identityStore, channelStore, userStore),
-		GetUserScopes: func(userID string) ([]string, error) {
+		GetSubjectScopes: func(userID string) ([]string, error) {
 			return []string{core.ScopeRead, core.ScopeWrite}, nil
 		},
 		CustomClaimsFunc: func(userID string, scopes []string) (map[string]any, error) {

--- a/apiauth/custom_claims_test.go
+++ b/apiauth/custom_claims_test.go
@@ -162,7 +162,7 @@ func TestMultiTenantValidation_DifferentHosts(t *testing.T) {
 	}
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		json.NewEncoder(w).Encode(map[string]any{"user_id": userID})
 	})
 
@@ -302,7 +302,7 @@ func TestMultiTenantValidation_FallbackToSingleKey(t *testing.T) {
 	}
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		json.NewEncoder(w).Encode(map[string]any{"user_id": userID})
 	})
 

--- a/apiauth/interfaces.go
+++ b/apiauth/interfaces.go
@@ -104,13 +104,9 @@ type PasswordGrantRequest struct {
 }
 
 // PasswordGrantResponse holds the output of a successful password grant.
-// The caller uses UserID + GrantedScopes to create a refresh token if needed.
-//
-// (Renamed from PasswordGrantResult during the 175 convention port; the
-// PasswordGrantResult type alias below preserves the old name for one
-// release as a deprecation bridge.)
+// The caller uses Subject + GrantedScopes to create a refresh token if needed.
 type PasswordGrantResponse struct {
-	UserID               string
+	Subject              string // RFC 7519 sub — user ID for password grant
 	AccessToken          string
 	ExpiresIn            int64
 	GrantedScopes        []string
@@ -292,8 +288,10 @@ type AuthenticateClientResponse struct {
 // TokenInfo holds the validated claims extracted from a token.
 // Returned wrapped inside ValidateTokenResponse.
 type TokenInfo struct {
-	// UserID is the subject (sub claim) — a user ID or client_id.
-	UserID string
+	// Subject is the principal the token represents (RFC 7519 sub) — a
+	// user ID for human-driven flows or a client_id for
+	// client_credentials.
+	Subject string
 
 	// Scopes are the granted scopes from the token.
 	Scopes []string

--- a/apiauth/introspection_client_test.go
+++ b/apiauth/introspection_client_test.go
@@ -227,7 +227,7 @@ func TestIntrospectionClient_MiddlewareIntegration(t *testing.T) {
 
 	var extractedUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		extractedUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		extractedUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/apiauth/oneauth.go
+++ b/apiauth/oneauth.go
@@ -61,7 +61,7 @@ type OneAuthConfig struct {
 
 	// Password grant callbacks (optional — only needed if password grant is used)
 	ValidateCredentials CredentialsValidator    // validates username/password
-	GetUserScopes       core.GetUserScopesFunc  // returns allowed scopes for a user
+	GetSubjectScopes    core.GetSubjectScopesFunc // returns allowed scopes for the subject (user ID or client_id)
 
 	// Hooks — lifecycle callbacks
 	Hooks Hooks
@@ -85,7 +85,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 		ClientKeyLookup:     cfg.KeyStore, // KeyStorage implements KeyLookup
 		RefreshStore:        cfg.RefreshStore,
 		ValidateCredentials: cfg.ValidateCredentials,
-		GetUserScopes:       cfg.GetUserScopes,
+		GetSubjectScopes:    cfg.GetSubjectScopes,
 		Hooks:               cfg.Hooks.Token,
 	})
 

--- a/apiauth/oneauth_grants_test.go
+++ b/apiauth/oneauth_grants_test.go
@@ -45,7 +45,7 @@ func TestOneAuth_RefreshGrant(t *testing.T) {
 
 	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tp.AccessToken})
 	require.NoError(t, err)
-	assert.Equal(t, "refresh-user", vresp.Info.UserID)
+	assert.Equal(t, "refresh-user", vresp.Info.Subject)
 }
 
 // TestOneAuth_RefreshGrant_RevokedToken verifies that refreshing a revoked
@@ -96,7 +96,7 @@ func newTestOneAuthWithPasswordGrant(t *testing.T) *apiauth.OneAuth {
 			}
 			return nil, fmt.Errorf("invalid credentials")
 		},
-		GetUserScopes: func(userID string) ([]string, error) {
+		GetSubjectScopes: func(userID string) ([]string, error) {
 			return []string{"read", "write", "profile"}, nil
 		},
 	})
@@ -115,14 +115,14 @@ func TestOneAuth_PasswordGrant(t *testing.T) {
 		Scopes:   []string{"read"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "user-alice", result.UserID)
+	assert.Equal(t, "user-alice", result.Subject)
 	assert.NotEmpty(t, result.AccessToken)
 	assert.True(t, result.ExpiresIn > 0)
 	assert.Equal(t, []string{"read"}, result.GrantedScopes)
 
 	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: result.AccessToken})
 	require.NoError(t, err)
-	assert.Equal(t, "user-alice", vresp.Info.UserID)
+	assert.Equal(t, "user-alice", vresp.Info.Subject)
 }
 
 // TestOneAuth_PasswordGrant_BadPassword verifies that wrong credentials
@@ -183,7 +183,7 @@ func TestOneAuth_PasswordGrant_CallerCreatesRefreshToken(t *testing.T) {
 
 	// Step 2: Caller creates refresh token with transport metadata
 	rt, err := oa.RefreshStore.CreateRefreshToken(
-		result.UserID, "my-app",
+		result.Subject, "my-app",
 		map[string]any{"user_agent": "TestBot/1.0", "ip": "127.0.0.1"},
 		result.GrantedScopes,
 	)

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -84,7 +84,7 @@ func TestOneAuth_ValidateToken(t *testing.T) {
 	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tok.Token})
 	require.NoError(t, err)
 	info := vresp.Info
-	assert.Equal(t, "bob", info.UserID)
+	assert.Equal(t, "bob", info.Subject)
 	assert.Equal(t, []string{"read"}, info.Scopes)
 	assert.Equal(t, "jwt", info.AuthType)
 }
@@ -209,7 +209,7 @@ func TestOneAuth_ClientCredentials(t *testing.T) {
 	// Token should be valid
 	vresp, err := oa.Validator.ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tp.AccessToken})
 	require.NoError(t, err)
-	assert.Equal(t, "test-client", vresp.Info.UserID) // sub = client_id for CC
+	assert.Equal(t, "test-client", vresp.Info.Subject) // sub = client_id for CC
 }
 
 // TestOneAuth_ClientCredentials_BadSecret verifies that bad credentials
@@ -411,7 +411,7 @@ func TestOneAuth_HTTPMiddleware(t *testing.T) {
 	token := tok.Token
 
 	handler := mw.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		w.Write([]byte(userID))
 	}))
 

--- a/apiauth/token_introspector.go
+++ b/apiauth/token_introspector.go
@@ -39,7 +39,7 @@ func (ti *tokenIntrospector) Introspect(ctx context.Context, req *IntrospectRequ
 
 	result := &IntrospectionResult{
 		Active:    true,
-		Sub:       info.UserID,
+		Sub:       info.Subject,
 		TokenType: "access_token",
 	}
 

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -134,7 +134,7 @@ func (v *jwtValidator) ValidateToken(ctx context.Context, req *ValidateTokenRequ
 	}
 
 	return &ValidateTokenResponse{Info: &TokenInfo{
-		UserID:               userID,
+		Subject:              userID,
 		Scopes:               scopes,
 		AuthorizationDetails: authzDetails,
 		CustomClaims:         customClaims,
@@ -233,7 +233,7 @@ type jwtIssuer struct {
 	clientKeyLookup     keys.KeyLookup
 	refreshStore        core.RefreshTokenStore
 	validateCredentials CredentialsValidator
-	getUserScopes       core.GetUserScopesFunc
+	getSubjectScopes    core.GetSubjectScopesFunc
 	hooks               TokenHooks
 }
 
@@ -247,7 +247,7 @@ type JWTIssuerConfig struct {
 	ClientKeyLookup     keys.KeyLookup         // for client_credentials authentication
 	RefreshStore        core.RefreshTokenStore  // for refresh_token grant
 	ValidateCredentials CredentialsValidator // for password grant
-	GetUserScopes       core.GetUserScopesFunc   // for password grant (optional)
+	GetSubjectScopes    core.GetSubjectScopesFunc // for password grant (optional)
 	Hooks               TokenHooks
 }
 
@@ -266,7 +266,7 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer {
 		clientKeyLookup:     cfg.ClientKeyLookup,
 		refreshStore:        cfg.RefreshStore,
 		validateCredentials: cfg.ValidateCredentials,
-		getUserScopes:       cfg.GetUserScopes,
+		getSubjectScopes:    cfg.GetSubjectScopes,
 		hooks:               cfg.Hooks,
 	}
 }
@@ -458,9 +458,9 @@ func (i *jwtIssuer) PasswordGrant(ctx context.Context, req *PasswordGrantRequest
 
 	// Get allowed scopes
 	allowedScopes := []string{core.ScopeRead, core.ScopeWrite, core.ScopeProfile, core.ScopeOffline}
-	if i.getUserScopes != nil {
+	if i.getSubjectScopes != nil {
 		var err error
-		allowedScopes, err = i.getUserScopes(user.Id())
+		allowedScopes, err = i.getSubjectScopes(user.Id())
 		if err != nil {
 			return nil, fmt.Errorf("server_error: failed to get user scopes: %w", err)
 		}
@@ -491,7 +491,7 @@ func (i *jwtIssuer) PasswordGrant(ctx context.Context, req *PasswordGrantRequest
 	i.hooks.fireOnIssued(user.Id(), "password")
 
 	return &PasswordGrantResponse{
-		UserID:               user.Id(),
+		Subject:              user.Id(),
 		AccessToken:          tok.Token,
 		ExpiresIn:            tok.ExpiresIn,
 		GrantedScopes:        grantedScopes,

--- a/cmd/demo-resource-server/main.go
+++ b/cmd/demo-resource-server/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	// Validate endpoint
 	validateHandler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		customClaims := apiauth.GetCustomClaimsFromContext(r.Context())
 		clientID, _ := customClaims["client_id"].(string)
 

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -254,7 +254,7 @@ func main() {
 		Blacklist:    blacklist,
 	}
 	mux.Handle("GET /api/me", apiMiddleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		scopes := apiauth.GetScopesFromAPIContext(r.Context())
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{

--- a/core/context.go
+++ b/core/context.go
@@ -2,23 +2,26 @@ package core
 
 import "context"
 
-type userParamNameKey string
+type subjectParamNameKey string
 
-// DefaultUserParamName is the default context key for user ID
-const DefaultUserParamName = "loggedInUserId"
+// DefaultSubjectParamName is the default context / session key for the
+// authenticated principal — RFC 7519 `sub`. Holds a user ID for
+// human-driven flows and a client_id for client_credentials.
+const DefaultSubjectParamName = "loggedInSubject"
 
-// GetUserIDFromContext retrieves the user ID from the request context
-// Uses the default key "loggedInUserId"
-func GetUserIDFromContext(ctx context.Context) string {
-	if v := ctx.Value(userParamNameKey(DefaultUserParamName)); v != nil {
-		if userID, ok := v.(string); ok {
-			return userID
+// GetSubjectFromContext retrieves the authenticated subject from the
+// request context. Uses the default key DefaultSubjectParamName.
+func GetSubjectFromContext(ctx context.Context) string {
+	if v := ctx.Value(subjectParamNameKey(DefaultSubjectParamName)); v != nil {
+		if subject, ok := v.(string); ok {
+			return subject
 		}
 	}
 	return ""
 }
 
-// SetUserIDInContext sets the user ID in the request context
-func SetUserIDInContext(ctx context.Context, userID string) context.Context {
-	return context.WithValue(ctx, userParamNameKey(DefaultUserParamName), userID)
+// SetSubjectInContext sets the authenticated subject in the request
+// context.
+func SetSubjectInContext(ctx context.Context, subject string) context.Context {
+	return context.WithValue(ctx, subjectParamNameKey(DefaultSubjectParamName), subject)
 }

--- a/core/scopes.go
+++ b/core/scopes.go
@@ -19,14 +19,15 @@ func AllBuiltinScopes() []string {
 	return []string{ScopeRead, ScopeWrite, ScopeProfile, ScopeOffline, ScopeAdmin}
 }
 
-// GetUserScopesFunc is a callback that returns allowed scopes for a user.
-// Applications implement this to determine what scopes a user is allowed to have.
-// This can be based on user roles, profile data, groups, etc.
-type GetUserScopesFunc func(userID string) ([]string, error)
+// GetSubjectScopesFunc is a callback that returns allowed scopes for a
+// principal. Applications implement this to determine what scopes a
+// subject (user ID for human-driven flows, client_id for
+// client_credentials) is allowed to have.
+type GetSubjectScopesFunc func(subject string) ([]string, error)
 
-// DefaultGetUserScopes returns a default implementation that grants basic scopes to all users
-func DefaultGetUserScopes() GetUserScopesFunc {
-	return func(userID string) ([]string, error) {
+// DefaultGetSubjectScopes returns a default implementation that grants basic scopes to all subjects.
+func DefaultGetSubjectScopes() GetSubjectScopesFunc {
+	return func(subject string) ([]string, error) {
 		return []string{ScopeRead, ScopeWrite, ScopeProfile, ScopeOffline}, nil
 	}
 }

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,5 +1,45 @@
 # Migration Guide
 
+## v0.1.3 → v0.1.4 — Subject vocab (phase 2: consumers, helpers, transports)
+
+Completes the rename started in v0.1.3. Go API surfaces that handle the *principal-of-a-token* concept move from **UserID** to **Subject**. Account-model types (`accounts.User`, `accounts.Identity.UserID`, etc.) remain untouched.
+
+### Code changes (consumers)
+
+Search-and-replace on your consumer:
+
+```
+core.GetUserIDFromContext         →  core.GetSubjectFromContext
+core.SetUserIDInContext           →  core.SetSubjectInContext
+core.DefaultUserParamName         →  core.DefaultSubjectParamName
+core.GetUserScopesFunc            →  core.GetSubjectScopesFunc
+core.DefaultGetUserScopes         →  core.DefaultGetSubjectScopes
+apiauth.GetUserIDFromAPIContext   →  apiauth.GetSubjectFromAPIContext
+APIAuth.GetUserScopes             →  GetSubjectScopes
+JWTIssuerConfig.GetUserScopes     →  GetSubjectScopes
+OneAuthConfig.GetUserScopes       →  GetSubjectScopes
+PasswordGrantResponse.UserID      →  .Subject
+TokenInfo.UserID                  →  .Subject
+Middleware.UserParamName          →  SubjectParamName
+Middleware.GetLoggedInUserId(     →  Middleware.GetLoggedInSubject(
+OneAuth.SetLoggedInUserID(        →  OneAuth.SetLoggedInSubject(
+grpc.UserIDFromContext            →  grpc.SubjectFromContext
+grpc.UserIDFromContextWithConfig  →  grpc.SubjectFromContextWithConfig
+grpc.UserIDToOutgoingContext      →  grpc.SubjectToOutgoingContext
+grpc.DefaultMetadataKeyUserID     →  grpc.DefaultMetadataKeySubject
+grpc.Config.MetadataKeyUserID     →  grpc.Config.MetadataKeySubject
+```
+
+### Session invalidation (no code action needed)
+
+The session-cookie key flipped from `loggedInUserId` to `loggedInSubject`. Cookies issued by ≤ v0.1.3 are not recognised — users re-login on next visit. No SQL or session-store migration needed.
+
+### gRPC fleet upgrade
+
+The metadata header changed from `x-user-id` to `x-subject`. Upgrade gRPC clients and servers together. `SwitchUserTo*` and `x-switch-user` are unchanged (impersonation is human-user-scoped).
+
+---
+
 ## v0.1.2 → v0.1.3 — Subject vocab (phase 1: token-bearing types)
 
 The principal field on token-bearing types renames from `UserID` to `Subject` to match RFC 7519 / RFC 8693 vocabulary. Affects `core.RefreshToken`, `core.APIKey`, `localauth.VerificationToken`, and the storage interface methods on `RefreshTokenStore`, `APIKeyStore`, and `VerificationTokenStore`.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,43 @@
 # OneAuth Release Notes
 
+## Version 0.1.4 (PR 2b — Subject vocab consumer-side rename)
+
+### Subject vocabulary — phase 2: consumers, helpers, transports
+
+**Breaking.** Completes the rename started in v0.1.3 (PR 2a). All Go API surfaces that handle the *principal-of-a-token* concept now use **Subject** — context helpers, scope callbacks, response types, HTTP middleware methods, gRPC functions, gRPC metadata header, and the session cookie key. Account-model types (`accounts.User`, `accounts.Identity.UserID`, `accounts.Username.UserID`, etc.) stay as **UserID** — see v0.1.3 notes.
+
+**Go API renames:**
+
+| Before | After |
+|---|---|
+| `core.GetUserIDFromContext(ctx)` | `core.GetSubjectFromContext(ctx)` |
+| `core.SetUserIDInContext(ctx, ...)` | `core.SetSubjectInContext(ctx, ...)` |
+| `core.DefaultUserParamName = "loggedInUserId"` | `core.DefaultSubjectParamName = "loggedInSubject"` |
+| `core.GetUserScopesFunc` / `DefaultGetUserScopes` | `core.GetSubjectScopesFunc` / `DefaultGetSubjectScopes` |
+| `apiauth.APIAuth.GetUserScopes` | `apiauth.APIAuth.GetSubjectScopes` |
+| `apiauth.OneAuthConfig.GetUserScopes` | `apiauth.OneAuthConfig.GetSubjectScopes` |
+| `apiauth.JWTIssuerConfig.GetUserScopes` | `apiauth.JWTIssuerConfig.GetSubjectScopes` |
+| `apiauth.PasswordGrantResponse.UserID` | `.Subject` |
+| `apiauth.TokenInfo.UserID` | `.Subject` |
+| `apiauth.GetUserIDFromAPIContext(ctx)` | `GetSubjectFromAPIContext(ctx)` |
+| `httpauth.Middleware.UserParamName` | `SubjectParamName` |
+| `httpauth.Middleware.GetLoggedInUserId(r)` | `GetLoggedInSubject(r)` |
+| `httpauth.OneAuth.SetLoggedInUserID(...)` | `SetLoggedInSubject(...)` |
+| `grpc.UserIDFromContext` / `UserIDFromContextWithConfig` | `SubjectFromContext` / `SubjectFromContextWithConfig` |
+| `grpc.UserIDToOutgoingContext` / `WithKey` | `SubjectToOutgoingContext` / `WithKey` |
+| `grpc.DefaultMetadataKeyUserID = "x-user-id"` | `DefaultMetadataKeySubject = "x-subject"` |
+| `grpc.Config.MetadataKeyUserID` | `MetadataKeySubject` |
+
+**Active sessions invalidated.** The session-cookie key flipped from `loggedInUserId` to `loggedInSubject`. Cookies issued by v0.1.3 and earlier are not recognised by v0.1.4 — affected users will be prompted to log in again. No code or data migration needed; the new cookies are issued on next login.
+
+**gRPC clients/servers must upgrade in lock-step.** The metadata header changed from `x-user-id` to `x-subject`. A v0.1.4 server will not see subjects sent by a v0.1.3 client (and vice versa).
+
+**`SwitchUser*` stays.** `grpc.SwitchUserToOutgoingContext`, `SwitchUserToOutgoingContextWithKey`, `MetadataKeySwitchUser`, and `DefaultMetadataKeySwitchUser = "x-switch-user"` are unchanged — impersonation is human-user-scoped by nature.
+
+Combined with v0.1.3, this completes the Subject vocab rename across the library.
+
+---
+
 ## Version 0.1.3 (PR 2a — token Subject foundation)
 
 ### Subject vocabulary — phase 1: token-bearing types

--- a/examples/01-client-credentials/main.go
+++ b/examples/01-client-credentials/main.go
@@ -114,7 +114,7 @@ func newResourceServer() http.Handler {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{
 				"message": "hello from protected resource",
-				"sub":     apiauth.GetUserIDFromAPIContext(r.Context()),
+				"sub":     apiauth.GetSubjectFromAPIContext(r.Context()),
 				"scopes":  apiauth.GetScopesFromAPIContext(r.Context()),
 			})
 		}),

--- a/examples/02-resource-token-hs256/main.go
+++ b/examples/02-resource-token-hs256/main.go
@@ -91,7 +91,7 @@ func newResourceServer(ks keys.KeyStorage) http.Handler {
 			custom := apiauth.GetCustomClaimsFromContext(ctx)
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{
-				"user":      apiauth.GetUserIDFromAPIContext(ctx),
+				"user":      apiauth.GetSubjectFromAPIContext(ctx),
 				"scopes":    apiauth.GetScopesFromAPIContext(ctx),
 				"client_id": custom["client_id"],
 				"max_rooms": custom["max_rooms"],

--- a/examples/03-resource-token-rs256-jwks/main.go
+++ b/examples/03-resource-token-rs256-jwks/main.go
@@ -99,7 +99,7 @@ func newResourceServer(jwksURL string) http.Handler {
 			ctx := r.Context()
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{
-				"user":   apiauth.GetUserIDFromAPIContext(ctx),
+				"user":   apiauth.GetSubjectFromAPIContext(ctx),
 				"scopes": apiauth.GetScopesFromAPIContext(ctx),
 			})
 		}),

--- a/examples/04-discovery/main.go
+++ b/examples/04-discovery/main.go
@@ -119,7 +119,7 @@ func newResourceServer(issuer string) http.Handler {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{
-				"user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+				"user":   apiauth.GetSubjectFromAPIContext(r.Context()),
 				"scopes": apiauth.GetScopesFromAPIContext(r.Context()),
 			})
 		}),

--- a/examples/07-client-sdk/main.go
+++ b/examples/07-client-sdk/main.go
@@ -100,7 +100,7 @@ func newResourceServer(issuer string) http.Handler {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{
-				"user":   apiauth.GetUserIDFromAPIContext(r.Context()),
+				"user":   apiauth.GetSubjectFromAPIContext(r.Context()),
 				"scopes": apiauth.GetScopesFromAPIContext(r.Context()),
 			})
 		}),

--- a/examples/09-key-rotation/main.go
+++ b/examples/09-key-rotation/main.go
@@ -104,7 +104,7 @@ func newResourceServer(ks keys.KeyStorage, kidStore *keys.KidStore) http.Handler
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprintf(w, `{"user":%q,"scopes":%q}`,
-				apiauth.GetUserIDFromAPIContext(r.Context()),
+				apiauth.GetSubjectFromAPIContext(r.Context()),
 				apiauth.GetScopesFromAPIContext(r.Context()))
 		}),
 	))

--- a/examples/10-security/main.go
+++ b/examples/10-security/main.go
@@ -103,7 +103,7 @@ func newResourceServer(ks keys.KeyStorage) http.Handler {
 			w.Header().Set("Content-Type", "application/json")
 			custom := apiauth.GetCustomClaimsFromContext(r.Context())
 			fmt.Fprintf(w, `{"user":%q,"client_id":%q}`,
-				apiauth.GetUserIDFromAPIContext(r.Context()),
+				apiauth.GetSubjectFromAPIContext(r.Context()),
 				custom["client_id"])
 		}),
 	))

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -53,7 +53,7 @@ func ExampleAppRegistrar_hs256FederatedFlow() {
 	// Resource server validates tokens using the same KeyStore
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	resSrv := httptest.NewServer(middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `{"user":"%s"}`, apiauth.GetUserIDFromAPIContext(r.Context()))
+		fmt.Fprintf(w, `{"user":"%s"}`, apiauth.GetSubjectFromAPIContext(r.Context()))
 	})))
 	defer resSrv.Close()
 
@@ -123,7 +123,7 @@ func ExampleAppRegistrar_rs256WithJWKS() {
 
 	middleware := &apiauth.APIMiddleware{KeyStore: resKeyStore}
 	resSrv := httptest.NewServer(middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `{"user":"%s"}`, apiauth.GetUserIDFromAPIContext(r.Context()))
+		fmt.Fprintf(w, `{"user":"%s"}`, apiauth.GetSubjectFromAPIContext(r.Context()))
 	})))
 	defer resSrv.Close()
 

--- a/federatedauth/callback.go
+++ b/federatedauth/callback.go
@@ -64,7 +64,7 @@ func (b *OAuthBridge) SaveUserAndRedirect(authtype, provider string, token *oaut
 
 	// We have verified an identity and a channel that is verifying this identity —
 	// now establish the logged-in session.
-	b.OneAuth.SetLoggedInUserID(user.Id(), w, r)
+	b.OneAuth.SetLoggedInSubject(user.Id(), w, r)
 
 	// Auth done — go back to where we need to be
 	callbackURL := "/"

--- a/grpc/context.go
+++ b/grpc/context.go
@@ -9,32 +9,37 @@ import (
 // Default metadata keys for authentication context.
 // These can be customized via Config if needed.
 const (
-	// DefaultMetadataKeyUserID is the default gRPC metadata key for the authenticated user ID
-	DefaultMetadataKeyUserID = "x-user-id"
+	// DefaultMetadataKeySubject is the default gRPC metadata key for the
+	// authenticated subject (RFC 7519 `sub` — user ID for human-driven
+	// flows, client_id for client_credentials).
+	DefaultMetadataKeySubject = "x-subject"
 
-	// DefaultMetadataKeySwitchUser is the default gRPC metadata key for switching to a different user (testing only)
+	// DefaultMetadataKeySwitchUser is the default gRPC metadata key for
+	// switching to a different user (testing/impersonation only — by
+	// nature scoped to human users, hence retains "User" naming).
 	DefaultMetadataKeySwitchUser = "x-switch-user"
 )
 
 // Config holds the metadata key configuration for auth context.
 type Config struct {
-	// MetadataKeyUserID is the gRPC metadata key for the authenticated user ID.
-	// Defaults to "x-user-id".
-	MetadataKeyUserID string
+	// MetadataKeySubject is the gRPC metadata key carrying the
+	// authenticated subject. Defaults to "x-subject".
+	MetadataKeySubject string
 
-	// MetadataKeySwitchUser is the gRPC metadata key for switching to a different user.
+	// MetadataKeySwitchUser is the gRPC metadata key for impersonation.
 	// Only used when switch auth is enabled. Defaults to "x-switch-user".
 	MetadataKeySwitchUser string
 
-	// EnableSwitchAuth when true allows the X-Switch-User header to override the user ID.
-	// Should only be enabled in development/testing environments.
+	// EnableSwitchAuth when true allows the X-Switch-User header to
+	// override the subject. Should only be enabled in development /
+	// testing environments.
 	EnableSwitchAuth bool
 }
 
 // DefaultConfig returns the default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		MetadataKeyUserID:     DefaultMetadataKeyUserID,
+		MetadataKeySubject:    DefaultMetadataKeySubject,
 		MetadataKeySwitchUser: DefaultMetadataKeySwitchUser,
 		EnableSwitchAuth:      false,
 	}
@@ -42,22 +47,23 @@ func DefaultConfig() *Config {
 
 // EnsureDefaults fills in default values for any unset fields.
 func (c *Config) EnsureDefaults() {
-	if c.MetadataKeyUserID == "" {
-		c.MetadataKeyUserID = DefaultMetadataKeyUserID
+	if c.MetadataKeySubject == "" {
+		c.MetadataKeySubject = DefaultMetadataKeySubject
 	}
 	if c.MetadataKeySwitchUser == "" {
 		c.MetadataKeySwitchUser = DefaultMetadataKeySwitchUser
 	}
 }
 
-// UserIDFromContext extracts the authenticated user ID from the gRPC context metadata.
-// Returns empty string if no user is authenticated.
-func UserIDFromContext(ctx context.Context) string {
-	return UserIDFromContextWithConfig(ctx, nil)
+// SubjectFromContext extracts the authenticated subject from the gRPC
+// context metadata. Returns empty string if no subject is present.
+func SubjectFromContext(ctx context.Context) string {
+	return SubjectFromContextWithConfig(ctx, nil)
 }
 
-// UserIDFromContextWithConfig extracts the authenticated user ID using the specified config.
-func UserIDFromContextWithConfig(ctx context.Context, config *Config) string {
+// SubjectFromContextWithConfig extracts the authenticated subject using
+// the specified config.
+func SubjectFromContextWithConfig(ctx context.Context, config *Config) string {
 	if config == nil {
 		config = DefaultConfig()
 	}
@@ -68,48 +74,54 @@ func UserIDFromContextWithConfig(ctx context.Context, config *Config) string {
 		return ""
 	}
 
-	// Check for switch user first (only if enabled)
+	// Check for switch user first (only if enabled) — impersonation is
+	// human-user-scoped by nature, so this header keeps its name.
 	if config.EnableSwitchAuth {
 		if values := md.Get(config.MetadataKeySwitchUser); len(values) > 0 && values[0] != "" {
 			return values[0]
 		}
 	}
 
-	// Get the actual user ID
-	if values := md.Get(config.MetadataKeyUserID); len(values) > 0 {
+	if values := md.Get(config.MetadataKeySubject); len(values) > 0 {
 		return values[0]
 	}
 
 	return ""
 }
 
-// UserIDToOutgoingContext adds the user ID to outgoing gRPC context metadata.
-func UserIDToOutgoingContext(ctx context.Context, userID string) context.Context {
-	return UserIDToOutgoingContextWithKey(ctx, userID, DefaultMetadataKeyUserID)
+// SubjectToOutgoingContext adds the subject to outgoing gRPC context
+// metadata.
+func SubjectToOutgoingContext(ctx context.Context, subject string) context.Context {
+	return SubjectToOutgoingContextWithKey(ctx, subject, DefaultMetadataKeySubject)
 }
 
-// UserIDToOutgoingContextWithKey adds the user ID to outgoing gRPC context metadata with a custom key.
-func UserIDToOutgoingContextWithKey(ctx context.Context, userID string, key string) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, key, userID)
+// SubjectToOutgoingContextWithKey adds the subject to outgoing gRPC
+// context metadata under a custom key.
+func SubjectToOutgoingContextWithKey(ctx context.Context, subject string, key string) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, key, subject)
 }
 
-// SwitchUserToOutgoingContext adds a switch-user header to outgoing gRPC context metadata.
-// This is only effective when EnableSwitchAuth is set on the server.
+// SwitchUserToOutgoingContext adds a switch-user header to outgoing
+// gRPC context metadata. Only effective when EnableSwitchAuth is set
+// on the server.
 func SwitchUserToOutgoingContext(ctx context.Context, switchToUserID string) context.Context {
 	return SwitchUserToOutgoingContextWithKey(ctx, switchToUserID, DefaultMetadataKeySwitchUser)
 }
 
-// SwitchUserToOutgoingContextWithKey adds a switch-user header with a custom key.
+// SwitchUserToOutgoingContextWithKey adds a switch-user header with a
+// custom key.
 func SwitchUserToOutgoingContextWithKey(ctx context.Context, switchToUserID string, key string) context.Context {
 	return metadata.AppendToOutgoingContext(ctx, key, switchToUserID)
 }
 
-// IsAuthenticated returns true if there is an authenticated user in the context.
+// IsAuthenticated returns true if there is an authenticated subject in
+// the context.
 func IsAuthenticated(ctx context.Context) bool {
-	return UserIDFromContext(ctx) != ""
+	return SubjectFromContext(ctx) != ""
 }
 
-// IsAuthenticatedWithConfig returns true if there is an authenticated user using the specified config.
+// IsAuthenticatedWithConfig returns true if there is an authenticated
+// subject using the specified config.
 func IsAuthenticatedWithConfig(ctx context.Context, config *Config) bool {
-	return UserIDFromContextWithConfig(ctx, config) != ""
+	return SubjectFromContextWithConfig(ctx, config) != ""
 }

--- a/grpc/context_test.go
+++ b/grpc/context_test.go
@@ -12,8 +12,8 @@ import (
 // TestDefaultConfig verifies that DefaultConfig returns a Config with expected default metadata keys and switch-auth disabled.
 func TestDefaultConfig(t *testing.T) {
 	config := DefaultConfig()
-	if config.MetadataKeyUserID != DefaultMetadataKeyUserID {
-		t.Errorf("expected MetadataKeyUserID %q, got %q", DefaultMetadataKeyUserID, config.MetadataKeyUserID)
+	if config.MetadataKeySubject != DefaultMetadataKeySubject {
+		t.Errorf("expected MetadataKeySubject %q, got %q", DefaultMetadataKeySubject, config.MetadataKeySubject)
 	}
 	if config.MetadataKeySwitchUser != DefaultMetadataKeySwitchUser {
 		t.Errorf("expected MetadataKeySwitchUser %q, got %q", DefaultMetadataKeySwitchUser, config.MetadataKeySwitchUser)
@@ -27,100 +27,100 @@ func TestDefaultConfig(t *testing.T) {
 func TestEnsureDefaults(t *testing.T) {
 	config := &Config{}
 	config.EnsureDefaults()
-	if config.MetadataKeyUserID != DefaultMetadataKeyUserID {
-		t.Errorf("expected MetadataKeyUserID %q, got %q", DefaultMetadataKeyUserID, config.MetadataKeyUserID)
+	if config.MetadataKeySubject != DefaultMetadataKeySubject {
+		t.Errorf("expected MetadataKeySubject %q, got %q", DefaultMetadataKeySubject, config.MetadataKeySubject)
 	}
 	if config.MetadataKeySwitchUser != DefaultMetadataKeySwitchUser {
 		t.Errorf("expected MetadataKeySwitchUser %q, got %q", DefaultMetadataKeySwitchUser, config.MetadataKeySwitchUser)
 	}
 }
 
-// TestUserIDFromContext_NoMetadata verifies that UserIDFromContext returns an empty string when no gRPC metadata is present.
-func TestUserIDFromContext_NoMetadata(t *testing.T) {
+// TestSubjectFromContext_NoMetadata verifies that SubjectFromContext returns an empty string when no gRPC metadata is present.
+func TestSubjectFromContext_NoMetadata(t *testing.T) {
 	ctx := context.Background()
-	userID := UserIDFromContext(ctx)
+	userID := SubjectFromContext(ctx)
 	if userID != "" {
 		t.Errorf("expected empty user ID, got %q", userID)
 	}
 }
 
-// TestUserIDFromContext_WithUserID verifies that UserIDFromContext extracts the user ID from incoming gRPC metadata.
-func TestUserIDFromContext_WithUserID(t *testing.T) {
-	md := metadata.Pairs(DefaultMetadataKeyUserID, "user123")
+// TestSubjectFromContext_WithUserID verifies that SubjectFromContext extracts the user ID from incoming gRPC metadata.
+func TestSubjectFromContext_WithUserID(t *testing.T) {
+	md := metadata.Pairs(DefaultMetadataKeySubject, "user123")
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	userID := UserIDFromContext(ctx)
+	userID := SubjectFromContext(ctx)
 	if userID != "user123" {
 		t.Errorf("expected user ID %q, got %q", "user123", userID)
 	}
 }
 
-// TestUserIDFromContext_SwitchUserDisabled verifies that the switch-user header is ignored when switch-auth is disabled.
-func TestUserIDFromContext_SwitchUserDisabled(t *testing.T) {
+// TestSubjectFromContext_SwitchUserDisabled verifies that the switch-user header is ignored when switch-auth is disabled.
+func TestSubjectFromContext_SwitchUserDisabled(t *testing.T) {
 	md := metadata.Pairs(
-		DefaultMetadataKeyUserID, "user123",
+		DefaultMetadataKeySubject, "user123",
 		DefaultMetadataKeySwitchUser, "switched456",
 	)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	// With default config (switch auth disabled), should return actual user ID
-	userID := UserIDFromContext(ctx)
+	userID := SubjectFromContext(ctx)
 	if userID != "user123" {
 		t.Errorf("expected user ID %q (switch auth disabled), got %q", "user123", userID)
 	}
 }
 
-// TestUserIDFromContext_SwitchUserEnabled verifies that the switch-user header overrides the real user ID when switch-auth is enabled.
-func TestUserIDFromContext_SwitchUserEnabled(t *testing.T) {
+// TestSubjectFromContext_SwitchUserEnabled verifies that the switch-user header overrides the real user ID when switch-auth is enabled.
+func TestSubjectFromContext_SwitchUserEnabled(t *testing.T) {
 	md := metadata.Pairs(
-		DefaultMetadataKeyUserID, "user123",
+		DefaultMetadataKeySubject, "user123",
 		DefaultMetadataKeySwitchUser, "switched456",
 	)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	config := &Config{EnableSwitchAuth: true}
-	userID := UserIDFromContextWithConfig(ctx, config)
+	userID := SubjectFromContextWithConfig(ctx, config)
 	if userID != "switched456" {
 		t.Errorf("expected switched user ID %q, got %q", "switched456", userID)
 	}
 }
 
-// TestUserIDFromContext_SwitchUserEmpty verifies that an empty switch-user header falls back to the actual user ID.
-func TestUserIDFromContext_SwitchUserEmpty(t *testing.T) {
+// TestSubjectFromContext_SwitchUserEmpty verifies that an empty switch-user header falls back to the actual user ID.
+func TestSubjectFromContext_SwitchUserEmpty(t *testing.T) {
 	md := metadata.Pairs(
-		DefaultMetadataKeyUserID, "user123",
+		DefaultMetadataKeySubject, "user123",
 		DefaultMetadataKeySwitchUser, "",
 	)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	config := &Config{EnableSwitchAuth: true}
-	userID := UserIDFromContextWithConfig(ctx, config)
+	userID := SubjectFromContextWithConfig(ctx, config)
 	// Should fall back to actual user when switch user is empty
 	if userID != "user123" {
 		t.Errorf("expected user ID %q (empty switch user), got %q", "user123", userID)
 	}
 }
 
-// TestUserIDToOutgoingContext verifies that UserIDToOutgoingContext attaches the user ID to outgoing gRPC metadata.
-func TestUserIDToOutgoingContext(t *testing.T) {
+// TestSubjectToOutgoingContext verifies that SubjectToOutgoingContext attaches the user ID to outgoing gRPC metadata.
+func TestSubjectToOutgoingContext(t *testing.T) {
 	ctx := context.Background()
-	ctx = UserIDToOutgoingContext(ctx, "user789")
+	ctx = SubjectToOutgoingContext(ctx, "user789")
 
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		t.Fatal("expected outgoing metadata")
 	}
 
-	values := md.Get(DefaultMetadataKeyUserID)
+	values := md.Get(DefaultMetadataKeySubject)
 	if len(values) != 1 || values[0] != "user789" {
 		t.Errorf("expected user ID %q in outgoing context, got %v", "user789", values)
 	}
 }
 
-// TestUserIDToOutgoingContextWithKey verifies that a custom metadata key can be used for the user ID in outgoing context.
-func TestUserIDToOutgoingContextWithKey(t *testing.T) {
+// TestSubjectToOutgoingContextWithKey verifies that a custom metadata key can be used for the user ID in outgoing context.
+func TestSubjectToOutgoingContextWithKey(t *testing.T) {
 	ctx := context.Background()
-	ctx = UserIDToOutgoingContextWithKey(ctx, "user789", "custom-user-key")
+	ctx = SubjectToOutgoingContextWithKey(ctx, "user789", "custom-user-key")
 
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
@@ -158,7 +158,7 @@ func TestIsAuthenticated(t *testing.T) {
 	}
 
 	// With user
-	md := metadata.Pairs(DefaultMetadataKeyUserID, "user123")
+	md := metadata.Pairs(DefaultMetadataKeySubject, "user123")
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 	if !IsAuthenticated(ctx) {
 		t.Error("expected authenticated with user in context")
@@ -182,17 +182,17 @@ func TestIsAuthenticatedWithConfig(t *testing.T) {
 	}
 }
 
-// TestCustomMetadataKeys verifies that UserIDFromContextWithConfig reads from custom metadata key names.
+// TestCustomMetadataKeys verifies that SubjectFromContextWithConfig reads from custom metadata key names.
 func TestCustomMetadataKeys(t *testing.T) {
 	config := &Config{
-		MetadataKeyUserID:     "x-custom-user",
+		MetadataKeySubject:     "x-custom-user",
 		MetadataKeySwitchUser: "x-custom-switch",
 	}
 
 	md := metadata.Pairs("x-custom-user", "customuser123")
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	userID := UserIDFromContextWithConfig(ctx, config)
+	userID := SubjectFromContextWithConfig(ctx, config)
 	if userID != "customuser123" {
 		t.Errorf("expected user ID %q with custom key, got %q", "customuser123", userID)
 	}

--- a/grpc/interceptor.go
+++ b/grpc/interceptor.go
@@ -15,7 +15,7 @@ type InterceptorConfig struct {
 	*Config
 
 	// RequireAuth when true rejects unauthenticated requests.
-	// When false, requests proceed but UserIDFromContext returns empty.
+	// When false, requests proceed but SubjectFromContext returns empty.
 	RequireAuth bool
 
 	// PublicMethods is a set of method names that don't require auth.
@@ -67,7 +67,7 @@ func UnaryAuthInterceptor(config *InterceptorConfig) grpc.UnaryServerInterceptor
 	config.Config.EnsureDefaults()
 
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		userID := extractUserID(ctx, config)
+		userID := extractSubject(ctx, config)
 
 		// Check if auth is required for this method
 		if config.RequireAuth && !config.PublicMethods[info.FullMethod] {
@@ -92,7 +92,7 @@ func StreamAuthInterceptor(config *InterceptorConfig) grpc.StreamServerIntercept
 
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := ss.Context()
-		userID := extractUserID(ctx, config)
+		userID := extractSubject(ctx, config)
 
 		// Check if auth is required for this method
 		if config.RequireAuth && !config.PublicMethods[info.FullMethod] {
@@ -105,8 +105,8 @@ func StreamAuthInterceptor(config *InterceptorConfig) grpc.StreamServerIntercept
 	}
 }
 
-// extractUserID extracts the user ID from context using the interceptor config.
-func extractUserID(ctx context.Context, config *InterceptorConfig) string {
+// extractSubject extracts the user ID from context using the interceptor config.
+func extractSubject(ctx context.Context, config *InterceptorConfig) string {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ""
@@ -120,7 +120,7 @@ func extractUserID(ctx context.Context, config *InterceptorConfig) string {
 	}
 
 	// Fall back to actual user ID
-	if values := md.Get(config.Config.MetadataKeyUserID); len(values) > 0 {
+	if values := md.Get(config.Config.MetadataKeySubject); len(values) > 0 {
 		return values[0]
 	}
 

--- a/grpc/interceptor_test.go
+++ b/grpc/interceptor_test.go
@@ -80,7 +80,7 @@ func TestUnaryAuthInterceptor_RequireAuth_NoUser(t *testing.T) {
 func TestUnaryAuthInterceptor_RequireAuth_WithUser(t *testing.T) {
 	interceptor := UnaryAuthInterceptor(nil)
 
-	md := metadata.Pairs(DefaultMetadataKeyUserID, "user123")
+	md := metadata.Pairs(DefaultMetadataKeySubject, "user123")
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Svc/Method"}
 
@@ -207,7 +207,7 @@ func TestStreamAuthInterceptor_RequireAuth_NoUser(t *testing.T) {
 func TestStreamAuthInterceptor_RequireAuth_WithUser(t *testing.T) {
 	interceptor := StreamAuthInterceptor(nil)
 
-	md := metadata.Pairs(DefaultMetadataKeyUserID, "user123")
+	md := metadata.Pairs(DefaultMetadataKeySubject, "user123")
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	stream := &mockServerStream{ctx: ctx}
 	info := &grpc.StreamServerInfo{FullMethod: "/pkg.Svc/StreamMethod"}

--- a/httpauth/middleware.go
+++ b/httpauth/middleware.go
@@ -10,26 +10,26 @@ import (
 )
 
 // middlewareContextKey is a local context key type used by Middleware
-// to store the logged-in user ID with a configurable param name.
+// to store the authenticated subject with a configurable param name.
 type middlewareContextKey string
 
 type Middleware struct {
 	AuthTokenHeaderName string
 	AuthTokenCookieName string
-	UserParamName       string
+	SubjectParamName    string
 	CallbackURLParam    string
 	SessionGetter       func(r *http.Request, param string) any
 	GetRedirURL         func(r *http.Request) string
 	DefaultRedirectURL  string
-	VerifyToken         func(tokenString string) (loggedInUserId string, token any, err error)
+	VerifyToken         func(tokenString string) (loggedInSubject string, token any, err error)
 }
 
 /**
  * Ensures that config values have reasonable defaults.
  */
 func (a *Middleware) EnsureReasonableDefaults() {
-	if a.UserParamName == "" {
-		a.UserParamName = "loggedInUserId"
+	if a.SubjectParamName == "" {
+		a.SubjectParamName = "loggedInSubject"
 	}
 	if a.CallbackURLParam == "" {
 		a.CallbackURLParam = "/"
@@ -39,22 +39,24 @@ func (a *Middleware) EnsureReasonableDefaults() {
 	}
 }
 
-// Get the ID of the logged in user from the current request
-func (a *Middleware) GetLoggedInUserId(r *http.Request) string {
+// GetLoggedInSubject returns the authenticated subject (RFC 7519 `sub`)
+// for the current request — a user ID for human-driven flows or a
+// client_id for client_credentials.
+func (a *Middleware) GetLoggedInSubject(r *http.Request) string {
 	a.EnsureReasonableDefaults()
 
-	v := r.Context().Value(middlewareContextKey(a.UserParamName))
+	v := r.Context().Value(middlewareContextKey(a.SubjectParamName))
 	if v != nil {
-		loggedInUserId := v.(string)
-		if loggedInUserId != "" {
-			return loggedInUserId
+		loggedInSubject := v.(string)
+		if loggedInSubject != "" {
+			return loggedInSubject
 		}
 	}
 
 	if a.SessionGetter != nil {
-		userParam := a.SessionGetter(r, a.UserParamName)
-		if userParam != "" && userParam != nil {
-			return userParam.(string)
+		sessParam := a.SessionGetter(r, a.SubjectParamName)
+		if sessParam != "" && sessParam != nil {
+			return sessParam.(string)
 		}
 	}
 
@@ -72,8 +74,6 @@ func (a *Middleware) GetLoggedInUserId(r *http.Request) string {
 			authTokens = append(authTokens, cookie.Value)
 		}
 	}
-	// log.Println("Auth Tokens Found: ", authTokens)
-	// log.Println("Cookies: ", r.Cookies())
 
 	for _, authToken := range authTokens {
 		// Strip "Bearer " prefix if present
@@ -84,34 +84,30 @@ func (a *Middleware) GetLoggedInUserId(r *http.Request) string {
 		if token == "" {
 			continue
 		}
-		loggedInUserId, _, err := a.VerifyToken(token)
-		if err == nil && loggedInUserId != "" {
-			return loggedInUserId
+		loggedInSubject, _, err := a.VerifyToken(token)
+		if err == nil && loggedInSubject != "" {
+			return loggedInSubject
 		} else if err != nil {
 			slog.Warn("Error verifying token: ", "token", token[:min(len(token), 20)]+"...", "error", err)
 		}
 	}
 
-	// Verify the JWT
 	return ""
 }
 
 /**
- * Fetches the user from the request and loads the UserId and User variables
- * available for other handlers.
+ * Fetches the subject from the request and loads it into the request
+ * context for downstream handlers.
  *
- * Note this does not perform any redirects if a valid user does not exist.
- * To also enforce a user exists, use the EnsureUser handler which both
- * calls ExgractUser and ensures that user is logged in.
+ * Note this does not perform any redirects if a valid subject does not
+ * exist. To also enforce that, use EnsureUser.
  */
 func (a *Middleware) ExtractUser(next http.Handler) http.Handler {
 	a.EnsureReasonableDefaults()
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			// Check session, context, and Authorization header for user ID
-			userParam := a.GetLoggedInUserId(r)
-			// set the logged in user ID as the request scoped variable
-			next.ServeHTTP(w, a.setLoggedInUserId(userParam, r))
+			subject := a.GetLoggedInSubject(r)
+			next.ServeHTTP(w, a.setLoggedInSubject(subject, r))
 		},
 	)
 }
@@ -120,11 +116,8 @@ func (a *Middleware) EnsureUser(next http.Handler) http.Handler {
 	a.EnsureReasonableDefaults()
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			// Check session, context, and Authorization header for user ID
-			userParam := a.GetLoggedInUserId(r)
-			if userParam == "" {
-				// Redirect to a login if user not logged in
-				// `/${a.redirectURLPrefix || "auth"}/login?callbackURL=${encodeURIComponent(req.originalUrl)}`;
+			subject := a.GetLoggedInSubject(r)
+			if subject == "" {
 				redirUrl := ""
 				if a.GetRedirURL != nil {
 					redirUrl = a.GetRedirURL(r)
@@ -136,23 +129,19 @@ func (a *Middleware) EnsureUser(next http.Handler) http.Handler {
 					fullRedirUrl := fmt.Sprintf("%s?%s=%s", redirUrl, a.CallbackURLParam, encodedUrl)
 					http.Redirect(w, r, fullRedirUrl, http.StatusFound)
 				} else {
-					// otherwise a 401
 					http.Error(w, "Login Failed", http.StatusUnauthorized)
 				}
 				return
-			} else {
-				// set the logged in user ID as the request scoped variable
-				next.ServeHTTP(w, a.setLoggedInUserId(userParam, r))
 			}
+			next.ServeHTTP(w, a.setLoggedInSubject(subject, r))
 		},
 	)
 }
 
-// Set the logged in user id into the request's variable set
-// This will make it available to all other handlers downstream
-func (a *Middleware) setLoggedInUserId(userId string, r *http.Request) *http.Request {
-	// set the logged in user ID as the request scoped variable
-	contextWithUser := context.WithValue(r.Context(), middlewareContextKey(a.UserParamName), userId)
-	//create a new request using that new context
-	return r.WithContext(contextWithUser)
+// setLoggedInSubject stores the authenticated subject in the request
+// context under the configured param name so downstream handlers can
+// read it back via GetLoggedInSubject.
+func (a *Middleware) setLoggedInSubject(subject string, r *http.Request) *http.Request {
+	contextWithSubject := context.WithValue(r.Context(), middlewareContextKey(a.SubjectParamName), subject)
+	return r.WithContext(contextWithSubject)
 }

--- a/httpauth/mux.go
+++ b/httpauth/mux.go
@@ -123,7 +123,7 @@ func (a *OneAuth) setupRoutes() *OneAuth {
 	return a
 }
 
-func (a *OneAuth) verifyJWT(tokenString string) (loggedInUserId string, t any, err error) {
+func (a *OneAuth) verifyJWT(tokenString string) (loggedInSubject string, t any, err error) {
 	// Parse the token with the secret key
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		return []byte(a.JWTSecretKey), nil
@@ -155,7 +155,7 @@ func (a *OneAuth) verifyJWT(tokenString string) (loggedInUserId string, t any, e
 
 func (a *OneAuth) onLogout(w http.ResponseWriter, r *http.Request) {
 	log.Println("Logging out user...")
-	a.SetLoggedInUserID("", w, r)
+	a.SetLoggedInSubject("", w, r)
 	log.Println("Accept Header Type: ", r.Header["Accept"])
 	toUrl := r.URL.Query()["to"]
 	log.Println("TOURL: ", toUrl)
@@ -166,14 +166,14 @@ func (a *OneAuth) onLogout(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// SetLoggedInUserID sets the auth token and logged-in user ID on each
-// configured cookie domain. Pass an empty userID to clear (logout).
+// SetLoggedInSubject stores the authenticated subject (RFC 7519 `sub`
+// — a user ID for human-driven flows or a client_id for
+// client_credentials) on each configured cookie domain. Pass an empty
+// string to clear (logout).
 //
-// Renamed from the previous setLoggedInUser(user core.User, ...) — httpauth
-// now owns only the transport layer and never sees the accounts.User shape.
 // Callers (typically federatedauth or localauth) translate their User
 // object to user.Id() at the call site.
-func (a *OneAuth) SetLoggedInUserID(userID string, w http.ResponseWriter, r *http.Request) string {
+func (a *OneAuth) SetLoggedInSubject(subject string, w http.ResponseWriter, r *http.Request) string {
 	a.EnsureDefaults()
 	log.Println("ReqHost, Cookie Domains: ", r.Host, a.CookieDomains)
 	domains := a.CookieDomains
@@ -189,11 +189,11 @@ func (a *OneAuth) SetLoggedInUserID(userID string, w http.ResponseWriter, r *htt
 			Path:   "/",
 		})
 
-		if userID != "" {
-			a.Session.Put(r.Context(), "loggedInUserId", userID)
+		if subject != "" {
+			a.Session.Put(r.Context(), "loggedInSubject", subject)
 			http.SetCookie(w, &http.Cookie{
-				Name:    "loggedInUserId",
-				Value:   userID,
+				Name:    "loggedInSubject",
+				Value:   subject,
 				Domain:  cookieDomain,
 				Path:    "/",
 				Expires: time.Now().Add(time.Second * time.Duration(a.SessionTimeoutInSeconds)),
@@ -201,7 +201,7 @@ func (a *OneAuth) SetLoggedInUserID(userID string, w http.ResponseWriter, r *htt
 			})
 
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-				"sub": userID,
+				"sub": subject,
 				"iss": a.JwtIssuer,
 				"aud": "admin", // replace with Role for the user later on
 				"exp": time.Now().Add(time.Hour).Unix(),
@@ -230,7 +230,7 @@ func (a *OneAuth) SetLoggedInUserID(userID string, w http.ResponseWriter, r *htt
 			slog.Warn("error clearing session ", "err", err)
 		}
 		http.SetCookie(w, &http.Cookie{
-			Name:    "loggedInUserId",
+			Name:    "loggedInSubject",
 			Domain:  cookieDomain,
 			Path:    "/",
 			MaxAge:  -1,

--- a/keys/jwks_e2e_test.go
+++ b/keys/jwks_e2e_test.go
@@ -65,7 +65,7 @@ func TestFederated_EndToEnd_HS256(t *testing.T) {
 	var gotUserID string
 	var gotClaims map[string]any
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		gotUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		gotClaims = apiauth.GetCustomClaimsFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -250,7 +250,7 @@ func TestFederated_EndToEnd_RS256_ViaRegistrar(t *testing.T) {
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	var gotUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		gotUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -317,7 +317,7 @@ func TestJWKS_EndToEnd_RS256(t *testing.T) {
 	var gotUserID string
 	var gotClaims map[string]any
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		gotUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		gotClaims = apiauth.GetCustomClaimsFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -368,7 +368,7 @@ func TestJWKS_EndToEnd_ES256(t *testing.T) {
 	middleware := &apiauth.APIMiddleware{KeyStore: resourceKeyStore}
 	var gotUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		gotUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/keys/kid_test.go
+++ b/keys/kid_test.go
@@ -320,7 +320,7 @@ func TestValidateJWT_WithKid(t *testing.T) {
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	var gotUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		gotUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -358,7 +358,7 @@ func TestValidateJWT_LegacyNoKid(t *testing.T) {
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	var gotUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		gotUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -204,7 +204,7 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 	mux.Handle("GET /api/me", apiMW.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"user_id": apiauth.GetUserIDFromAPIContext(r.Context()),
+			"user_id": apiauth.GetSubjectFromAPIContext(r.Context()),
 			"scopes":  apiauth.GetScopesFromAPIContext(r.Context()),
 		})
 	})))

--- a/tests/e2e/resourceserver_test.go
+++ b/tests/e2e/resourceserver_test.go
@@ -73,7 +73,7 @@ func buildOneResourceServer(t *testing.T, name string, authServer *httptest.Serv
 	})
 
 	mux.Handle("POST /validate", mw.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := apiauth.GetUserIDFromAPIContext(r.Context())
+		userID := apiauth.GetSubjectFromAPIContext(r.Context())
 		customClaims := apiauth.GetCustomClaimsFromContext(r.Context())
 
 		entry := map[string]any{
@@ -93,7 +93,7 @@ func buildOneResourceServer(t *testing.T, name string, authServer *httptest.Serv
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"data":    "protected-resource",
-			"user_id": apiauth.GetUserIDFromAPIContext(r.Context()),
+			"user_id": apiauth.GetSubjectFromAPIContext(r.Context()),
 		})
 	})))
 

--- a/tests/keycloak/interop_test.go
+++ b/tests/keycloak/interop_test.go
@@ -244,7 +244,7 @@ func TestKeycloak_ValidateToken_ClientCredentials(t *testing.T) {
 	// Validate via HTTP middleware
 	var extractedUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		extractedUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		extractedUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/tests/keycloak/private_key_jwt_test.go
+++ b/tests/keycloak/private_key_jwt_test.go
@@ -87,7 +87,7 @@ func TestKeycloak_PrivateKeyJWT_ClientCredentials(t *testing.T) {
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	var extractedUserID string
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		extractedUserID = apiauth.GetUserIDFromAPIContext(r.Context())
+		extractedUserID = apiauth.GetSubjectFromAPIContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/protected", nil)


### PR DESCRIPTION
Phase 2 of the Subject vocab rename. Completes what PR 2a (#214) started — the consumer-side surfaces that handle the principal-of-a-token concept. Account-model types (`accounts.User`, `Identity.UserID`, `Username.UserID`) remain as UserID.

## What changes

Go API renames in `core/`, `apiauth/`, `httpauth/`, `grpc/`:

- `core.GetSubjectFromContext`, `SetSubjectInContext`, `DefaultSubjectParamName = \"loggedInSubject\"`, `GetSubjectScopesFunc`, `DefaultGetSubjectScopes`
- `apiauth.GetSubjectFromAPIContext`, `PasswordGrantResponse.Subject`, `TokenInfo.Subject`, `APIAuth.GetSubjectScopes`, `OneAuthConfig.GetSubjectScopes`, `JWTIssuerConfig.GetSubjectScopes`, `contextKeySubject`
- `httpauth.Middleware.GetLoggedInSubject`, `SubjectParamName`, `setLoggedInSubject`, `OneAuth.SetLoggedInSubject`, session cookie key `loggedInSubject`
- `grpc.SubjectFromContext`, `SubjectFromContextWithConfig`, `SubjectToOutgoingContext`, `SubjectToOutgoingContextWithKey`, `DefaultMetadataKeySubject = \"x-subject\"`, `Config.MetadataKeySubject`

`SwitchUserTo*` / `x-switch-user` retained (impersonation is human-user-scoped).

## Reviewer's guide

1. [core/context.go](https://github.com/panyam/oneauth/pull/215/files#diff-8025ebf231dbfdc1f13ee600fde1c1415837f9ed980b9d3758f3903a5c32f4b3) — start here. The two helpers + the default param name constant flip together; the cookie key value flips from `loggedInUserId` to `loggedInSubject` (sessions invalidated, documented).
2. [core/scopes.go](https://github.com/panyam/oneauth/pull/215/files#diff-5cb5ba49677991c7af2e1a1fc3938dff65515ee7a87b6c88abf0af7765c8dc95) — `GetSubjectScopesFunc` + `DefaultGetSubjectScopes` follow.
3. [apiauth/interfaces.go](https://github.com/panyam/oneauth/pull/215/files#diff-70e91801f2bded0e74189e030f3eaf40f17499af168247231ef458224dc6c5bc) — public response types `PasswordGrantResponse.Subject` and `TokenInfo.Subject`. These flow to introspection/grant outputs that callers depend on.
4. [apiauth/auth.go](https://github.com/panyam/oneauth/pull/215/files#diff-6f548dbab24d0609200ec2c43738d8d522c8f3d3b5b288eae95c1dc06b239bf8) — internal context key + `GetSubjectFromAPIContext` (this is the public read-back call site that the most consumers — examples, tests — touch).
5. [httpauth/middleware.go](https://github.com/panyam/oneauth/pull/215/files#diff-48d91054bcce93b6da92b069e4206ee0d164eb242697b611e2717f797f4a3b84), [httpauth/mux.go](https://github.com/panyam/oneauth/pull/215/files#diff-4673067499892c5545aec1db77000903bff151d7c62a3671fc415c2f127e4627) — flips the public surface. Session cookie key changes here.
6. [grpc/context.go](https://github.com/panyam/oneauth/pull/215/files#diff-ff364f7273ab43da160843ef05c5a351cd44aef5b5c4baa71f90d3ce43585729) — gRPC metadata header `x-user-id` → `x-subject`, plus the four context helpers. Note: `SwitchUserTo*` and `x-switch-user` deliberately stay.
7. [docs/RELEASE_NOTES.md](https://github.com/panyam/oneauth/pull/215/files#diff-06470f44e11a4acf72ecac0f68c7438ff957181a677bbc006439d2532b9794b6), [docs/MIGRATION.md](https://github.com/panyam/oneauth/pull/215/files#diff-9069ee5e76909ff15e297f35234e161ce30629f025cd9072dddba403cc875c31) — v0.1.4 section + consumer search-and-replace recipe + session-invalidation note + gRPC lock-step caveat.

Skim: every example/test/cmd touched is mechanical — same rename pattern applied via `sed`. Spot-check 1-2 and you'll have read them all.

## Decision log

- **Session cookie key flipped (`loggedInUserId` → `loggedInSubject`).** Active sessions become invalid on upgrade. Trade-off accepted (per the design discussion): one-time \"please log in again\" is cheaper than living forever with Go-API ↔ cookie-value vocabulary skew.
- **gRPC metadata header flipped (`x-user-id` → `x-subject`).** Consequence: clients and servers must upgrade in lock-step. Documented.
- **`SwitchUserTo*` and `x-switch-user` retained.** Impersonation is human-user-scoped by nature — a service account doesn't \"switch to\" another principal. Renaming would obscure intent.
- **`UserParamName` on Middleware also became `SubjectParamName`.** Considered keeping the old name to ease consumer churn — rejected for vocabulary uniformity (the same reasoning as the field-level rename in PR 2a).

## Risk / blast radius

- **Source-break for any consumer** of the renamed symbols. Confirmed zero external production consumers; mcpkit/goapplib/notation can re-run their consumer updates following the migration guide.
- **Active sessions invalidated** on upgrade (cookie key flip). One-time, no data action needed.
- **gRPC fleet upgrade required** in lock-step.
- **Tests:** all green — `make test`, `make e2e`, gorm sub-module tests, full diagnostics-clean after the rename.

## Out of scope (deliberate)

- mcpkit / goapplib / notation / lilbattle consumer bumps — separate per-repo PRs, tracked downstream.
- Stored-data migration (was PR 2a's concern, already documented in the v0.1.2 → v0.1.3 migration section).
- Tag v0.1.4 — cut after merge.
