### PR TITLE
refactor(apiauth,admin): close convention migration (closes #175, #172)

### DIFF
--- a/apiauth/SUMMARY.md
+++ b/apiauth/SUMMARY.md
@@ -11,6 +11,10 @@ JWT-based API authentication: token issuance (login/refresh/client_credentials),
 
 ## Transport-Independent Core (OneAuth)
 
+All transport-agnostic interfaces in this package follow the gRPC-shape convention `MethodName(ctx context.Context, req *XRequest) (*XResponse, error)` — `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`. HTTP handlers are thin wrappers that construct the request type from the HTTP message and format the response. The same shape is used in `admin/` (`ClientRegistrar`, `ClientRegistrationManager`). Convention rationale: issue #110; apiauth adoption: issue #175.
+
+Legacy positional methods on `APIAuth` (`CreateAccessToken`, `ValidateAccessToken`, `ValidateAccessTokenFull`, `VerifyTokenFunc`) are marked `// Deprecated:` — they remain as the internal implementation backing the HTTP handlers until consolidation lands. Tracked under issue #218.
+
 The `OneAuth` struct composes focused interfaces for all auth operations without HTTP:
 - **interfaces.go** — `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`, `TokenInfo`
 - **hooks.go** — `Hooks` (grouped: `TokenHooks`, `AuthHooks`, `ClientHooks`, `SecurityHooks`)

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -563,6 +563,11 @@ var standardClaims = map[string]bool{
 // CreateAccessToken creates a signed JWT access token. If CustomClaimsFunc is set,
 // its returned claims are merged into the token (standard claims cannot be overridden).
 // authzDetails is an optional RFC 9396 authorization_details array embedded in the JWT.
+//
+// Deprecated: prefer the transport-agnostic TokenIssuer.CreateAccessToken(ctx,
+// *CreateAccessTokenRequest) (*CreateAccessTokenResponse, error) on the OneAuth.Issuer
+// (or NewJWTIssuer-built jwtIssuer). This positional method is retained as the internal
+// implementation that APIAuth's HTTP handlers still call; consolidation tracked under issue 218.
 func (a *APIAuth) CreateAccessToken(userID string, scopes []string, authzDetails []core.AuthorizationDetail) (string, int64, error) {
 	expiry := a.AccessTokenExpiry
 	if expiry == 0 {
@@ -640,6 +645,10 @@ func (a *APIAuth) CreateAccessToken(userID string, scopes []string, authzDetails
 
 // VerifyTokenFunc returns a function that can be used as Middleware.VerifyToken.
 // This allows the Middleware to validate Bearer tokens using the APIAuth's JWT configuration.
+//
+// Deprecated: prefer the transport-agnostic TokenValidator.ValidateToken(ctx,
+// *ValidateTokenRequest) (*ValidateTokenResponse, error) on the OneAuth.Validator.
+// Retained for httpauth.Middleware wiring; consolidation tracked under issue 218.
 func (a *APIAuth) VerifyTokenFunc() func(tokenString string) (userID string, token any, err error) {
 	return func(tokenString string) (string, any, error) {
 		userID, scopes, err := a.ValidateAccessToken(tokenString)
@@ -650,7 +659,12 @@ func (a *APIAuth) VerifyTokenFunc() func(tokenString string) (userID string, tok
 	}
 }
 
-// ValidateAccessToken validates a JWT access token and returns the claims
+// ValidateAccessToken validates a JWT access token and returns the claims.
+//
+// Deprecated: prefer the transport-agnostic TokenValidator.ValidateToken(ctx,
+// *ValidateTokenRequest) (*ValidateTokenResponse, error) on the OneAuth.Validator.
+// Retained as the implementation backing the deprecated VerifyTokenFunc;
+// consolidation tracked under issue 218.
 func (a *APIAuth) ValidateAccessToken(tokenString string) (userID string, scopes []string, err error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		return a.jwtKeyFunc(token)
@@ -721,6 +735,12 @@ func (a *APIAuth) ValidateAccessToken(tokenString string) (userID string, scopes
 
 // ValidateAccessTokenFull validates a JWT access token and returns the standard claims
 // plus any custom claims (non-standard keys) as a separate map.
+//
+// Deprecated: prefer the transport-agnostic TokenValidator.ValidateToken(ctx,
+// *ValidateTokenRequest) (*ValidateTokenResponse, error) on the OneAuth.Validator —
+// its response carries the same standard + custom claims split via TokenInfo.
+// Retained as the implementation backing IntrospectionHandler today; consolidation
+// tracked separately.
 func (a *APIAuth) ValidateAccessTokenFull(tokenString string) (userID string, scopes []string, customClaims map[string]any, err error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		return a.jwtKeyFunc(token)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,20 @@
 # OneAuth Release Notes
 
+## Version 0.1.6
+
+### Convention closure for issues 175 + 172
+
+The `(ctx, *XRequest) → (*XResponse, error)` convention adopted across the library (CLAUDE.md "gRPC-shape convention everywhere") is now closed-loop for `apiauth/` and `admin/`:
+
+- **`apiauth/`**: all five transport-agnostic interfaces (`TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`) follow the convention. HTTP handlers are thin wrappers. Four legacy positional methods on `APIAuth` — `CreateAccessToken`, `ValidateAccessToken`, `ValidateAccessTokenFull`, `VerifyTokenFunc` — are now marked `// Deprecated:` and point at the canonical interface methods. They remain as the internal implementation backing the HTTP handlers; consolidation + outright removal is tracked under issue 218.
+- **`admin/`**: `ClientRegistrar` interface (Register / RegisterLegacy / ListClients / GetClient / DeleteClient / RotateSecret) is in shape, implemented on `AppRegistrar`, and covered by pure-Go interface tests (`client_admin_test.go`) that bypass HTTP entirely. `ClientRegistrationManager` (RFC 7592 self-service) already adopted the convention via issues 168/169/170.
+
+Documentation updated: `apiauth/SUMMARY.md` now carries the convention paragraph that `admin/SUMMARY.md` already had.
+
+Closes 175, 172. Follow-up consolidation tracked under 218. Client SDK migration tracked under 217.
+
+---
+
 ## Version 0.1.5
 
 ### Client SDK — RFC 8693 token exchange + RFC 7523 §2.1 JWT bearer grant


### PR DESCRIPTION
Closes #175 and #172.

## What changes

Both issues are largely **implementation-complete already**:

- `apiauth/`: `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator` — all five on the `(ctx, *XRequest) → (*XResponse, error)` shape, with dedicated request/response types and HTTP handlers as thin wrappers.
- `admin/`: `ClientRegistrar` interface (`Register` / `RegisterLegacy` / `ListClients` / `GetClient` / `DeleteClient` / `RotateSecret`) on the convention, implemented on `AppRegistrar`, with pure-Go interface tests in `client_admin_test.go` that bypass HTTP entirely. `ClientRegistrationManager` already adopted via #168 / #169 / #170.

This PR closes the loop with the three remaining items:

1. **Deprecation comments** on four legacy positional methods on `APIAuth` — `CreateAccessToken`, `ValidateAccessToken`, `ValidateAccessTokenFull`, `VerifyTokenFunc` — pointing at the canonical interface methods. They remain as the internal implementation backing the HTTP handlers; outright removal tracked separately.
2. **`apiauth/SUMMARY.md` convention paragraph** — matches the one already in `admin/SUMMARY.md`.
3. **v0.1.6 release notes entry** summarising the closure.

No behaviour change. Wire format byte-identical pre/post.

## Reviewer's guide

1. [apiauth/auth.go](https://github.com/panyam/oneauth/pull/219/files#diff-6f548dbab24d0609200ec2c43738d8d522c8f3d3b5b288eae95c1dc06b239bf8) — `// Deprecated:` doc blocks on `CreateAccessToken` (~line 566), `VerifyTokenFunc` (~line 651), `ValidateAccessToken` (~line 663), `ValidateAccessTokenFull` (~line 736). Each points at the canonical interface method and at issue #218 for the consolidation work.
2. [apiauth/SUMMARY.md](https://github.com/panyam/oneauth/pull/219/files#diff-f3bbacfca08d00c3458076319ba481fec63aa40f5488dd2adf1254e38b90986e) — convention paragraph inserted at the top of the \"Transport-Independent Core (OneAuth)\" section, plus a paragraph explaining the deprecated legacy positional methods.
3. [docs/RELEASE_NOTES.md](https://github.com/panyam/oneauth/pull/219/files#diff-06470f44e11a4acf72ecac0f68c7438ff957181a677bbc006439d2532b9794b6) — v0.1.6 entry. Frame the closure relative to the two issues.

Skim / skip: nothing else changed.

## Decision log

- **Deprecate, not remove.** The four legacy methods are the **actual implementation** backing the HTTP handlers (~7 internal call sites) and they're called from ~25 test sites in `apiauth_test` external-test packages. True removal requires consolidating their behaviour into `TokenIssuer` / `TokenValidator` impls AND migrating every test. That's ~400 LOC and is tracked as #218.
- **No code change for #172.** The implementation is done. The PR closes it via the release notes + the deprecation work that completes #175.
- **`#218` filed separately.** Outright removal of the legacy methods is its own unit of work — bigger diff, focused review.

## Risk / blast radius

- **Public API:** unchanged. `// Deprecated:` annotations don't affect behaviour; `go vet` and golangci-lint will surface them to consumers.
- **Wire format:** unchanged.
- **Tests:** `make test` + `make e2e` green, no test churn.

## Out of scope

- **Issue #218** — consolidate + remove the deprecated legacy methods.
- **Issue #217** — `client/` SDK convention migration.
- Tag v0.1.6 — after merge.
