### PR TITLE
WIP refactor(keys): migrate KeyStorage / KidStorage to (ctx, *Req) → (*Resp, error) shape (#204a)

### DIFF
--- a/admin/client_admin_test.go
+++ b/admin/client_admin_test.go
@@ -139,7 +139,7 @@ func TestClientRegistrar_DeleteClient_RemovesFromStoreAndKeyStore(t *testing.T) 
 		t.Errorf("store should report ErrAppNotFound after DeleteClient, got %v", err)
 	}
 	// KeyStore side: gone.
-	if _, err := ks.GetKey(clientID); !errors.Is(err, keys.ErrKeyNotFound) {
+	if _, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); !errors.Is(err, keys.ErrKeyNotFound) {
 		t.Errorf("KeyStore should report ErrKeyNotFound after DeleteClient, got %v", err)
 	}
 	// Repeat delete: ErrAppNotFound (idempotency by accident — safe).
@@ -157,7 +157,7 @@ func TestClientRegistrar_RotateSecret_Symmetric(t *testing.T) {
 	registered, err := r.RegisterLegacy(context.Background(), &admin.RegisterLegacyRequest{ClientDomain: "rotate.me"})
 	require.NoError(t, err)
 
-	preRotateKey, err := ks.GetKey(registered.ClientID)
+	preRotateKeyResp_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: registered.ClientID}); var preRotateKey *keys.KeyRecord; if preRotateKeyResp_ != nil { preRotateKey = preRotateKeyResp_.Record }
 	require.NoError(t, err)
 	preRotateKid := preRotateKey.Kid
 

--- a/admin/dcr_management_test.go
+++ b/admin/dcr_management_test.go
@@ -482,7 +482,7 @@ func TestDeleteRegistration_HappyPath(t *testing.T) {
 
 	// Signing key is gone — tokens issued under this client_id can no longer
 	// be re-validated against the AS.
-	if _, err := ks.GetKey(clientID); err != keys.ErrKeyNotFound {
+	if _, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); err != keys.ErrKeyNotFound {
 		t.Errorf("expected ErrKeyNotFound after delete, got %v", err)
 	}
 }

--- a/admin/dcr_test.go
+++ b/admin/dcr_test.go
@@ -10,6 +10,7 @@ package admin_test
 //   - See: https://github.com/panyam/oneauth/issues/48
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -51,7 +52,7 @@ func TestDCR_SymmetricRegistration(t *testing.T) {
 
 	// Verify the key was stored
 	clientID := resp["client_id"].(string)
-	rec, err := ks.GetKey(clientID)
+	recResp_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var rec *keys.KeyRecord; if recResp_ != nil { rec = recResp_.Record }
 	require.NoError(t, err)
 	assert.Equal(t, "HS256", rec.Algorithm)
 }

--- a/admin/mint_test.go
+++ b/admin/mint_test.go
@@ -4,11 +4,12 @@ package admin_test
 // KeyStore-based verification, and rejection of tokens signed with incorrect secrets.
 
 import (
-	"github.com/panyam/oneauth/admin"
-	"github.com/panyam/oneauth/keys"
+	"context"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/keys"
 )
 
 // TestMintResourceToken_Basic verifies that MintResourceToken produces a valid HS256 JWT
@@ -86,8 +87,7 @@ func TestMintResourceToken_VerifiableByMiddleware(t *testing.T) {
 
 	// Resource server verifies using KeyStore
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey(clientID, []byte(secret), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: "HS256"}})
 	// Parse with KeyStore-based keyfunc (mimics what APIMiddleware does)
 	parsed, err := jwt.Parse(token, func(t *jwt.Token) (any, error) {
 		claims, ok := t.Claims.(jwt.MapClaims)
@@ -95,14 +95,14 @@ func TestMintResourceToken_VerifiableByMiddleware(t *testing.T) {
 			return nil, keys.ErrKeyNotFound
 		}
 		cid, _ := claims["client_id"].(string)
-		expectedAlg, err := ks.GetExpectedAlg(cid)
+		resp, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: cid})
 		if err != nil {
 			return nil, err
 		}
-		if t.Header["alg"] != expectedAlg {
+		if t.Header["alg"] != resp.Record.Algorithm {
 			return nil, keys.ErrAlgorithmMismatch
 		}
-		return ks.GetVerifyKey(cid)
+		return resp.Record.Key, nil
 	})
 	if err != nil {
 		t.Fatalf("KeyStore-based verification failed: %v", err)

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -183,7 +183,7 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 		if err != nil {
 			return nil, fmt.Errorf("encode public key: %w", err)
 		}
-		if err := h.KeyStore.PutKey(&keys.KeyRecord{ClientID: clientID, Key: pemBytes, Algorithm: signingAlg}); err != nil {
+		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: pemBytes, Algorithm: signingAlg}}); err != nil {
 			return nil, fmt.Errorf("store key: %w", err)
 		}
 		// No client_secret in response for asymmetric.
@@ -192,7 +192,7 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 		if err != nil {
 			return nil, fmt.Errorf("generate secret: %w", err)
 		}
-		if err := h.KeyStore.PutKey(&keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}); err != nil {
+		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}}); err != nil {
 			return nil, fmt.Errorf("store key: %w", err)
 		}
 		resp.ClientSecret = secret
@@ -269,7 +269,7 @@ func (h *AppRegistrar) RegisterLegacy(ctx context.Context, req *RegisterLegacyRe
 		if _, err := utils.DecodeVerifyKey([]byte(req.PublicKey), signingAlg); err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrInvalidPublicKey, err)
 		}
-		if err := h.KeyStore.PutKey(&keys.KeyRecord{ClientID: clientID, Key: []byte(req.PublicKey), Algorithm: signingAlg}); err != nil {
+		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: []byte(req.PublicKey), Algorithm: signingAlg}}); err != nil {
 			return nil, fmt.Errorf("store key: %w", err)
 		}
 		// No client_secret in response for asymmetric.
@@ -278,7 +278,7 @@ func (h *AppRegistrar) RegisterLegacy(ctx context.Context, req *RegisterLegacyRe
 		if err != nil {
 			return nil, fmt.Errorf("generate secret: %w", err)
 		}
-		if err := h.KeyStore.PutKey(&keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}); err != nil {
+		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}}); err != nil {
 			return nil, fmt.Errorf("store key: %w", err)
 		}
 		resp.ClientSecret = secret
@@ -361,7 +361,7 @@ func (h *AppRegistrar) DeleteClient(ctx context.Context, req *DeleteClientReques
 
 	// KeyStore deletion is best-effort: a stranded key is unreachable
 	// once the registration is gone (same rationale as DeleteRegistration).
-	_ = h.KeyStore.DeleteKey(req.ClientID)
+	_, _ = h.KeyStore.DeleteKey(ctx, &keys.DeleteKeyRequest{ClientID: req.ClientID})
 
 	return &DeleteClientResponse{}, nil
 }
@@ -403,7 +403,8 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 	var oldKey any
 	var oldAlg, oldKid string
 	if h.KidStore != nil {
-		if oldRec, err := h.KeyStore.GetKey(req.ClientID); err == nil {
+		if oldResp, err := h.KeyStore.GetKey(ctx, &keys.GetKeyRequest{ClientID: req.ClientID}); err == nil {
+			oldRec := oldResp.Record
 			oldKey = oldRec.Key
 			oldAlg = oldRec.Algorithm
 			oldKid = oldRec.Kid
@@ -422,7 +423,7 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 		if _, err := utils.DecodeVerifyKey([]byte(req.PublicKey), reg.SigningAlg); err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrInvalidPublicKey, err)
 		}
-		if err := h.KeyStore.PutKey(&keys.KeyRecord{ClientID: req.ClientID, Key: []byte(req.PublicKey), Algorithm: reg.SigningAlg}); err != nil {
+		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: req.ClientID, Key: []byte(req.PublicKey), Algorithm: reg.SigningAlg}}); err != nil {
 			return nil, fmt.Errorf("update key: %w", err)
 		}
 	} else {
@@ -430,7 +431,7 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 		if err != nil {
 			return nil, fmt.Errorf("generate secret: %w", err)
 		}
-		if err := h.KeyStore.PutKey(&keys.KeyRecord{ClientID: req.ClientID, Key: []byte(newSecret), Algorithm: reg.SigningAlg}); err != nil {
+		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: req.ClientID, Key: []byte(newSecret), Algorithm: reg.SigningAlg}}); err != nil {
 			return nil, fmt.Errorf("update key: %w", err)
 		}
 		resp.ClientSecret = newSecret
@@ -440,15 +441,15 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 		// Surface persistence failures: silently dropping the old kid
 		// would advertise a grace period that didn't actually persist,
 		// rejecting in-flight tokens. Fail the rotation instead.
-		if err := h.KidStore.Add(oldKid, oldKey, oldAlg, req.ClientID, time.Now().Add(gracePeriod)); err != nil {
+		if _, err := h.KidStore.Add(context.Background(), &keys.AddKidRequest{Kid: oldKid, Key: oldKey, Algorithm: oldAlg, ClientID: req.ClientID, ExpiresAt: time.Now().Add(gracePeriod)}); err != nil {
 			return nil, fmt.Errorf("retain previous key: %w", err)
 		}
 		resp.PreviousKid = oldKid
 		resp.GracePeriod = gracePeriod
 	}
 
-	if newRec, err := h.KeyStore.GetKey(req.ClientID); err == nil && newRec.Kid != "" {
-		resp.Kid = newRec.Kid
+	if newResp, err := h.KeyStore.GetKey(ctx, &keys.GetKeyRequest{ClientID: req.ClientID}); err == nil && newResp.Record.Kid != "" {
+		resp.Kid = newResp.Record.Kid
 	}
 	return resp, nil
 }
@@ -650,7 +651,7 @@ func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegist
 	// registration is gone, which is the user-visible deletion contract;
 	// a stranded key is at worst an internal cleanup concern (the KeyStore
 	// entry is unreachable without an AppRegistration to point at it).
-	_ = h.KeyStore.DeleteKey(req.ClientID)
+	_, _ = h.KeyStore.DeleteKey(ctx, &keys.DeleteKeyRequest{ClientID: req.ClientID})
 
 	return &DeleteRegistrationResponse{}, nil
 }

--- a/admin/registrar_test.go
+++ b/admin/registrar_test.go
@@ -4,6 +4,7 @@ package admin_test
 // deletion, secret/key rotation, admin auth enforcement, and input validation.
 
 import (
+	"context"
 	"github.com/panyam/oneauth/admin"
 	"github.com/panyam/oneauth/keys"
 	"bytes"
@@ -56,7 +57,7 @@ func TestAppRegistrar_Register(t *testing.T) {
 	}
 
 	// Verify key was stored
-	key, err := ks.GetVerifyKey(clientID)
+	keyResp_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var key any; if keyResp_ != nil { key = keyResp_.Record.Key }
 	if err != nil {
 		t.Fatalf("Key should be stored: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestAppRegistrar_Register(t *testing.T) {
 		t.Error("Stored key should match returned secret")
 	}
 
-	alg, _ := ks.GetExpectedAlg(clientID)
+	algResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var alg string; if algResp_ != nil { alg = algResp_.Record.Algorithm }
 	if alg != "HS256" {
 		t.Errorf("Expected alg HS256, got %s", alg)
 	}
@@ -215,7 +216,7 @@ func TestAppRegistrar_DeleteApp(t *testing.T) {
 	}
 
 	// Should be gone from KeyStore
-	_, err := ks.GetVerifyKey(clientID)
+	_Resp_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var _ any; if _Resp_ != nil { _ = _Resp_.Record.Key }
 	if err != keys.ErrKeyNotFound {
 		t.Errorf("Expected ErrKeyNotFound after delete, got %v", err)
 	}
@@ -273,7 +274,7 @@ func TestAppRegistrar_RotateSecret(t *testing.T) {
 	}
 
 	// KeyStore should have the new secret
-	key, _ := ks.GetVerifyKey(clientID)
+	keyResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var key any; if keyResp_ != nil { key = keyResp_.Record.Key }
 	if string(key.([]byte)) != newSecret {
 		t.Error("KeyStore should have the rotated secret")
 	}
@@ -403,11 +404,11 @@ func TestAppRegistrar_Register_RS256(t *testing.T) {
 
 	// Verify key stored as PEM bytes
 	clientID := resp["client_id"].(string)
-	key, _ := ks.GetVerifyKey(clientID)
+	keyResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var key any; if keyResp_ != nil { key = keyResp_.Record.Key }
 	if string(key.([]byte)) != string(pubPEM) {
 		t.Error("Stored key should be the public key PEM")
 	}
-	alg, _ := ks.GetExpectedAlg(clientID)
+	algResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var alg string; if algResp_ != nil { alg = algResp_.Record.Algorithm }
 	if alg != "RS256" {
 		t.Errorf("Expected alg RS256, got %s", alg)
 	}
@@ -501,7 +502,7 @@ func TestAppRegistrar_RotateKey_RS256(t *testing.T) {
 	}
 
 	// KeyStore should have the new key
-	key, _ := ks.GetVerifyKey(clientID)
+	keyResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var key any; if keyResp_ != nil { key = keyResp_.Record.Key }
 	if string(key.([]byte)) != string(pubPEM2) {
 		t.Error("KeyStore should have the rotated public key")
 	}

--- a/apiauth/asymmetric_jwt_test.go
+++ b/apiauth/asymmetric_jwt_test.go
@@ -5,6 +5,7 @@ package apiauth_test
 // with mixed algorithm support and algorithm confusion attack prevention.
 
 import (
+	"context"
 	"github.com/panyam/oneauth/admin"
 	"github.com/panyam/oneauth/apiauth"
 	"github.com/panyam/oneauth/keys"
@@ -257,8 +258,7 @@ func TestAPIMiddleware_RS256_MultiTenant(t *testing.T) {
 	// Register an RS256 app with its public key
 	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
 	// Mint a token with the private key
 	tokenStr, err := admin.MintResourceTokenWithKey("user-1", "app-rsa", privKey, admin.AppQuota{}, []string{"read"}, nil)
 	if err != nil {
@@ -291,8 +291,7 @@ func TestAPIMiddleware_ES256_MultiTenant(t *testing.T) {
 
 	privPEM, pubPEM, _ := utils.GenerateECDSAKeyPair()
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
-	ks.RegisterKey("app-ec", pubPEM, "ES256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-ec", Key: pubPEM, Algorithm: "ES256"}})
 	tokenStr, _ := admin.MintResourceTokenWithKey("user-2", "app-ec", privKey, admin.AppQuota{}, []string{"write"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
@@ -316,18 +315,15 @@ func TestAPIMiddleware_MixedAlgorithms(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 
 	// Register HS256 app
-	ks.RegisterKey("app-hs", []byte("hs-secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-hs", Key: []byte("hs-secret"), Algorithm: "HS256"}})
 	// Register RS256 app
 	rsaPrivPEM, rsaPubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	rsaPrivKey, _ := utils.ParsePrivateKeyPEM(rsaPrivPEM)
-	ks.RegisterKey("app-rsa", rsaPubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: rsaPubPEM, Algorithm: "RS256"}})
 	// Register ES256 app
 	ecPrivPEM, ecPubPEM, _ := utils.GenerateECDSAKeyPair()
 	ecPrivKey, _ := utils.ParsePrivateKeyPEM(ecPrivPEM)
-	ks.RegisterKey("app-ec", ecPubPEM, "ES256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-ec", Key: ecPubPEM, Algorithm: "ES256"}})
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -362,8 +358,7 @@ func TestAPIMiddleware_AlgorithmConfusion(t *testing.T) {
 
 	// Register app as RS256
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
 	// Try to forge a token using HS256 with the public key as the HMAC secret
 	// This is the classic algorithm confusion attack
 	forgedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -1338,8 +1338,9 @@ func (m *APIMiddleware) validateJWTInline(tokenString string) (userID string, sc
 		if m.KeyStore != nil {
 			// Try kid-based lookup first (if kid header present)
 			if kid, ok := token.Header["kid"].(string); ok && kid != "" {
-				rec, err := m.KeyStore.GetKeyByKid(kid)
+				kidResp, err := m.KeyStore.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
 				if err == nil {
+					rec := kidResp.Record
 					if token.Header["alg"] != rec.Algorithm {
 						return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
 					}
@@ -1369,10 +1370,11 @@ func (m *APIMiddleware) validateJWTInline(tokenString string) (userID string, sc
 				return nil, fmt.Errorf("missing client_id claim")
 			}
 
-			rec, err := m.KeyStore.GetKey(clientID)
+			getResp, err := m.KeyStore.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
 			if err != nil {
 				return nil, fmt.Errorf("unknown client: %w", err)
 			}
+			rec := getResp.Record
 			if token.Header["alg"] != rec.Algorithm {
 				return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
 			}

--- a/apiauth/auth_rar_test.go
+++ b/apiauth/auth_rar_test.go
@@ -6,6 +6,7 @@ package apiauth_test
 // See: https://www.rfc-editor.org/rfc/rfc9396
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -25,11 +26,11 @@ import (
 func setupRARAuth(t *testing.T) (*apiauth.APIAuth, *keys.InMemoryKeyStore) {
 	t.Helper()
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "test-client",
 		Key:       []byte("test-client-secret"),
 		Algorithm: "HS256",
-	})
+	}})
 
 	auth := &apiauth.APIAuth{
 		JWTSecretKey:   "rar-test-jwt-secret-32chars-min!",
@@ -241,11 +242,11 @@ func TestCreateAccessToken_StandardClaimsGuard_RAR(t *testing.T) {
 // See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
 func TestIntrospection_WithRAR(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "resource-server",
 		Key:       []byte("rs-secret"),
 		Algorithm: "HS256",
-	})
+	}})
 
 	auth := &apiauth.APIAuth{
 		JWTSecretKey:   "introspect-rar-secret-32chars-m!",
@@ -290,11 +291,11 @@ func TestIntrospection_WithRAR(t *testing.T) {
 // See: https://www.rfc-editor.org/rfc/rfc9396#section-9.1
 func TestIntrospection_WithoutRAR(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "resource-server",
 		Key:       []byte("rs-secret"),
 		Algorithm: "HS256",
-	})
+	}})
 
 	auth := &apiauth.APIAuth{
 		JWTSecretKey:   "introspect-norar-secret-32ch-m!",

--- a/apiauth/blacklist_test.go
+++ b/apiauth/blacklist_test.go
@@ -11,6 +11,7 @@ package apiauth_test
 //     Insufficient Session Expiration
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -246,8 +247,7 @@ func TestBlacklist_ValidateAccessTokenFull_ChecksBlacklist(t *testing.T) {
 func TestBlacklist_MultiTenantMiddleware(t *testing.T) {
 	bl := core.NewInMemoryBlacklist()
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app1", []byte("secret1"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app1", Key: []byte("secret1"), Algorithm: "HS256"}})
 	mw := &apiauth.APIMiddleware{
 		KeyStore:  ks,
 		Blacklist: bl,

--- a/apiauth/client_authenticator.go
+++ b/apiauth/client_authenticator.go
@@ -75,10 +75,11 @@ func (a *clientAuthenticator) AuthenticateClient(ctx context.Context, req *Authe
 }
 
 func (a *clientAuthenticator) authenticateSecret(req *AuthenticateClientRequest) (*AuthenticateClientResponse, error) {
-	rec, err := a.keyLookup.GetKey(req.ClientID)
-	if err != nil || rec == nil {
+	resp, err := a.keyLookup.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: req.ClientID})
+	if err != nil || resp == nil || resp.Record == nil {
 		return nil, errInvalidClient
 	}
+	rec := resp.Record
 	storedKey, ok := rec.Key.([]byte)
 	if !ok {
 		return nil, errInvalidClient
@@ -142,10 +143,11 @@ func (a *clientAuthenticator) authenticateAssertion(req *AuthenticateClientReque
 		return nil, fmt.Errorf("%w: client_id form param does not match assertion iss/sub", errInvalidClient)
 	}
 
-	rec, err := a.keyLookup.GetKey(clientID)
-	if err != nil || rec == nil {
+	keyResp, err := a.keyLookup.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+	if err != nil || keyResp == nil || keyResp.Record == nil {
 		return nil, errInvalidClient
 	}
+	rec := keyResp.Record
 	if !utils.IsAsymmetricAlg(rec.Algorithm) {
 		// Symmetric-keyed clients cannot use private_key_jwt.
 		// client_secret_jwt is a separate ticket (#159).

--- a/apiauth/client_credentials_test.go
+++ b/apiauth/client_credentials_test.go
@@ -11,6 +11,7 @@ package apiauth_test
 //   - See: https://github.com/panyam/oneauth/issues/53
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -29,11 +30,11 @@ func setupClientCredentialsAuth(t *testing.T) (*apiauth.APIAuth, *keys.InMemoryK
 	t.Helper()
 	ks := keys.NewInMemoryKeyStore()
 	// Register a client with HS256 secret
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "test-service",
 		Key:       []byte("service-secret-key"),
 		Algorithm: "HS256",
-	})
+	}})
 	auth := &apiauth.APIAuth{
 		JWTSecretKey:   "server-jwt-secret-key-32chars!!",
 		JWTIssuer:      "test-issuer",

--- a/apiauth/custom_claims_test.go
+++ b/apiauth/custom_claims_test.go
@@ -3,6 +3,7 @@
 package apiauth_test
 
 import (
+	"context"
 	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/apiauth"
 	"github.com/panyam/oneauth/keys"
@@ -149,9 +150,8 @@ func TestCustomClaimsFunc_NoOverrideStandard(t *testing.T) {
 // are verified with their respective secrets via KeyStore.
 func TestMultiTenantValidation_DifferentHosts(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("host-alpha", []byte("alpha-secret"), "HS256")
-	ks.RegisterKey("host-beta", []byte("beta-secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "host-alpha", Key: []byte("alpha-secret"), Algorithm: "HS256"}})
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "host-beta", Key: []byte("beta-secret"), Algorithm: "HS256"}})
 	// Mint token for host-alpha
 	alphaToken := mintTestToken(t, "user-1", "host-alpha", "alpha-secret")
 	// Mint token for host-beta
@@ -204,8 +204,7 @@ func TestMultiTenantValidation_DifferentHosts(t *testing.T) {
 // TestMultiTenantValidation_WrongSecret tests that a token signed with wrong secret is rejected
 func TestMultiTenantValidation_WrongSecret(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("host-alpha", []byte("alpha-secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "host-alpha", Key: []byte("alpha-secret"), Algorithm: "HS256"}})
 	// Mint token claiming to be from host-alpha but signed with wrong secret
 	wrongToken := mintTestToken(t, "user-1", "host-alpha", "wrong-secret")
 
@@ -256,7 +255,7 @@ func TestMultiTenantValidation_UnknownClientID(t *testing.T) {
 // when the KeyStore says the client uses HS512
 func TestMultiTenantValidation_AlgorithmConfusion(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("host-alpha", []byte("shared-secret"), "HS512") // registered as HS512
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "host-alpha", Key: []byte("shared-secret"), Algorithm: "HS512"}}) // registered as HS512
 
 	// Mint with HS256 (algorithm mismatch)
 	token := mintTestToken(t, "user-1", "host-alpha", "shared-secret")

--- a/apiauth/introspection_test.go
+++ b/apiauth/introspection_test.go
@@ -17,6 +17,7 @@ package apiauth_test
 //   - See: https://github.com/panyam/oneauth/issues/47
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,12 +41,11 @@ func setupIntrospection(t *testing.T) (*apiauth.IntrospectionHandler, *apiauth.A
 	t.Helper()
 	ks := keys.NewInMemoryKeyStore()
 	// Register a resource server client that can call introspection
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "resource-server",
 		Key:       []byte("rs-secret"),
 		Algorithm: "HS256",
-	})
-
+	}})
 	blacklist := core.NewInMemoryBlacklist()
 
 	auth := &apiauth.APIAuth{

--- a/apiauth/oneauth_grants_test.go
+++ b/apiauth/oneauth_grants_test.go
@@ -82,7 +82,7 @@ func newTestOneAuthWithPasswordGrant(t *testing.T) *apiauth.OneAuth {
 	t.Helper()
 	signingSecret := []byte("test-signing-secret-32chars-min!")
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{ClientID: "test-issuer", Key: signingSecret, Algorithm: "HS256"})
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "test-issuer", Key: signingSecret, Algorithm: "HS256"}})
 
 	return apiauth.NewOneAuth(apiauth.OneAuthConfig{
 		KeyStore:     ks,

--- a/apiauth/oneauth_test.go
+++ b/apiauth/oneauth_test.go
@@ -32,17 +32,17 @@ func newTestOneAuth(t *testing.T) *apiauth.OneAuth {
 
 	ks := keys.NewInMemoryKeyStore()
 	// Server's own signing key (for validating self-issued tokens)
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "test-issuer",
 		Key:       signingSecret,
 		Algorithm: "HS256",
-	})
+	}})
 	// A registered client (for client_credentials tests)
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "test-client",
 		Key:       []byte("test-client-secret-32chars-min!!"),
 		Algorithm: "HS256",
-	})
+	}})
 
 	return apiauth.NewOneAuth(apiauth.OneAuthConfig{
 		KeyStore:     ks,
@@ -269,7 +269,7 @@ func TestOneAuth_Hooks_OnIssued(t *testing.T) {
 	var firedSubject, firedGrant string
 	secret := []byte("hooks-test-secret-32chars-min!!!")
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{ClientID: "test", Key: secret, Algorithm: "HS256"})
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "test", Key: secret, Algorithm: "HS256"}})
 	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
 		KeyStore:   ks,
 		SigningKey:  secret,
@@ -324,7 +324,7 @@ func TestOneAuth_Hooks_OnBlacklistHit(t *testing.T) {
 	var firedJTI string
 	secret := []byte("hooks-test-secret-32chars-min!!!")
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{ClientID: "test", Key: secret, Algorithm: "HS256"})
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "test", Key: secret, Algorithm: "HS256"}})
 	oa := apiauth.NewOneAuth(apiauth.OneAuthConfig{
 		KeyStore:   ks,
 		SigningKey:  secret,

--- a/apiauth/private_key_jwt_test.go
+++ b/apiauth/private_key_jwt_test.go
@@ -15,6 +15,7 @@ package apiauth_test
 //     in apiauth/client_authenticator.go.
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -56,11 +57,12 @@ func newPKJWTFixture(t *testing.T) *pkjwtFixture {
 
 	ks := keys.NewInMemoryKeyStore()
 	const clientID = "test-app"
-	require.NoError(t, ks.PutKey(&keys.KeyRecord{
+	_, err = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}))
+	}})
+	require.NoError(t, err)
 
 	auth := &apiauth.APIAuth{
 		JWTSecretKey:        "server-jwt-secret-key-32chars!!",

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -14,6 +14,7 @@ package apiauth_test
 // See: https://www.rfc-editor.org/rfc/rfc7009
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -34,12 +35,11 @@ import (
 func setupRevocation(t *testing.T) (*apiauth.RevocationHandler, *apiauth.APIAuth, *apiauth.IntrospectionHandler) {
 	t.Helper()
 	ks := keys.NewInMemoryKeyStore()
-	ks.PutKey(&keys.KeyRecord{
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "revoke-client",
 		Key:       []byte("revoke-client-secret"),
 		Algorithm: "HS256",
-	})
-
+	}})
 	blacklist := core.NewInMemoryBlacklist()
 	refreshStore := newInMemoryRefreshStore()
 

--- a/apiauth/security_test.go
+++ b/apiauth/security_test.go
@@ -11,6 +11,7 @@ package apiauth_test
 //     JWT security best practices
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -55,8 +56,7 @@ func validateViaMiddleware(t *testing.T, ks keys.KeyLookup, token string) int {
 // See: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
 func TestSecurity_AlgNone_Rejected(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app1", []byte("secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app1", Key: []byte("secret"), Algorithm: "HS256"}})
 	// Craft a token with alg: none
 	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
 		"sub":       "attacker",
@@ -84,8 +84,7 @@ func TestSecurity_AlgConfusion_HS256WithRSAPubKey(t *testing.T) {
 
 	ks := keys.NewInMemoryKeyStore()
 	pubPEM, _ := utils.EncodePublicKeyPEM(&privKey.PublicKey)
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
 	// Attacker uses the public key PEM bytes as HMAC secret
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub":       "attacker",
@@ -109,8 +108,7 @@ func TestSecurity_RS256Token_AgainstHS256Store(t *testing.T) {
 	require.NoError(t, err)
 
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app-hmac", []byte("my-secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-hmac", Key: []byte("my-secret"), Algorithm: "HS256"}})
 	// Sign with RSA but claim the HMAC app's client_id
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"sub":       "attacker",
@@ -295,8 +293,7 @@ func TestSecurity_SigningMethodForAlg_UnknownAlgorithm(t *testing.T) {
 // a kid header still work via client_id claim fallback (legacy compatibility).
 func TestSecurity_NoKidHeader_FallsBackToClientID(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app1", []byte("secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app1", Key: []byte("secret"), Algorithm: "HS256"}})
 	// Mint a token WITHOUT kid header
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub":       "user1",
@@ -321,8 +318,7 @@ func TestSecurity_CrossAlgorithm_ES256TokenAgainstRS256Store(t *testing.T) {
 	rsaPriv, _ := rsa.GenerateKey(rand.Reader, 2048)
 	ks := keys.NewInMemoryKeyStore()
 	pubPEM, _ := utils.EncodePublicKeyPEM(&rsaPriv.PublicKey)
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
 	// Attacker signs with EC key
 	ecPriv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
@@ -344,8 +340,7 @@ func TestSecurity_CrossAlgorithm_ES256TokenAgainstRS256Store(t *testing.T) {
 // via RequireScopes. This test documents that ValidateToken does NOT filter scopes.
 func TestSecurity_ScopeEscalation_Prevented(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app1", []byte("secret"), "HS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app1", Key: []byte("secret"), Algorithm: "HS256"}})
 	// Mint with admin scope
 	token, _ := admin.MintResourceToken("user1", "app1", "secret",
 		admin.AppQuota{}, []string{"admin"}, nil)

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -188,8 +188,9 @@ func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) {
 
 	// Try kid-based lookup first
 	if kid, ok := token.Header["kid"].(string); ok && kid != "" {
-		rec, err := v.keyLookup.GetKeyByKid(kid)
-		if err == nil && rec != nil {
+		kidResp, err := v.keyLookup.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
+		if err == nil && kidResp != nil && kidResp.Record != nil {
+			rec := kidResp.Record
 			if token.Header["alg"] != rec.Algorithm {
 				v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
 				return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
@@ -209,8 +210,9 @@ func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) {
 	// Fall back to client_id claim
 	if claims, ok := token.Claims.(jwt.MapClaims); ok {
 		if clientID, ok := claims["client_id"].(string); ok && clientID != "" {
-			rec, err := v.keyLookup.GetKey(clientID)
-			if err == nil && rec != nil {
+			getResp, err := v.keyLookup.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+			if err == nil && getResp != nil && getResp.Record != nil {
+				rec := getResp.Record
 				if token.Header["alg"] != rec.Algorithm {
 					v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
 					return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
@@ -339,10 +341,11 @@ func (i *jwtIssuer) ClientCredentials(ctx context.Context, req *ClientCredential
 	}
 
 	// Authenticate client
-	rec, err := i.clientKeyLookup.GetKey(req.ClientID)
-	if err != nil || rec == nil {
+	resp, err := i.clientKeyLookup.GetKey(ctx, &keys.GetKeyRequest{ClientID: req.ClientID})
+	if err != nil || resp == nil || resp.Record == nil {
 		return nil, fmt.Errorf("invalid_client: unknown client")
 	}
+	rec := resp.Record
 	storedKey, ok := rec.Key.([]byte)
 	if !ok {
 		return nil, fmt.Errorf("invalid_client: client does not support secret authentication")

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -150,11 +150,11 @@ func main() {
 
 		// Register the public key in the keystore so JWKS exposes it.
 		// kid is auto-derived from the key material by the keystore.
-		if err := keyStore.PutKey(&keys.KeyRecord{
+		if _, err := keyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 			ClientID:  issuerClientID,
 			Key:       pubPEM,
 			Algorithm: alg,
-		}); err != nil {
+		}}); err != nil {
 			log.Fatalf("Failed to register issuer public key: %v", err)
 		}
 		log.Printf("Asymmetric token signing enabled (alg=%s, public key registered as %q for JWKS)", alg, issuerClientID)

--- a/examples/10-security/main.go
+++ b/examples/10-security/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"flag"
@@ -40,8 +41,8 @@ import (
 func servePreseededApps(ks *keys.InMemoryKeyStore) (*rsa.PrivateKey, []byte) {
 	rsaPrivKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	pubPEM, _ := utils.EncodePublicKeyPEM(&rsaPrivKey.PublicKey)
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-	ks.RegisterKey("app-hmac", []byte("shared-secret-for-hs256-app"), "HS256")
+	ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
+	ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-hmac", Key: []byte("shared-secret-for-hs256-app"), Algorithm: "HS256"}})
 	return rsaPrivKey, pubPEM
 }
 

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -5,6 +5,7 @@ package examples_test
 // Run with: go test -run Example -v ./examples/
 
 import (
+	"context"
 	"bytes"
 	"crypto/rsa"
 	cryptorand "crypto/rand"
@@ -155,11 +156,10 @@ func ExampleAPIMiddleware_kidBasedLookup() {
 	ks := keys.NewInMemoryKeyStore()
 
 	// Register an HS256 app and an RS256 app in the same KeyStore
-	ks.RegisterKey("app-hs256", []byte("my-secret"), "HS256")
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-hs256", Key: []byte("my-secret"), Algorithm: "HS256"}})
 	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
-	ks.RegisterKey("app-rs256", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rs256", Key: pubPEM, Algorithm: "RS256"}})
 	// Mint tokens — both get kid headers automatically
 	hsToken, _ := admin.MintResourceToken("alice", "app-hs256", "my-secret", admin.AppQuota{}, []string{"read"}, nil)
 	rsToken, _ := admin.MintResourceTokenWithKey("bob", "app-rs256", privKey, admin.AppQuota{}, []string{"read"}, nil)
@@ -327,10 +327,9 @@ func ExampleJWKSHandler_securityProperties() {
 	ks := keys.NewInMemoryKeyStore()
 
 	// Register one HS256 (symmetric) and one RS256 (asymmetric) app
-	ks.RegisterKey("app-secret", []byte("my-hs256-secret"), "HS256")
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-secret", Key: []byte("my-hs256-secret"), Algorithm: "HS256"}})
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-	ks.RegisterKey("app-public", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-public", Key: pubPEM, Algorithm: "RS256"}})
 	// Serve JWKS
 	jwksHandler := &keys.JWKSHandler{KeyStore: ks}
 	srv := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))
@@ -388,12 +387,11 @@ func ExampleJWKSHandler_multiAlgorithm() {
 	ks := keys.NewInMemoryKeyStore()
 
 	// Register one HS256 app and one RS256 app
-	ks.RegisterKey("app-hmac", []byte("shared-secret"), "HS256")
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-hmac", Key: []byte("shared-secret"), Algorithm: "HS256"}})
 	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
-	ids, _ := ks.ListKeyIDs()
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
+	ids, _ := ks.ListKeyIDs(context.Background(), &keys.ListKeyIDsRequest{})
 	fmt.Println("total_apps:", len(ids))
 
 	// Serve JWKS (only asymmetric keys appear)
@@ -469,8 +467,7 @@ func ExampleAPIMiddleware_algorithmConfusionPrevention() {
 	pubPEM, _ := utils.EncodePublicKeyPEM(&privKey.PublicKey)
 
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
-
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
 	handler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -190,8 +190,8 @@ func ExampleAPIMiddleware_kidBasedLookup() {
 
 	// Demonstrate kid-based lookup directly
 	kid := hsParsed.Header["kid"].(string)
-	rec, _ := ks.GetKeyByKid(kid)
-	fmt.Println("kid_lookup_alg:", rec.Algorithm)
+	resp, _ := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
+	fmt.Println("kid_lookup_alg:", resp.Record.Algorithm)
 
 	// Output:
 	// hs256_has_kid: true
@@ -391,8 +391,8 @@ func ExampleJWKSHandler_multiAlgorithm() {
 	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}})
-	ids, _ := ks.ListKeyIDs(context.Background(), &keys.ListKeyIDsRequest{})
-	fmt.Println("total_apps:", len(ids))
+	idsResp, _ := ks.ListKeyIDs(context.Background(), &keys.ListKeyIDsRequest{})
+	fmt.Println("total_apps:", len(idsResp.ClientIDs))
 
 	// Serve JWKS (only asymmetric keys appear)
 	jwksHandler := &keys.JWKSHandler{KeyStore: ks}

--- a/keys/encrypted.go
+++ b/keys/encrypted.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -61,7 +62,11 @@ func NewEncryptedKeyStorage(inner KeyStorage, masterKeyHex string) (*EncryptedKe
 }
 
 // PutKey computes kid from plaintext, then encrypts HMAC keys before storing.
-func (e *EncryptedKeyStorage) PutKey(rec *KeyRecord) error {
+func (e *EncryptedKeyStorage) PutKey(ctx context.Context, req *PutKeyRequest) (*PutKeyResponse, error) {
+	if req == nil || req.Record == nil {
+		return nil, fmt.Errorf("PutKey: req.Record is required")
+	}
+	rec := req.Record
 	// Compute kid from plaintext BEFORE encryption
 	if rec.Kid == "" {
 		rec.Kid = computeKid(rec.Key, rec.Algorithm)
@@ -70,49 +75,49 @@ func (e *EncryptedKeyStorage) PutKey(rec *KeyRecord) error {
 	if isHMACAlgorithm(rec.Algorithm) {
 		keyBytes, ok := rec.Key.([]byte)
 		if !ok {
-			return fmt.Errorf("HMAC key must be []byte, got %T", rec.Key)
+			return nil, fmt.Errorf("HMAC key must be []byte, got %T", rec.Key)
 		}
 		encrypted, err := e.encrypt(keyBytes)
 		if err != nil {
-			return fmt.Errorf("failed to encrypt key for %s: %w", rec.ClientID, err)
+			return nil, fmt.Errorf("failed to encrypt key for %s: %w", rec.ClientID, err)
 		}
 		// Store with encrypted key but plaintext-derived kid
-		return e.inner.PutKey(&KeyRecord{
+		return e.inner.PutKey(ctx, &PutKeyRequest{Record: &KeyRecord{
 			ClientID:  rec.ClientID,
 			Key:       encrypted,
 			Algorithm: rec.Algorithm,
 			Kid:       rec.Kid,
-		})
+		}})
 	}
-	return e.inner.PutKey(rec)
+	return e.inner.PutKey(ctx, req)
 }
 
 // GetKey retrieves and decrypts the key for the given clientID.
-func (e *EncryptedKeyStorage) GetKey(clientID string) (*KeyRecord, error) {
-	rec, err := e.inner.GetKey(clientID)
+func (e *EncryptedKeyStorage) GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error) {
+	resp, err := e.inner.GetKey(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	return e.maybeDecryptRecord(rec), nil
+	return &GetKeyResponse{Record: e.maybeDecryptRecord(resp.Record)}, nil
 }
 
 // GetKeyByKid retrieves and decrypts the key matching the given kid.
-func (e *EncryptedKeyStorage) GetKeyByKid(kid string) (*KeyRecord, error) {
-	rec, err := e.inner.GetKeyByKid(kid)
+func (e *EncryptedKeyStorage) GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error) {
+	resp, err := e.inner.GetKeyByKid(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	return e.maybeDecryptRecord(rec), nil
+	return &GetKeyByKidResponse{Record: e.maybeDecryptRecord(resp.Record)}, nil
 }
 
 // DeleteKey delegates to the inner store.
-func (e *EncryptedKeyStorage) DeleteKey(clientID string) error {
-	return e.inner.DeleteKey(clientID)
+func (e *EncryptedKeyStorage) DeleteKey(ctx context.Context, req *DeleteKeyRequest) (*DeleteKeyResponse, error) {
+	return e.inner.DeleteKey(ctx, req)
 }
 
 // ListKeyIDs delegates to the inner store.
-func (e *EncryptedKeyStorage) ListKeyIDs() ([]string, error) {
-	return e.inner.ListKeyIDs()
+func (e *EncryptedKeyStorage) ListKeyIDs(ctx context.Context, req *ListKeyIDsRequest) (*ListKeyIDsResponse, error) {
+	return e.inner.ListKeyIDs(ctx, req)
 }
 
 // maybeDecryptRecord decrypts the Key field for HMAC algorithms.
@@ -136,50 +141,6 @@ func (e *EncryptedKeyStorage) maybeDecryptRecord(rec *KeyRecord) *KeyRecord {
 		Algorithm: rec.Algorithm,
 		Kid:       rec.Kid,
 	}
-}
-
-// Backward-compatible aliases
-
-// RegisterKey is a convenience method for callers using the old interface.
-func (e *EncryptedKeyStorage) RegisterKey(clientID string, key any, algorithm string) error {
-	return e.PutKey(&KeyRecord{ClientID: clientID, Key: key, Algorithm: algorithm})
-}
-
-// GetVerifyKey is a convenience method for callers using the old interface.
-func (e *EncryptedKeyStorage) GetVerifyKey(clientID string) (any, error) {
-	rec, err := e.GetKey(clientID)
-	if err != nil {
-		return nil, err
-	}
-	return rec.Key, nil
-}
-
-// GetSigningKey is a convenience method for callers using the old interface.
-func (e *EncryptedKeyStorage) GetSigningKey(clientID string) (any, error) {
-	return e.GetVerifyKey(clientID)
-}
-
-// GetExpectedAlg is a convenience method for callers using the old interface.
-func (e *EncryptedKeyStorage) GetExpectedAlg(clientID string) (string, error) {
-	rec, err := e.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Algorithm, nil
-}
-
-// ListKeys is a convenience alias for ListKeyIDs.
-func (e *EncryptedKeyStorage) ListKeys() ([]string, error) {
-	return e.ListKeyIDs()
-}
-
-// GetCurrentKid returns the kid for the given clientID.
-func (e *EncryptedKeyStorage) GetCurrentKid(clientID string) (string, error) {
-	rec, err := e.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Kid, nil
 }
 
 // encrypt produces AES-256-GCM ciphertext with a random 12-byte nonce prepended.

--- a/keys/encrypted_test.go
+++ b/keys/encrypted_test.go
@@ -3,21 +3,19 @@
 package keys_test
 
 import (
-	"github.com/panyam/oneauth/keys"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"testing"
+
+	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/keystoretest"
 	"github.com/panyam/oneauth/utils"
 )
 
-// testMasterKey is a fixed 32-byte hex key used across tests for determinism.
 const testMasterKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-// newTestEncryptedKeyStore creates an EncryptedKeyStore wrapping a fresh
-// InMemoryKeyStore for isolated test use. Returns both so tests can inspect
-// the inner store's raw bytes.
 func newTestEncryptedKeyStore(t *testing.T) (*keys.EncryptedKeyStorage, *keys.InMemoryKeyStore) {
 	t.Helper()
 	inner := keys.NewInMemoryKeyStore()
@@ -28,8 +26,6 @@ func newTestEncryptedKeyStore(t *testing.T) (*keys.EncryptedKeyStorage, *keys.In
 	return enc, inner
 }
 
-// randomMasterKey generates a cryptographically random 64-char hex master key
-// for tests that need distinct keys (e.g., cross-key failure tests).
 func randomMasterKey(t *testing.T) string {
 	t.Helper()
 	key := make([]byte, 32)
@@ -39,65 +35,59 @@ func randomMasterKey(t *testing.T) string {
 	return hex.EncodeToString(key)
 }
 
-// TestEncryptedKeyStoreRoundTrip verifies that registering a secret via the
+func putKey(t *testing.T, ks keys.KeyStorage, rec *keys.KeyRecord) {
+	t.Helper()
+	if _, err := ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: rec}); err != nil {
+		t.Fatalf("PutKey failed: %v", err)
+	}
+}
+
+func getKeyBytes(t *testing.T, ks keys.KeyLookup, clientID string) []byte {
+	t.Helper()
+	resp, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+	if err != nil {
+		t.Fatalf("GetKey failed: %v", err)
+	}
+	b, ok := resp.Record.Key.([]byte)
+	if !ok {
+		t.Fatalf("expected []byte, got %T", resp.Record.Key)
+	}
+	return b
+}
+
+// TestEncryptedKeyStoreRoundTrip verifies that storing a secret via the
 // encrypted wrapper and reading it back yields the original plaintext.
 func TestEncryptedKeyStoreRoundTrip(t *testing.T) {
 	enc, _ := newTestEncryptedKeyStore(t)
 	secret := []byte("my-super-secret-key")
 
-	if err := enc.RegisterKey("app-1", secret, "HS256"); err != nil {
-		t.Fatalf("RegisterKey failed: %v", err)
-	}
+	putKey(t, enc, &keys.KeyRecord{ClientID: "app-1", Key: secret, Algorithm: "HS256"})
 
-	got, err := enc.GetVerifyKey("app-1")
-	if err != nil {
-		t.Fatalf("GetVerifyKey failed: %v", err)
-	}
-	if !bytes.Equal(got.([]byte), secret) {
+	got := getKeyBytes(t, enc, "app-1")
+	if !bytes.Equal(got, secret) {
 		t.Errorf("round-trip mismatch: got %q, want %q", got, secret)
-	}
-
-	// GetSigningKey should also return the same plaintext
-	sigKey, err := enc.GetSigningKey("app-1")
-	if err != nil {
-		t.Fatalf("GetSigningKey failed: %v", err)
-	}
-	if !bytes.Equal(sigKey.([]byte), secret) {
-		t.Errorf("GetSigningKey round-trip mismatch: got %q, want %q", sigKey, secret)
 	}
 }
 
 // TestStoredBytesAreEncrypted verifies that the inner store holds ciphertext,
-// not the original plaintext secret. This is the core security guarantee:
-// a database dump will not expose raw HMAC secrets.
+// not the original plaintext secret.
 func TestStoredBytesAreEncrypted(t *testing.T) {
 	enc, inner := newTestEncryptedKeyStore(t)
 	secret := []byte("plaintext-secret-value")
 
-	if err := enc.RegisterKey("app-1", secret, "HS256"); err != nil {
-		t.Fatalf("RegisterKey failed: %v", err)
-	}
+	putKey(t, enc, &keys.KeyRecord{ClientID: "app-1", Key: secret, Algorithm: "HS256"})
 
-	// Read directly from the inner store (bypassing decryption)
-	raw, err := inner.GetVerifyKey("app-1")
-	if err != nil {
-		t.Fatalf("inner.GetVerifyKey failed: %v", err)
-	}
-	rawBytes := raw.([]byte)
-
+	rawBytes := getKeyBytes(t, inner, "app-1")
 	if bytes.Equal(rawBytes, secret) {
 		t.Error("inner store contains plaintext secret — encryption is not working")
 	}
-
-	// Ciphertext should be longer than plaintext (12-byte nonce + 16-byte GCM tag)
 	if len(rawBytes) <= len(secret) {
 		t.Errorf("ciphertext (%d bytes) should be longer than plaintext (%d bytes)", len(rawBytes), len(secret))
 	}
 }
 
 // TestAsymmetricPassthrough verifies that asymmetric keys (RS256 public PEM)
-// are stored in the inner store without modification. Public keys are not
-// sensitive and should not be encrypted.
+// are stored in the inner store without modification.
 func TestAsymmetricPassthrough(t *testing.T) {
 	enc, inner := newTestEncryptedKeyStore(t)
 
@@ -106,87 +96,56 @@ func TestAsymmetricPassthrough(t *testing.T) {
 		t.Fatalf("GenerateRSAKeyPair failed: %v", err)
 	}
 
-	if err := enc.RegisterKey("app-rsa", pubPEM, "RS256"); err != nil {
-		t.Fatalf("RegisterKey failed: %v", err)
-	}
+	putKey(t, enc, &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"})
 
-	// Inner store should have the exact same PEM bytes (no encryption)
-	raw, err := inner.GetVerifyKey("app-rsa")
-	if err != nil {
-		t.Fatalf("inner.GetVerifyKey failed: %v", err)
-	}
-	if !bytes.Equal(raw.([]byte), pubPEM) {
+	raw := getKeyBytes(t, inner, "app-rsa")
+	if !bytes.Equal(raw, pubPEM) {
 		t.Error("asymmetric key was modified — should pass through unchanged")
 	}
-
-	// Reading via encrypted wrapper should also return the same PEM
-	got, err := enc.GetVerifyKey("app-rsa")
-	if err != nil {
-		t.Fatalf("GetVerifyKey failed: %v", err)
-	}
-	if !bytes.Equal(got.([]byte), pubPEM) {
+	got := getKeyBytes(t, enc, "app-rsa")
+	if !bytes.Equal(got, pubPEM) {
 		t.Error("encrypted wrapper altered asymmetric key on read")
 	}
 }
 
 // TestWrongMasterKeyFails verifies that a secret encrypted with one master key
-// cannot be decrypted with a different master key. Due to the plaintext
-// fallback, the wrong (still-encrypted) bytes are returned instead of the
-// original secret.
+// cannot be decrypted with a different master key.
 func TestWrongMasterKeyFails(t *testing.T) {
 	inner := keys.NewInMemoryKeyStore()
 	secret := []byte("sensitive-secret")
 
-	// Encrypt with key A
 	encA, err := keys.NewEncryptedKeyStorage(inner, testMasterKey)
 	if err != nil {
 		t.Fatalf("NewEncryptedKeyStorage (A) failed: %v", err)
 	}
-	if err := encA.RegisterKey("app-1", secret, "HS256"); err != nil {
-		t.Fatalf("RegisterKey failed: %v", err)
-	}
+	putKey(t, encA, &keys.KeyRecord{ClientID: "app-1", Key: secret, Algorithm: "HS256"})
 
-	// Try to read with key B — GCM auth will fail, fallback returns raw ciphertext
 	encB, err := keys.NewEncryptedKeyStorage(inner, randomMasterKey(t))
 	if err != nil {
 		t.Fatalf("NewEncryptedKeyStorage (B) failed: %v", err)
 	}
-	got, err := encB.GetVerifyKey("app-1")
-	if err != nil {
-		t.Fatalf("GetVerifyKey with wrong key should not error (fallback): %v", err)
-	}
-
-	// The returned bytes should NOT match the original secret
-	if bytes.Equal(got.([]byte), secret) {
+	got := getKeyBytes(t, encB, "app-1")
+	if bytes.Equal(got, secret) {
 		t.Error("wrong master key returned the original plaintext — encryption is broken")
 	}
 }
 
 // TestPlaintextMigration verifies backward compatibility: a key stored directly
 // in the inner store (without encryption) is still readable through the
-// encrypted wrapper. This is the migration path for existing deployments that
-// enable encryption without re-registering all apps.
+// encrypted wrapper.
 func TestPlaintextMigration(t *testing.T) {
 	enc, inner := newTestEncryptedKeyStore(t)
 	secret := []byte("legacy-unencrypted-secret")
 
-	// Store directly in inner store (simulating pre-encryption data)
-	if err := inner.RegisterKey("legacy-app", secret, "HS256"); err != nil {
-		t.Fatalf("inner.RegisterKey failed: %v", err)
-	}
+	putKey(t, inner, &keys.KeyRecord{ClientID: "legacy-app", Key: secret, Algorithm: "HS256"})
 
-	// Reading via encrypted wrapper should return the plaintext (GCM fails, fallback)
-	got, err := enc.GetVerifyKey("legacy-app")
-	if err != nil {
-		t.Fatalf("GetVerifyKey failed: %v", err)
-	}
-	if !bytes.Equal(got.([]byte), secret) {
+	got := getKeyBytes(t, enc, "legacy-app")
+	if !bytes.Equal(got, secret) {
 		t.Errorf("plaintext migration failed: got %q, want %q", got, secret)
 	}
 }
 
-// TestInvalidMasterKey verifies that NewEncryptedKeyStore rejects master keys
-// that are too short, too long, not valid hex, or empty.
+// TestInvalidMasterKey verifies that NewEncryptedKeyStorage rejects bad keys.
 func TestInvalidMasterKey(t *testing.T) {
 	inner := keys.NewInMemoryKeyStore()
 
@@ -210,10 +169,8 @@ func TestInvalidMasterKey(t *testing.T) {
 	}
 }
 
-// TestEncryptedKeyStoreContractCompliance runs the shared WritableKeyStore
-// test suite (keystoretest.RunAll) against the EncryptedKeyStore wrapper,
-// verifying it correctly implements the full interface contract including
-// register, get, delete, list, overwrite, and asymmetric key handling.
+// TestEncryptedKeyStoreContractCompliance runs the shared KeyStorage
+// test suite against the EncryptedKeyStore wrapper.
 func TestEncryptedKeyStoreContractCompliance(t *testing.T) {
 	keystoretest.RunAll(t, func(t *testing.T) keys.KeyStorage {
 		enc, _ := newTestEncryptedKeyStore(t)
@@ -221,54 +178,33 @@ func TestEncryptedKeyStoreContractCompliance(t *testing.T) {
 	})
 }
 
-// TestGetExpectedAlgPassthrough verifies that algorithm metadata is returned
-// unchanged by the encrypted wrapper (algorithms are never encrypted).
-func TestGetExpectedAlgPassthrough(t *testing.T) {
-	enc, _ := newTestEncryptedKeyStore(t)
-
-	if err := enc.RegisterKey("app-1", []byte("secret"), "HS512"); err != nil {
-		t.Fatalf("RegisterKey failed: %v", err)
-	}
-
-	alg, err := enc.GetExpectedAlg("app-1")
-	if err != nil {
-		t.Fatalf("GetExpectedAlg failed: %v", err)
-	}
-	if alg != "HS512" {
-		t.Errorf("expected HS512, got %s", alg)
-	}
-}
-
 // TestDeleteKeyPassthrough verifies that deleting a key through the encrypted
 // wrapper correctly removes it from the inner store.
 func TestDeleteKeyPassthrough(t *testing.T) {
 	enc, inner := newTestEncryptedKeyStore(t)
 
-	if err := enc.RegisterKey("app-1", []byte("secret"), "HS256"); err != nil {
-		t.Fatalf("RegisterKey failed: %v", err)
-	}
-	if err := enc.DeleteKey("app-1"); err != nil {
+	putKey(t, enc, &keys.KeyRecord{ClientID: "app-1", Key: []byte("secret"), Algorithm: "HS256"})
+	if _, err := enc.DeleteKey(context.Background(), &keys.DeleteKeyRequest{ClientID: "app-1"}); err != nil {
 		t.Fatalf("DeleteKey failed: %v", err)
 	}
-
-	if _, err := inner.GetVerifyKey("app-1"); err != keys.ErrKeyNotFound {
+	if _, err := inner.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: "app-1"}); err != keys.ErrKeyNotFound {
 		t.Errorf("expected ErrKeyNotFound from inner store, got %v", err)
 	}
 }
 
-// TestListKeysPassthrough verifies that ListKeys returns the same client IDs
+// TestListKeysPassthrough verifies that ListKeyIDs returns the same client IDs
 // regardless of whether encryption is active.
 func TestListKeysPassthrough(t *testing.T) {
 	enc, _ := newTestEncryptedKeyStore(t)
 
-	enc.RegisterKey("a", []byte("s1"), "HS256")
-	enc.RegisterKey("b", []byte("s2"), "HS256")
+	putKey(t, enc, &keys.KeyRecord{ClientID: "a", Key: []byte("s1"), Algorithm: "HS256"})
+	putKey(t, enc, &keys.KeyRecord{ClientID: "b", Key: []byte("s2"), Algorithm: "HS256"})
 
-	keys, err := enc.ListKeys()
+	resp, err := enc.ListKeyIDs(context.Background(), &keys.ListKeyIDsRequest{})
 	if err != nil {
-		t.Fatalf("ListKeys failed: %v", err)
+		t.Fatalf("ListKeyIDs failed: %v", err)
 	}
-	if len(keys) != 2 {
-		t.Errorf("expected 2 keys, got %d", len(keys))
+	if len(resp.ClientIDs) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(resp.ClientIDs))
 	}
 }

--- a/keys/jwks_e2e_test.go
+++ b/keys/jwks_e2e_test.go
@@ -6,14 +6,16 @@ package keys_test
 // from the auth server's /.well-known/jwks.json endpoint.
 
 import (
-	"github.com/panyam/oneauth/admin"
-	"github.com/panyam/oneauth/apiauth"
-	"github.com/panyam/oneauth/keys"
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/utils"
 )
 
@@ -285,10 +287,10 @@ func TestJWKS_EndToEnd_RS256(t *testing.T) {
 		t.Fatal(err)
 	}
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
-	authKeyStore.RegisterKey("app_rsa_e2e", pubPEM, "RS256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_rsa_e2e", Key: pubPEM, Algorithm: "RS256"}})
 
 	// Also register an HS256 app (should NOT appear in JWKS)
-	authKeyStore.RegisterKey("app_hmac_e2e", []byte("secret123"), "HS256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_hmac_e2e", Key: []byte("secret123"), Algorithm: "HS256"}})
 
 	// --- Auth server side: serve JWKS ---
 	jwksHandler := &keys.JWKSHandler{KeyStore: authKeyStore}
@@ -346,7 +348,7 @@ func TestJWKS_EndToEnd_ES256(t *testing.T) {
 		t.Fatal(err)
 	}
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
-	authKeyStore.RegisterKey("app_ec_e2e", pubPEM, "ES256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_ec_e2e", Key: pubPEM, Algorithm: "ES256"}})
 
 	jwksHandler := &keys.JWKSHandler{KeyStore: authKeyStore}
 	authServer := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))
@@ -389,7 +391,7 @@ func TestJWKS_EndToEnd_ES256(t *testing.T) {
 // via JWKS (since HS256 secrets are never exposed).
 func TestJWKS_EndToEnd_HS256Excluded(t *testing.T) {
 	authKeyStore := keys.NewInMemoryKeyStore()
-	authKeyStore.RegisterKey("app_hmac", []byte("supersecret"), "HS256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_hmac", Key: []byte("supersecret"), Algorithm: "HS256"}})
 
 	jwksHandler := &keys.JWKSHandler{KeyStore: authKeyStore}
 	authServer := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))
@@ -431,7 +433,7 @@ func TestJWKS_EndToEnd_HS256Excluded(t *testing.T) {
 func TestJWKS_EndToEnd_WrongPrivateKey(t *testing.T) {
 	authKeyStore := keys.NewInMemoryKeyStore()
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-	authKeyStore.RegisterKey("app_rsa", pubPEM, "RS256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_rsa", Key: pubPEM, Algorithm: "RS256"}})
 
 	// Mint with a DIFFERENT private key
 	otherPrivPEM, _, _ := utils.GenerateRSAKeyPair(2048)
@@ -469,14 +471,14 @@ func TestJWKS_EndToEnd_MixedAlgorithms(t *testing.T) {
 
 	rsaPrivPEM, rsaPubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	rsaPrivKey, _ := utils.ParsePrivateKeyPEM(rsaPrivPEM)
-	authKeyStore.RegisterKey("app_rsa_mix", rsaPubPEM, "RS256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_rsa_mix", Key: rsaPubPEM, Algorithm: "RS256"}})
 
 	ecPrivPEM, ecPubPEM, _ := utils.GenerateECDSAKeyPair()
 	ecPrivKey, _ := utils.ParsePrivateKeyPEM(ecPrivPEM)
-	authKeyStore.RegisterKey("app_ec_mix", ecPubPEM, "ES256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_ec_mix", Key: ecPubPEM, Algorithm: "ES256"}})
 
 	// Also HS256 (should be invisible to JWKS)
-	authKeyStore.RegisterKey("app_hs_mix", []byte("secret"), "HS256")
+	_, _ = authKeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: "app_hs_mix", Key: []byte("secret"), Algorithm: "HS256"}})
 
 	jwksHandler := &keys.JWKSHandler{KeyStore: authKeyStore}
 	authServer := httptest.NewServer(http.HandlerFunc(jwksHandler.ServeHTTP))

--- a/keys/jwks_handler.go
+++ b/keys/jwks_handler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/panyam/oneauth/utils"
 )
 
+
+
 // JWKSHandler serves a JWKS (JSON Web Key Set) endpoint at /.well-known/jwks.json.
 // Only asymmetric keys (RS256/ES256) are included — HS256 secrets are never exposed.
 type JWKSHandler struct {
@@ -20,19 +22,21 @@ type JWKSHandler struct {
 }
 
 func (h *JWKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	clientIDs, err := h.KeyStore.ListKeyIDs()
+	ctx := r.Context()
+	listResp, err := h.KeyStore.ListKeyIDs(ctx, &ListKeyIDsRequest{})
 	if err != nil {
 		http.Error(w, `{"error":"failed to list keys"}`, http.StatusInternalServerError)
 		return
 	}
 
 	var keys []utils.JWK
-	for _, clientID := range clientIDs {
-		rec, err := h.KeyStore.GetKey(clientID)
+	for _, clientID := range listResp.ClientIDs {
+		getResp, err := h.KeyStore.GetKey(ctx, &GetKeyRequest{ClientID: clientID})
 		if err != nil {
 			log.Printf("jwks: failed to get key for %s: %v", clientID, err)
 			continue
 		}
+		rec := getResp.Record
 		if !utils.IsAsymmetricAlg(rec.Algorithm) {
 			continue
 		}

--- a/keys/jwks_handler_test.go
+++ b/keys/jwks_handler_test.go
@@ -4,6 +4,7 @@ package keys
 // key filtering (asymmetric only), response format, Cache-Control, and Content-Type headers.
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,11 +19,11 @@ func TestJWKSHandler_MixedKeys(t *testing.T) {
 	ks := NewInMemoryKeyStore()
 
 	// Register HS256 key (should NOT appear)
-	ks.RegisterKey("app_hmac", []byte("secret"), "HS256")
+	ks.PutKey(context.Background(), &PutKeyRequest{Record: &KeyRecord{ClientID: "app_hmac", Key: []byte("secret"), Algorithm: "HS256"}})
 
 	// Register RS256 key (should appear)
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-	ks.RegisterKey("app_rsa", pubPEM, "RS256")
+	ks.PutKey(context.Background(), &PutKeyRequest{Record: &KeyRecord{ClientID: "app_rsa", Key: pubPEM, Algorithm: "RS256"}})
 
 	handler := &JWKSHandler{KeyStore: ks}
 	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
@@ -58,10 +59,10 @@ func TestJWKSHandler_RSAAndECDSA(t *testing.T) {
 	ks := NewInMemoryKeyStore()
 
 	_, rsaPub, _ := utils.GenerateRSAKeyPair(2048)
-	ks.RegisterKey("app_rsa", rsaPub, "RS256")
+	ks.PutKey(context.Background(), &PutKeyRequest{Record: &KeyRecord{ClientID: "app_rsa", Key: rsaPub, Algorithm: "RS256"}})
 
 	_, ecPub, _ := utils.GenerateECDSAKeyPair()
-	ks.RegisterKey("app_ec", ecPub, "ES256")
+	ks.PutKey(context.Background(), &PutKeyRequest{Record: &KeyRecord{ClientID: "app_ec", Key: ecPub, Algorithm: "ES256"}})
 
 	handler := &JWKSHandler{KeyStore: ks}
 	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)

--- a/keys/jwks_keystore.go
+++ b/keys/jwks_keystore.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"context"
 	"crypto"
 	"encoding/json"
 	"fmt"
@@ -12,7 +13,7 @@ import (
 	"github.com/panyam/oneauth/utils"
 )
 
-// JWKSKeyStore implements KeyStore (read-only) by fetching public keys from a remote JWKS endpoint.
+// JWKSKeyStore implements KeyLookup (read-only) by fetching public keys from a remote JWKS endpoint.
 // It caches keys locally and refreshes them periodically.
 type JWKSKeyStore struct {
 	JWKSURL         string
@@ -141,79 +142,34 @@ func (s *JWKSKeyStore) refresh() error {
 	return nil
 }
 
-// GetVerifyKey returns the public key for the given client ID.
-// If the key is not cached, triggers a refresh before returning ErrKeyNotFound.
-func (s *JWKSKeyStore) GetVerifyKey(clientID string) (any, error) {
-	s.mu.RLock()
-	entry, ok := s.keys[clientID]
-	s.mu.RUnlock()
-	if ok {
-		return entry.PublicKey, nil
-	}
-
-	// Cache miss — try refreshing
-	s.refresh()
-
-	s.mu.RLock()
-	entry, ok = s.keys[clientID]
-	s.mu.RUnlock()
-	if ok {
-		return entry.PublicKey, nil
-	}
-	return nil, ErrKeyNotFound
-}
-
-// GetSigningKey always returns an error — JWKS only exposes public keys.
-func (s *JWKSKeyStore) GetSigningKey(clientID string) (any, error) {
-	return nil, fmt.Errorf("jwks keystore is read-only (public keys only)")
-}
-
 // GetKey returns ErrKeyNotFound — JWKSKeyStore only supports kid-based lookup.
 // JWKS doesn't carry clientID→key mappings; use GetKeyByKid instead.
-func (s *JWKSKeyStore) GetKey(clientID string) (*KeyRecord, error) {
+func (s *JWKSKeyStore) GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error) {
 	return nil, ErrKeyNotFound
 }
 
 // GetKeyByKid returns the key record for the given kid.
 // ClientID is empty since JWKS doesn't carry client_id metadata —
 // the middleware skips the cross-app check in this case.
-func (s *JWKSKeyStore) GetKeyByKid(kid string) (*KeyRecord, error) {
+func (s *JWKSKeyStore) GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	s.mu.RLock()
-	entry, ok := s.keys[kid]
+	entry, ok := s.keys[req.Kid]
 	s.mu.RUnlock()
 	if ok {
-		return &KeyRecord{Key: entry.PublicKey, Algorithm: entry.Algorithm, Kid: kid}, nil
+		return &GetKeyByKidResponse{Record: &KeyRecord{Key: entry.PublicKey, Algorithm: entry.Algorithm, Kid: req.Kid}}, nil
 	}
 
 	// Cache miss — try refreshing
 	s.refresh()
 
 	s.mu.RLock()
-	entry, ok = s.keys[kid]
+	entry, ok = s.keys[req.Kid]
 	s.mu.RUnlock()
 	if ok {
-		return &KeyRecord{Key: entry.PublicKey, Algorithm: entry.Algorithm, Kid: kid}, nil
+		return &GetKeyByKidResponse{Record: &KeyRecord{Key: entry.PublicKey, Algorithm: entry.Algorithm, Kid: req.Kid}}, nil
 	}
 	return nil, ErrKidNotFound
-}
-
-// GetExpectedAlg returns the algorithm for the given client ID.
-func (s *JWKSKeyStore) GetExpectedAlg(clientID string) (string, error) {
-	s.mu.RLock()
-	entry, ok := s.keys[clientID]
-	s.mu.RUnlock()
-	if ok {
-		return entry.Algorithm, nil
-	}
-
-	// Cache miss — try refreshing
-	s.refresh()
-
-	s.mu.RLock()
-	entry, ok = s.keys[clientID]
-	s.mu.RUnlock()
-	if ok {
-		return entry.Algorithm, nil
-	}
-	return "", ErrKeyNotFound
 }

--- a/keys/jwks_keystore_test.go
+++ b/keys/jwks_keystore_test.go
@@ -2,10 +2,10 @@ package keys
 
 // Tests for JWKSKeyStore: fetching and caching keys from a remote JWKS endpoint,
 // cache-miss-triggered refresh, resilience when the server is down, concurrent access
-// safety, and error handling for unsupported operations.
+// safety.
 
 import (
-	"crypto/ecdsa"
+	"context"
 	"crypto/rsa"
 	"encoding/json"
 	"net/http"
@@ -25,9 +25,7 @@ func serveJWKS(t *testing.T, keys []utils.JWK) *httptest.Server {
 	}))
 }
 
-// TestJWKSKeyStore_GetVerifyKey verifies that JWKSKeyStore fetches an RSA public key
-// from a remote JWKS endpoint and returns it for token verification.
-func TestJWKSKeyStore_GetVerifyKey(t *testing.T) {
+func TestJWKSKeyStore_GetKeyByKid_RSA(t *testing.T) {
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	pub, _ := utils.ParsePublicKeyPEM(pubPEM)
 	rsaPub := pub.(*rsa.PublicKey)
@@ -42,45 +40,32 @@ func TestJWKSKeyStore_GetVerifyKey(t *testing.T) {
 	}
 	defer ks.Stop()
 
-	key, err := ks.GetVerifyKey("app_rsa")
+	resp, err := ks.GetKeyByKid(context.Background(), &GetKeyByKidRequest{Kid: "app_rsa"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, ok := key.(*rsa.PublicKey)
+	rec := resp.Record
+	got, ok := rec.Key.(*rsa.PublicKey)
 	if !ok {
-		t.Fatalf("expected *rsa.PublicKey, got %T", key)
+		t.Fatalf("expected *rsa.PublicKey, got %T", rec.Key)
 	}
 	if rsaPub.N.Cmp(got.N) != 0 {
 		t.Error("RSA modulus mismatch")
 	}
-}
-
-// TestJWKSKeyStore_GetExpectedAlg verifies that JWKSKeyStore returns the correct
-// algorithm (ES256) for a key fetched from the remote JWKS endpoint.
-func TestJWKSKeyStore_GetExpectedAlg(t *testing.T) {
-	_, pubPEM, _ := utils.GenerateECDSAKeyPair()
-	pub, _ := utils.ParsePublicKeyPEM(pubPEM)
-	ecPub := pub.(*ecdsa.PublicKey)
-	jwk := utils.ECDSAPublicKeyToJWK("app_ec", "ES256", ecPub)
-
-	srv := serveJWKS(t, []utils.JWK{jwk})
-	defer srv.Close()
-
-	ks := NewJWKSKeyStore(srv.URL, WithMinRefreshGap(0))
-	ks.Start()
-	defer ks.Stop()
-
-	alg, err := ks.GetExpectedAlg("app_ec")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if alg != "ES256" {
-		t.Errorf("expected ES256, got %s", alg)
+	if rec.Algorithm != "RS256" {
+		t.Errorf("expected RS256, got %s", rec.Algorithm)
 	}
 }
 
-// TestJWKSKeyStore_CacheMissTriggersRefresh verifies that a cache miss for an unknown key
-// triggers a refresh from the remote endpoint and returns ErrKeyNotFound if the key still does not exist.
+func TestJWKSKeyStore_GetKey_AlwaysNotFound(t *testing.T) {
+	// JWKSKeyStore.GetKey by clientID must always return ErrKeyNotFound.
+	ks := NewJWKSKeyStore("http://localhost:0")
+	_, err := ks.GetKey(context.Background(), &GetKeyRequest{ClientID: "anything"})
+	if err != ErrKeyNotFound {
+		t.Errorf("expected ErrKeyNotFound, got %v", err)
+	}
+}
+
 func TestJWKSKeyStore_CacheMissTriggersRefresh(t *testing.T) {
 	fetchCount := 0
 	var mu sync.Mutex
@@ -101,22 +86,15 @@ func TestJWKSKeyStore_CacheMissTriggersRefresh(t *testing.T) {
 	ks.Start()
 	defer ks.Stop()
 
-	// First fetch at Start(), then cache miss for "dynamic_app" shouldn't need another
-	// since "dynamic_app" was returned in the first fetch
-	_, err := ks.GetVerifyKey("dynamic_app")
-	if err != nil {
+	if _, err := ks.GetKeyByKid(context.Background(), &GetKeyByKidRequest{Kid: "dynamic_app"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Unknown key should trigger refresh attempt then return ErrKeyNotFound
-	_, err = ks.GetVerifyKey("nonexistent")
-	if err != ErrKeyNotFound {
-		t.Errorf("expected ErrKeyNotFound, got %v", err)
+	if _, err := ks.GetKeyByKid(context.Background(), &GetKeyByKidRequest{Kid: "nonexistent"}); err != ErrKidNotFound {
+		t.Errorf("expected ErrKidNotFound, got %v", err)
 	}
 }
 
-// TestJWKSKeyStore_ServerDown_UsesCachedKeys verifies that JWKSKeyStore continues to serve
-// previously cached keys even after the remote JWKS server goes down.
 func TestJWKSKeyStore_ServerDown_UsesCachedKeys(t *testing.T) {
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	pub, _ := utils.ParsePublicKeyPEM(pubPEM)
@@ -129,32 +107,18 @@ func TestJWKSKeyStore_ServerDown_UsesCachedKeys(t *testing.T) {
 	ks.Start()
 	defer ks.Stop()
 
-	// Shut down the server
 	srv.Close()
 
-	// Should still return cached key
-	key, err := ks.GetVerifyKey("cached_app")
+	resp, err := ks.GetKeyByKid(context.Background(), &GetKeyByKidRequest{Kid: "cached_app"})
 	if err != nil {
 		t.Fatalf("expected cached key, got error: %v", err)
 	}
-	got := key.(*rsa.PublicKey)
+	got := resp.Record.Key.(*rsa.PublicKey)
 	if rsaPub.N.Cmp(got.N) != 0 {
 		t.Error("cached key mismatch")
 	}
 }
 
-// TestJWKSKeyStore_GetSigningKey_Errors verifies that GetSigningKey always returns an error
-// since JWKSKeyStore is read-only and does not hold private keys.
-func TestJWKSKeyStore_GetSigningKey_Errors(t *testing.T) {
-	ks := NewJWKSKeyStore("http://localhost:0")
-	_, err := ks.GetSigningKey("anything")
-	if err == nil {
-		t.Error("expected error from GetSigningKey")
-	}
-}
-
-// TestJWKSKeyStore_ConcurrentAccess verifies that concurrent GetVerifyKey and GetExpectedAlg
-// calls do not race or panic.
 func TestJWKSKeyStore_ConcurrentAccess(t *testing.T) {
 	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	pub, _ := utils.ParsePublicKeyPEM(pubPEM)
@@ -172,9 +136,8 @@ func TestJWKSKeyStore_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ks.GetVerifyKey("concurrent_app")
-			ks.GetExpectedAlg("concurrent_app")
-			ks.GetVerifyKey("missing")
+			ks.GetKeyByKid(context.Background(), &GetKeyByKidRequest{Kid: "concurrent_app"})
+			ks.GetKeyByKid(context.Background(), &GetKeyByKidRequest{Kid: "missing"})
 		}()
 	}
 	wg.Wait()

--- a/keys/keystore.go
+++ b/keys/keystore.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -23,16 +24,72 @@ type KeyRecord struct {
 	Kid       string // key identifier, computed from key material
 }
 
+// ----------------------------------------------------------------------------
+// Request / response types — KeyLookup
+// ----------------------------------------------------------------------------
+
+// GetKeyRequest is the input to KeyLookup.GetKey.
+type GetKeyRequest struct {
+	ClientID string
+}
+
+// GetKeyResponse is the output of KeyLookup.GetKey.
+type GetKeyResponse struct {
+	Record *KeyRecord
+}
+
+// GetKeyByKidRequest is the input to KeyLookup.GetKeyByKid.
+type GetKeyByKidRequest struct {
+	Kid string
+}
+
+// GetKeyByKidResponse is the output of KeyLookup.GetKeyByKid.
+type GetKeyByKidResponse struct {
+	Record *KeyRecord
+}
+
+// ----------------------------------------------------------------------------
+// Request / response types — KeyStorage
+// ----------------------------------------------------------------------------
+
+// PutKeyRequest is the input to KeyStorage.PutKey.
+type PutKeyRequest struct {
+	Record *KeyRecord
+}
+
+// PutKeyResponse is the output of KeyStorage.PutKey.
+type PutKeyResponse struct{}
+
+// DeleteKeyRequest is the input to KeyStorage.DeleteKey.
+type DeleteKeyRequest struct {
+	ClientID string
+}
+
+// DeleteKeyResponse is the output of KeyStorage.DeleteKey.
+type DeleteKeyResponse struct{}
+
+// ListKeyIDsRequest is the input to KeyStorage.ListKeyIDs.
+type ListKeyIDsRequest struct{}
+
+// ListKeyIDsResponse is the output of KeyStorage.ListKeyIDs.
+type ListKeyIDsResponse struct {
+	ClientIDs []string
+}
+
+// ----------------------------------------------------------------------------
+// Interfaces
+// ----------------------------------------------------------------------------
+
 // KeyLookup provides read-only key lookup by clientID or kid.
 // Implemented by all keystores, including read-only ones like JWKSKeyStore.
 type KeyLookup interface {
 	// GetKey returns the key record for the given clientID.
 	// Returns ErrKeyNotFound if the client has no registered key.
-	GetKey(clientID string) (*KeyRecord, error)
+	GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error)
 
 	// GetKeyByKid returns the key record matching the given kid.
 	// Returns ErrKidNotFound if no key matches or the key has expired.
-	GetKeyByKid(kid string) (*KeyRecord, error)
+	GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error)
 }
 
 // KeyStorage extends KeyLookup with write operations.
@@ -40,16 +97,16 @@ type KeyLookup interface {
 type KeyStorage interface {
 	KeyLookup
 
-	// PutKey stores a key record. If Kid is empty, it is auto-computed
-	// from the key material and algorithm. Overwrites any existing key
-	// for the same ClientID.
-	PutKey(record *KeyRecord) error
+	// PutKey stores a key record. If req.Record.Kid is empty, it is
+	// auto-computed from the key material and algorithm. Overwrites any
+	// existing key for the same ClientID.
+	PutKey(ctx context.Context, req *PutKeyRequest) (*PutKeyResponse, error)
 
 	// DeleteKey removes the key for the given clientID.
-	DeleteKey(clientID string) error
+	DeleteKey(ctx context.Context, req *DeleteKeyRequest) (*DeleteKeyResponse, error)
 
 	// ListKeyIDs returns all registered client IDs.
-	ListKeyIDs() ([]string, error)
+	ListKeyIDs(ctx context.Context, req *ListKeyIDsRequest) (*ListKeyIDsResponse, error)
 }
 
 // keyEntry is the internal storage representation for InMemoryKeyStore.
@@ -81,7 +138,11 @@ func computeKid(key any, alg string) string {
 }
 
 // PutKey stores a key record. Computes Kid from key material if not set.
-func (s *InMemoryKeyStore) PutKey(rec *KeyRecord) error {
+func (s *InMemoryKeyStore) PutKey(ctx context.Context, req *PutKeyRequest) (*PutKeyResponse, error) {
+	if req == nil || req.Record == nil {
+		return nil, fmt.Errorf("PutKey: req.Record is required")
+	}
+	rec := req.Record
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -99,116 +160,79 @@ func (s *InMemoryKeyStore) PutKey(rec *KeyRecord) error {
 	if kid != "" {
 		s.kidIndex[kid] = rec.ClientID
 	}
-	return nil
+	return &PutKeyResponse{}, nil
 }
 
 // DeleteKey removes the key for the given clientID.
-func (s *InMemoryKeyStore) DeleteKey(clientID string) error {
+func (s *InMemoryKeyStore) DeleteKey(ctx context.Context, req *DeleteKeyRequest) (*DeleteKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteKey: req is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	entry, ok := s.keys[clientID]
+	entry, ok := s.keys[req.ClientID]
 	if !ok {
-		return ErrKeyNotFound
+		return nil, ErrKeyNotFound
 	}
 	if entry.Kid != "" {
 		delete(s.kidIndex, entry.Kid)
 	}
-	delete(s.keys, clientID)
-	return nil
+	delete(s.keys, req.ClientID)
+	return &DeleteKeyResponse{}, nil
 }
 
 // GetKey returns the key record for the given clientID.
-func (s *InMemoryKeyStore) GetKey(clientID string) (*KeyRecord, error) {
+func (s *InMemoryKeyStore) GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKey: req is required")
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	entry, ok := s.keys[clientID]
+	entry, ok := s.keys[req.ClientID]
 	if !ok {
 		return nil, ErrKeyNotFound
 	}
-	return &KeyRecord{
-		ClientID:  clientID,
+	return &GetKeyResponse{Record: &KeyRecord{
+		ClientID:  req.ClientID,
 		Key:       entry.Key,
 		Algorithm: entry.Algorithm,
 		Kid:       entry.Kid,
-	}, nil
+	}}, nil
 }
 
 // GetKeyByKid returns the key record matching the given kid.
-func (s *InMemoryKeyStore) GetKeyByKid(kid string) (*KeyRecord, error) {
+func (s *InMemoryKeyStore) GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	clientID, ok := s.kidIndex[kid]
+	clientID, ok := s.kidIndex[req.Kid]
 	if !ok {
 		return nil, ErrKidNotFound
 	}
 
 	entry, ok := s.keys[clientID]
-	if !ok || entry.Kid != kid {
+	if !ok || entry.Kid != req.Kid {
 		return nil, ErrKidNotFound
 	}
 
-	return &KeyRecord{
+	return &GetKeyByKidResponse{Record: &KeyRecord{
 		ClientID:  clientID,
 		Key:       entry.Key,
 		Algorithm: entry.Algorithm,
 		Kid:       entry.Kid,
-	}, nil
+	}}, nil
 }
 
 // ListKeyIDs returns all registered client IDs.
-func (s *InMemoryKeyStore) ListKeyIDs() ([]string, error) {
+func (s *InMemoryKeyStore) ListKeyIDs(ctx context.Context, req *ListKeyIDsRequest) (*ListKeyIDsResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	ids := make([]string, 0, len(s.keys))
 	for k := range s.keys {
 		ids = append(ids, k)
 	}
-	return ids, nil
-}
-
-// ============================================================================
-// Backward-compatible aliases (used by existing callers during migration)
-// ============================================================================
-
-// RegisterKey is a convenience method matching the old WritableKeyStore interface.
-func (s *InMemoryKeyStore) RegisterKey(clientID string, key any, algorithm string) error {
-	return s.PutKey(&KeyRecord{ClientID: clientID, Key: key, Algorithm: algorithm})
-}
-
-// GetVerifyKey is a convenience method matching the old KeyStore interface.
-func (s *InMemoryKeyStore) GetVerifyKey(clientID string) (any, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return nil, err
-	}
-	return rec.Key, nil
-}
-
-// GetSigningKey is a convenience method matching the old KeyStore interface.
-func (s *InMemoryKeyStore) GetSigningKey(clientID string) (any, error) {
-	return s.GetVerifyKey(clientID)
-}
-
-// GetExpectedAlg is a convenience method matching the old KeyStore interface.
-func (s *InMemoryKeyStore) GetExpectedAlg(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Algorithm, nil
-}
-
-// ListKeys is a convenience alias for ListKeyIDs.
-func (s *InMemoryKeyStore) ListKeys() ([]string, error) {
-	return s.ListKeyIDs()
-}
-
-// GetCurrentKid returns the kid for the given clientID.
-func (s *InMemoryKeyStore) GetCurrentKid(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Kid, nil
+	return &ListKeyIDsResponse{ClientIDs: ids}, nil
 }

--- a/keys/kid.go
+++ b/keys/kid.go
@@ -1,6 +1,8 @@
 package keys
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -19,6 +21,40 @@ func (r *kidRecord) isExpired() bool {
 	return !r.ExpiresAt.IsZero() && time.Now().After(r.ExpiresAt)
 }
 
+// ----------------------------------------------------------------------------
+// Request / response types — KidStorage
+// ----------------------------------------------------------------------------
+
+// AddKidRequest is the input to KidStorage.Add. If ExpiresAt is zero,
+// the kid has no expiry (current key).
+type AddKidRequest struct {
+	Kid       string
+	Key       any
+	Algorithm string
+	ClientID  string
+	ExpiresAt time.Time
+}
+
+// AddKidResponse is the output of KidStorage.Add.
+type AddKidResponse struct{}
+
+// RemoveKidRequest is the input to KidStorage.Remove.
+type RemoveKidRequest struct {
+	Kid string
+}
+
+// RemoveKidResponse is the output of KidStorage.Remove.
+type RemoveKidResponse struct{}
+
+// CleanExpiredRequest is the input to KidStorage.CleanExpired.
+type CleanExpiredRequest struct{}
+
+// CleanExpiredResponse is the output of KidStorage.CleanExpired.
+type CleanExpiredResponse struct {
+	// Removed is the number of expired records evicted by this call.
+	Removed int
+}
+
 // KidStorage is the write side of a kid-indexed key store. It extends the
 // read-only KeyLookup with the grace-period operations KidStore provides,
 // so retired keys can be persisted across process restarts by backends in
@@ -29,23 +65,23 @@ func (r *kidRecord) isExpired() bool {
 type KidStorage interface {
 	KeyLookup
 
-	// Add registers a kid→key mapping. If expiresAt is zero, the key has
-	// no expiry. Re-adding an existing kid overwrites it.
-	Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error
+	// Add registers a kid→key mapping. If req.ExpiresAt is zero, the key
+	// has no expiry. Re-adding an existing kid overwrites it.
+	Add(ctx context.Context, req *AddKidRequest) (*AddKidResponse, error)
 
 	// Remove deletes a kid entry. Removing an absent kid is not an error.
-	Remove(kid string) error
+	Remove(ctx context.Context, req *RemoveKidRequest) (*RemoveKidResponse, error)
 
 	// CleanExpired removes all entries whose expiry has passed.
-	CleanExpired() error
+	CleanExpired(ctx context.Context, req *CleanExpiredRequest) (*CleanExpiredResponse, error)
 }
 
 // KidStore is an in-memory KidStorage that tracks kid→key mappings,
 // including grace-period entries retained during key rotation.
 //
 // Usage during rotation:
-//  1. kidStore.Add(oldKid, oldKey, alg, clientID, time.Now().Add(gracePeriod))
-//  2. keyStorage.PutKey(newRecord)  // overwrites current
+//  1. kidStore.Add(ctx, &AddKidRequest{Kid: oldKid, Key: oldKey, Algorithm: alg, ClientID: clientID, ExpiresAt: time.Now().Add(gracePeriod)})
+//  2. keyStorage.PutKey(ctx, &PutKeyRequest{Record: newRecord})  // overwrites current
 //  3. kidStore holds the old key until grace period expires
 type KidStore struct {
 	mu      sync.RWMutex
@@ -61,60 +97,71 @@ func NewKidStore() *KidStore {
 	}
 }
 
-// Add registers a kid→key mapping. If expiresAt is zero, the key has no expiry.
-func (s *KidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
+// Add registers a kid→key mapping. If req.ExpiresAt is zero, the key has no expiry.
+func (s *KidStore) Add(ctx context.Context, req *AddKidRequest) (*AddKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Add: req is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.records[kid] = &kidRecord{
-		Key:       key,
-		Algorithm: algorithm,
-		ClientID:  clientID,
-		ExpiresAt: expiresAt,
+	s.records[req.Kid] = &kidRecord{
+		Key:       req.Key,
+		Algorithm: req.Algorithm,
+		ClientID:  req.ClientID,
+		ExpiresAt: req.ExpiresAt,
 	}
-	return nil
+	return &AddKidResponse{}, nil
 }
 
 // Remove deletes a kid entry. Removing an absent kid is not an error.
-func (s *KidStore) Remove(kid string) error {
+func (s *KidStore) Remove(ctx context.Context, req *RemoveKidRequest) (*RemoveKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Remove: req is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.records, kid)
-	return nil
+	delete(s.records, req.Kid)
+	return &RemoveKidResponse{}, nil
 }
 
 // GetKey always returns ErrKeyNotFound — KidStore only supports kid-based lookup.
-func (s *KidStore) GetKey(clientID string) (*KeyRecord, error) {
+func (s *KidStore) GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error) {
 	return nil, ErrKeyNotFound
 }
 
 // GetKeyByKid returns the key record for the given kid.
 // Returns ErrKidNotFound if the kid is unknown or expired.
-func (s *KidStore) GetKeyByKid(kid string) (*KeyRecord, error) {
+func (s *KidStore) GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rec, ok := s.records[kid]
+	rec, ok := s.records[req.Kid]
 	if !ok || rec.isExpired() {
 		return nil, ErrKidNotFound
 	}
-	return &KeyRecord{
+	return &GetKeyByKidResponse{Record: &KeyRecord{
 		ClientID:  rec.ClientID,
 		Key:       rec.Key,
 		Algorithm: rec.Algorithm,
-		Kid:       kid,
-	}, nil
+		Kid:       req.Kid,
+	}}, nil
 }
 
 // CleanExpired removes all expired entries.
-func (s *KidStore) CleanExpired() error {
+func (s *KidStore) CleanExpired(ctx context.Context, req *CleanExpiredRequest) (*CleanExpiredResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	removed := 0
 	for kid, rec := range s.records {
 		if rec.isExpired() {
 			delete(s.records, kid)
+			removed++
 		}
 	}
-	return nil
+	return &CleanExpiredResponse{Removed: removed}, nil
 }
 
 // Len returns the number of entries (including expired ones not yet cleaned).
@@ -132,22 +179,22 @@ type CompositeKeyLookup struct {
 }
 
 // GetKey tries each lookup in order for a client_id match.
-func (c *CompositeKeyLookup) GetKey(clientID string) (*KeyRecord, error) {
+func (c *CompositeKeyLookup) GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error) {
 	for _, l := range c.Lookups {
-		rec, err := l.GetKey(clientID)
+		resp, err := l.GetKey(ctx, req)
 		if err == nil {
-			return rec, nil
+			return resp, nil
 		}
 	}
 	return nil, ErrKeyNotFound
 }
 
 // GetKeyByKid tries each lookup in order for a kid match.
-func (c *CompositeKeyLookup) GetKeyByKid(kid string) (*KeyRecord, error) {
+func (c *CompositeKeyLookup) GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error) {
 	for _, l := range c.Lookups {
-		rec, err := l.GetKeyByKid(kid)
+		resp, err := l.GetKeyByKid(ctx, req)
 		if err == nil {
-			return rec, nil
+			return resp, nil
 		}
 	}
 	return nil, ErrKidNotFound

--- a/keys/kid_test.go
+++ b/keys/kid_test.go
@@ -4,10 +4,8 @@ package keys_test
 // kid-based JWT verification, and AppRegistrar rotation with grace.
 
 import (
-	"github.com/panyam/oneauth/admin"
-	"github.com/panyam/oneauth/apiauth"
-	"github.com/panyam/oneauth/keys"
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -15,12 +13,27 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/utils"
 )
 
-// ============================================================================
-// Phase 1: kid header in minted JWTs
-// ============================================================================
+func putKidKey(t *testing.T, ks keys.KeyStorage, rec *keys.KeyRecord) {
+	t.Helper()
+	if _, err := ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: rec}); err != nil {
+		t.Fatalf("PutKey failed: %v", err)
+	}
+}
+
+func currentKid(t *testing.T, ks keys.KeyStorage, clientID string) string {
+	t.Helper()
+	resp, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+	if err != nil {
+		t.Fatalf("GetKey(%s) failed: %v", clientID, err)
+	}
+	return resp.Record.Kid
+}
 
 func TestMintResourceToken_HasKid(t *testing.T) {
 	secret := "test-secret-for-kid"
@@ -29,7 +42,6 @@ func TestMintResourceToken_HasKid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Parse without verification to inspect header
 	parser := jwt.NewParser()
 	parsed, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
 	if err != nil {
@@ -40,8 +52,6 @@ func TestMintResourceToken_HasKid(t *testing.T) {
 	if !ok || kid == "" {
 		t.Fatal("expected kid header in minted JWT")
 	}
-
-	// kid should match ComputeKid for the same key
 	expectedKid, err := utils.ComputeKid([]byte(secret), "HS256")
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +107,6 @@ func TestCreateAccessToken_HasKid(t *testing.T) {
 	if !ok || kid == "" {
 		t.Fatal("expected kid header in access token JWT")
 	}
-
 	expectedKid, _ := utils.ComputeKid([]byte("my-secret"), "HS256")
 	if kid != expectedKid {
 		t.Errorf("kid=%s, want %s", kid, expectedKid)
@@ -106,9 +115,8 @@ func TestCreateAccessToken_HasKid(t *testing.T) {
 
 func TestJWKS_KidMatchesThumbprint(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-	_ = privPEM
-	ks.RegisterKey("app-rsa", pubPEM, "RS256")
+	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"})
 
 	handler := &keys.JWKSHandler{KeyStore: ks}
 	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
@@ -122,13 +130,10 @@ func TestJWKS_KidMatchesThumbprint(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(jwkSet.Keys))
 	}
 
-	// kid in JWKS should be a thumbprint, not clientID
 	jwkKid := jwkSet.Keys[0].Kid
 	if jwkKid == "app-rsa" {
 		t.Error("JWKS kid should be a thumbprint, not clientID")
 	}
-
-	// Verify it matches what ComputeKid produces
 	pubKey, _ := utils.DecodeVerifyKey(pubPEM, "RS256")
 	expectedKid, _ := utils.ComputeKid(pubKey, "RS256")
 	if jwkKid != expectedKid {
@@ -136,30 +141,22 @@ func TestJWKS_KidMatchesThumbprint(t *testing.T) {
 	}
 }
 
-// ============================================================================
-// Phase 2: KidResolver on InMemoryKeyStore
-// ============================================================================
-
 func TestInMemoryKeyStore_KidResolver(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	secret := []byte("my-secret")
-	ks.RegisterKey("app-1", secret, "HS256")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: secret, Algorithm: "HS256"})
 
-	// GetCurrentKid should return computed kid
-	kid, err := ks.GetCurrentKid("app-1")
-	if err != nil {
-		t.Fatal(err)
-	}
+	kid := currentKid(t, ks, "app-1")
 	expectedKid, _ := utils.ComputeKid(secret, "HS256")
 	if kid != expectedKid {
-		t.Errorf("GetCurrentKid=%s, want %s", kid, expectedKid)
+		t.Errorf("kid=%s, want %s", kid, expectedKid)
 	}
 
-	// GetKeyByKid should return the key record
-	rec, err := ks.GetKeyByKid(kid)
+	resp, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
 	if err != nil {
 		t.Fatal(err)
 	}
+	rec := resp.Record
 	if string(rec.Key.([]byte)) != string(secret) {
 		t.Error("key mismatch")
 	}
@@ -173,7 +170,7 @@ func TestInMemoryKeyStore_KidResolver(t *testing.T) {
 
 func TestInMemoryKeyStore_KidResolver_NotFound(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	_, err := ks.GetKeyByKid("nonexistent-kid")
+	_, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "nonexistent-kid"})
 	if err != keys.ErrKidNotFound {
 		t.Errorf("expected ErrKidNotFound, got %v", err)
 	}
@@ -181,54 +178,54 @@ func TestInMemoryKeyStore_KidResolver_NotFound(t *testing.T) {
 
 func TestInMemoryKeyStore_KidUpdatesOnOverwrite(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app-1", []byte("old-secret"), "HS256")
-	oldKid, _ := ks.GetCurrentKid("app-1")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: []byte("old-secret"), Algorithm: "HS256"})
+	oldKid := currentKid(t, ks, "app-1")
 
-	ks.RegisterKey("app-1", []byte("new-secret"), "HS256")
-	newKid, _ := ks.GetCurrentKid("app-1")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: []byte("new-secret"), Algorithm: "HS256"})
+	newKid := currentKid(t, ks, "app-1")
 
 	if oldKid == newKid {
 		t.Error("kid should change when key changes")
 	}
 
-	// Old kid should no longer resolve
-	_, err := ks.GetKeyByKid(oldKid)
-	if err != keys.ErrKidNotFound {
+	if _, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: oldKid}); err != keys.ErrKidNotFound {
 		t.Errorf("old kid should not resolve after overwrite, got %v", err)
 	}
-
-	// New kid should resolve
-	_, err = ks.GetKeyByKid(newKid)
-	if err != nil {
+	if _, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: newKid}); err != nil {
 		t.Errorf("new kid should resolve: %v", err)
 	}
 }
 
 func TestInMemoryKeyStore_KidCleanedOnDelete(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app-1", []byte("secret"), "HS256")
-	kid, _ := ks.GetCurrentKid("app-1")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: []byte("secret"), Algorithm: "HS256"})
+	kid := currentKid(t, ks, "app-1")
 
-	ks.DeleteKey("app-1")
+	if _, err := ks.DeleteKey(context.Background(), &keys.DeleteKeyRequest{ClientID: "app-1"}); err != nil {
+		t.Fatalf("DeleteKey failed: %v", err)
+	}
 
-	_, err := ks.GetKeyByKid(kid)
-	if err != keys.ErrKidNotFound {
+	if _, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid}); err != keys.ErrKidNotFound {
 		t.Errorf("kid should not resolve after delete, got %v", err)
 	}
 }
 
-// ============================================================================
-// KidStore: grace period for rotated keys
-// ============================================================================
+func addKidEntry(t *testing.T, store *keys.KidStore, req *keys.AddKidRequest) {
+	t.Helper()
+	if _, err := store.Add(context.Background(), req); err != nil {
+		t.Fatalf("KidStore.Add failed: %v", err)
+	}
+}
 
 func TestKidStore_BasicAddAndLookup(t *testing.T) {
 	store := keys.NewKidStore()
-	store.Add("kid-1", []byte("secret"), "HS256", "app-1", time.Time{})
+	addKidEntry(t, store, &keys.AddKidRequest{Kid: "kid-1", Key: []byte("secret"), Algorithm: "HS256", ClientID: "app-1"})
 
-	rec, err := store.GetKeyByKid("kid-1")
+	resp, err := store.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "kid-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
+	rec := resp.Record
 	if string(rec.Key.([]byte)) != "secret" || rec.Algorithm != "HS256" || rec.ClientID != "app-1" {
 		t.Error("unexpected values from KidStore lookup")
 	}
@@ -236,9 +233,9 @@ func TestKidStore_BasicAddAndLookup(t *testing.T) {
 
 func TestKidStore_ExpiredKeyNotReturned(t *testing.T) {
 	store := keys.NewKidStore()
-	store.Add("kid-old", []byte("old-secret"), "HS256", "app-1", time.Now().Add(-1*time.Hour))
+	addKidEntry(t, store, &keys.AddKidRequest{Kid: "kid-old", Key: []byte("old-secret"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(-1 * time.Hour)})
 
-	_, err := store.GetKeyByKid("kid-old")
+	_, err := store.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "kid-old"})
 	if err != keys.ErrKidNotFound {
 		t.Errorf("expected ErrKidNotFound for expired key, got %v", err)
 	}
@@ -246,27 +243,29 @@ func TestKidStore_ExpiredKeyNotReturned(t *testing.T) {
 
 func TestKidStore_NonExpiredKeyReturned(t *testing.T) {
 	store := keys.NewKidStore()
-	store.Add("kid-old", []byte("old-secret"), "HS256", "app-1", time.Now().Add(1*time.Hour))
+	addKidEntry(t, store, &keys.AddKidRequest{Kid: "kid-old", Key: []byte("old-secret"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)})
 
-	rec, err := store.GetKeyByKid("kid-old")
+	resp, err := store.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "kid-old"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(rec.Key.([]byte)) != "old-secret" {
+	if string(resp.Record.Key.([]byte)) != "old-secret" {
 		t.Error("expected old secret for non-expired key")
 	}
 }
 
 func TestKidStore_CleanExpired(t *testing.T) {
 	store := keys.NewKidStore()
-	store.Add("kid-alive", []byte("a"), "HS256", "app-1", time.Now().Add(1*time.Hour))
-	store.Add("kid-dead", []byte("b"), "HS256", "app-2", time.Now().Add(-1*time.Hour))
+	addKidEntry(t, store, &keys.AddKidRequest{Kid: "kid-alive", Key: []byte("a"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)})
+	addKidEntry(t, store, &keys.AddKidRequest{Kid: "kid-dead", Key: []byte("b"), Algorithm: "HS256", ClientID: "app-2", ExpiresAt: time.Now().Add(-1 * time.Hour)})
 
 	if store.Len() != 2 {
 		t.Fatalf("expected 2 entries, got %d", store.Len())
 	}
 
-	store.CleanExpired()
+	if _, err := store.CleanExpired(context.Background(), &keys.CleanExpiredRequest{}); err != nil {
+		t.Fatalf("CleanExpired failed: %v", err)
+	}
 
 	if store.Len() != 1 {
 		t.Fatalf("expected 1 entry after cleanup, got %d", store.Len())
@@ -275,46 +274,35 @@ func TestKidStore_CleanExpired(t *testing.T) {
 
 func TestCompositeKidResolver(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app-1", []byte("current-secret"), "HS256")
-	currentKid, _ := ks.GetCurrentKid("app-1")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: []byte("current-secret"), Algorithm: "HS256"})
+	curKid := currentKid(t, ks, "app-1")
 
 	kidStore := keys.NewKidStore()
-	kidStore.Add("old-kid", []byte("old-secret"), "HS256", "app-1", time.Now().Add(1*time.Hour))
+	addKidEntry(t, kidStore, &keys.AddKidRequest{Kid: "old-kid", Key: []byte("old-secret"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)})
 
 	composite := &keys.CompositeKeyLookup{Lookups: []keys.KeyLookup{ks, kidStore}}
 
-	// Current kid resolves via InMemoryKeyStore
-	_, err := composite.GetKeyByKid(currentKid)
-	if err != nil {
+	if _, err := composite.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: curKid}); err != nil {
 		t.Errorf("current kid should resolve: %v", err)
 	}
 
-	// Old kid resolves via KidStore
-	rec, err := composite.GetKeyByKid("old-kid")
+	resp, err := composite.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "old-kid"})
 	if err != nil {
 		t.Errorf("old kid should resolve: %v", err)
-	}
-	if string(rec.Key.([]byte)) != "old-secret" {
+	} else if string(resp.Record.Key.([]byte)) != "old-secret" {
 		t.Error("expected old secret")
 	}
 
-	// Unknown kid fails
-	_, err = composite.GetKeyByKid("unknown")
-	if err != keys.ErrKidNotFound {
+	if _, err := composite.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "unknown"}); err != keys.ErrKidNotFound {
 		t.Errorf("expected ErrKidNotFound, got %v", err)
 	}
 }
 
-// ============================================================================
-// Phase 5: kid-based JWT verification in middleware
-// ============================================================================
-
 func TestValidateJWT_WithKid(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	secret := []byte("test-secret")
-	ks.RegisterKey("app-1", secret, "HS256")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: secret, Algorithm: "HS256"})
 
-	// Mint token (now includes kid header)
 	tokenStr, _ := admin.MintResourceToken("user-1", "app-1", string(secret), admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
@@ -340,9 +328,8 @@ func TestValidateJWT_WithKid(t *testing.T) {
 func TestValidateJWT_LegacyNoKid(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	secret := []byte("test-secret")
-	ks.RegisterKey("app-1", secret, "HS256")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-1", Key: secret, Algorithm: "HS256"})
 
-	// Manually create a token WITHOUT kid header (legacy)
 	claims := jwt.MapClaims{
 		"sub":       "user-1",
 		"client_id": "app-1",
@@ -352,7 +339,6 @@ func TestValidateJWT_LegacyNoKid(t *testing.T) {
 		"exp":       time.Now().Add(15 * time.Minute).Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	// Deliberately no kid header
 	tokenStr, _ := token.SignedString(secret)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
@@ -377,11 +363,9 @@ func TestValidateJWT_LegacyNoKid(t *testing.T) {
 
 func TestValidateJWT_CrossAppRejectedViaKid(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	ks.RegisterKey("app-a", []byte("secret-a"), "HS256")
-	ks.RegisterKey("app-b", []byte("secret-b"), "HS256")
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-a", Key: []byte("secret-a"), Algorithm: "HS256"})
+	putKidKey(t, ks, &keys.KeyRecord{ClientID: "app-b", Key: []byte("secret-b"), Algorithm: "HS256"})
 
-	// Mint with app-a's secret but claim client_id=app-b
-	// The kid will be derived from secret-a, so cross-check should fail
 	tokenStr, _ := admin.MintResourceToken("user-1", "app-b", "secret-a", admin.AppQuota{}, []string{"read"}, nil)
 
 	middleware := &apiauth.APIMiddleware{KeyStore: ks}
@@ -399,21 +383,13 @@ func TestValidateJWT_CrossAppRejectedViaKid(t *testing.T) {
 	}
 }
 
-// ============================================================================
-// Phase 6: AppRegistrar rotation with grace period
-// ============================================================================
-
 func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	kidStore := keys.NewKidStore()
-	registrar := func() *admin.AppRegistrar {
-		r := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-		r.KidStore = kidStore
-		return r
-	}()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registrar.KidStore = kidStore
 	regHandler := registrar.Handler()
 
-	// Register app
 	body, _ := json.Marshal(map[string]any{"client_domain": "grace-test.com"})
 	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -425,10 +401,8 @@ func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 	clientID := regResp["client_id"].(string)
 	oldSecret := regResp["client_secret"].(string)
 
-	// Mint token with old secret
 	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"}, nil)
 
-	// Rotate with grace period
 	rotBody, _ := json.Marshal(map[string]any{"grace_period": "1h"})
 	req = httptest.NewRequest(http.MethodPost, "/apps/"+clientID+"/rotate", bytes.NewReader(rotBody))
 	req.Header.Set("Content-Type", "application/json")
@@ -446,15 +420,12 @@ func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 		t.Error("expected grace_period in rotation response")
 	}
 
-	// Build composite resolver: KeyStore (current keys) + KidStore (old keys)
 	composite := &keys.CompositeKeyLookup{Lookups: []keys.KeyLookup{ks, kidStore}}
-
 	middleware := &apiauth.APIMiddleware{KeyStore: composite}
 	okHandler := middleware.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Old token should still work (grace period active)
 	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
 	req.Header.Set("Authorization", "Bearer "+oldToken)
 	rr = httptest.NewRecorder()
@@ -463,7 +434,6 @@ func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 		t.Errorf("old token during grace: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	// New token should work
 	newToken, _ := admin.MintResourceToken("user-1", clientID, newSecret, admin.AppQuota{}, []string{"read"}, nil)
 	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
 	req.Header.Set("Authorization", "Bearer "+newToken)
@@ -479,10 +449,9 @@ func TestAppRegistrar_RotateExpiredGrace(t *testing.T) {
 	kidStore := keys.NewKidStore()
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	registrar.KidStore = kidStore
-	registrar.DefaultGracePeriod = 1 * time.Millisecond // tiny grace for testing
+	registrar.DefaultGracePeriod = 1 * time.Millisecond
 	regHandler := registrar.Handler()
 
-	// Register
 	body, _ := json.Marshal(map[string]any{"client_domain": "expire-test.com"})
 	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -496,12 +465,10 @@ func TestAppRegistrar_RotateExpiredGrace(t *testing.T) {
 
 	oldToken, _ := admin.MintResourceToken("user-1", clientID, oldSecret, admin.AppQuota{}, []string{"read"}, nil)
 
-	// Rotate (uses default tiny grace period)
 	req = httptest.NewRequest(http.MethodPost, "/apps/"+clientID+"/rotate", nil)
 	rr = httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)
 
-	// Wait for grace period to expire
 	time.Sleep(5 * time.Millisecond)
 
 	composite := &keys.CompositeKeyLookup{Lookups: []keys.KeyLookup{ks, kidStore}}
@@ -510,7 +477,6 @@ func TestAppRegistrar_RotateExpiredGrace(t *testing.T) {
 		t.Fatal("handler should not be called for expired grace token")
 	}))
 
-	// Old token should now fail (grace expired)
 	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
 	req.Header.Set("Authorization", "Bearer "+oldToken)
 	rr = httptest.NewRecorder()

--- a/keystoretest/keystoretest.go
+++ b/keystoretest/keystoretest.go
@@ -3,6 +3,7 @@
 package keystoretest
 
 import (
+	"context"
 	"crypto/rsa"
 	"sort"
 	"testing"
@@ -13,6 +14,13 @@ import (
 
 // Factory creates a fresh KeyStorage for each test.
 type Factory func(t *testing.T) keys.KeyStorage
+
+func putKey(t *testing.T, ks keys.KeyStorage, rec *keys.KeyRecord) {
+	t.Helper()
+	if _, err := ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: rec}); err != nil {
+		t.Fatalf("PutKey failed: %v", err)
+	}
+}
 
 // RunAll runs the complete KeyStore test suite against the provided factory.
 func RunAll(t *testing.T, factory Factory) {
@@ -33,17 +41,16 @@ func RunAll(t *testing.T, factory Factory) {
 
 func TestRegisterAndGet(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	secret := []byte("host-secret-123")
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "host-abc", Key: secret, Algorithm: "HS256"}); err != nil {
-		t.Fatalf("PutKey failed: %v", err)
-	}
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-abc", Key: secret, Algorithm: "HS256"})
 
-	// GetKey should return the secret
-	rec, err := ks.GetKey("host-abc")
+	resp, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-abc"})
 	if err != nil {
 		t.Fatalf("GetKey failed: %v", err)
 	}
+	rec := resp.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
 		t.Fatalf("Expected []byte, got %T", rec.Key)
@@ -51,21 +58,6 @@ func TestRegisterAndGet(t *testing.T, factory Factory) {
 	if string(keyBytes) != string(secret) {
 		t.Errorf("Expected secret %q, got %q", secret, keyBytes)
 	}
-
-	// For HS256, signing key and verify key are the same
-	rec2, err := ks.GetKey("host-abc")
-	if err != nil {
-		t.Fatalf("GetKey (signing) failed: %v", err)
-	}
-	sigKeyBytes, ok := rec2.Key.([]byte)
-	if !ok {
-		t.Fatalf("Expected []byte, got %T", rec2.Key)
-	}
-	if string(sigKeyBytes) != string(secret) {
-		t.Errorf("Expected signing key %q, got %q", secret, sigKeyBytes)
-	}
-
-	// Algorithm should be HS256
 	if rec.Algorithm != "HS256" {
 		t.Errorf("Expected alg HS256, got %s", rec.Algorithm)
 	}
@@ -73,8 +65,7 @@ func TestRegisterAndGet(t *testing.T, factory Factory) {
 
 func TestNotFound(t *testing.T, factory Factory) {
 	ks := factory(t)
-
-	_, err := ks.GetKey("nonexistent")
+	_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: "nonexistent"})
 	if err != keys.ErrKeyNotFound {
 		t.Errorf("Expected ErrKeyNotFound, got %v", err)
 	}
@@ -82,61 +73,47 @@ func TestNotFound(t *testing.T, factory Factory) {
 
 func TestMultipleHosts(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	secret1 := []byte("secret-for-host-1")
 	secret2 := []byte("secret-for-host-2")
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-1", Key: secret1, Algorithm: "HS256"})
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-2", Key: secret2, Algorithm: "HS256"})
 
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "host-1", Key: secret1, Algorithm: "HS256"}); err != nil {
-		t.Fatalf("PutKey host-1 failed: %v", err)
-	}
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "host-2", Key: secret2, Algorithm: "HS256"}); err != nil {
-		t.Fatalf("PutKey host-2 failed: %v", err)
-	}
-
-	rec1, err := ks.GetKey("host-1")
+	resp1, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-1"})
 	if err != nil {
 		t.Fatalf("GetKey host-1 failed: %v", err)
 	}
-	rec2, err := ks.GetKey("host-2")
+	resp2, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-2"})
 	if err != nil {
 		t.Fatalf("GetKey host-2 failed: %v", err)
 	}
-
-	if string(rec1.Key.([]byte)) != string(secret1) {
+	if string(resp1.Record.Key.([]byte)) != string(secret1) {
 		t.Errorf("host-1 key mismatch")
 	}
-	if string(rec2.Key.([]byte)) != string(secret2) {
+	if string(resp2.Record.Key.([]byte)) != string(secret2) {
 		t.Errorf("host-2 key mismatch")
-	}
-	if string(rec1.Key.([]byte)) == string(rec2.Key.([]byte)) {
-		t.Error("host-1 and host-2 should have different keys")
 	}
 }
 
 func TestDeleteKey(t *testing.T, factory Factory) {
 	ks := factory(t)
-
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "host-abc", Key: []byte("secret"), Algorithm: "HS256"}); err != nil {
-		t.Fatalf("PutKey failed: %v", err)
-	}
-
-	if _, err := ks.GetKey("host-abc"); err != nil {
+	ctx := context.Background()
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-abc", Key: []byte("secret"), Algorithm: "HS256"})
+	if _, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-abc"}); err != nil {
 		t.Fatalf("Key should exist: %v", err)
 	}
-
-	if err := ks.DeleteKey("host-abc"); err != nil {
+	if _, err := ks.DeleteKey(ctx, &keys.DeleteKeyRequest{ClientID: "host-abc"}); err != nil {
 		t.Fatalf("DeleteKey failed: %v", err)
 	}
-
-	if _, err := ks.GetKey("host-abc"); err != keys.ErrKeyNotFound {
+	if _, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-abc"}); err != keys.ErrKeyNotFound {
 		t.Errorf("Expected ErrKeyNotFound after delete, got %v", err)
 	}
 }
 
 func TestDeleteNonexistent(t *testing.T, factory Factory) {
 	ks := factory(t)
-
-	err := ks.DeleteKey("nonexistent")
+	_, err := ks.DeleteKey(context.Background(), &keys.DeleteKeyRequest{ClientID: "nonexistent"})
 	if err != keys.ErrKeyNotFound {
 		t.Errorf("Expected ErrKeyNotFound, got %v", err)
 	}
@@ -144,99 +121,83 @@ func TestDeleteNonexistent(t *testing.T, factory Factory) {
 
 func TestOverwriteKey(t *testing.T, factory Factory) {
 	ks := factory(t)
-
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "host-abc", Key: []byte("old-secret"), Algorithm: "HS256"}); err != nil {
-		t.Fatalf("PutKey failed: %v", err)
-	}
-
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "host-abc", Key: []byte("new-secret"), Algorithm: "HS512"}); err != nil {
-		t.Fatalf("PutKey overwrite failed: %v", err)
-	}
-
-	rec, _ := ks.GetKey("host-abc")
-	if string(rec.Key.([]byte)) != "new-secret" {
+	ctx := context.Background()
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-abc", Key: []byte("old-secret"), Algorithm: "HS256"})
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-abc", Key: []byte("new-secret"), Algorithm: "HS512"})
+	resp, _ := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-abc"})
+	if string(resp.Record.Key.([]byte)) != "new-secret" {
 		t.Error("Expected overwritten secret")
 	}
-
-	if rec.Algorithm != "HS512" {
-		t.Errorf("Expected overwritten alg HS512, got %s", rec.Algorithm)
+	if resp.Record.Algorithm != "HS512" {
+		t.Errorf("Expected overwritten alg HS512, got %s", resp.Record.Algorithm)
 	}
 }
 
 func TestListKeys(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-alpha", Key: []byte("secret-a"), Algorithm: "HS256"})
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-beta", Key: []byte("secret-b"), Algorithm: "HS256"})
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-gamma", Key: []byte("secret-g"), Algorithm: "HS512"})
 
-	ks.PutKey(&keys.KeyRecord{ClientID: "host-alpha", Key: []byte("secret-a"), Algorithm: "HS256"})
-	ks.PutKey(&keys.KeyRecord{ClientID: "host-beta", Key: []byte("secret-b"), Algorithm: "HS256"})
-	ks.PutKey(&keys.KeyRecord{ClientID: "host-gamma", Key: []byte("secret-g"), Algorithm: "HS512"})
-
-	keys, err := ks.ListKeyIDs()
+	resp, err := ks.ListKeyIDs(ctx, &keys.ListKeyIDsRequest{})
 	if err != nil {
 		t.Fatalf("ListKeyIDs failed: %v", err)
 	}
-	if len(keys) != 3 {
-		t.Fatalf("Expected 3 keys, got %d", len(keys))
+	ids := resp.ClientIDs
+	if len(ids) != 3 {
+		t.Fatalf("Expected 3 keys, got %d", len(ids))
 	}
-
-	sort.Strings(keys)
+	sort.Strings(ids)
 	expected := []string{"host-alpha", "host-beta", "host-gamma"}
 	for i, e := range expected {
-		if keys[i] != e {
-			t.Errorf("Expected keys[%d] = %s, got %s", i, e, keys[i])
+		if ids[i] != e {
+			t.Errorf("Expected ids[%d] = %s, got %s", i, e, ids[i])
 		}
 	}
 }
 
 func TestListKeysEmpty(t *testing.T, factory Factory) {
 	ks := factory(t)
-
-	keys, err := ks.ListKeyIDs()
+	resp, err := ks.ListKeyIDs(context.Background(), &keys.ListKeyIDsRequest{})
 	if err != nil {
 		t.Fatalf("ListKeyIDs failed: %v", err)
 	}
-	if len(keys) != 0 {
-		t.Errorf("Expected 0 keys, got %d", len(keys))
+	if len(resp.ClientIDs) != 0 {
+		t.Errorf("Expected 0 keys, got %d", len(resp.ClientIDs))
 	}
 }
 
 func TestPersistence(t *testing.T, factory Factory) {
-	// This test verifies that two store instances sharing the same backend
-	// see each other's data. For InMemoryKeyStore this is trivially true
-	// (same instance). For persistent stores, the factory should return
-	// stores sharing the same underlying storage.
 	ks := factory(t)
-
-	ks.PutKey(&keys.KeyRecord{ClientID: "host-abc", Key: []byte("persistent-secret"), Algorithm: "HS256"})
-
-	// Re-read from the same store — all backends must support this
-	rec, err := ks.GetKey("host-abc")
+	ctx := context.Background()
+	putKey(t, ks, &keys.KeyRecord{ClientID: "host-abc", Key: []byte("persistent-secret"), Algorithm: "HS256"})
+	resp, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "host-abc"})
 	if err != nil {
 		t.Fatalf("Should see persisted key: %v", err)
 	}
-	if string(rec.Key.([]byte)) != "persistent-secret" {
+	if string(resp.Record.Key.([]byte)) != "persistent-secret" {
 		t.Error("Key material should persist")
 	}
 }
 
 func TestKidResolverBasic(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	secret := []byte("kid-test-secret")
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "app-kid", Key: secret, Algorithm: "HS256"}); err != nil {
-		t.Fatalf("PutKey failed: %v", err)
-	}
+	putKey(t, ks, &keys.KeyRecord{ClientID: "app-kid", Key: secret, Algorithm: "HS256"})
 
-	// Compute expected kid
 	expectedKid, err := utils.ComputeKid(secret, "HS256")
 	if err != nil {
 		t.Fatalf("ComputeKid failed: %v", err)
 	}
 
-	// Look up by kid
-	rec, err := ks.GetKeyByKid(expectedKid)
+	resp, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: expectedKid})
 	if err != nil {
 		t.Fatalf("GetKeyByKid failed: %v", err)
 	}
+	rec := resp.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
 		t.Fatalf("Expected []byte, got %T", rec.Key)
@@ -251,8 +212,7 @@ func TestKidResolverBasic(t *testing.T, factory Factory) {
 		t.Errorf("clientID=%s, want app-kid", rec.ClientID)
 	}
 
-	// Unknown kid should fail
-	_, err = ks.GetKeyByKid("nonexistent-kid")
+	_, err = ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "nonexistent-kid"})
 	if err != keys.ErrKidNotFound {
 		t.Errorf("expected ErrKidNotFound, got %v", err)
 	}
@@ -260,38 +220,33 @@ func TestKidResolverBasic(t *testing.T, factory Factory) {
 
 func TestKidResolverAsymmetric(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	_, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	if err != nil {
 		t.Fatal(err)
 	}
+	putKey(t, ks, &keys.KeyRecord{ClientID: "app-rsa-kid", Key: pubPEM, Algorithm: "RS256"})
 
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "app-rsa-kid", Key: pubPEM, Algorithm: "RS256"}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Compute kid from the public key
 	pubKey, _ := utils.DecodeVerifyKey(pubPEM, "RS256")
 	expectedKid, _ := utils.ComputeKid(pubKey, "RS256")
 
-	// For backends that store []byte PEM, ComputeKid on []byte with RS256
-	// should parse PEM and compute the same thumbprint
 	storedKid, _ := utils.ComputeKid(pubPEM, "RS256")
 	if storedKid != expectedKid {
 		t.Errorf("ComputeKid(PEM) should equal ComputeKid(pubKey): %s != %s", storedKid, expectedKid)
 	}
 
-	rec, err := ks.GetKeyByKid(expectedKid)
+	resp, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: expectedKid})
 	if err != nil {
 		t.Fatalf("GetKeyByKid failed: %v", err)
 	}
+	rec := resp.Record
 	if rec.Algorithm != "RS256" {
 		t.Errorf("alg=%s, want RS256", rec.Algorithm)
 	}
 	if rec.ClientID != "app-rsa-kid" {
 		t.Errorf("clientID=%s, want app-rsa-kid", rec.ClientID)
 	}
-	// Key should be the PEM bytes
 	if keyBytes, ok := rec.Key.([]byte); ok {
 		if string(keyBytes) != string(pubPEM) {
 			t.Error("key material mismatch")
@@ -301,26 +256,25 @@ func TestKidResolverAsymmetric(t *testing.T, factory Factory) {
 
 func TestGetCurrentKid(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	secret := []byte("kid-getter-secret")
-	ks.PutKey(&keys.KeyRecord{ClientID: "app-kg", Key: secret, Algorithm: "HS256"})
+	putKey(t, ks, &keys.KeyRecord{ClientID: "app-kg", Key: secret, Algorithm: "HS256"})
 
-	rec, err := ks.GetKey("app-kg")
+	resp, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "app-kg"})
 	if err != nil {
 		t.Fatalf("GetKey failed: %v", err)
 	}
-	kid := rec.Kid
+	kid := resp.Record.Kid
 	if kid == "" {
 		t.Error("expected non-empty kid")
 	}
-
 	expectedKid, _ := utils.ComputeKid(secret, "HS256")
 	if kid != expectedKid {
 		t.Errorf("kid=%s, want %s", kid, expectedKid)
 	}
 
-	// Nonexistent client
-	_, err = ks.GetKey("nonexistent")
+	_, err = ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "nonexistent"})
 	if err != keys.ErrKeyNotFound {
 		t.Errorf("expected ErrKeyNotFound, got %v", err)
 	}
@@ -328,22 +282,19 @@ func TestGetCurrentKid(t *testing.T, factory Factory) {
 
 func TestRegisterAndGetAsymmetricKey(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
-	// Generate an RSA key pair and store the public key PEM
 	_, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	if err != nil {
 		t.Fatalf("GenerateRSAKeyPair failed: %v", err)
 	}
+	putKey(t, ks, &keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"})
 
-	if err := ks.PutKey(&keys.KeyRecord{ClientID: "app-rsa", Key: pubPEM, Algorithm: "RS256"}); err != nil {
-		t.Fatalf("PutKey failed: %v", err)
-	}
-
-	// GetKey should return the same PEM bytes
-	rec, err := ks.GetKey("app-rsa")
+	resp, err := ks.GetKey(ctx, &keys.GetKeyRequest{ClientID: "app-rsa"})
 	if err != nil {
 		t.Fatalf("GetKey failed: %v", err)
 	}
+	rec := resp.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
 		t.Fatalf("Expected []byte, got %T", rec.Key)
@@ -351,13 +302,10 @@ func TestRegisterAndGetAsymmetricKey(t *testing.T, factory Factory) {
 	if string(keyBytes) != string(pubPEM) {
 		t.Error("Stored PEM should match original")
 	}
-
-	// Algorithm should be RS256
 	if rec.Algorithm != "RS256" {
 		t.Errorf("Expected alg RS256, got %s", rec.Algorithm)
 	}
 
-	// DecodeVerifyKey should parse PEM into *rsa.PublicKey
 	decoded, err := utils.DecodeVerifyKey(rec.Key, rec.Algorithm)
 	if err != nil {
 		t.Fatalf("DecodeVerifyKey failed: %v", err)

--- a/kidstoretest/kidstoretest.go
+++ b/kidstoretest/kidstoretest.go
@@ -1,6 +1,7 @@
 package kidstoretest
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,6 +11,13 @@ import (
 
 // Factory creates a fresh KidStorage for each test.
 type Factory func(t *testing.T) keys.KidStorage
+
+func addKid(t *testing.T, ks keys.KidStorage, req *keys.AddKidRequest) {
+	t.Helper()
+	if _, err := ks.Add(context.Background(), req); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+}
 
 // RunAll runs the complete KidStorage test suite against the provided factory.
 func RunAll(t *testing.T, factory Factory) {
@@ -27,16 +35,16 @@ func RunAll(t *testing.T, factory Factory) {
 
 func TestAddAndGetByKid(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	secret := []byte("kid-secret")
-	if err := ks.Add("kid-1", secret, "HS256", "app-1", time.Time{}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-1", Key: secret, Algorithm: "HS256", ClientID: "app-1"})
 
-	rec, err := ks.GetKeyByKid("kid-1")
+	resp, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-1"})
 	if err != nil {
 		t.Fatalf("GetKeyByKid failed: %v", err)
 	}
+	rec := resp.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
 		t.Fatalf("Expected []byte, got %T", rec.Key)
@@ -57,25 +65,17 @@ func TestAddAndGetByKid(t *testing.T, factory Factory) {
 
 func TestGetByUnknownKid(t *testing.T, factory Factory) {
 	ks := factory(t)
-
-	_, err := ks.GetKeyByKid("does-not-exist")
+	_, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "does-not-exist"})
 	if err != keys.ErrKidNotFound {
 		t.Errorf("Expected ErrKidNotFound, got %v", err)
 	}
 }
 
-// TestGetKeyByClientIDAlwaysNotFound enforces the documented KidStorage
-// semantic: lookup by clientID is meaningless for a kid-indexed store and
-// must always return ErrKeyNotFound, regardless of whether the client has
-// any kids registered.
 func TestGetKeyByClientIDAlwaysNotFound(t *testing.T, factory Factory) {
 	ks := factory(t)
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-1", Key: []byte("s"), Algorithm: "HS256", ClientID: "app-1"})
 
-	if err := ks.Add("kid-1", []byte("s"), "HS256", "app-1", time.Time{}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	_, err := ks.GetKey("app-1")
+	_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: "app-1"})
 	if err != keys.ErrKeyNotFound {
 		t.Errorf("GetKey by clientID must always return ErrKeyNotFound, got %v", err)
 	}
@@ -83,18 +83,16 @@ func TestGetKeyByClientIDAlwaysNotFound(t *testing.T, factory Factory) {
 
 func TestOverwriteSameKid(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
-	if err := ks.Add("kid-1", []byte("old"), "HS256", "app-1", time.Time{}); err != nil {
-		t.Fatalf("first Add failed: %v", err)
-	}
-	if err := ks.Add("kid-1", []byte("new"), "HS512", "app-2", time.Time{}); err != nil {
-		t.Fatalf("overwrite Add failed: %v", err)
-	}
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-1", Key: []byte("old"), Algorithm: "HS256", ClientID: "app-1"})
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-1", Key: []byte("new"), Algorithm: "HS512", ClientID: "app-2"})
 
-	rec, err := ks.GetKeyByKid("kid-1")
+	resp, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-1"})
 	if err != nil {
 		t.Fatalf("GetKeyByKid failed: %v", err)
 	}
+	rec := resp.Record
 	if string(rec.Key.([]byte)) != "new" {
 		t.Errorf("expected overwritten key, got %q", rec.Key)
 	}
@@ -106,39 +104,32 @@ func TestOverwriteSameKid(t *testing.T, factory Factory) {
 	}
 }
 
-// TestRemoveIdempotent enforces that Remove on an absent kid is not an
-// error — KidStorage Remove is intentionally idempotent (differs from
-// KeyStorage.DeleteKey which returns ErrKeyNotFound).
 func TestRemoveIdempotent(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
-	if err := ks.Remove("never-existed"); err != nil {
+	if _, err := ks.Remove(ctx, &keys.RemoveKidRequest{Kid: "never-existed"}); err != nil {
 		t.Errorf("Remove of absent kid should be nil, got %v", err)
 	}
 
-	if err := ks.Add("kid-1", []byte("s"), "HS256", "app-1", time.Time{}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-	if err := ks.Remove("kid-1"); err != nil {
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-1", Key: []byte("s"), Algorithm: "HS256", ClientID: "app-1"})
+	if _, err := ks.Remove(ctx, &keys.RemoveKidRequest{Kid: "kid-1"}); err != nil {
 		t.Errorf("Remove of present kid failed: %v", err)
 	}
-	if _, err := ks.GetKeyByKid("kid-1"); err != keys.ErrKidNotFound {
+	if _, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-1"}); err != keys.ErrKidNotFound {
 		t.Errorf("kid should be gone after Remove, got %v", err)
 	}
-	if err := ks.Remove("kid-1"); err != nil {
+	if _, err := ks.Remove(ctx, &keys.RemoveKidRequest{Kid: "kid-1"}); err != nil {
 		t.Errorf("second Remove (now absent) should be nil, got %v", err)
 	}
 }
 
 func TestExpiredKidNotReturned(t *testing.T, factory Factory) {
 	ks := factory(t)
-
 	past := time.Now().Add(-1 * time.Hour)
-	if err := ks.Add("kid-old", []byte("s"), "HS256", "app-1", past); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-old", Key: []byte("s"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: past})
 
-	_, err := ks.GetKeyByKid("kid-old")
+	_, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "kid-old"})
 	if err != keys.ErrKidNotFound {
 		t.Errorf("expired kid should return ErrKidNotFound, got %v", err)
 	}
@@ -146,81 +137,64 @@ func TestExpiredKidNotReturned(t *testing.T, factory Factory) {
 
 func TestZeroExpiryNeverExpires(t *testing.T, factory Factory) {
 	ks := factory(t)
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-forever", Key: []byte("s"), Algorithm: "HS256", ClientID: "app-1"})
 
-	// Zero time.Time = no expiry. A check far in the future must still find it.
-	if err := ks.Add("kid-forever", []byte("s"), "HS256", "app-1", time.Time{}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	rec, err := ks.GetKeyByKid("kid-forever")
+	resp, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "kid-forever"})
 	if err != nil {
 		t.Fatalf("zero-expiry kid must be returned: %v", err)
 	}
-	if rec.Kid != "kid-forever" {
-		t.Errorf("kid=%s, want kid-forever", rec.Kid)
+	if resp.Record.Kid != "kid-forever" {
+		t.Errorf("kid=%s, want kid-forever", resp.Record.Kid)
 	}
 }
 
 func TestCleanExpired(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
-	if err := ks.Add("kid-alive", []byte("a"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
-		t.Fatalf("Add kid-alive failed: %v", err)
-	}
-	if err := ks.Add("kid-dead", []byte("b"), "HS256", "app-2", time.Now().Add(-1*time.Hour)); err != nil {
-		t.Fatalf("Add kid-dead failed: %v", err)
-	}
-	if err := ks.Add("kid-forever", []byte("c"), "HS256", "app-3", time.Time{}); err != nil {
-		t.Fatalf("Add kid-forever failed: %v", err)
-	}
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-alive", Key: []byte("a"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)})
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-dead", Key: []byte("b"), Algorithm: "HS256", ClientID: "app-2", ExpiresAt: time.Now().Add(-1 * time.Hour)})
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-forever", Key: []byte("c"), Algorithm: "HS256", ClientID: "app-3"})
 
-	if err := ks.CleanExpired(); err != nil {
+	if _, err := ks.CleanExpired(ctx, &keys.CleanExpiredRequest{}); err != nil {
 		t.Fatalf("CleanExpired failed: %v", err)
 	}
 
-	if _, err := ks.GetKeyByKid("kid-alive"); err != nil {
+	if _, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-alive"}); err != nil {
 		t.Errorf("live kid was swept: %v", err)
 	}
-	if _, err := ks.GetKeyByKid("kid-forever"); err != nil {
+	if _, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-forever"}); err != nil {
 		t.Errorf("non-expiring kid was swept: %v", err)
 	}
-	// Re-add kid-dead and confirm it's gone from the backing store
-	// (GetKeyByKid already filters expired entries even before CleanExpired,
-	// so this also confirms CleanExpired physically removed the row/file
-	// — re-adding with a future expiry must not collide with stale state).
-	if err := ks.Add("kid-dead", []byte("b2"), "HS256", "app-2", time.Now().Add(1*time.Hour)); err != nil {
-		t.Fatalf("re-Add kid-dead failed: %v", err)
-	}
-	rec, err := ks.GetKeyByKid("kid-dead")
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-dead", Key: []byte("b2"), Algorithm: "HS256", ClientID: "app-2", ExpiresAt: time.Now().Add(1 * time.Hour)})
+	resp, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-dead"})
 	if err != nil {
 		t.Fatalf("re-added kid-dead missing: %v", err)
 	}
-	if string(rec.Key.([]byte)) != "b2" {
-		t.Errorf("expected fresh value b2 after re-Add, got %q", rec.Key)
+	if string(resp.Record.Key.([]byte)) != "b2" {
+		t.Errorf("expected fresh value b2 after re-Add, got %q", resp.Record.Key)
 	}
 }
 
 func TestAsymmetricKeyRoundTrip(t *testing.T, factory Factory) {
 	ks := factory(t)
+	ctx := context.Background()
 
 	_, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	if err != nil {
 		t.Fatalf("GenerateRSAKeyPair failed: %v", err)
 	}
-
 	kid, err := utils.ComputeKid(pubPEM, "RS256")
 	if err != nil {
 		t.Fatalf("ComputeKid failed: %v", err)
 	}
+	addKid(t, ks, &keys.AddKidRequest{Kid: kid, Key: pubPEM, Algorithm: "RS256", ClientID: "app-rsa", ExpiresAt: time.Now().Add(1 * time.Hour)})
 
-	if err := ks.Add(kid, pubPEM, "RS256", "app-rsa", time.Now().Add(1*time.Hour)); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	rec, err := ks.GetKeyByKid(kid)
+	resp, err := ks.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: kid})
 	if err != nil {
 		t.Fatalf("GetKeyByKid failed: %v", err)
 	}
+	rec := resp.Record
 	if rec.Algorithm != "RS256" {
 		t.Errorf("alg=%s, want RS256", rec.Algorithm)
 	}
@@ -233,22 +207,15 @@ func TestAsymmetricKeyRoundTrip(t *testing.T, factory Factory) {
 	}
 }
 
-// TestPersistence verifies the store reads back what it wrote. For
-// persistent backends (FS, GORM, GAE) this exercises the actual storage
-// layer; for in-memory it is trivially true. Cross-instance restart proof
-// is handled in backend-specific tests where reopening makes sense.
 func TestPersistence(t *testing.T, factory Factory) {
 	ks := factory(t)
+	addKid(t, ks, &keys.AddKidRequest{Kid: "kid-1", Key: []byte("persistent"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)})
 
-	if err := ks.Add("kid-1", []byte("persistent"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	rec, err := ks.GetKeyByKid("kid-1")
+	resp, err := ks.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: "kid-1"})
 	if err != nil {
 		t.Fatalf("GetKeyByKid failed: %v", err)
 	}
-	if string(rec.Key.([]byte)) != "persistent" {
+	if string(resp.Record.Key.([]byte)) != "persistent" {
 		t.Error("persisted key material mismatch")
 	}
 }

--- a/stores/fs/fskeystore.go
+++ b/stores/fs/fskeystore.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -62,22 +63,26 @@ func (s *FSKeyStore) loadEntry(clientID string) (*fsKeyEntry, error) {
 	return &entry, nil
 }
 
-func (s *FSKeyStore) PutKey(rec *keys.KeyRecord) error {
+func (s *FSKeyStore) PutKey(ctx context.Context, req *keys.PutKeyRequest) (*keys.PutKeyResponse, error) {
+	if req == nil || req.Record == nil {
+		return nil, fmt.Errorf("PutKey: req.Record is required")
+	}
+	rec := req.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
-		return keys.ErrAlgorithmMismatch
+		return nil, keys.ErrAlgorithmMismatch
 	}
 
 	path, err := s.getKeyPath(rec.ClientID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := os.MkdirAll(s.getKeyDir(), 0700); err != nil {
-		return err
+		return nil, err
 	}
 
 	kid := rec.Kid
@@ -92,42 +97,57 @@ func (s *FSKeyStore) PutKey(rec *keys.KeyRecord) error {
 	}
 	data, err := json.MarshalIndent(entry, "", "  ")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return writeAtomicFile(path, data)
+	if err := writeAtomicFile(path, data); err != nil {
+		return nil, err
+	}
+	return &keys.PutKeyResponse{}, nil
 }
 
-func (s *FSKeyStore) DeleteKey(clientID string) error {
+func (s *FSKeyStore) DeleteKey(ctx context.Context, req *keys.DeleteKeyRequest) (*keys.DeleteKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteKey: req is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	path, err := s.getKeyPath(clientID)
-	if err != nil {
-		return err
-	}
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return keys.ErrKeyNotFound
-	}
-	return os.Remove(path)
-}
-
-func (s *FSKeyStore) GetKey(clientID string) (*keys.KeyRecord, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	entry, err := s.loadEntry(clientID)
+	path, err := s.getKeyPath(req.ClientID)
 	if err != nil {
 		return nil, err
 	}
-	return &keys.KeyRecord{
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, keys.ErrKeyNotFound
+	}
+	if err := os.Remove(path); err != nil {
+		return nil, err
+	}
+	return &keys.DeleteKeyResponse{}, nil
+}
+
+func (s *FSKeyStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKey: req is required")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, err := s.loadEntry(req.ClientID)
+	if err != nil {
+		return nil, err
+	}
+	return &keys.GetKeyResponse{Record: &keys.KeyRecord{
 		ClientID:  entry.ClientID,
 		Key:       entry.Key,
 		Algorithm: entry.Algorithm,
 		Kid:       entry.Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *FSKeyStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+func (s *FSKeyStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -149,19 +169,19 @@ func (s *FSKeyStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
 		if err := json.Unmarshal(data, &entry); err != nil {
 			continue
 		}
-		if entry.Kid == kid {
-			return &keys.KeyRecord{
+		if entry.Kid == req.Kid {
+			return &keys.GetKeyByKidResponse{Record: &keys.KeyRecord{
 				ClientID:  entry.ClientID,
 				Key:       entry.Key,
 				Algorithm: entry.Algorithm,
 				Kid:       entry.Kid,
-			}, nil
+			}}, nil
 		}
 	}
 	return nil, keys.ErrKidNotFound
 }
 
-func (s *FSKeyStore) ListKeyIDs() ([]string, error) {
+func (s *FSKeyStore) ListKeyIDs(ctx context.Context, req *keys.ListKeyIDsRequest) (*keys.ListKeyIDsResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -169,12 +189,12 @@ func (s *FSKeyStore) ListKeyIDs() ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []string{}, nil
+			return &keys.ListKeyIDsResponse{ClientIDs: []string{}}, nil
 		}
 		return nil, err
 	}
 
-	var keys []string
+	var ids []string
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
@@ -187,45 +207,7 @@ func (s *FSKeyStore) ListKeyIDs() ([]string, error) {
 		if err := json.Unmarshal(data, &entry); err != nil {
 			continue
 		}
-		keys = append(keys, entry.ClientID)
+		ids = append(ids, entry.ClientID)
 	}
-	return keys, nil
-}
-
-// Backward-compatible aliases
-
-func (s *FSKeyStore) RegisterKey(clientID string, key any, algorithm string) error {
-	return s.PutKey(&keys.KeyRecord{ClientID: clientID, Key: key, Algorithm: algorithm})
-}
-
-func (s *FSKeyStore) GetVerifyKey(clientID string) (any, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return nil, err
-	}
-	return rec.Key, nil
-}
-
-func (s *FSKeyStore) GetSigningKey(clientID string) (any, error) {
-	return s.GetVerifyKey(clientID)
-}
-
-func (s *FSKeyStore) GetExpectedAlg(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Algorithm, nil
-}
-
-func (s *FSKeyStore) ListKeys() ([]string, error) {
-	return s.ListKeyIDs()
-}
-
-func (s *FSKeyStore) GetCurrentKid(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Kid, nil
+	return &keys.ListKeyIDsResponse{ClientIDs: ids}, nil
 }

--- a/stores/fs/fskidstore.go
+++ b/stores/fs/fskidstore.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,8 +14,6 @@ import (
 )
 
 // fsKidEntry is the on-disk JSON representation of a kid→key grace entry.
-// Mirrors fsKeyEntry but keyed by kid (not clientID) and carries an expiry
-// — the grace-period TTL set when a key is retired during rotation.
 type fsKidEntry struct {
 	Kid       string    `json:"kid"`
 	Key       []byte    `json:"key"`
@@ -24,8 +23,6 @@ type fsKidEntry struct {
 }
 
 // FSKidStore implements keys.KidStorage using filesystem storage.
-// One file per kid under {StoragePath}/kid_keys/, mirroring FSKeyStore's
-// file-per-record layout.
 type FSKidStore struct {
 	StoragePath string
 	mu          sync.RWMutex
@@ -50,69 +47,77 @@ func (s *FSKidStore) getKidPath(kid string) (string, error) {
 	return filepath.Join(s.getKidDir(), safeKid+".json"), nil
 }
 
-// isExpired matches keys.kidRecord.isExpired: zero time = never expires.
 func isExpired(t time.Time) bool {
 	return !t.IsZero() && time.Now().After(t)
 }
 
-func (s *FSKidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
-	keyBytes, ok := key.([]byte)
+func (s *FSKidStore) Add(ctx context.Context, req *keys.AddKidRequest) (*keys.AddKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Add: req is required")
+	}
+	keyBytes, ok := req.Key.([]byte)
 	if !ok {
-		return keys.ErrAlgorithmMismatch
+		return nil, keys.ErrAlgorithmMismatch
 	}
 
-	path, err := s.getKidPath(kid)
+	path, err := s.getKidPath(req.Kid)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := os.MkdirAll(s.getKidDir(), 0700); err != nil {
-		return err
+		return nil, err
 	}
 
 	entry := &fsKidEntry{
-		Kid:       kid,
+		Kid:       req.Kid,
 		Key:       keyBytes,
-		Algorithm: algorithm,
-		ClientID:  clientID,
-		ExpiresAt: expiresAt,
+		Algorithm: req.Algorithm,
+		ClientID:  req.ClientID,
+		ExpiresAt: req.ExpiresAt,
 	}
 	data, err := json.MarshalIndent(entry, "", "  ")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return writeAtomicFile(path, data)
+	if err := writeAtomicFile(path, data); err != nil {
+		return nil, err
+	}
+	return &keys.AddKidResponse{}, nil
 }
 
-// Remove is idempotent — deleting an absent kid is not an error.
-func (s *FSKidStore) Remove(kid string) error {
+func (s *FSKidStore) Remove(ctx context.Context, req *keys.RemoveKidRequest) (*keys.RemoveKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Remove: req is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	path, err := s.getKidPath(kid)
+	path, err := s.getKidPath(req.Kid)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return err
+		return nil, err
 	}
-	return nil
+	return &keys.RemoveKidResponse{}, nil
 }
 
-// GetKey always returns ErrKeyNotFound — KidStorage is kid-indexed and
-// has no clientID→key lookup. Matches the in-memory KidStore.
-func (s *FSKidStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+func (s *FSKidStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
 	return nil, keys.ErrKeyNotFound
 }
 
-func (s *FSKidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+func (s *FSKidStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	path, err := s.getKidPath(kid)
+	path, err := s.getKidPath(req.Kid)
 	if err != nil {
 		return nil, keys.ErrKidNotFound
 	}
@@ -130,15 +135,15 @@ func (s *FSKidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
 	if isExpired(entry.ExpiresAt) {
 		return nil, keys.ErrKidNotFound
 	}
-	return &keys.KeyRecord{
+	return &keys.GetKeyByKidResponse{Record: &keys.KeyRecord{
 		ClientID:  entry.ClientID,
 		Key:       entry.Key,
 		Algorithm: entry.Algorithm,
 		Kid:       entry.Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *FSKidStore) CleanExpired() error {
+func (s *FSKidStore) CleanExpired(ctx context.Context, req *keys.CleanExpiredRequest) (*keys.CleanExpiredResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -146,11 +151,12 @@ func (s *FSKidStore) CleanExpired() error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return &keys.CleanExpiredResponse{}, nil
 		}
-		return err
+		return nil, err
 	}
 
+	removed := 0
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
@@ -166,9 +172,10 @@ func (s *FSKidStore) CleanExpired() error {
 		}
 		if isExpired(entry.ExpiresAt) {
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return err
+				return nil, err
 			}
+			removed++
 		}
 	}
-	return nil
+	return &keys.CleanExpiredResponse{Removed: removed}, nil
 }

--- a/stores/fs/fskidstore_test.go
+++ b/stores/fs/fskidstore_test.go
@@ -1,11 +1,7 @@
 package fs
 
-// Tests for the filesystem-based KidStorage implementation. The shared
-// conformance suite is in kidstoretest; the cross-instance restart test
-// below is FS-specific — it's the headline proof that grace-period kids
-// survive a process restart.
-
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -19,24 +15,21 @@ func TestFSKidStore(t *testing.T) {
 	})
 }
 
-// TestFSKidStorePersistsAcrossInstances exercises the actual gap this
-// backend closes: a second store instance opened over the same directory
-// must see kids written by the first. Without this, "survives a process
-// restart" is only an interface-level claim, not a verified behavior.
 func TestFSKidStorePersistsAcrossInstances(t *testing.T) {
 	dir := t.TempDir()
+	ctx := context.Background()
 
 	writer := NewFSKidStore(dir)
-	if err := writer.Add("kid-grace", []byte("retired-secret"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
+	if _, err := writer.Add(ctx, &keys.AddKidRequest{Kid: "kid-grace", Key: []byte("retired-secret"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)}); err != nil {
 		t.Fatalf("writer.Add failed: %v", err)
 	}
 
-	// Fresh instance over the same backing directory — simulates a process restart.
 	reader := NewFSKidStore(dir)
-	rec, err := reader.GetKeyByKid("kid-grace")
+	resp, err := reader.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-grace"})
 	if err != nil {
 		t.Fatalf("reader.GetKeyByKid failed after restart: %v", err)
 	}
+	rec := resp.Record
 	if string(rec.Key.([]byte)) != "retired-secret" {
 		t.Errorf("key material did not survive restart: got %q", rec.Key)
 	}

--- a/stores/fs/security_test.go
+++ b/stores/fs/security_test.go
@@ -12,6 +12,7 @@ package fs
 // Run with: go test -v -run TestSecurity ./stores/fs/
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -93,17 +94,17 @@ func TestSecurity_PathTraversal_KeyStore(t *testing.T) {
 
 	for _, tc := range maliciousInputs {
 		t.Run("PutKey_"+tc.name, func(t *testing.T) {
-			err := store.PutKey(&keys.KeyRecord{
+			_, err := store.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 				ClientID:  tc.input,
 				Key:       []byte("test-secret"),
 				Algorithm: "HS256",
-			})
+			}})
 			assert.Error(t, err, "PutKey should reject malicious clientID %q", tc.input)
 			assertNoEscape(t, dir, "keys")
 		})
 
 		t.Run("GetKey_"+tc.name, func(t *testing.T) {
-			_, err := store.GetKey(tc.input)
+			_, err := store.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: tc.input})
 			assert.Error(t, err, "GetKey should reject malicious clientID %q", tc.input)
 		})
 	}
@@ -270,11 +271,11 @@ func TestSecurity_SanitizedInputs_KeyStore(t *testing.T) {
 
 	for _, tc := range sanitizedInputs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := store.PutKey(&keys.KeyRecord{
+			_, err := store.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 				ClientID:  tc.input,
 				Key:       []byte("secret"),
 				Algorithm: "HS256",
-			})
+			}})
 			assert.NoError(t, err, "PutKey should accept sanitizable input %q", tc.input)
 		})
 	}
@@ -374,11 +375,11 @@ func TestSecurity_KeyFilePermissions(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFSKeyStore(dir)
 
-	err := store.PutKey(&keys.KeyRecord{
+	_, err := store.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "testapp",
 		Key:       []byte("super-secret-key"),
 		Algorithm: "HS256",
-	})
+	}})
 	require.NoError(t, err)
 
 	// Find the key file (FSKeyStore uses "signing_keys" subdirectory)

--- a/stores/gae/keystore.go
+++ b/stores/gae/keystore.go
@@ -5,6 +5,7 @@ package gae
 
 import (
 	"context"
+	"fmt"
 
 	"cloud.google.com/go/datastore"
 	"github.com/panyam/oneauth/keys"
@@ -25,7 +26,6 @@ type SigningKeyEntity struct {
 type GAEKeyStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewKeyStore creates a new Datastore-backed KeyStore.
@@ -33,16 +33,6 @@ func NewKeyStore(client *datastore.Client, namespace string) *GAEKeyStore {
 	return &GAEKeyStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-// WithContext returns a copy of the store with the given context.
-func (s *GAEKeyStore) WithContext(ctx context.Context) *GAEKeyStore {
-	return &GAEKeyStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -52,10 +42,14 @@ func (s *GAEKeyStore) namespacedKey(name string) *datastore.Key {
 	return key
 }
 
-func (s *GAEKeyStore) PutKey(rec *keys.KeyRecord) error {
+func (s *GAEKeyStore) PutKey(ctx context.Context, req *keys.PutKeyRequest) (*keys.PutKeyResponse, error) {
+	if req == nil || req.Record == nil {
+		return nil, fmt.Errorf("PutKey: req.Record is required")
+	}
+	rec := req.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
-		return keys.ErrAlgorithmMismatch
+		return nil, keys.ErrAlgorithmMismatch
 	}
 
 	kid := rec.Kid
@@ -69,26 +63,34 @@ func (s *GAEKeyStore) PutKey(rec *keys.KeyRecord) error {
 		Algorithm: rec.Algorithm,
 		Kid:       kid,
 	}
-	_, err := s.client.Put(s.ctx, entity.Key, entity)
-	return err
-}
-
-func (s *GAEKeyStore) DeleteKey(clientID string) error {
-	key := s.namespacedKey(clientID)
-	var entity SigningKeyEntity
-	if err := s.client.Get(s.ctx, key, &entity); err != nil {
-		if err == datastore.ErrNoSuchEntity {
-			return keys.ErrKeyNotFound
-		}
-		return err
+	if _, err := s.client.Put(ctx, entity.Key, entity); err != nil {
+		return nil, err
 	}
-	return s.client.Delete(s.ctx, key)
+	return &keys.PutKeyResponse{}, nil
 }
 
-func (s *GAEKeyStore) getEntity(clientID string) (*SigningKeyEntity, error) {
+func (s *GAEKeyStore) DeleteKey(ctx context.Context, req *keys.DeleteKeyRequest) (*keys.DeleteKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteKey: req is required")
+	}
+	key := s.namespacedKey(req.ClientID)
+	var entity SigningKeyEntity
+	if err := s.client.Get(ctx, key, &entity); err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, keys.ErrKeyNotFound
+		}
+		return nil, err
+	}
+	if err := s.client.Delete(ctx, key); err != nil {
+		return nil, err
+	}
+	return &keys.DeleteKeyResponse{}, nil
+}
+
+func (s *GAEKeyStore) getEntity(ctx context.Context, clientID string) (*SigningKeyEntity, error) {
 	key := s.namespacedKey(clientID)
 	var entity SigningKeyEntity
-	if err := s.client.Get(s.ctx, key, &entity); err != nil {
+	if err := s.client.Get(ctx, key, &entity); err != nil {
 		if err == datastore.ErrNoSuchEntity {
 			return nil, keys.ErrKeyNotFound
 		}
@@ -97,90 +99,58 @@ func (s *GAEKeyStore) getEntity(clientID string) (*SigningKeyEntity, error) {
 	return &entity, nil
 }
 
-func (s *GAEKeyStore) GetKey(clientID string) (*keys.KeyRecord, error) {
-	entity, err := s.getEntity(clientID)
+func (s *GAEKeyStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKey: req is required")
+	}
+	entity, err := s.getEntity(ctx, req.ClientID)
 	if err != nil {
 		return nil, err
 	}
-	return &keys.KeyRecord{
-		ClientID:  clientID,
+	return &keys.GetKeyResponse{Record: &keys.KeyRecord{
+		ClientID:  req.ClientID,
 		Key:       entity.KeyBytes,
 		Algorithm: entity.Algorithm,
 		Kid:       entity.Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *GAEKeyStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
-	q := datastore.NewQuery(KindSigningKey).FilterField("kid", "=", kid).Limit(1)
+func (s *GAEKeyStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
+	q := datastore.NewQuery(KindSigningKey).FilterField("kid", "=", req.Kid).Limit(1)
 	if s.namespace != "" {
 		q = q.Namespace(s.namespace)
 	}
 	var entities []SigningKeyEntity
-	dsKeys, err := s.client.GetAll(s.ctx, q, &entities)
+	dsKeys, err := s.client.GetAll(ctx, q, &entities)
 	if err != nil {
 		return nil, err
 	}
 	if len(entities) == 0 {
 		return nil, keys.ErrKidNotFound
 	}
-	return &keys.KeyRecord{
+	return &keys.GetKeyByKidResponse{Record: &keys.KeyRecord{
 		ClientID:  dsKeys[0].Name,
 		Key:       entities[0].KeyBytes,
 		Algorithm: entities[0].Algorithm,
 		Kid:       entities[0].Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *GAEKeyStore) ListKeyIDs() ([]string, error) {
+func (s *GAEKeyStore) ListKeyIDs(ctx context.Context, req *keys.ListKeyIDsRequest) (*keys.ListKeyIDsResponse, error) {
 	q := datastore.NewQuery(KindSigningKey).KeysOnly()
 	if s.namespace != "" {
 		q = q.Namespace(s.namespace)
 	}
-	dsKeys, err := s.client.GetAll(s.ctx, q, nil)
+	dsKeys, err := s.client.GetAll(ctx, q, nil)
 	if err != nil {
 		return nil, err
 	}
-	result := make([]string, len(dsKeys))
+	ids := make([]string, len(dsKeys))
 	for i, k := range dsKeys {
-		result[i] = k.Name
+		ids[i] = k.Name
 	}
-	return result, nil
-}
-
-// Backward-compatible aliases
-
-func (s *GAEKeyStore) RegisterKey(clientID string, key any, algorithm string) error {
-	return s.PutKey(&keys.KeyRecord{ClientID: clientID, Key: key, Algorithm: algorithm})
-}
-
-func (s *GAEKeyStore) GetVerifyKey(clientID string) (any, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return nil, err
-	}
-	return rec.Key, nil
-}
-
-func (s *GAEKeyStore) GetSigningKey(clientID string) (any, error) {
-	return s.GetVerifyKey(clientID)
-}
-
-func (s *GAEKeyStore) GetExpectedAlg(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Algorithm, nil
-}
-
-func (s *GAEKeyStore) ListKeys() ([]string, error) {
-	return s.ListKeyIDs()
-}
-
-func (s *GAEKeyStore) GetCurrentKid(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Kid, nil
+	return &keys.ListKeyIDsResponse{ClientIDs: ids}, nil
 }

--- a/stores/gae/kidstore.go
+++ b/stores/gae/kidstore.go
@@ -5,6 +5,7 @@ package gae
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"cloud.google.com/go/datastore"
@@ -14,23 +15,18 @@ import (
 const KindKidKey = "KidKey"
 
 // KidKeyEntity is the Datastore entity for kid→key grace entries.
-// The Datastore key name is the kid itself.
 type KidKeyEntity struct {
 	Key       *datastore.Key `datastore:"__key__"`
 	KeyBytes  []byte         `datastore:"key_bytes,noindex"`
 	Algorithm string         `datastore:"algorithm"`
 	ClientID  string         `datastore:"client_id"`
-	// ExpiresAt is unindexed: CleanExpired scans + filters in Go (kid
-	// stores are small, and we'd need a not-equal-zero filter combined
-	// with a less-than filter which Datastore doesn't support natively).
-	ExpiresAt time.Time `datastore:"expires_at,noindex"`
+	ExpiresAt time.Time      `datastore:"expires_at,noindex"`
 }
 
 // GAEKidStore implements keys.KidStorage using Google Cloud Datastore.
 type GAEKidStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 var _ keys.KidStorage = (*GAEKidStore)(nil)
@@ -40,18 +36,6 @@ func NewKidStore(client *datastore.Client, namespace string) *GAEKidStore {
 	return &GAEKidStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-// WithContext returns a copy of the store with the given context, matching
-// the GAEKeyStore.WithContext pattern (see issue 110 / 175 for the planned
-// ctx-as-parameter migration).
-func (s *GAEKidStore) WithContext(ctx context.Context) *GAEKidStore {
-	return &GAEKidStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -61,36 +45,48 @@ func (s *GAEKidStore) namespacedKey(name string) *datastore.Key {
 	return key
 }
 
-func (s *GAEKidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
-	keyBytes, ok := key.([]byte)
+func (s *GAEKidStore) Add(ctx context.Context, req *keys.AddKidRequest) (*keys.AddKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Add: req is required")
+	}
+	keyBytes, ok := req.Key.([]byte)
 	if !ok {
-		return keys.ErrAlgorithmMismatch
+		return nil, keys.ErrAlgorithmMismatch
 	}
 
 	entity := &KidKeyEntity{
-		Key:       s.namespacedKey(kid),
+		Key:       s.namespacedKey(req.Kid),
 		KeyBytes:  keyBytes,
-		Algorithm: algorithm,
-		ClientID:  clientID,
-		ExpiresAt: expiresAt,
+		Algorithm: req.Algorithm,
+		ClientID:  req.ClientID,
+		ExpiresAt: req.ExpiresAt,
 	}
-	_, err := s.client.Put(s.ctx, entity.Key, entity)
-	return err
+	if _, err := s.client.Put(ctx, entity.Key, entity); err != nil {
+		return nil, err
+	}
+	return &keys.AddKidResponse{}, nil
 }
 
-// Remove is idempotent — Datastore Delete on a missing key returns nil.
-func (s *GAEKidStore) Remove(kid string) error {
-	return s.client.Delete(s.ctx, s.namespacedKey(kid))
+func (s *GAEKidStore) Remove(ctx context.Context, req *keys.RemoveKidRequest) (*keys.RemoveKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Remove: req is required")
+	}
+	if err := s.client.Delete(ctx, s.namespacedKey(req.Kid)); err != nil {
+		return nil, err
+	}
+	return &keys.RemoveKidResponse{}, nil
 }
 
-// GetKey always returns ErrKeyNotFound — KidStorage is kid-indexed.
-func (s *GAEKidStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+func (s *GAEKidStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
 	return nil, keys.ErrKeyNotFound
 }
 
-func (s *GAEKidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+func (s *GAEKidStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	var entity KidKeyEntity
-	if err := s.client.Get(s.ctx, s.namespacedKey(kid), &entity); err != nil {
+	if err := s.client.Get(ctx, s.namespacedKey(req.Kid), &entity); err != nil {
 		if err == datastore.ErrNoSuchEntity {
 			return nil, keys.ErrKidNotFound
 		}
@@ -99,23 +95,23 @@ func (s *GAEKidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
 	if !entity.ExpiresAt.IsZero() && time.Now().After(entity.ExpiresAt) {
 		return nil, keys.ErrKidNotFound
 	}
-	return &keys.KeyRecord{
+	return &keys.GetKeyByKidResponse{Record: &keys.KeyRecord{
 		ClientID:  entity.ClientID,
 		Key:       entity.KeyBytes,
 		Algorithm: entity.Algorithm,
-		Kid:       kid,
-	}, nil
+		Kid:       req.Kid,
+	}}, nil
 }
 
-func (s *GAEKidStore) CleanExpired() error {
+func (s *GAEKidStore) CleanExpired(ctx context.Context, req *keys.CleanExpiredRequest) (*keys.CleanExpiredResponse, error) {
 	q := datastore.NewQuery(KindKidKey)
 	if s.namespace != "" {
 		q = q.Namespace(s.namespace)
 	}
 	var entities []KidKeyEntity
-	dsKeys, err := s.client.GetAll(s.ctx, q, &entities)
+	dsKeys, err := s.client.GetAll(ctx, q, &entities)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	now := time.Now()
 	var toDelete []*datastore.Key
@@ -125,7 +121,10 @@ func (s *GAEKidStore) CleanExpired() error {
 		}
 	}
 	if len(toDelete) == 0 {
-		return nil
+		return &keys.CleanExpiredResponse{}, nil
 	}
-	return s.client.DeleteMulti(s.ctx, toDelete)
+	if err := s.client.DeleteMulti(ctx, toDelete); err != nil {
+		return nil, err
+	}
+	return &keys.CleanExpiredResponse{Removed: len(toDelete)}, nil
 }

--- a/stores/gorm/keystore.go
+++ b/stores/gorm/keystore.go
@@ -4,6 +4,8 @@
 package gorm
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/panyam/oneauth/keys"
@@ -35,10 +37,14 @@ func NewKeyStore(db *gorm.DB) *KeyStore {
 	return &KeyStore{db: db}
 }
 
-func (s *KeyStore) PutKey(rec *keys.KeyRecord) error {
+func (s *KeyStore) PutKey(ctx context.Context, req *keys.PutKeyRequest) (*keys.PutKeyResponse, error) {
+	if req == nil || req.Record == nil {
+		return nil, fmt.Errorf("PutKey: req.Record is required")
+	}
+	rec := req.Record
 	keyBytes, ok := rec.Key.([]byte)
 	if !ok {
-		return keys.ErrAlgorithmMismatch
+		return nil, keys.ErrAlgorithmMismatch
 	}
 	kid := rec.Kid
 	if kid == "" {
@@ -50,98 +56,72 @@ func (s *KeyStore) PutKey(rec *keys.KeyRecord) error {
 		Algorithm: rec.Algorithm,
 		Kid:       kid,
 	}
-	return s.db.Save(model).Error
+	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
+		return nil, err
+	}
+	return &keys.PutKeyResponse{}, nil
 }
 
-func (s *KeyStore) DeleteKey(clientID string) error {
-	result := s.db.Delete(&SigningKeyModel{}, "client_id = ?", clientID)
+func (s *KeyStore) DeleteKey(ctx context.Context, req *keys.DeleteKeyRequest) (*keys.DeleteKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteKey: req is required")
+	}
+	result := s.db.WithContext(ctx).Delete(&SigningKeyModel{}, "client_id = ?", req.ClientID)
 	if result.Error != nil {
-		return result.Error
+		return nil, result.Error
 	}
 	if result.RowsAffected == 0 {
-		return keys.ErrKeyNotFound
+		return nil, keys.ErrKeyNotFound
 	}
-	return nil
+	return &keys.DeleteKeyResponse{}, nil
 }
 
-func (s *KeyStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+func (s *KeyStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKey: req is required")
+	}
 	var model SigningKeyModel
-	if err := s.db.First(&model, "client_id = ?", clientID).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "client_id = ?", req.ClientID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, keys.ErrKeyNotFound
 		}
 		return nil, err
 	}
-	return &keys.KeyRecord{
+	return &keys.GetKeyResponse{Record: &keys.KeyRecord{
 		ClientID:  model.ClientID,
 		Key:       model.Key,
 		Algorithm: model.Algorithm,
 		Kid:       model.Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *KeyStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+func (s *KeyStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	var model SigningKeyModel
-	if err := s.db.First(&model, "kid = ?", kid).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "kid = ?", req.Kid).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, keys.ErrKidNotFound
 		}
 		return nil, err
 	}
-	return &keys.KeyRecord{
+	return &keys.GetKeyByKidResponse{Record: &keys.KeyRecord{
 		ClientID:  model.ClientID,
 		Key:       model.Key,
 		Algorithm: model.Algorithm,
 		Kid:       model.Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *KeyStore) ListKeyIDs() ([]string, error) {
+func (s *KeyStore) ListKeyIDs(ctx context.Context, req *keys.ListKeyIDsRequest) (*keys.ListKeyIDsResponse, error) {
 	var models []SigningKeyModel
-	if err := s.db.Select("client_id").Find(&models).Error; err != nil {
+	if err := s.db.WithContext(ctx).Select("client_id").Find(&models).Error; err != nil {
 		return nil, err
 	}
-	keys := make([]string, len(models))
+	ids := make([]string, len(models))
 	for i, m := range models {
-		keys[i] = m.ClientID
+		ids[i] = m.ClientID
 	}
-	return keys, nil
-}
-
-// Backward-compatible aliases
-
-func (s *KeyStore) RegisterKey(clientID string, key any, algorithm string) error {
-	return s.PutKey(&keys.KeyRecord{ClientID: clientID, Key: key, Algorithm: algorithm})
-}
-
-func (s *KeyStore) GetVerifyKey(clientID string) (any, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return nil, err
-	}
-	return rec.Key, nil
-}
-
-func (s *KeyStore) GetSigningKey(clientID string) (any, error) {
-	return s.GetVerifyKey(clientID)
-}
-
-func (s *KeyStore) GetExpectedAlg(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Algorithm, nil
-}
-
-func (s *KeyStore) ListKeys() ([]string, error) {
-	return s.ListKeyIDs()
-}
-
-func (s *KeyStore) GetCurrentKid(clientID string) (string, error) {
-	rec, err := s.GetKey(clientID)
-	if err != nil {
-		return "", err
-	}
-	return rec.Kid, nil
+	return &keys.ListKeyIDsResponse{ClientIDs: ids}, nil
 }

--- a/stores/gorm/kidstore.go
+++ b/stores/gorm/kidstore.go
@@ -4,16 +4,15 @@
 package gorm
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/panyam/oneauth/keys"
 	"gorm.io/gorm"
 )
 
-// KidKeyModel is the GORM model for kid→key grace entries. Mirrors the
-// fields the in-memory KidStore tracks per kid. ExpiresAt is nullable;
-// nil means "no expiry" (matches zero time.Time in the in-memory store)
-// — avoiding the messy 0001-01-01 zero-date some SQL dialects produce.
+// KidKeyModel is the GORM model for kid→key grace entries.
 type KidKeyModel struct {
 	Kid       string     `gorm:"primaryKey;size:128"`
 	Key       []byte     `gorm:"not null"`
@@ -39,59 +38,71 @@ func NewKidStore(db *gorm.DB) *KidStore {
 	return &KidStore{db: db}
 }
 
-func (s *KidStore) Add(kid string, key any, algorithm string, clientID string, expiresAt time.Time) error {
-	keyBytes, ok := key.([]byte)
+func (s *KidStore) Add(ctx context.Context, req *keys.AddKidRequest) (*keys.AddKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Add: req is required")
+	}
+	keyBytes, ok := req.Key.([]byte)
 	if !ok {
-		return keys.ErrAlgorithmMismatch
+		return nil, keys.ErrAlgorithmMismatch
 	}
 	model := &KidKeyModel{
-		Kid:       kid,
+		Kid:       req.Kid,
 		Key:       keyBytes,
-		Algorithm: algorithm,
-		ClientID:  clientID,
+		Algorithm: req.Algorithm,
+		ClientID:  req.ClientID,
 	}
-	if !expiresAt.IsZero() {
-		t := expiresAt
+	if !req.ExpiresAt.IsZero() {
+		t := req.ExpiresAt
 		model.ExpiresAt = &t
 	}
-	// Save = upsert by primary key (kid), matching KidStore.Add's
-	// "re-adding an existing kid overwrites it" contract.
-	return s.db.Save(model).Error
+	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
+		return nil, err
+	}
+	return &keys.AddKidResponse{}, nil
 }
 
-// Remove is idempotent — deleting an absent kid is not an error.
-func (s *KidStore) Remove(kid string) error {
-	return s.db.Delete(&KidKeyModel{}, "kid = ?", kid).Error
+func (s *KidStore) Remove(ctx context.Context, req *keys.RemoveKidRequest) (*keys.RemoveKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Remove: req is required")
+	}
+	if err := s.db.WithContext(ctx).Delete(&KidKeyModel{}, "kid = ?", req.Kid).Error; err != nil {
+		return nil, err
+	}
+	return &keys.RemoveKidResponse{}, nil
 }
 
-// GetKey always returns ErrKeyNotFound — KidStorage is kid-indexed.
-func (s *KidStore) GetKey(clientID string) (*keys.KeyRecord, error) {
+func (s *KidStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
 	return nil, keys.ErrKeyNotFound
 }
 
-func (s *KidStore) GetKeyByKid(kid string) (*keys.KeyRecord, error) {
+func (s *KidStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetKeyByKid: req is required")
+	}
 	var model KidKeyModel
-	if err := s.db.First(&model, "kid = ?", kid).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "kid = ?", req.Kid).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, keys.ErrKidNotFound
 		}
 		return nil, err
 	}
-	// Expired entries are filtered at read time (CleanExpired physically
-	// removes them); mirrors the in-memory KidStore semantics.
 	if model.ExpiresAt != nil && time.Now().After(*model.ExpiresAt) {
 		return nil, keys.ErrKidNotFound
 	}
-	return &keys.KeyRecord{
+	return &keys.GetKeyByKidResponse{Record: &keys.KeyRecord{
 		ClientID:  model.ClientID,
 		Key:       model.Key,
 		Algorithm: model.Algorithm,
 		Kid:       model.Kid,
-	}, nil
+	}}, nil
 }
 
-func (s *KidStore) CleanExpired() error {
-	// expires_at IS NOT NULL excludes zero-expiry (never-expiring) rows.
-	return s.db.Where("expires_at IS NOT NULL AND expires_at < ?", time.Now()).
-		Delete(&KidKeyModel{}).Error
+func (s *KidStore) CleanExpired(ctx context.Context, req *keys.CleanExpiredRequest) (*keys.CleanExpiredResponse, error) {
+	result := s.db.WithContext(ctx).Where("expires_at IS NOT NULL AND expires_at < ?", time.Now()).
+		Delete(&KidKeyModel{})
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &keys.CleanExpiredResponse{Removed: int(result.RowsAffected)}, nil
 }

--- a/tests/e2e/app_persistence_test.go
+++ b/tests/e2e/app_persistence_test.go
@@ -10,6 +10,7 @@ package e2e_test
 // needs to reuse the same Store/KeyStore across two AppRegistrar instances.
 
 import (
+	"context"
 	"bytes"
 	"encoding/json"
 	"io"
@@ -73,7 +74,7 @@ func TestAppRegistrar_PersistsAcrossRestart(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, getResp.StatusCode, "revoked app must not be resurrected on restart")
 
 	// And the revoked app's signing key must be gone from the KeyStore too.
-	if _, err := ks.GetKey(revokeID); err != keys.ErrKeyNotFound {
+	if _, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: revokeID}); err != keys.ErrKeyNotFound {
 		t.Errorf("expected ErrKeyNotFound for revoked app's signing key, got %v", err)
 	}
 }

--- a/tests/e2e/authcode_test.go
+++ b/tests/e2e/authcode_test.go
@@ -16,6 +16,7 @@ package e2e_test
 //   - See: https://github.com/panyam/oneauth/issues/72
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -105,11 +106,11 @@ func TestE2E_ClientCredentials_BasicAuth(t *testing.T) {
 	// Register a client
 	clientID := "e2e-basic-auth-client"
 	secret := "e2e-basic-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       []byte(secret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Discover AS metadata (includes token_endpoint_auth_methods_supported)
 	meta, err := client.DiscoverAS(env.BaseURL())
@@ -139,11 +140,11 @@ func TestE2E_ClientCredentials_PostAuth(t *testing.T) {
 
 	clientID := "e2e-post-auth-client"
 	secret := "e2e-post-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       []byte(secret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Force client_secret_post only
 	meta := &client.ASMetadata{
@@ -174,11 +175,11 @@ func TestE2E_ClientCredentials_FormEncoded(t *testing.T) {
 
 	clientID := "e2e-form-client"
 	secret := "e2e-form-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       []byte(secret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Direct form-encoded request to /oauth/token
 	data := url.Values{
@@ -262,11 +263,11 @@ func TestE2E_AuthCodePKCE_ExplicitEndpoints_ConfidentialClient(t *testing.T) {
 	// Register a confidential client
 	clientID := "e2e-explicit-confidential"
 	secret := "e2e-explicit-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       []byte(secret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	store := &memCredentialStore{creds: make(map[string]*client.ServerCredential)}
 	authClient := client.NewAuthClient(env.BaseURL(), store,

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -4,6 +4,7 @@ package e2e_test
 // but uses in-memory stores and no templates.
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -169,9 +170,12 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 			}
 
 			// Validate against KeyStore
-			rec, err := e.KeyStore.GetKey(clientID)
-			keyBytes, _ := rec.Key.([]byte)
-			if err != nil || rec == nil || string(keyBytes) != clientSecret {
+			resp, err := e.KeyStore.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+			var keyBytes []byte
+			if resp != nil && resp.Record != nil {
+				keyBytes, _ = resp.Record.Key.([]byte)
+			}
+			if err != nil || resp == nil || resp.Record == nil || string(keyBytes) != clientSecret {
 				w.WriteHeader(http.StatusUnauthorized)
 				json.NewEncoder(w).Encode(map[string]string{
 					"error": "invalid_client", "error_description": "bad credentials"})

--- a/tests/e2e/client_credentials_test.go
+++ b/tests/e2e/client_credentials_test.go
@@ -11,6 +11,7 @@ package e2e_test
 //   - See: https://github.com/panyam/oneauth/issues/53
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -44,11 +45,11 @@ func TestClientCredentials_E2E_FullFlow(t *testing.T) {
 	// Step 1: Register an app to get client_id + client_secret
 	secret := "e2e-machine-secret"
 	clientID := "e2e-machine-client"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       []byte(secret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Step 2: Get token via client_credentials grant
 	tokenReqBody := `{"grant_type":"client_credentials","client_id":"` + clientID + `","client_secret":"` + secret + `","scope":"read write"}`
@@ -96,11 +97,11 @@ func TestClientCredentials_E2E_WrongSecret(t *testing.T) {
 	}
 
 	// Register a client
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  "e2e-bad-secret-client",
 		Key:       []byte("correct-secret"),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Try with wrong secret
 	tokenReqBody := `{"grant_type":"client_credentials","client_id":"e2e-bad-secret-client","client_secret":"wrong-secret"}`

--- a/tests/e2e/dcr_introspection_test.go
+++ b/tests/e2e/dcr_introspection_test.go
@@ -11,6 +11,7 @@ package e2e_test
 //   - See: https://github.com/panyam/oneauth/issues/55
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -120,11 +121,11 @@ func TestIntrospectionClient_E2E_ValidateViaIntrospection(t *testing.T) {
 	// Register a resource server client for introspection auth
 	rsClientID := "e2e-rs-introspect-client"
 	rsSecret := "e2e-rs-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  rsClientID,
 		Key:       []byte(rsSecret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Create a user and get an access token
 	email, password := CreateTestUser(t, env, "introspect-client-user")

--- a/tests/e2e/introspection_test.go
+++ b/tests/e2e/introspection_test.go
@@ -10,6 +10,7 @@ package e2e_test
 //   - See: https://github.com/panyam/oneauth/issues/47
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -40,11 +41,11 @@ func TestIntrospection_E2E_ActiveToken(t *testing.T) {
 	// Register a resource server client that can call introspection
 	rsClientID := "e2e-resource-server"
 	rsSecret := "rs-introspection-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  rsClientID,
 		Key:       []byte(rsSecret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Create a user and get an access token
 	email, password := CreateTestUser(t, env, "introspect-user")
@@ -89,11 +90,11 @@ func TestIntrospection_E2E_RevokedToken(t *testing.T) {
 
 	rsClientID := "e2e-rs-revoke"
 	rsSecret := "rs-revoke-secret"
-	env.KeyStore.PutKey(&keys.KeyRecord{
+	_, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  rsClientID,
 		Key:       []byte(rsSecret),
 		Algorithm: "HS256",
-	})
+	}})
 
 	// Get a token
 	email, password := CreateTestUser(t, env, "revoke-introspect")

--- a/tests/e2e/private_key_jwt_test.go
+++ b/tests/e2e/private_key_jwt_test.go
@@ -37,11 +37,11 @@ func TestPrivateKeyJWT_E2E_FullFlow(t *testing.T) {
 	const clientID = "e2e-pkjwt-client"
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	require.NoError(t, err)
-	require.NoError(t, _, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
+	_, errPutKey := env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}}))
+	}}); require.NoError(t, errPutKey)
 
 	priv, err := utils.ParsePrivateKeyPEM(privPEM)
 	require.NoError(t, err)
@@ -100,11 +100,11 @@ func TestPrivateKeyJWT_E2E_SDKHelper(t *testing.T) {
 	const clientID = "e2e-pkjwt-sdk-client"
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	require.NoError(t, err)
-	require.NoError(t, _, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
+	_, errPutKey := env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}}))
+	}}); require.NoError(t, errPutKey)
 	priv, err := utils.ParsePrivateKeyPEM(privPEM)
 	require.NoError(t, err)
 
@@ -136,11 +136,11 @@ func TestPrivateKeyJWT_E2E_ClientCredentialsSource(t *testing.T) {
 	const clientID = "e2e-pkjwt-source-client"
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	require.NoError(t, err)
-	require.NoError(t, _, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
+	_, errPutKey := env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}}))
+	}}); require.NoError(t, errPutKey)
 	priv, err := utils.ParsePrivateKeyPEM(privPEM)
 	require.NoError(t, err)
 

--- a/tests/e2e/private_key_jwt_test.go
+++ b/tests/e2e/private_key_jwt_test.go
@@ -6,6 +6,7 @@ package e2e_test
 // signed assertion instead of a shared secret.
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -36,11 +37,11 @@ func TestPrivateKeyJWT_E2E_FullFlow(t *testing.T) {
 	const clientID = "e2e-pkjwt-client"
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	require.NoError(t, err)
-	require.NoError(t, env.KeyStore.PutKey(&keys.KeyRecord{
+	require.NoError(t, _, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}))
+	}}))
 
 	priv, err := utils.ParsePrivateKeyPEM(privPEM)
 	require.NoError(t, err)
@@ -99,11 +100,11 @@ func TestPrivateKeyJWT_E2E_SDKHelper(t *testing.T) {
 	const clientID = "e2e-pkjwt-sdk-client"
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	require.NoError(t, err)
-	require.NoError(t, env.KeyStore.PutKey(&keys.KeyRecord{
+	require.NoError(t, _, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}))
+	}}))
 	priv, err := utils.ParsePrivateKeyPEM(privPEM)
 	require.NoError(t, err)
 
@@ -135,11 +136,11 @@ func TestPrivateKeyJWT_E2E_ClientCredentialsSource(t *testing.T) {
 	const clientID = "e2e-pkjwt-source-client"
 	privPEM, pubPEM, err := utils.GenerateRSAKeyPair(2048)
 	require.NoError(t, err)
-	require.NoError(t, env.KeyStore.PutKey(&keys.KeyRecord{
+	require.NoError(t, _, _ = env.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  clientID,
 		Key:       pubPEM,
 		Algorithm: "RS256",
-	}))
+	}}))
 	priv, err := utils.ParsePrivateKeyPEM(privPEM)
 	require.NoError(t, err)
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -199,12 +200,12 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("testutil: failed to compute kid: %w", err)
 	}
-	if err := ks.PutKey(&keys.KeyRecord{
+	if _, err := ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
 		ClientID:  cfg.issuer,
 		Key:       pubPEM,
 		Algorithm: "RS256",
 		Kid:       kid,
-	}); err != nil {
+	}}); err != nil {
 		return nil, fmt.Errorf("testutil: failed to store RSA key: %w", err)
 	}
 


### PR DESCRIPTION
Refs #204. First slice of #204 — only `keys/` and its 4 backends; `accounts/`, `core/` token stores, `admin/AppRegistrationStore`, and `localauth/VerificationTokenStore` are tracked as #204b/c/d for later PRs.

**Status: all tests green — `make test`, `make e2e` (race detector) pass across root + all 9 sub-modules. Marked draft only because GH token can't flip it; flip via UI when ready to review.**

## What changes

Migrates the `keys/` persistence interfaces to the gRPC-shape convention already adopted in `apiauth/` (#175) and `admin/` (#172):

```go
GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyResponse, error)
GetKeyByKid(ctx context.Context, req *GetKeyByKidRequest) (*GetKeyByKidResponse, error)
PutKey(ctx context.Context, req *PutKeyRequest) (*PutKeyResponse, error)
DeleteKey(ctx context.Context, req *DeleteKeyRequest) (*DeleteKeyResponse, error)
ListKeyIDs(ctx context.Context, req *ListKeyIDsRequest) (*ListKeyIDsResponse, error)
Add(ctx context.Context, req *AddKidRequest) (*AddKidResponse, error)
Remove(ctx context.Context, req *RemoveKidRequest) (*RemoveKidResponse, error)
CleanExpired(ctx context.Context, req *CleanExpiredRequest) (*CleanExpiredResponse, error)
```

**No aliases** — removed `RegisterKey`, `GetVerifyKey`, `GetSigningKey`, `GetExpectedAlg`, `ListKeys`, `GetCurrentKid` from every backend, and the `WithContext()` workaround on the GAE backends (`ctx` is now a method parameter).

## Reviewer's guide

Read in this order:

1. [keys/keystore.go](https://github.com/panyam/oneauth/pull/220/files#diff-9793ad3a9a38ff5e15f09c337761059c1d6ce1eba300567911a55b5782bc0ef0) — start here. New request/response types + `KeyLookup` / `KeyStorage` interfaces + `InMemoryKeyStore` impl.
2. [keys/kid.go](https://github.com/panyam/oneauth/pull/220/files#diff-fc78fe28fa55ca6e80dea9bd4a799d24392feec8b29cf4a3a9622319c5f47dbd) — `KidStorage` interface + `KidStore` impl + `CompositeKeyLookup`.
3. [keys/encrypted.go](https://github.com/panyam/oneauth/pull/220/files#diff-5948a01c177a0d834e6fa06010a47ddba81da8aefea2a9de2bffa2fcc0dd86d1) — `EncryptedKeyStorage` decorator on the new shape (HMAC encryption-at-rest unchanged).
4. [keys/jwks_keystore.go](https://github.com/panyam/oneauth/pull/220/files#diff-65e7f9f04bc0a1ae920de0859fe4c243c80fe362d1883964ed97ebb9d831b05d) — `JWKSKeyStore` (read-only KeyLookup) on the new shape. `GetVerifyKey/GetSigningKey/GetExpectedAlg` removed in favour of `GetKeyByKid` returning the full `KeyRecord`.
5. `stores/fs/`, `stores/gorm/`, `stores/gae/` × `keystore + kidstore` (6 files) — 3 backend implementations.
6. [keystoretest/keystoretest.go](https://github.com/panyam/oneauth/pull/220/files#diff-2c00502768c0c7d4b062a9cac007a41c2c61f13bb2b251f4309f7510c3a2af6d), [kidstoretest/kidstoretest.go](https://github.com/panyam/oneauth/pull/220/files#diff-0d564c776e4e52acb66fb93c4e5b9afbf4af116ba58992e5645d42f56ac9028b) — shared conformance suites every backend runs against.
7. `apiauth/{auth,client_authenticator,token_validator}.go`, [admin/registrar.go](https://github.com/panyam/oneauth/pull/220/files#diff-357a2ab591dde1d22068c00e675d315f4bbc15d7c36f0e89b29a4dd0b1ff953e), [cmd/oneauth-server/main.go](https://github.com/panyam/oneauth/pull/220/files#diff-e10cea20e37f1e5e5e61786642a3b5a2da9fa5b930d457555ca11400927e495a), [testutil/server.go](https://github.com/panyam/oneauth/pull/220/files#diff-99024381707d0f5eb1ec0cae31d4cfb27ae17fa491994eb366083e03640fda7f), [examples/10-security/main.go](https://github.com/panyam/oneauth/pull/220/files#diff-1d06d1b389f3d0fed5e197d8e84898aef754945c7e3d4d046c8faadc35f8f5b1) — production consumers updated.

Skim: every `*_test.go` is mechanical.

## Decision log

- **Replace, not alias** — per discussion. Old positional methods deleted, not deprecated. The test churn that follows is a one-time cost.
- **GAE `WithContext()` removed.** `ctx` flows through every method call now.
- **`*Response` wrappers everywhere** including single-field returns. Consistent with the rest of the library.

## Out of scope

- Other store interfaces (`accounts/`, `core/`, `admin/AppRegistrationStore`, `localauth/VerificationTokenStore`) — tracked as #204b/c/d.
- Tag — `v0.1.7` after merge.
