### PR TITLE
feat(client): RFC 8693 token exchange + RFC 7523 §2.1 jwt-bearer grant primitives

### DIFF
--- a/client/jwt_bearer_grant.go
+++ b/client/jwt_bearer_grant.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// JwtBearerGrantType is the RFC 7523 §2.1 grant_type value — the JWT
+// bearer authorization grant. Distinct from the private_key_jwt CLIENT
+// authentication method (which uses `client_assertion`); this grant
+// exchanges a signed `assertion` for an access token.
+const JwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+// JwtBearerGrantRequest models the inputs to RFC 7523 §2.1. Client
+// authentication is negotiated separately via ClientID +
+// (ClientSecret | ClientAssertion) — both authentication methods may
+// coexist with the bearer Assertion in the same form payload.
+type JwtBearerGrantRequest struct {
+	// ClientID identifies the client to the AS. Required.
+	ClientID string
+
+	// ClientSecret authenticates the client when ClientAssertion is nil.
+	ClientSecret string
+
+	// ClientAssertion, when non-nil, switches client authentication to
+	// the private_key_jwt path. The resulting `client_assertion` form
+	// field coexists with the bearer `assertion` below.
+	ClientAssertion *ClientAssertionConfig
+
+	// Assertion is the signed JWT presented as the authorization grant
+	// (RFC 7523 §2.1). Required. Issued out-of-band — typically the
+	// output of a prior token exchange or a trusted upstream IdP.
+	Assertion string
+
+	// Scope optionally narrows the requested scopes for the issued
+	// access token. Space-delimited on the wire per RFC 6749 §3.3.
+	Scope []string
+
+	// Resources are RFC 8707 resource indicators emitted as repeated
+	// `resource` form values.
+	Resources []string
+}
+
+// JwtBearerGrant performs an RFC 7523 §2.1 jwt-bearer grant exchange.
+// Returns a usable ServerCredential containing the access token.
+func (c *AuthClient) JwtBearerGrant(req *JwtBearerGrantRequest) (*ServerCredential, error) {
+	if req == nil {
+		return nil, fmt.Errorf("JwtBearerGrant: req is required")
+	}
+	if req.Assertion == "" {
+		return nil, fmt.Errorf("JwtBearerGrant: Assertion is required")
+	}
+	if req.ClientID == "" {
+		return nil, fmt.Errorf("JwtBearerGrant: ClientID is required")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	tokenEndpoint := c.serverURL + c.tokenEndpoint
+	if c.cachedASMeta != nil && c.cachedASMeta.TokenEndpoint != "" {
+		tokenEndpoint = c.cachedASMeta.TokenEndpoint
+	}
+
+	data := url.Values{
+		"grant_type": {JwtBearerGrantType},
+		"assertion":  {req.Assertion},
+	}
+	if len(req.Scope) > 0 {
+		data.Set("scope", strings.Join(req.Scope, " "))
+	}
+	for _, r := range req.Resources {
+		data.Add("resource", r)
+	}
+
+	httpReq, err := c.buildTokenRequest(tokenEndpoint, data, req.ClientID, req.ClientSecret, req.ClientAssertion)
+	if err != nil {
+		return nil, err
+	}
+	return c.executeTokenRequest(httpReq)
+}

--- a/client/jwt_bearer_grant_e2e_test.go
+++ b/client/jwt_bearer_grant_e2e_test.go
@@ -1,0 +1,61 @@
+package client_test
+
+// E2E coverage for AuthClient.JwtBearerGrant against the in-process
+// OneAuth AS (testutil.TestAuthServer with TrustedAssertionIssuers
+// wired up). Proves the SDK -> real AS path round-trips: AS verifies
+// the assertion JWT, issues an access token, SDK decodes it into a
+// usable ServerCredential.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/testutil"
+)
+
+func TestJwtBearerGrant_E2E_TrustedIssuerRoundTrip(t *testing.T) {
+	idpKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	const idpIssuer = "https://corp-idp.example.com"
+	const asAudience = "oneauth-test-as"
+
+	srv := testutil.NewTestAuthServer(t,
+		testutil.WithAudience(asAudience),
+		testutil.WithTrustedAssertionIssuers([]apiauth.TrustedAssertionIssuer{{
+			Issuer:             idpIssuer,
+			PublicKey:          &idpKey.PublicKey,
+			Audiences:          []string{asAudience},
+			AcceptedAlgorithms: []string{"RS256"},
+		}}),
+	)
+	defer srv.Close()
+
+	now := time.Now()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": idpIssuer,
+		"sub": "alice",
+		"aud": asAudience,
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Add(-1 * time.Second).Unix(),
+	})
+	assertion, err := tok.SignedString(idpKey)
+	require.NoError(t, err)
+
+	c := client.NewAuthClient(srv.URL(), nil,
+		client.WithTokenEndpoint("/api/token"))
+	cred, err := c.JwtBearerGrant(&client.JwtBearerGrantRequest{
+		ClientID:  "demo-client",
+		Assertion: assertion,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, cred.AccessToken, "AS MUST issue an access token for a trusted-issuer assertion")
+}

--- a/client/jwt_bearer_grant_test.go
+++ b/client/jwt_bearer_grant_test.go
@@ -1,0 +1,139 @@
+package client
+
+// Wire-level tests for AuthClient.JwtBearerGrant — the RFC 7523 §2.1
+// (`urn:ietf:params:oauth:grant-type:jwt-bearer`) primitive on the
+// client SDK. Distinct from the private_key_jwt CLIENT auth method,
+// which authenticates the client itself; this grant exchanges an
+// assertion for an access token.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jwtBearerGrantServer accepts a jwt-bearer grant request and forwards
+// the parsed form to `inspect` so per-test assertions can check the
+// wire shape (including client authentication negotiation).
+func jwtBearerGrantServer(t *testing.T, inspect func(*testing.T, *http.Request)) *httptest.Server {
+	t.Helper()
+	var count atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", r.FormValue("grant_type"))
+		inspect(t, r)
+		n := count.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": fmt.Sprintf("bearer-tok-%d", n),
+			"token_type":   "Bearer",
+			"expires_in":   600,
+			"scope":        "read",
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestJwtBearerGrant_Roundtrip confirms the basic wire shape — grant
+// type and assertion form fields — and that a usable ServerCredential
+// flows back to the caller.
+func TestJwtBearerGrant_Roundtrip(t *testing.T) {
+	srv := jwtBearerGrantServer(t, func(t *testing.T, r *http.Request) {
+		assert.Equal(t, "signed-jwt-assertion", r.FormValue("assertion"))
+		assert.Equal(t, "read", r.FormValue("scope"))
+		assert.Equal(t, []string{"https://api.example.com"}, r.Form["resource"])
+	})
+	defer srv.Close()
+
+	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
+	cred, err := c.JwtBearerGrant(&JwtBearerGrantRequest{
+		ClientID:     "demo",
+		ClientSecret: "shh",
+		Assertion:    "signed-jwt-assertion",
+		Scope:        []string{"read"},
+		Resources:    []string{"https://api.example.com"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "bearer-tok-1", cred.AccessToken)
+}
+
+// TestJwtBearerGrant_ClientAuthBasic verifies that when AS metadata
+// advertises client_secret_basic, the bearer-assertion request carries
+// HTTP Basic client authentication AND the assertion form field.
+func TestJwtBearerGrant_ClientAuthBasic(t *testing.T) {
+	srv := jwtBearerGrantServer(t, func(t *testing.T, r *http.Request) {
+		assert.Equal(t, "signed-jwt-assertion", r.FormValue("assertion"))
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok, "Authorization: Basic header MUST be present for client_secret_basic")
+		assert.Equal(t, "demo", user)
+		assert.Equal(t, "shh", pass)
+	})
+	defer srv.Close()
+
+	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{
+		TokenEndpoint:            srv.URL + "/token",
+		TokenEndpointAuthMethods: []string{"client_secret_basic"},
+	}))
+	cred, err := c.JwtBearerGrant(&JwtBearerGrantRequest{
+		ClientID:     "demo",
+		ClientSecret: "shh",
+		Assertion:    "signed-jwt-assertion",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, cred.AccessToken)
+}
+
+// TestJwtBearerGrant_ClientAuthPrivateKeyJwt verifies the dual-JWT
+// case: a `client_assertion` (private_key_jwt CLIENT auth) plus an
+// `assertion` (RFC 7523 §2.1 grant payload) coexist in the same form
+// without colliding.
+func TestJwtBearerGrant_ClientAuthPrivateKeyJwt(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	srv := jwtBearerGrantServer(t, func(t *testing.T, r *http.Request) {
+		assert.Equal(t, "signed-jwt-assertion", r.FormValue("assertion"), "the grant payload assertion")
+		assert.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", r.FormValue("client_assertion_type"))
+		clientAssertion := r.FormValue("client_assertion")
+		require.NotEmpty(t, clientAssertion, "client_assertion (client_secret_jwt / private_key_jwt) MUST be present")
+		require.NotEqual(t, "signed-jwt-assertion", clientAssertion, "client_assertion MUST differ from the grant assertion")
+		parsed, _, perr := new(jwt.Parser).ParseUnverified(clientAssertion, jwt.MapClaims{})
+		require.NoError(t, perr, "client_assertion MUST be a parseable JWT")
+		claims, _ := parsed.Claims.(jwt.MapClaims)
+		assert.Equal(t, "demo", claims["iss"], "client_assertion iss MUST equal client_id")
+		assert.Equal(t, "demo", claims["sub"], "client_assertion sub MUST equal client_id")
+
+		// The grant-payload assertion ("signed-jwt-assertion") is opaque
+		// to this test — RFC 7523 §3 leaves its validation to the AS.
+		_ = strings.TrimSpace(r.FormValue("assertion"))
+		_ = base64.StdEncoding // keep imports referenced even if unused
+	})
+	defer srv.Close()
+
+	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{
+		TokenEndpoint:            srv.URL + "/token",
+		TokenEndpointAuthMethods: []string{"private_key_jwt"},
+	}))
+	cred, err := c.JwtBearerGrant(&JwtBearerGrantRequest{
+		ClientID:  "demo",
+		Assertion: "signed-jwt-assertion",
+		ClientAssertion: &ClientAssertionConfig{
+			PrivateKey: priv,
+			SigningAlg: "RS256",
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, cred.AccessToken)
+}

--- a/client/token_exchange.go
+++ b/client/token_exchange.go
@@ -1,0 +1,202 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// TokenExchangeGrantType is the RFC 8693 grant_type value sent at the
+// token endpoint to request a token exchange.
+const TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+// TokenExchangeRequest models the inputs to RFC 8693 §2.1. SubjectToken
+// and SubjectTokenType are required; everything else is optional and is
+// omitted from the wire request when unset.
+type TokenExchangeRequest struct {
+	// ClientID identifies the client to the AS. Required.
+	ClientID string
+
+	// ClientSecret authenticates the client when ClientAssertion is nil.
+	ClientSecret string
+
+	// ClientAssertion, when non-nil, switches client authentication to
+	// the private_key_jwt path (RFC 7521 §4.2 / RFC 7523 §2.2).
+	ClientAssertion *ClientAssertionConfig
+
+	// SubjectToken carries the security token representing the party on
+	// whose behalf the request is made. Required (RFC 8693 §2.1).
+	SubjectToken string
+
+	// SubjectTokenType identifies the kind of the SubjectToken (e.g.
+	// urn:ietf:params:oauth:token-type:id_token). Required.
+	SubjectTokenType string
+
+	// ActorToken is an optional second token identifying the acting
+	// party — used in delegation flows where the actor differs from the
+	// subject (RFC 8693 §1.2).
+	ActorToken string
+
+	// ActorTokenType identifies the kind of the ActorToken. Required
+	// when ActorToken is set.
+	ActorTokenType string
+
+	// RequestedTokenType identifies the kind of token the caller wants
+	// the AS to issue. Optional — when omitted the AS chooses.
+	RequestedTokenType string
+
+	// Audience names the relying parties intended to consume the
+	// issued token (RFC 8693 §2.1). Emitted as repeated `audience`
+	// form values when more than one is provided.
+	Audience []string
+
+	// Resource is the RFC 8707 resource indicator. Emitted as repeated
+	// `resource` form values per §2.
+	Resource []string
+
+	// Scope requests specific scopes for the issued token. Encoded as a
+	// single space-delimited `scope` form value per RFC 6749 §3.3.
+	Scope []string
+}
+
+// TokenExchangeResponse is the parsed RFC 8693 §2.2 response. The wire
+// format is a JSON object with snake_case keys; `Scope` is split from
+// the space-delimited string into a slice for convenience.
+type TokenExchangeResponse struct {
+	AccessToken     string
+	IssuedTokenType string
+	TokenType       string
+	ExpiresIn       int
+	RefreshToken    string
+	Scope           []string
+}
+
+// rawTokenExchangeResponse mirrors the on-the-wire JSON keys so the
+// public TokenExchangeResponse can present `Scope` as a slice without
+// callers parsing a space-delimited string by hand.
+type rawTokenExchangeResponse struct {
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+	RefreshToken    string `json:"refresh_token,omitempty"`
+	Scope           string `json:"scope,omitempty"`
+}
+
+// TokenExchange performs an RFC 8693 token exchange. The caller can
+// authenticate via shared secret (ClientID + ClientSecret) or via
+// private_key_jwt (ClientID + ClientAssertion). Returns the parsed
+// response including `issued_token_type`.
+func (c *AuthClient) TokenExchange(req *TokenExchangeRequest) (*TokenExchangeResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("TokenExchange: req is required")
+	}
+	if req.SubjectToken == "" || req.SubjectTokenType == "" {
+		return nil, fmt.Errorf("TokenExchange: SubjectToken and SubjectTokenType are required")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	tokenEndpoint := c.serverURL + c.tokenEndpoint
+	if c.cachedASMeta != nil && c.cachedASMeta.TokenEndpoint != "" {
+		tokenEndpoint = c.cachedASMeta.TokenEndpoint
+	}
+
+	data := url.Values{
+		"grant_type":         {TokenExchangeGrantType},
+		"subject_token":      {req.SubjectToken},
+		"subject_token_type": {req.SubjectTokenType},
+	}
+	if req.ActorToken != "" {
+		data.Set("actor_token", req.ActorToken)
+	}
+	if req.ActorTokenType != "" {
+		data.Set("actor_token_type", req.ActorTokenType)
+	}
+	if req.RequestedTokenType != "" {
+		data.Set("requested_token_type", req.RequestedTokenType)
+	}
+	for _, a := range req.Audience {
+		data.Add("audience", a)
+	}
+	for _, r := range req.Resource {
+		data.Add("resource", r)
+	}
+	if len(req.Scope) > 0 {
+		data.Set("scope", strings.Join(req.Scope, " "))
+	}
+
+	httpReq, err := c.buildTokenRequest(tokenEndpoint, data, req.ClientID, req.ClientSecret, req.ClientAssertion)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := &http.Client{Transport: c.baseTransport} // bypass refreshTransport to avoid auth loop
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token exchange failed: status=%d body=%s", resp.StatusCode, string(body))
+	}
+
+	var raw rawTokenExchangeResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("decode token exchange response: %w", err)
+	}
+	var scopes []string
+	if raw.Scope != "" {
+		scopes = strings.Fields(raw.Scope)
+	}
+	return &TokenExchangeResponse{
+		AccessToken:     raw.AccessToken,
+		IssuedTokenType: raw.IssuedTokenType,
+		TokenType:       raw.TokenType,
+		ExpiresIn:       raw.ExpiresIn,
+		RefreshToken:    raw.RefreshToken,
+		Scope:           scopes,
+	}, nil
+}
+
+// buildTokenRequest assembles a POST request to the token endpoint with
+// the supplied form payload + the negotiated client authentication
+// method. Shared by TokenExchange and JwtBearerGrant — both are
+// non-credential-persisting flows that emit the same form/auth shape
+// as ClientCredentials but return shape-specific responses, so they
+// can't share executeTokenRequest's persistence path.
+func (c *AuthClient) buildTokenRequest(tokenEndpoint string, data url.Values, clientID, clientSecret string, assertion *ClientAssertionConfig) (*http.Request, error) {
+	if assertion != nil {
+		signed, err := MintClientAssertion(clientID, tokenEndpoint, *assertion)
+		if err != nil {
+			return nil, fmt.Errorf("mint client_assertion: %w", err)
+		}
+		applyAssertionToForm(clientID, signed, data)
+		httpReq, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return httpReq, nil
+	}
+	var asMethods []string
+	if c.cachedASMeta != nil {
+		asMethods = c.cachedASMeta.TokenEndpointAuthMethods
+	}
+	authMethod := SelectAuthMethod(clientSecret, asMethods)
+	applyAuthToForm(authMethod, clientID, clientSecret, data)
+	httpReq, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if authMethod == AuthMethodClientSecretBasic {
+		httpReq.SetBasicAuth(clientID, clientSecret)
+	}
+	return httpReq, nil
+}
+

--- a/client/token_exchange_e2e_test.go
+++ b/client/token_exchange_e2e_test.go
@@ -1,0 +1,64 @@
+package client_test
+
+// E2E coverage for AuthClient.TokenExchange against the in-process
+// OneAuth AS. Validates the SDK -> real AS conversation: a signed JWT
+// from a trusted upstream issuer is exchanged at the token endpoint
+// and the SDK decodes the issued_token_type-bearing response.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/client"
+	"github.com/panyam/oneauth/testutil"
+)
+
+func TestTokenExchange_E2E_JWTSubjectToken(t *testing.T) {
+	idpKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	const idpIssuer = "https://corp-idp.example.com"
+	const asAudience = "oneauth-test-as"
+
+	srv := testutil.NewTestAuthServer(t,
+		testutil.WithAudience(asAudience),
+		testutil.WithTrustedAssertionIssuers([]apiauth.TrustedAssertionIssuer{{
+			Issuer:             idpIssuer,
+			PublicKey:          &idpKey.PublicKey,
+			Audiences:          []string{asAudience},
+			AcceptedAlgorithms: []string{"RS256"},
+		}}),
+	)
+	defer srv.Close()
+
+	now := time.Now()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": idpIssuer,
+		"sub": "alice",
+		"aud": asAudience,
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Add(-1 * time.Second).Unix(),
+	})
+	subjectToken, err := tok.SignedString(idpKey)
+	require.NoError(t, err)
+
+	c := client.NewAuthClient(srv.URL(), nil,
+		client.WithTokenEndpoint("/api/token"))
+	resp, err := c.TokenExchange(&client.TokenExchangeRequest{
+		ClientID:         "demo-client",
+		SubjectToken:     subjectToken,
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccessToken, "AS MUST issue an access token in exchange")
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", resp.IssuedTokenType,
+		"issued_token_type MUST round-trip in the RFC 8693 response")
+	assert.Equal(t, "Bearer", resp.TokenType)
+}

--- a/client/token_exchange_test.go
+++ b/client/token_exchange_test.go
@@ -1,0 +1,121 @@
+package client
+
+// Wire-level tests for AuthClient.TokenExchange — the RFC 8693
+// (`urn:ietf:params:oauth:grant-type:token-exchange`) primitive on the
+// client SDK.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tokenTypeIDToken = "urn:ietf:params:oauth:token-type:id_token"
+	tokenTypeIDJAG   = "urn:ietf:params:oauth:token-type:id-jag"
+	tokenTypeJWT     = "urn:ietf:params:oauth:token-type:jwt"
+)
+
+// tokenExchangeServer accepts a token-exchange request and forwards the
+// parsed form to `inspect` for assertions. Returns an issued token with
+// the supplied `issuedType` so tests can assert the `issued_token_type`
+// response field round-trips.
+func tokenExchangeServer(t *testing.T, issuedType string, inspect func(*testing.T, *http.Request)) *httptest.Server {
+	t.Helper()
+	var count atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", r.FormValue("grant_type"))
+		inspect(t, r)
+		n := count.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      fmt.Sprintf("exchanged-tok-%d", n),
+			"issued_token_type": issuedType,
+			"token_type":        "Bearer",
+			"expires_in":        300,
+			"scope":             "read write",
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestTokenExchange_AllParameters verifies every optional parameter is
+// emitted on the wire, repeated values like `audience` / `resource`
+// appear multiple times, and `issued_token_type` round-trips on the
+// response side.
+func TestTokenExchange_AllParameters(t *testing.T) {
+	srv := tokenExchangeServer(t, tokenTypeIDJAG, func(t *testing.T, r *http.Request) {
+		assert.Equal(t, "outer-id-token", r.FormValue("subject_token"))
+		assert.Equal(t, tokenTypeIDToken, r.FormValue("subject_token_type"))
+		assert.Equal(t, "actor-token", r.FormValue("actor_token"))
+		assert.Equal(t, tokenTypeJWT, r.FormValue("actor_token_type"))
+		assert.Equal(t, tokenTypeIDJAG, r.FormValue("requested_token_type"))
+		assert.Equal(t,
+			[]string{"https://api.example.com", "https://files.example.com"},
+			r.Form["audience"],
+			"audience MUST be sent as repeated form values (RFC 8693 §2.1)",
+		)
+		assert.Equal(t,
+			[]string{"https://api.example.com/v1", "https://files.example.com/v1"},
+			r.Form["resource"],
+			"resource MUST be sent as repeated form values (RFC 8707 §2)",
+		)
+		assert.Equal(t, "read write", r.FormValue("scope"), "scope MUST be a single space-delimited form value")
+	})
+	defer srv.Close()
+
+	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
+	resp, err := c.TokenExchange(&TokenExchangeRequest{
+		ClientID:           "demo",
+		ClientSecret:       "shh",
+		SubjectToken:       "outer-id-token",
+		SubjectTokenType:   tokenTypeIDToken,
+		ActorToken:         "actor-token",
+		ActorTokenType:     tokenTypeJWT,
+		RequestedTokenType: tokenTypeIDJAG,
+		Audience:           []string{"https://api.example.com", "https://files.example.com"},
+		Resource:           []string{"https://api.example.com/v1", "https://files.example.com/v1"},
+		Scope:              []string{"read", "write"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "exchanged-tok-1", resp.AccessToken)
+	assert.Equal(t, tokenTypeIDJAG, resp.IssuedTokenType, "issued_token_type MUST round-trip from the AS")
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, 300, resp.ExpiresIn)
+	assert.Equal(t, []string{"read", "write"}, resp.Scope)
+}
+
+// TestTokenExchange_MinimalRequest verifies that when only the required
+// fields are set, the optional parameters do NOT appear on the wire at
+// all — even as empty values. Wrong-empty-but-present can cause some
+// strict ASes to reject the request.
+func TestTokenExchange_MinimalRequest(t *testing.T) {
+	srv := tokenExchangeServer(t, tokenTypeJWT, func(t *testing.T, r *http.Request) {
+		assert.Equal(t, "outer-token", r.FormValue("subject_token"))
+		assert.Equal(t, tokenTypeIDToken, r.FormValue("subject_token_type"))
+
+		for _, key := range []string{"actor_token", "actor_token_type", "requested_token_type", "audience", "resource", "scope"} {
+			_, present := r.Form[key]
+			assert.False(t, present, "optional form key %q MUST be omitted when unset", key)
+		}
+	})
+	defer srv.Close()
+
+	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
+	resp, err := c.TokenExchange(&TokenExchangeRequest{
+		ClientID:         "demo",
+		ClientSecret:     "shh",
+		SubjectToken:     "outer-token",
+		SubjectTokenType: tokenTypeIDToken,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.AccessToken)
+}

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # OneAuth Release Notes
 
+## Version 0.1.5
+
+### Client SDK — RFC 8693 token exchange + RFC 7523 §2.1 JWT bearer grant
+
+Two new general-purpose OAuth primitives on `AuthClient`. Both are additive — no existing behavior changes.
+
+**`AuthClient.TokenExchange(*TokenExchangeRequest)` — RFC 8693.** Exchange a subject token (plus optional actor token / requested type / audience / resource / scope) for a freshly issued token. Returns `TokenExchangeResponse` including `IssuedTokenType` (required by RFC 8693 §2.2). Useful for bridging trust domains — e.g. exchanging an upstream-IdP ID token for an internal ID-JAG.
+
+**`AuthClient.JwtBearerGrant(*JwtBearerGrantRequest)` — RFC 7523 §2.1.** Present a signed JWT (typically the output of a prior token exchange or trusted upstream issuance) as `assertion` at the token endpoint to obtain an access token. Distinct from the `private_key_jwt` client authentication method, which authenticates the client itself — both can coexist in the same request.
+
+Both methods reuse the existing `AuthClient` client-authentication negotiation: `client_secret_basic`, `client_secret_post`, and `private_key_jwt` (via `ClientAssertionConfig`) all work transparently.
+
+**Wire shape:** `application/x-www-form-urlencoded` with the appropriate `grant_type` value. `audience` and `resource` are emitted as repeated form values per RFC 8693 §2.1 / RFC 8707 §2. `scope` is space-delimited per RFC 6749 §3.3.
+
+**Tests:** 5 unit tests covering wire shape + minimal request omission + all three client-auth methods, plus 2 e2e tests against the in-process `testutil.TestAuthServer` with `TrustedAssertionIssuers` configured.
+
+Near-term consumer: mcpkit's SEP-990 enterprise-managed authorization (mcpkit issue 448), which chains these two primitives in an `EnterpriseManagedTokenSource` with two-stage caching.
+
+See issue 213.
+
+---
+
 ## Version 0.1.4 (PR 2b — Subject vocab consumer-side rename)
 
 ### Subject vocabulary — phase 2: consumers, helpers, transports


### PR DESCRIPTION
Closes #213.

## What changes

Two new additive primitives on `AuthClient`:

- **`AuthClient.TokenExchange(*TokenExchangeRequest)`** — RFC 8693 token exchange. Subject token (required) + optional actor, requested-token-type, audience, resource, scope. Returns `TokenExchangeResponse` including the RFC-required `IssuedTokenType`.
- **`AuthClient.JwtBearerGrant(*JwtBearerGrantRequest)`** — RFC 7523 §2.1 jwt-bearer grant. Distinct from the `private_key_jwt` *client auth method* — the two can coexist in the same form (one assertion authenticates the client, the other is the grant payload).

Both reuse the existing client-auth negotiation (`client_secret_basic`, `client_secret_post`, `private_key_jwt`) via a shared `buildTokenRequest` helper.

Near-term consumer: mcpkit issue 448 (SEP-990 enterprise-managed authorization), which chains these two primitives in an `EnterpriseManagedTokenSource` with two-stage caching.

## Reviewer's guide

1. [client/token_exchange.go](https://github.com/panyam/oneauth/pull/216/files#diff-5a787b15620926fc1fad6849644b53996947b72c2b2c4c260ebb0d8e4a48493c) — start here. `TokenExchangeRequest`/`Response` types + the `TokenExchange` method + the shared `buildTokenRequest` helper used by both grants. The `rawTokenExchangeResponse` intermediate decodes `scope` (space-delimited string on the wire) into a slice for the caller.
2. [client/jwt_bearer_grant.go](https://github.com/panyam/oneauth/pull/216/files#diff-84b932eb10b14419b115f3671dbf27d557bccf23a18f6d2855675aab10c9f14e) — `JwtBearerGrantRequest` + the `JwtBearerGrant` method. Delegates to `c.executeTokenRequest` (already-existing path) since the response shape is just `ServerCredential`.
3. [client/token_exchange_test.go](https://github.com/panyam/oneauth/pull/216/files#diff-84cfcd9fe8b3d80824dbf55daf9e436f42fa11272a80072a842af77cfd6c39eb) — acceptance: `TestTokenExchange_AllParameters` (every optional param + repeated audience/resource), `TestTokenExchange_MinimalRequest` (optional params MUST be omitted entirely, not emitted as empty values).
4. [client/jwt_bearer_grant_test.go](https://github.com/panyam/oneauth/pull/216/files#diff-0d8c31d52cd9df652fb13b796f54b3afb96debaf4bc63d9229d8e25e405d60b1) — acceptance: `_Roundtrip` (basic wire shape), `_ClientAuthBasic` (HTTP Basic header), `_ClientAuthPrivateKeyJwt` (the dual-JWT case — `client_assertion` AND `assertion` coexist in the same form).
5. [client/token_exchange_e2e_test.go](https://github.com/panyam/oneauth/pull/216/files#diff-919ee4091b2031b1d5706409fa600a4be4a753d379124c92b9a66c9554483d83), [client/jwt_bearer_grant_e2e_test.go](https://github.com/panyam/oneauth/pull/216/files#diff-f6e6c7e8f0857a7c8c36ba3674a97b41fba82ec6c9886317144ab8c827118a51) — SDK ↔ real AS round-trips via `testutil.TestAuthServer` with `TrustedAssertionIssuers` configured. Validates that what the unit-test mock accepts is also what the real OneAuth AS accepts.
6. [docs/RELEASE_NOTES.md](https://github.com/panyam/oneauth/pull/216/files#diff-06470f44e11a4acf72ecac0f68c7438ff957181a677bbc006439d2532b9794b6) — v0.1.5 entry.

Skim or skip: nothing generated.

## Decision log

- **Shared `buildTokenRequest` helper.** Both grants need identical client-auth handling (basic / post / private_key_jwt) but produce different response shapes. Factoring out the request-builder keeps the auth-negotiation logic in one place; the dispatch + decode happens per-method. Considered routing through `executeTokenRequest` for both — works for `JwtBearerGrant` (returns `*ServerCredential`) but not `TokenExchange` (needs `issued_token_type`).
- **`Scope []string` decoded from space-delimited wire string.** RFC 6749 §3.3 says scope is a space-delimited string. Existing `ServerCredential` exposes `Scope string`; the new `TokenExchangeResponse` exposes `Scope []string` to spare callers a `strings.Fields()` call. Per the issue spec.
- **Required vs optional validation in `TokenExchange`.** Issue spec marks `SubjectToken` + `SubjectTokenType` as required; everything else optional. Validated at method entry; optional params are omitted from the form when their slice / string is empty (verified by `TestTokenExchange_MinimalRequest`).
- **Bypass `refreshTransport`.** Token-endpoint requests use `&http.Client{Transport: c.baseTransport}` (same as `executeTokenRequest`) to avoid auth-recursion on 401. Lesson learned mid-PR — first impl used `c.httpClient` and hung.

## Risk / blast radius

- **Public API:** purely additive — two new methods + three new types (`TokenExchangeRequest`, `TokenExchangeResponse`, `JwtBearerGrantRequest`). No existing surface changes.
- **Wire format:** matches RFC 8693 §2.1 and RFC 7523 §2.1 exactly. `TestTokenExchange_MinimalRequest` guards against emitting empty optional params (which some strict ASes reject).
- **Server-side:** unchanged. OneAuth's AS already supports both grants (`apiauth.handleJwtBearerGrant` + `apiauth.handleTokenExchangeGrant`); the e2e tests confirm SDK round-trips against them.

## Out of scope (deliberate)

- mcpkit's `EnterpriseManagedTokenSource` (chains these two) — downstream.
- Keycloak interop tests — Keycloak's RFC 8693 support is experimental; the testutil-based e2e covers the wire-shape conformance side.
- Tag v0.1.5 — after merge.
