### PR TITLE
refactor(accounts): migrate UserStore / IdentityStore / ChannelStore / UsernameStore to (ctx, *Req) shape (#204b)

### DIFF
--- a/accounts/stores.go
+++ b/accounts/stores.go
@@ -1,62 +1,230 @@
 package accounts
 
+import "context"
+
+// ----------------------------------------------------------------------------
+// UserStore — request / response types and interface
+// ----------------------------------------------------------------------------
+
+// CreateUserRequest is the input to UserStore.CreateUser.
+type CreateUserRequest struct {
+	UserID   string
+	IsActive bool
+	Profile  map[string]any
+}
+
+// CreateUserResponse wraps the created user.
+type CreateUserResponse struct {
+	User User
+}
+
+// GetUserByIDRequest is the input to UserStore.GetUserById.
+type GetUserByIDRequest struct {
+	UserID string
+}
+
+// GetUserByIDResponse wraps the requested user.
+type GetUserByIDResponse struct {
+	User User
+}
+
+// SaveUserRequest is the input to UserStore.SaveUser.
+type SaveUserRequest struct {
+	User User
+}
+
+// SaveUserResponse is the output of UserStore.SaveUser.
+type SaveUserResponse struct{}
+
 // UserStore manages unified user accounts.
 type UserStore interface {
 	// CreateUser creates a new user with the given ID and profile.
-	CreateUser(userId string, isActive bool, profile map[string]any) (User, error)
+	CreateUser(ctx context.Context, req *CreateUserRequest) (*CreateUserResponse, error)
 
 	// GetUserById retrieves a user by their ID.
-	GetUserById(userId string) (User, error)
+	GetUserById(ctx context.Context, req *GetUserByIDRequest) (*GetUserByIDResponse, error)
 
 	// SaveUser creates or updates a user (upsert).
-	SaveUser(user User) error
+	SaveUser(ctx context.Context, req *SaveUserRequest) (*SaveUserResponse, error)
+}
+
+// ----------------------------------------------------------------------------
+// IdentityStore — request / response types and interface
+// ----------------------------------------------------------------------------
+
+// GetIdentityRequest is the input to IdentityStore.GetIdentity.
+type GetIdentityRequest struct {
+	IdentityType    string
+	IdentityValue   string
+	CreateIfMissing bool
+}
+
+// GetIdentityResponse wraps the looked-up Identity and whether it was
+// newly created in this call.
+type GetIdentityResponse struct {
+	Identity   *Identity
+	NewCreated bool
+}
+
+// SaveIdentityRequest is the input to IdentityStore.SaveIdentity.
+type SaveIdentityRequest struct {
+	Identity *Identity
+}
+
+// SaveIdentityResponse is the output of IdentityStore.SaveIdentity.
+type SaveIdentityResponse struct{}
+
+// SetUserForIdentityRequest is the input to IdentityStore.SetUserForIdentity.
+type SetUserForIdentityRequest struct {
+	IdentityType  string
+	IdentityValue string
+	NewUserID     string
+}
+
+// SetUserForIdentityResponse is the output of IdentityStore.SetUserForIdentity.
+type SetUserForIdentityResponse struct{}
+
+// MarkIdentityVerifiedRequest is the input to IdentityStore.MarkIdentityVerified.
+type MarkIdentityVerifiedRequest struct {
+	IdentityType  string
+	IdentityValue string
+}
+
+// MarkIdentityVerifiedResponse is the output of IdentityStore.MarkIdentityVerified.
+type MarkIdentityVerifiedResponse struct{}
+
+// GetUserIdentitiesRequest is the input to IdentityStore.GetUserIdentities.
+type GetUserIdentitiesRequest struct {
+	UserID string
+}
+
+// GetUserIdentitiesResponse wraps the identities owned by the user.
+type GetUserIdentitiesResponse struct {
+	Identities []*Identity
 }
 
 // IdentityStore manages contact identities (email, phone).
 type IdentityStore interface {
 	// GetIdentity gets or optionally creates an identity.
-	GetIdentity(identityType, identityValue string, createIfMissing bool) (identity *Identity, newCreated bool, err error)
+	GetIdentity(ctx context.Context, req *GetIdentityRequest) (*GetIdentityResponse, error)
 
 	// SaveIdentity creates or updates an identity (upsert).
-	SaveIdentity(identity *Identity) error
+	SaveIdentity(ctx context.Context, req *SaveIdentityRequest) (*SaveIdentityResponse, error)
 
 	// SetUserForIdentity associates an identity with a user.
-	SetUserForIdentity(identityType, identityValue string, newUserId string) error
+	SetUserForIdentity(ctx context.Context, req *SetUserForIdentityRequest) (*SetUserForIdentityResponse, error)
 
 	// MarkIdentityVerified marks an identity as verified.
-	MarkIdentityVerified(identityType, identityValue string) error
+	MarkIdentityVerified(ctx context.Context, req *MarkIdentityVerifiedRequest) (*MarkIdentityVerifiedResponse, error)
 
 	// GetUserIdentities returns all identities for a user.
-	GetUserIdentities(userId string) ([]*Identity, error)
+	GetUserIdentities(ctx context.Context, req *GetUserIdentitiesRequest) (*GetUserIdentitiesResponse, error)
+}
+
+// ----------------------------------------------------------------------------
+// ChannelStore — request / response types and interface
+// ----------------------------------------------------------------------------
+
+// GetChannelRequest is the input to ChannelStore.GetChannel.
+type GetChannelRequest struct {
+	Provider        string
+	IdentityKey     string
+	CreateIfMissing bool
+}
+
+// GetChannelResponse wraps the looked-up Channel and whether it was
+// newly created in this call.
+type GetChannelResponse struct {
+	Channel    *Channel
+	NewCreated bool
+}
+
+// SaveChannelRequest is the input to ChannelStore.SaveChannel.
+type SaveChannelRequest struct {
+	Channel *Channel
+}
+
+// SaveChannelResponse is the output of ChannelStore.SaveChannel.
+type SaveChannelResponse struct{}
+
+// GetChannelsByIdentityRequest is the input to ChannelStore.GetChannelsByIdentity.
+type GetChannelsByIdentityRequest struct {
+	IdentityKey string
+}
+
+// GetChannelsByIdentityResponse wraps the channels for an identity.
+type GetChannelsByIdentityResponse struct {
+	Channels []*Channel
 }
 
 // ChannelStore manages authentication channels/providers.
 type ChannelStore interface {
 	// GetChannel gets or optionally creates a channel.
-	GetChannel(provider string, identityKey string, createIfMissing bool) (channel *Channel, newCreated bool, err error)
+	GetChannel(ctx context.Context, req *GetChannelRequest) (*GetChannelResponse, error)
 
 	// SaveChannel creates or updates a channel (upsert).
-	SaveChannel(channel *Channel) error
+	SaveChannel(ctx context.Context, req *SaveChannelRequest) (*SaveChannelResponse, error)
 
 	// GetChannelsByIdentity returns all channels for an identity.
-	GetChannelsByIdentity(identityKey string) ([]*Channel, error)
+	GetChannelsByIdentity(ctx context.Context, req *GetChannelsByIdentityRequest) (*GetChannelsByIdentityResponse, error)
 }
+
+// ----------------------------------------------------------------------------
+// UsernameStore — request / response types and interface
+// ----------------------------------------------------------------------------
+
+// ReserveUsernameRequest is the input to UsernameStore.ReserveUsername.
+type ReserveUsernameRequest struct {
+	Username string
+	UserID   string
+}
+
+// ReserveUsernameResponse is the output of UsernameStore.ReserveUsername.
+type ReserveUsernameResponse struct{}
+
+// GetUserByUsernameRequest is the input to UsernameStore.GetUserByUsername.
+type GetUserByUsernameRequest struct {
+	Username string
+}
+
+// GetUserByUsernameResponse wraps the userID for the queried username.
+type GetUserByUsernameResponse struct {
+	UserID string
+}
+
+// ReleaseUsernameRequest is the input to UsernameStore.ReleaseUsername.
+type ReleaseUsernameRequest struct {
+	Username string
+}
+
+// ReleaseUsernameResponse is the output of UsernameStore.ReleaseUsername.
+type ReleaseUsernameResponse struct{}
+
+// ChangeUsernameRequest is the input to UsernameStore.ChangeUsername.
+type ChangeUsernameRequest struct {
+	OldUsername string
+	NewUsername string
+	UserID      string
+}
+
+// ChangeUsernameResponse is the output of UsernameStore.ChangeUsername.
+type ChangeUsernameResponse struct{}
 
 // UsernameStore manages username uniqueness (optional — for apps that need
 // username-based login).
 type UsernameStore interface {
 	// ReserveUsername reserves a username for a user (creates username -> userID mapping).
 	// Returns error if username is already taken.
-	ReserveUsername(username string, userID string) error
+	ReserveUsername(ctx context.Context, req *ReserveUsernameRequest) (*ReserveUsernameResponse, error)
 
 	// GetUserByUsername looks up a userID by username.
 	// Returns error if username not found.
-	GetUserByUsername(username string) (userID string, err error)
+	GetUserByUsername(ctx context.Context, req *GetUserByUsernameRequest) (*GetUserByUsernameResponse, error)
 
 	// ReleaseUsername removes a username reservation.
-	ReleaseUsername(username string) error
+	ReleaseUsername(ctx context.Context, req *ReleaseUsernameRequest) (*ReleaseUsernameResponse, error)
 
 	// ChangeUsername atomically changes a username (release old, reserve new).
 	// Returns error if new username is already taken.
-	ChangeUsername(oldUsername, newUsername, userID string) error
+	ChangeUsername(ctx context.Context, req *ChangeUsernameRequest) (*ChangeUsernameResponse, error)
 }

--- a/apiauth/auth_flows_test.go
+++ b/apiauth/auth_flows_test.go
@@ -3,6 +3,7 @@
 package apiauth_test
 
 import (
+	"context"
 	"github.com/panyam/oneauth/localauth"
 	"encoding/json"
 	"net/http"
@@ -134,7 +135,9 @@ func TestCompleteSignupFlow(t *testing.T) {
 
 	// Verify user was created in storage
 	t.Run("verify user in storage", func(t *testing.T) {
-		identity, _, err := identityStore.GetIdentity("email", "test@example.com", false)
+		identityResp_, err := identityStore.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: "test@example.com", CreateIfMissing: false})
+	var identity *accounts.Identity
+	if identityResp_ != nil { identity = identityResp_.Identity }
 		if err != nil {
 			t.Fatalf("Failed to get identity: %v", err)
 		}
@@ -142,7 +145,7 @@ func TestCompleteSignupFlow(t *testing.T) {
 			t.Error("Identity should have a user ID")
 		}
 
-		user, err := userStore.GetUserById(identity.UserID)
+		user, err := userStore.GetUserById(context.Background(), &accounts.GetUserByIDRequest{UserID: identity.UserID})
 		if err != nil {
 			t.Fatalf("Failed to get user: %v", err)
 		}
@@ -152,7 +155,9 @@ func TestCompleteSignupFlow(t *testing.T) {
 
 		// Verify channel exists
 		identityKey := accounts.IdentityKey("email", "test@example.com")
-		channel, _, err := channelStore.GetChannel("local", identityKey, false)
+		channelResp_, err := channelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	var channel *accounts.Channel
+	if channelResp_ != nil { channel = channelResp_.Channel }
 		if err != nil {
 			t.Fatalf("Failed to get channel: %v", err)
 		}
@@ -261,7 +266,7 @@ func TestEmailVerificationFlow(t *testing.T) {
 		UserID:   "testuser123",
 		Verified: false,
 	}
-	if err := identityStore.SaveIdentity(identity); err != nil {
+	if _, err := identityStore.SaveIdentity(context.Background(), &accounts.SaveIdentityRequest{Identity: identity}); err != nil {
 		t.Fatalf("Failed to save identity: %v", err)
 	}
 
@@ -315,7 +320,9 @@ func TestEmailVerificationFlow(t *testing.T) {
 				}
 
 				// Verify identity is marked as verified
-				verifiedIdentity, _, err := identityStore.GetIdentity("email", testEmail, false)
+				verifiedIdentityResp_, err := identityStore.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: testEmail, CreateIfMissing: false})
+	var verifiedIdentity *accounts.Identity
+	if verifiedIdentityResp_ != nil { verifiedIdentity = verifiedIdentityResp_.Identity }
 				if err != nil {
 					t.Fatalf("Failed to get identity: %v", err)
 				}

--- a/federatedauth/callback.go
+++ b/federatedauth/callback.go
@@ -142,13 +142,14 @@ func (b *OAuthBridge) HandleLinkOAuthCallback(linkingUserID, provider string, us
 		return
 	}
 
-	user, err := b.UserStore.GetUserById(linkingUserID)
+	ctx := r.Context()
+	userResp, err := b.UserStore.GetUserById(ctx, &accounts.GetUserByIDRequest{UserID: linkingUserID})
 	if err != nil {
 		http.Error(w, `{"error": "User not found"}`, http.StatusNotFound)
 		return
 	}
 
-	profile := user.Profile()
+	profile := userResp.User.Profile()
 	userEmail, _ := profile["email"].(string)
 
 	// SECURITY: OAuth email must match user's email
@@ -164,8 +165,8 @@ func (b *OAuthBridge) HandleLinkOAuthCallback(linkingUserID, provider string, us
 
 	identityKey := accounts.IdentityKey("email", userEmail)
 
-	existingChannel, _, err := b.UserStore.GetChannel(provider, identityKey, false)
-	if err == nil && existingChannel != nil {
+	existingResp, err := b.UserStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: provider, IdentityKey: identityKey})
+	if err == nil && existingResp != nil && existingResp.Channel != nil {
 		log.Printf("Updating existing %s channel for user %s", provider, linkingUserID)
 	}
 
@@ -175,7 +176,7 @@ func (b *OAuthBridge) HandleLinkOAuthCallback(linkingUserID, provider string, us
 		Credentials: make(map[string]any),
 		Profile:     userInfo,
 	}
-	if err := b.UserStore.SaveChannel(channel); err != nil {
+	if _, err := b.UserStore.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
 		http.Error(w, fmt.Sprintf(`{"error": "Failed to link OAuth account: %s"}`, err.Error()), http.StatusInternalServerError)
 		return
 	}
@@ -200,7 +201,7 @@ func (b *OAuthBridge) HandleLinkOAuthCallback(linkingUserID, provider string, us
 		}
 
 		updatedUser := &accounts.BasicUser{ID: linkingUserID, ProfileData: profile}
-		if err := b.UserStore.SaveUser(updatedUser); err != nil {
+		if _, err := b.UserStore.SaveUser(ctx, &accounts.SaveUserRequest{User: updatedUser}); err != nil {
 			log.Printf("Warning: failed to update user profile: %v", err)
 		}
 	}

--- a/federatedauth/ensure_user.go
+++ b/federatedauth/ensure_user.go
@@ -2,90 +2,33 @@
 // OAuth and SAML callback handlers plus account-linking helpers — that build
 // on the account model in accounts/ and the session/middleware machinery in
 // httpauth/.
-//
-// What this package owns:
-//   - SaveUserAndRedirect          — entry point OAuth/SAML callbacks call after token exchange
-//   - HandleLinkOAuthCallback      — links a new provider channel to an existing user
-//   - LinkOAuthConfig              — config for the linking flow
-//   - StartLinkOAuth / GetLinkingUserID — session bookkeeping for the linking flow
-//   - AuthUserStore                — composite store interface for callbacks
-//   - EnsureAuthUserConfig / NewEnsureAuthUserFunc — provider-driven user creation
-//
-// What this package deliberately does NOT own:
-//   - Username/password flows — see localauth/
-//   - The account data model (User/Identity/Channel) — see accounts/
-//   - Session/cookie/CSRF machinery — see httpauth/
 package federatedauth
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/panyam/oneauth/accounts"
 )
 
-// =============================================================================
-// Channel-aware user creation
-// =============================================================================
-
 // EnsureAuthUserConfig holds configuration for NewEnsureAuthUserFunc.
-//
-// Example setup in your app:
-//
-//	config := federatedauth.EnsureAuthUserConfig{
-//	    UserStore:     gaeStores.UserStore,
-//	    IdentityStore: gaeStores.IdentityStore,
-//	    ChannelStore:  gaeStores.ChannelStore,
-//	    UsernameStore: gaeStores.UsernameStore, // optional
-//	}
-//	ensureUser := federatedauth.NewEnsureAuthUserFunc(config)
 type EnsureAuthUserConfig struct {
 	UserStore     accounts.UserStore
 	IdentityStore accounts.IdentityStore
 	ChannelStore  accounts.ChannelStore
-	UsernameStore accounts.UsernameStore // Optional — for username uniqueness
+	UsernameStore accounts.UsernameStore
 }
 
 // EnsureAuthUserFunc handles user creation/lookup for both OAuth and local
-// authentication with channel linking support. Returned by
-// NewEnsureAuthUserFunc; passed to the AuthUserStore implementations callbacks
-// supply to SaveUserAndRedirect.
+// authentication with channel linking support.
 type EnsureAuthUserFunc func(authtype string, provider string, token any, userInfo map[string]any) (accounts.User, error)
 
-// NewEnsureAuthUserFunc creates a function that handles user creation/lookup for both
-// OAuth and local authentication with channel linking support.
-//
-// # Who Calls This
-//
-// This function is called by SaveUserAndRedirect after a successful OAuth callback
-// or local login. The returned function implements the core logic for AuthUserStore.EnsureAuthUser.
-//
-// # Flow for OAuth (e.g., Google Login)
-//
-//  1. User clicks "Login with Google" → redirects to Google
-//  2. Google redirects back to /auth/google/callback with auth code
-//  3. OAuth handler exchanges code for token, fetches userInfo (email, name, picture)
-//  4. OAuth handler calls SaveUserAndRedirect(authtype="oauth", provider="google", token, userInfo)
-//  5. SaveUserAndRedirect calls UserStore.EnsureAuthUser → this function
-//  6. This function checks if email identity exists:
-//     - EXISTS: Link Google channel to existing user, update profile["channels"]
-//     - NEW: Create User, Identity (verified=true), Google Channel
-//  7. SaveUserAndRedirect creates JWT, sets cookies, redirects to app
-//
-// # Channel Linking Logic
-//
-// Multiple channels (local, google, github) can point to the same user via shared email:
-//
-//	User (id: abc123)
-//	├── Identity: email → user@example.com
-//	├── Channel: local → email:user@example.com (password_hash)
-//	├── Channel: google → email:user@example.com (oauth profile)
-//	└── Channel: github → email:user@example.com (oauth profile)
-//
-// User profile tracks linked providers: profile["channels"] = ["local", "google", "github"]
+// NewEnsureAuthUserFunc creates a function that handles user creation/lookup
+// for both OAuth and local authentication with channel linking support.
 func NewEnsureAuthUserFunc(config EnsureAuthUserConfig) EnsureAuthUserFunc {
 	return func(authtype string, provider string, token any, userInfo map[string]any) (accounts.User, error) {
-		// Extract email from userInfo (primary identifier for linking)
+		ctx := context.Background()
 		email, _ := userInfo["email"].(string)
 		if email == "" {
 			return nil, fmt.Errorf("email is required for authentication")
@@ -94,44 +37,40 @@ func NewEnsureAuthUserFunc(config EnsureAuthUserConfig) EnsureAuthUserFunc {
 		identityType := "email"
 		identityKey := accounts.IdentityKey(identityType, email)
 
-		// Check if identity already exists
-		identity, _, err := config.IdentityStore.GetIdentity(identityType, email, false)
+		idResp, err := config.IdentityStore.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: identityType, IdentityValue: email})
 
-		if err == nil && identity != nil && identity.UserID != "" {
-			// Existing user — link new channel if needed
-			return handleExistingUser(config, identity, authtype, provider, identityKey, userInfo)
+		if err == nil && idResp != nil && idResp.Identity != nil && idResp.Identity.UserID != "" {
+			return handleExistingUser(ctx, config, idResp.Identity, authtype, provider, identityKey, userInfo)
 		}
 
-		// New user — create user, identity, and channel
-		return handleNewUser(config, authtype, provider, identityType, email, identityKey, userInfo)
+		return handleNewUser(ctx, config, authtype, provider, identityType, email, identityKey, userInfo)
 	}
 }
 
-// handleExistingUser links a new auth channel to an existing user.
-func handleExistingUser(config EnsureAuthUserConfig, identity *accounts.Identity, authtype, provider, identityKey string, userInfo map[string]any) (accounts.User, error) {
-	user, err := config.UserStore.GetUserById(identity.UserID)
+func handleExistingUser(ctx context.Context, config EnsureAuthUserConfig, identity *accounts.Identity, authtype, provider, identityKey string, userInfo map[string]any) (accounts.User, error) {
+	userResp, err := config.UserStore.GetUserById(ctx, &accounts.GetUserByIDRequest{UserID: identity.UserID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user for identity (%v): %w", identity, err)
 	}
+	user := userResp.User
 
-	// Check if channel already exists for this provider
-	channel, isNew, err := config.ChannelStore.GetChannel(provider, identityKey, true)
+	chResp, err := config.ChannelStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: provider, IdentityKey: identityKey, CreateIfMissing: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get/create channel: %w", err)
 	}
+	channel := chResp.Channel
+	isNew := chResp.NewCreated
 
-	// Update channel with latest OAuth info
 	if channel.Profile == nil {
 		channel.Profile = make(map[string]any)
 	}
 	for k, v := range userInfo {
 		channel.Profile[k] = v
 	}
-	if err := config.ChannelStore.SaveChannel(channel); err != nil {
+	if _, err := config.ChannelStore.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
 		return nil, fmt.Errorf("failed to save channel: %w", err)
 	}
 
-	// Update user profile with linked channels
 	profile := user.Profile()
 	if profile == nil {
 		profile = make(map[string]any)
@@ -141,7 +80,6 @@ func handleExistingUser(config EnsureAuthUserConfig, identity *accounts.Identity
 		channels = append(channels, provider)
 		profile["channels"] = channels
 
-		// Update other profile fields from OAuth if not set
 		if profile["name"] == nil || profile["name"] == "" {
 			if name, ok := userInfo["name"].(string); ok && name != "" {
 				profile["name"] = name
@@ -154,7 +92,7 @@ func handleExistingUser(config EnsureAuthUserConfig, identity *accounts.Identity
 		}
 
 		updatedUser := &accounts.BasicUser{ID: user.Id(), ProfileData: profile}
-		if err := config.UserStore.SaveUser(updatedUser); err != nil {
+		if _, err := config.UserStore.SaveUser(ctx, &accounts.SaveUserRequest{User: updatedUser}); err != nil {
 			log.Printf("Warning: failed to update user profile: %v", err)
 		}
 	}
@@ -168,20 +106,17 @@ func handleExistingUser(config EnsureAuthUserConfig, identity *accounts.Identity
 	return user, nil
 }
 
-// handleNewUser creates a new user with identity and channel.
-func handleNewUser(config EnsureAuthUserConfig, authtype, provider, identityType, email, identityKey string, userInfo map[string]any) (accounts.User, error) {
+func handleNewUser(ctx context.Context, config EnsureAuthUserConfig, authtype, provider, identityType, email, identityKey string, userInfo map[string]any) (accounts.User, error) {
 	userId, err := newSecureUserId()
 	if err != nil {
 		return nil, err
 	}
 
-	// Build initial profile
 	profile := map[string]any{
 		"email":    email,
 		"channels": []string{provider},
 	}
 
-	// Copy relevant fields from OAuth userInfo
 	if name, ok := userInfo["name"].(string); ok && name != "" {
 		profile["name"] = name
 	}
@@ -192,18 +127,19 @@ func handleNewUser(config EnsureAuthUserConfig, authtype, provider, identityType
 		profile["username"] = username
 	}
 
-	user, err := config.UserStore.CreateUser(userId, true, profile)
+	userResp, err := config.UserStore.CreateUser(ctx, &accounts.CreateUserRequest{UserID: userId, IsActive: true, Profile: profile})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
+	user := userResp.User
 
 	identity := &accounts.Identity{
 		Type:     identityType,
 		Value:    email,
 		UserID:   userId,
-		Verified: authtype == "oauth", // OAuth-verified emails are trusted
+		Verified: authtype == "oauth",
 	}
-	if err := config.IdentityStore.SaveIdentity(identity); err != nil {
+	if _, err := config.IdentityStore.SaveIdentity(ctx, &accounts.SaveIdentityRequest{Identity: identity}); err != nil {
 		return nil, fmt.Errorf("failed to create identity: %w", err)
 	}
 
@@ -213,7 +149,7 @@ func handleNewUser(config EnsureAuthUserConfig, authtype, provider, identityType
 		Credentials: make(map[string]any),
 		Profile:     userInfo,
 	}
-	if err := config.ChannelStore.SaveChannel(channel); err != nil {
+	if _, err := config.ChannelStore.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
 		return nil, fmt.Errorf("failed to create channel: %w", err)
 	}
 

--- a/localauth/channel_linking_test.go
+++ b/localauth/channel_linking_test.go
@@ -3,6 +3,8 @@
 package localauth_test
 
 import (
+	"github.com/panyam/oneauth/accounts"
+	"context"
 	"github.com/panyam/oneauth/localauth"
 	"os"
 	"testing"
@@ -28,13 +30,15 @@ func TestUsernameStoreReserve(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Reserve a username
-	err := store.ReserveUsername("JohnDoe", "user123")
+	_, err := store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "JohnDoe", UserID: "user123"})
 	if err != nil {
 		t.Fatalf("Failed to reserve username: %v", err)
 	}
 
 	// Lookup should work (case-insensitive)
-	userID, err := store.GetUserByUsername("johndoe")
+	userIDResp_, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "johndoe"})
+	var userID string
+	if userIDResp_ != nil { userID = userIDResp_.UserID }
 	if err != nil {
 		t.Fatalf("Failed to lookup username: %v", err)
 	}
@@ -43,7 +47,9 @@ func TestUsernameStoreReserve(t *testing.T) {
 	}
 
 	// Lookup with original case should also work
-	userID, err = store.GetUserByUsername("JohnDoe")
+	userIDResp2, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "JohnDoe"})
+	userID = ""
+	if userIDResp2 != nil { userID = userIDResp2.UserID }
 	if err != nil {
 		t.Fatalf("Failed to lookup username with original case: %v", err)
 	}
@@ -59,19 +65,19 @@ func TestUsernameStoreDuplicateReservation(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Reserve a username
-	err := store.ReserveUsername("testuser", "user123")
+	_, err := store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "testuser", UserID: "user123"})
 	if err != nil {
 		t.Fatalf("Failed to reserve username: %v", err)
 	}
 
 	// Try to reserve same username for different user
-	err = store.ReserveUsername("testuser", "user456")
+	_, err = store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "testuser", UserID: "user456"})
 	if err == nil {
 		t.Error("Expected error for duplicate username reservation")
 	}
 
 	// Same user can re-reserve (update case)
-	err = store.ReserveUsername("TestUser", "user123")
+	_, err = store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "TestUser", UserID: "user123"})
 	if err != nil {
 		t.Errorf("Same user should be able to update case: %v", err)
 	}
@@ -82,18 +88,18 @@ func TestUsernameStoreCaseInsensitive(t *testing.T) {
 	store, tmpDir := setupUsernameStore(t)
 	defer os.RemoveAll(tmpDir)
 
-	err := store.ReserveUsername("TestUser", "user123")
+	_, err := store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "TestUser", UserID: "user123"})
 	if err != nil {
 		t.Fatalf("Failed to reserve username: %v", err)
 	}
 
 	// Try different case variations
-	err = store.ReserveUsername("TESTUSER", "user456")
+	_, err = store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "TESTUSER", UserID: "user456"})
 	if err == nil {
 		t.Error("Should not allow same username with different case for different user")
 	}
 
-	err = store.ReserveUsername("testuser", "user789")
+	_, err = store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "testuser", UserID: "user789"})
 	if err == nil {
 		t.Error("Should not allow same username lowercase for different user")
 	}
@@ -105,14 +111,14 @@ func TestUsernameStoreRelease(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Reserve and release
-	store.ReserveUsername("releaseme", "user123")
-	err := store.ReleaseUsername("releaseme")
+	store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "releaseme", UserID: "user123"})
+	_, err := store.ReleaseUsername(context.Background(), &accounts.ReleaseUsernameRequest{Username: "releaseme"})
 	if err != nil {
 		t.Fatalf("Failed to release username: %v", err)
 	}
 
 	// Should be available again
-	err = store.ReserveUsername("releaseme", "user456")
+	_, err = store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "releaseme", UserID: "user456"})
 	if err != nil {
 		t.Errorf("Username should be available after release: %v", err)
 	}
@@ -124,25 +130,29 @@ func TestUsernameStoreChange(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Reserve initial username
-	err := store.ReserveUsername("oldname", "user123")
+	_, err := store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "oldname", UserID: "user123"})
 	if err != nil {
 		t.Fatalf("Failed to reserve username: %v", err)
 	}
 
 	// Change to new username
-	err = store.ChangeUsername("oldname", "newname", "user123")
+	_, err = store.ChangeUsername(context.Background(), &accounts.ChangeUsernameRequest{OldUsername: "oldname", NewUsername: "newname", UserID: "user123"})
 	if err != nil {
 		t.Fatalf("Failed to change username: %v", err)
 	}
 
 	// Old username should be available
-	_, err = store.GetUserByUsername("oldname")
+	_Resp_, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "oldname"})
+	_ = ""
+	if _Resp_ != nil { _ = _Resp_.UserID }
 	if err == nil {
 		t.Error("Old username should not exist after change")
 	}
 
 	// New username should work
-	userID, err := store.GetUserByUsername("newname")
+	userIDResp_, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "newname"})
+	var userID string
+	if userIDResp_ != nil { userID = userIDResp_.UserID }
 	if err != nil {
 		t.Fatalf("New username lookup failed: %v", err)
 	}
@@ -156,16 +166,18 @@ func TestUsernameStoreChangeCaseOnly(t *testing.T) {
 	store, tmpDir := setupUsernameStore(t)
 	defer os.RemoveAll(tmpDir)
 
-	store.ReserveUsername("myname", "user123")
+	store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "myname", UserID: "user123"})
 
 	// Change case only
-	err := store.ChangeUsername("myname", "MyName", "user123")
+	_, err := store.ChangeUsername(context.Background(), &accounts.ChangeUsernameRequest{OldUsername: "myname", NewUsername: "MyName", UserID: "user123"})
 	if err != nil {
 		t.Fatalf("Failed to change username case: %v", err)
 	}
 
 	// Should still work
-	userID, err := store.GetUserByUsername("myname")
+	userIDResp_, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "myname"})
+	var userID string
+	if userIDResp_ != nil { userID = userIDResp_.UserID }
 	if err != nil {
 		t.Fatalf("Username lookup failed: %v", err)
 	}
@@ -179,11 +191,11 @@ func TestUsernameStoreChangeToTaken(t *testing.T) {
 	store, tmpDir := setupUsernameStore(t)
 	defer os.RemoveAll(tmpDir)
 
-	store.ReserveUsername("name1", "user1")
-	store.ReserveUsername("name2", "user2")
+	store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "name1", UserID: "user1"})
+	store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "name2", UserID: "user2"})
 
 	// Try to change to taken username
-	err := store.ChangeUsername("name1", "name2", "user1")
+	_, err := store.ChangeUsername(context.Background(), &accounts.ChangeUsernameRequest{OldUsername: "name1", NewUsername: "name2", UserID: "user1"})
 	if err == nil {
 		t.Error("Should not allow changing to a taken username")
 	}
@@ -194,7 +206,9 @@ func TestUsernameStoreNotFound(t *testing.T) {
 	store, tmpDir := setupUsernameStore(t)
 	defer os.RemoveAll(tmpDir)
 
-	_, err := store.GetUserByUsername("nonexistent")
+	_Resp_, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "nonexistent"})
+	var _ string
+	if _Resp_ != nil { _ = _Resp_.UserID }
 	if err == nil {
 		t.Error("Expected error for non-existent username")
 	}
@@ -360,7 +374,9 @@ func TestLinkLocalCredentials(t *testing.T) {
 	}
 
 	// Verify username was reserved
-	userID, err := config.UsernameStore.GetUserByUsername("newusername")
+	userIDResp_, err := config.UsernameStore.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: "newusername"})
+	var userID string
+	if userIDResp_ != nil { userID = userIDResp_.UserID }
 	if err != nil {
 		t.Fatalf("Failed to lookup username: %v", err)
 	}

--- a/localauth/helpers.go
+++ b/localauth/helpers.go
@@ -1,6 +1,7 @@
 package localauth
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -13,14 +14,13 @@ import (
 // dummyBcryptHash is used for timing oracle prevention (CWE-208).
 // When a user is not found, we still run bcrypt against this dummy hash
 // so the response time matches that of a real user lookup.
-// This is a valid bcrypt hash of "dummy" — the actual value doesn't matter,
-// only that bcrypt.CompareHashAndPassword runs in constant time.
 var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("oneauth-timing-dummy"), bcrypt.DefaultCost)
 
 // NewCreateUserFunc creates a CreateUserFunc from stores.
 func NewCreateUserFunc(userStore accounts.UserStore, identityStore accounts.IdentityStore, channelStore accounts.ChannelStore) CreateUserFunc {
 	return func(creds *Credentials) (accounts.User, error) {
-		// Determine primary identity
+		ctx := context.Background()
+
 		var identityType, identityValue string
 		if creds.Email != nil && *creds.Email != "" {
 			identityType = "email"
@@ -32,19 +32,16 @@ func NewCreateUserFunc(userStore accounts.UserStore, identityStore accounts.Iden
 			return nil, fmt.Errorf("email or phone required")
 		}
 
-		// Check if identity already exists
-		identity, _, err := identityStore.GetIdentity(identityType, identityValue, false)
-		if err == nil && identity != nil {
+		idResp, err := identityStore.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: identityType, IdentityValue: identityValue})
+		if err == nil && idResp != nil && idResp.Identity != nil {
 			return nil, fmt.Errorf("%s already registered", identityType)
 		}
 
-		// Hash password
 		passwordHash, err := bcrypt.GenerateFromPassword([]byte(creds.Password), bcrypt.DefaultCost)
 		if err != nil {
 			return nil, fmt.Errorf("failed to hash password: %w", err)
 		}
 
-		// Create user
 		userId := generateSecureUserId()
 		profile := map[string]any{
 			"username": creds.Username,
@@ -56,23 +53,22 @@ func NewCreateUserFunc(userStore accounts.UserStore, identityStore accounts.Iden
 			profile["phone"] = *creds.Phone
 		}
 
-		user, err := userStore.CreateUser(userId, true, profile)
+		userResp, err := userStore.CreateUser(ctx, &accounts.CreateUserRequest{UserID: userId, IsActive: true, Profile: profile})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create user: %w", err)
 		}
+		user := userResp.User
 
-		// Create identity
-		identity = &accounts.Identity{
+		identity := &accounts.Identity{
 			Type:     identityType,
 			Value:    identityValue,
 			UserID:   userId,
 			Verified: false,
 		}
-		if err := identityStore.SaveIdentity(identity); err != nil {
+		if _, err := identityStore.SaveIdentity(ctx, &accounts.SaveIdentityRequest{Identity: identity}); err != nil {
 			return nil, fmt.Errorf("failed to create identity: %w", err)
 		}
 
-		// Create local channel with password
 		identityKey := accounts.IdentityKey(identityType, identityValue)
 		channel := &accounts.Channel{
 			Provider:    "local",
@@ -83,7 +79,7 @@ func NewCreateUserFunc(userStore accounts.UserStore, identityStore accounts.Iden
 			},
 			Profile: profile,
 		}
-		if err := channelStore.SaveChannel(channel); err != nil {
+		if _, err := channelStore.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
 			return nil, fmt.Errorf("failed to create channel: %w", err)
 		}
 
@@ -95,31 +91,24 @@ func NewCreateUserFunc(userStore accounts.UserStore, identityStore accounts.Iden
 // NewCredentialsValidator creates a CredentialsValidator from stores.
 func NewCredentialsValidator(identityStore accounts.IdentityStore, channelStore accounts.ChannelStore, userStore accounts.UserStore) CredentialsValidator {
 	return func(username, password, usernameType string) (accounts.User, error) {
-		// Auto-detect username type if not specified
+		ctx := context.Background()
 		if usernameType == "" {
 			usernameType = DetectUsernameType(username)
 		}
 
-		// For username type, search is not implemented yet
 		if usernameType == "username" {
 			return nil, fmt.Errorf("username login not yet implemented - please use email or phone")
 		}
 
-		// For email/phone, lookup identity directly
 		identityKey := accounts.IdentityKey(usernameType, username)
 
-		// Get local channel for this identity
-		channel, _, err := channelStore.GetChannel("local", identityKey, false)
+		chResp, err := channelStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey})
 		if err != nil {
-			// Timing oracle fix (CWE-208): run bcrypt against a dummy hash
-			// so response time is constant regardless of whether the user exists.
-			// Without this, non-existent users return instantly (~1ms) while
-			// existing users take ~50ms (bcrypt), allowing username enumeration.
 			bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 			return nil, fmt.Errorf("invalid credentials")
 		}
+		channel := chResp.Channel
 
-		// Verify password
 		passwordHash, ok := channel.Credentials["password_hash"].(string)
 		if !ok {
 			bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
@@ -130,19 +119,23 @@ func NewCredentialsValidator(identityStore accounts.IdentityStore, channelStore 
 			return nil, fmt.Errorf("invalid credentials")
 		}
 
-		// Get identity and user
-		identity, _, err := identityStore.GetIdentity(usernameType, username, false)
+		idResp, err := identityStore.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: usernameType, IdentityValue: username})
 		if err != nil {
 			return nil, fmt.Errorf("user not found")
 		}
 
-		return userStore.GetUserById(identity.UserID)
+		userResp, err := userStore.GetUserById(ctx, &accounts.GetUserByIDRequest{UserID: idResp.Identity.UserID})
+		if err != nil {
+			return nil, err
+		}
+		return userResp.User, nil
 	}
 }
 
 // NewVerifyEmailFunc creates a VerifyEmailFunc from stores.
 func NewVerifyEmailFunc(identityStore accounts.IdentityStore, tokenStore VerificationTokenStore) VerifyEmailFunc {
 	return func(token string) error {
+		ctx := context.Background()
 		verToken, err := tokenStore.GetToken(token)
 		if err != nil {
 			return fmt.Errorf("invalid or expired token")
@@ -152,12 +145,10 @@ func NewVerifyEmailFunc(identityStore accounts.IdentityStore, tokenStore Verific
 			return fmt.Errorf("invalid token type")
 		}
 
-		// Mark the email identity as verified
-		if err := identityStore.MarkIdentityVerified("email", verToken.Email); err != nil {
+		if _, err := identityStore.MarkIdentityVerified(ctx, &accounts.MarkIdentityVerifiedRequest{IdentityType: "email", IdentityValue: verToken.Email}); err != nil {
 			return fmt.Errorf("failed to verify email: %w", err)
 		}
 
-		// Delete the token (one-time use)
 		if err := tokenStore.DeleteToken(token); err != nil {
 			log.Printf("Warning: failed to delete token: %v", err)
 		}
@@ -167,25 +158,24 @@ func NewVerifyEmailFunc(identityStore accounts.IdentityStore, tokenStore Verific
 }
 
 // NewUpdatePasswordFunc creates an UpdatePasswordFunc from stores.
-// If the user has no local channel (e.g. OAuth-only user), one is created automatically.
 func NewUpdatePasswordFunc(identityStore accounts.IdentityStore, channelStore accounts.ChannelStore) UpdatePasswordFunc {
 	return func(email, newPassword string) error {
-		// Get the identity
-		identity, _, err := identityStore.GetIdentity("email", email, false)
+		ctx := context.Background()
+		idResp, err := identityStore.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: email})
 		if err != nil {
 			return fmt.Errorf("user not found")
 		}
+		identity := idResp.Identity
 
-		// Hash new password
 		passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 		if err != nil {
 			return fmt.Errorf("failed to hash password: %w", err)
 		}
 
-		// Get or create local channel (supports OAuth-only users setting a password via reset)
 		identityKey := accounts.IdentityKey("email", email)
-		channel, _, err := channelStore.GetChannel("local", identityKey, false)
-		if err != nil || channel == nil {
+		chResp, err := channelStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey})
+		var channel *accounts.Channel
+		if err != nil || chResp == nil || chResp.Channel == nil {
 			channel = &accounts.Channel{
 				Provider:    "local",
 				IdentityKey: identityKey,
@@ -195,11 +185,12 @@ func NewUpdatePasswordFunc(identityStore accounts.IdentityStore, channelStore ac
 				},
 			}
 			log.Printf("Creating local channel for user %s (password set via reset)", identity.UserID)
+		} else {
+			channel = chResp.Channel
 		}
 
-		// Update password
 		channel.Credentials["password_hash"] = string(passwordHash)
-		if err := channelStore.SaveChannel(channel); err != nil {
+		if _, err := channelStore.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
 			return fmt.Errorf("failed to update password: %w", err)
 		}
 
@@ -215,65 +206,38 @@ func generateSecureUserId() string {
 	return hex.EncodeToString(b)
 }
 
-// =============================================================================
-// Credential Linking Helpers
-// =============================================================================
-
 // LinkLocalCredentialsConfig groups the stores LinkLocalCredentials needs.
-// Self-contained so localauth doesn't have to import federatedauth just for
-// the cross-cutting "add local password to an OAuth user" flow.
 type LinkLocalCredentialsConfig struct {
 	UserStore     accounts.UserStore
 	IdentityStore accounts.IdentityStore
 	ChannelStore  accounts.ChannelStore
-	UsernameStore accounts.UsernameStore // Optional — reserves the username if set
+	UsernameStore accounts.UsernameStore
 }
 
 // LinkLocalCredentials adds local (password) authentication to an existing OAuth-only user.
-// This enables "incremental auth" where users sign up via OAuth and later add a password.
-//
-// # Who Calls This
-//
-// Your app calls this from a "Set Password" or "Complete Profile" page. Typically:
-//
-//  1. User signed up via Google OAuth (has google channel, no local channel)
-//  2. User visits profile page, sees "Add password for email login"
-//  3. User submits password (and optionally username) form
-//  4. Your handler calls LinkLocalCredentials with the logged-in user's ID
-//  5. User can now login with email/password OR Google
-//
-// # What It Does
-//
-//  1. Verifies the email belongs to the given userID
-//  2. Checks that local channel doesn't already exist
-//  3. Creates local channel with hashed password
-//  4. Reserves username in UsernameStore (if configured and username provided)
-//  5. Updates user profile["channels"] to include "local"
 func LinkLocalCredentials(config LinkLocalCredentialsConfig, userID string, username, password, email string) error {
-	// Get existing identity
-	identity, _, err := config.IdentityStore.GetIdentity("email", email, false)
+	ctx := context.Background()
+	idResp, err := config.IdentityStore.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: email})
 	if err != nil {
 		return fmt.Errorf("identity not found: %w", err)
 	}
+	identity := idResp.Identity
 	if identity.UserID != userID {
 		return fmt.Errorf("email does not belong to this user")
 	}
 
 	identityKey := accounts.IdentityKey("email", email)
 
-	// Check if local channel already exists
-	existingChannel, _, err := config.ChannelStore.GetChannel("local", identityKey, false)
-	if err == nil && existingChannel != nil {
+	existingResp, err := config.ChannelStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey})
+	if err == nil && existingResp != nil && existingResp.Channel != nil {
 		return fmt.Errorf("local credentials already exist for this user")
 	}
 
-	// Hash password
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	// Create local channel
 	channel := &accounts.Channel{
 		Provider:    "local",
 		IdentityKey: identityKey,
@@ -289,23 +253,21 @@ func LinkLocalCredentials(config LinkLocalCredentialsConfig, userID string, user
 		channel.Profile["username"] = username
 	}
 
-	if err := config.ChannelStore.SaveChannel(channel); err != nil {
+	if _, err := config.ChannelStore.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
 		return fmt.Errorf("failed to create local channel: %w", err)
 	}
 
-	// Reserve username if store configured and username provided
 	if username != "" && config.UsernameStore != nil {
-		if err := config.UsernameStore.ReserveUsername(username, userID); err != nil {
+		if _, err := config.UsernameStore.ReserveUsername(ctx, &accounts.ReserveUsernameRequest{Username: username, UserID: userID}); err != nil {
 			log.Printf("Warning: failed to reserve username: %v", err)
-			// Don't fail - channel was created successfully
 		}
 	}
 
-	// Update user profile to include local channel
-	user, err := config.UserStore.GetUserById(userID)
+	userResp, err := config.UserStore.GetUserById(ctx, &accounts.GetUserByIDRequest{UserID: userID})
 	if err != nil {
 		return fmt.Errorf("failed to get user: %w", err)
 	}
+	user := userResp.User
 
 	profile := user.Profile()
 	if profile == nil {
@@ -321,7 +283,7 @@ func LinkLocalCredentials(config LinkLocalCredentialsConfig, userID string, user
 	}
 
 	updatedUser := &accounts.BasicUser{ID: userID, ProfileData: profile}
-	if err := config.UserStore.SaveUser(updatedUser); err != nil {
+	if _, err := config.UserStore.SaveUser(ctx, &accounts.SaveUserRequest{User: updatedUser}); err != nil {
 		log.Printf("Warning: failed to update user profile: %v", err)
 	}
 
@@ -331,49 +293,32 @@ func LinkLocalCredentials(config LinkLocalCredentialsConfig, userID string, user
 
 // NewCredentialsValidatorWithUsername creates a CredentialsValidator that supports
 // logging in with username (in addition to email/phone).
-//
-// # How Username Login Works
-//
-//  1. User enters "johndoe" and password on login form
-//  2. DetectUsernameType returns "username" (not email, not phone)
-//  3. This validator looks up "johndoe" in UsernameStore → gets userID
-//  4. Gets user's email identity from IdentityStore
-//  5. Gets local channel for that email identity
-//  6. Verifies password against channel's password_hash
-//  7. Returns the user
-//
-// # Fallback Behavior
-//
-// If user enters an email or phone number instead of username, it falls back to
-// the standard email/phone lookup (same as NewCredentialsValidator).
 func NewCredentialsValidatorWithUsername(identityStore accounts.IdentityStore, channelStore accounts.ChannelStore, userStore accounts.UserStore, usernameStore accounts.UsernameStore) CredentialsValidator {
 	return func(username, password, usernameType string) (accounts.User, error) {
-		// Auto-detect username type if not specified
+		ctx := context.Background()
 		if usernameType == "" {
 			usernameType = DetectUsernameType(username)
 		}
 
 		var identityKey string
 
-		// For username type, lookup via UsernameStore
 		if usernameType == "username" {
 			if usernameStore == nil {
 				return nil, fmt.Errorf("username login not configured")
 			}
-			userID, err := usernameStore.GetUserByUsername(username)
+			userResp, err := usernameStore.GetUserByUsername(ctx, &accounts.GetUserByUsernameRequest{Username: username})
 			if err != nil {
 				return nil, fmt.Errorf("invalid credentials")
 			}
+			userID := userResp.UserID
 
-			// Get user's identities to find the primary email
-			identities, err := identityStore.GetUserIdentities(userID)
-			if err != nil || len(identities) == 0 {
+			idsResp, err := identityStore.GetUserIdentities(ctx, &accounts.GetUserIdentitiesRequest{UserID: userID})
+			if err != nil || len(idsResp.Identities) == 0 {
 				return nil, fmt.Errorf("invalid credentials")
 			}
 
-			// Find email identity
 			var emailIdentity *accounts.Identity
-			for _, id := range identities {
+			for _, id := range idsResp.Identities {
 				if id.Type == "email" {
 					emailIdentity = id
 					break
@@ -384,17 +329,15 @@ func NewCredentialsValidatorWithUsername(identityStore accounts.IdentityStore, c
 			}
 			identityKey = accounts.IdentityKey("email", emailIdentity.Value)
 		} else {
-			// For email/phone, lookup identity directly
 			identityKey = accounts.IdentityKey(usernameType, username)
 		}
 
-		// Get local channel for this identity
-		channel, _, err := channelStore.GetChannel("local", identityKey, false)
+		chResp, err := channelStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey})
 		if err != nil {
 			return nil, fmt.Errorf("invalid credentials")
 		}
+		channel := chResp.Channel
 
-		// Verify password
 		passwordHash, ok := channel.Credentials["password_hash"].(string)
 		if !ok {
 			return nil, fmt.Errorf("invalid credentials")
@@ -404,18 +347,21 @@ func NewCredentialsValidatorWithUsername(identityStore accounts.IdentityStore, c
 			return nil, fmt.Errorf("invalid credentials")
 		}
 
-		// Get identity and user via parsed identity key
 		parts := parseIdentityKey(identityKey)
 		if parts == nil {
 			return nil, fmt.Errorf("invalid credentials")
 		}
 
-		identity, _, err := identityStore.GetIdentity(parts[0], parts[1], false)
+		idResp, err := identityStore.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: parts[0], IdentityValue: parts[1]})
 		if err != nil {
 			return nil, fmt.Errorf("invalid credentials")
 		}
 
-		return userStore.GetUserById(identity.UserID)
+		userResp, err := userStore.GetUserById(ctx, &accounts.GetUserByIDRequest{UserID: idResp.Identity.UserID})
+		if err != nil {
+			return nil, fmt.Errorf("invalid credentials")
+		}
+		return userResp.User, nil
 	}
 }
 

--- a/localauth/local.go
+++ b/localauth/local.go
@@ -583,13 +583,13 @@ func (a *LocalAuth) HandleLinkCredentials(config LinkCredentialsConfig, getUser 
 		}
 
 		// Get user to find their email
-		user, err := config.UserStore.GetUserById(userID)
+		userResp, err := config.UserStore.GetUserById(r.Context(), &accounts.GetUserByIDRequest{UserID: userID})
 		if err != nil {
 			http.Error(w, `{"error": "User not found"}`, http.StatusUnauthorized)
 			return
 		}
 
-		profile := user.Profile()
+		profile := userResp.User.Profile()
 		email, _ := profile["email"].(string)
 		if email == "" {
 			http.Error(w, `{"error": "User has no email identity"}`, http.StatusBadRequest)
@@ -643,8 +643,8 @@ func (a *LocalAuth) HandleLinkCredentials(config LinkCredentialsConfig, getUser 
 
 			// Check username availability if UsernameStore configured
 			if config.UsernameStore != nil {
-				existingUserID, err := config.UsernameStore.GetUserByUsername(username)
-				if err == nil && existingUserID != userID {
+				existingResp, err := config.UsernameStore.GetUserByUsername(r.Context(), &accounts.GetUserByUsernameRequest{Username: username})
+				if err == nil && existingResp.UserID != userID {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusBadRequest)
 					json.NewEncoder(w).Encode(map[string]any{

--- a/localauth/signup.go
+++ b/localauth/signup.go
@@ -35,7 +35,7 @@ func (a *LocalAuth) HandleSignup(w http.ResponseWriter, r *http.Request) {
 	if creds.Username != "" && a.UsernameStore != nil {
 		policy := a.getSignupPolicy()
 		if policy.EnforceUsernameUnique {
-			if _, err := a.UsernameStore.GetUserByUsername(creds.Username); err == nil {
+			if _, err := a.UsernameStore.GetUserByUsername(r.Context(), &accounts.GetUserByUsernameRequest{Username: creds.Username}); err == nil {
 				authErr := accounts.NewAuthError(accounts.ErrCodeUsernameTaken, "Username is already taken", "username")
 				a.handleSignupError(authErr, w, r)
 				return
@@ -61,7 +61,7 @@ func (a *LocalAuth) HandleSignup(w http.ResponseWriter, r *http.Request) {
 
 	// Reserve username if UsernameStore is configured
 	if creds.Username != "" && a.UsernameStore != nil {
-		if err := a.UsernameStore.ReserveUsername(creds.Username, user.Id()); err != nil {
+		if _, err := a.UsernameStore.ReserveUsername(r.Context(), &accounts.ReserveUsernameRequest{Username: creds.Username, UserID: user.Id()}); err != nil {
 			log.Printf("Warning: failed to reserve username %s: %v", creds.Username, err)
 			// Don't fail signup - user was already created
 		}

--- a/localauth/user_journeys_test.go
+++ b/localauth/user_journeys_test.go
@@ -1,6 +1,7 @@
 package localauth_test
 
 import (
+	"context"
 	"github.com/panyam/oneauth/localauth"
 	"encoding/json"
 	"net/http"
@@ -95,7 +96,9 @@ func TestJourney1_MultipleOAuthSameEmail(t *testing.T) {
 
 	// Verify Google channel exists
 	identityKey := accounts.IdentityKey("email", email)
-	googleChannel, _, err := j.ChannelStore.GetChannel("google", identityKey, false)
+	googleChannelResp_, err := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "google", IdentityKey: identityKey, CreateIfMissing: false})
+	var googleChannel *accounts.Channel
+	if googleChannelResp_ != nil { googleChannel = googleChannelResp_.Channel }
 	if err != nil || googleChannel == nil {
 		t.Error("Google channel should exist")
 	}
@@ -117,7 +120,9 @@ func TestJourney1_MultipleOAuthSameEmail(t *testing.T) {
 	}
 
 	// Verify both channels exist for the same identity
-	githubChannel, _, err := j.ChannelStore.GetChannel("github", identityKey, false)
+	githubChannelResp_, err := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "github", IdentityKey: identityKey, CreateIfMissing: false})
+	var githubChannel *accounts.Channel
+	if githubChannelResp_ != nil { githubChannel = githubChannelResp_.Channel }
 	if err != nil || githubChannel == nil {
 		t.Error("GitHub channel should exist")
 	}
@@ -164,14 +169,16 @@ func TestJourney2_OAuthUserAddsCredentials(t *testing.T) {
 
 	// Verify NO local channel exists yet
 	identityKey := accounts.IdentityKey("email", email)
-	localChannel, _, _ := j.ChannelStore.GetChannel("local", identityKey, false)
+	localChannelResp_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	var localChannel *accounts.Channel
+	if localChannelResp_ != nil { localChannel = localChannelResp_.Channel }
 	if localChannel != nil {
 		t.Error("Local channel should NOT exist yet for OAuth-only user")
 	}
 
 	// Day 3, Step 1: User sets username
 	newUsername := "bobsmith"
-	err = j.UsernameStore.ReserveUsername(newUsername, userID)
+	_, err = j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: newUsername, UserID: userID})
 	if err != nil {
 		t.Fatalf("Failed to reserve username: %v", err)
 	}
@@ -179,12 +186,14 @@ func TestJourney2_OAuthUserAddsCredentials(t *testing.T) {
 	// Update profile with username
 	profile := user.Profile()
 	profile["username"] = newUsername
-	if err := j.UserStore.SaveUser(user); err != nil {
+	if _, err := j.UserStore.SaveUser(context.Background(), &accounts.SaveUserRequest{User: user}); err != nil {
 		t.Fatalf("Failed to save user: %v", err)
 	}
 
 	// Verify username lookup works
-	lookupUserID, err := j.UsernameStore.GetUserByUsername(newUsername)
+	lookupUserIDResp_, err := j.UsernameStore.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: newUsername})
+	var lookupUserID string
+	if lookupUserIDResp_ != nil { lookupUserID = lookupUserIDResp_.UserID }
 	if err != nil {
 		t.Fatalf("Username lookup failed: %v", err)
 	}
@@ -199,7 +208,9 @@ func TestJourney2_OAuthUserAddsCredentials(t *testing.T) {
 	}
 
 	// Verify local channel NOW exists
-	localChannel, _, _ = j.ChannelStore.GetChannel("local", identityKey, false)
+	localChannelResp2_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	localChannel = nil
+	if localChannelResp2_ != nil { localChannel = localChannelResp2_.Channel }
 	if localChannel == nil {
 		t.Error("Local channel should exist after linking credentials")
 	}
@@ -278,13 +289,17 @@ func TestJourney3_EmailSignupThenLinkOAuth(t *testing.T) {
 	}
 
 	// Get the user ID from the identity
-	identity, _, _ := j.IdentityStore.GetIdentity("email", email, false)
+	identityResp_, _ := j.IdentityStore.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: email, CreateIfMissing: false})
+	var identity *accounts.Identity
+	if identityResp_ != nil { identity = identityResp_.Identity }
 	user1ID := identity.UserID
 	t.Logf("Created local user: %s", user1ID)
 
 	// Verify local channel exists
 	identityKey := accounts.IdentityKey("email", email)
-	localChannel, _, _ := j.ChannelStore.GetChannel("local", identityKey, false)
+	localChannelResp_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	var localChannel *accounts.Channel
+	if localChannelResp_ != nil { localChannel = localChannelResp_.Channel }
 	if localChannel == nil {
 		t.Error("Local channel should exist")
 	}
@@ -305,7 +320,9 @@ func TestJourney3_EmailSignupThenLinkOAuth(t *testing.T) {
 	}
 
 	// Verify both channels exist
-	googleChannel, _, _ := j.ChannelStore.GetChannel("google", identityKey, false)
+	googleChannelResp_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "google", IdentityKey: identityKey, CreateIfMissing: false})
+	var googleChannel *accounts.Channel
+	if googleChannelResp_ != nil { googleChannel = googleChannelResp_.Channel }
 	if googleChannel == nil {
 		t.Error("Google channel should exist after linking")
 	}
@@ -357,11 +374,13 @@ func TestJourney4_UsernameAsPrimaryLogin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	localAuth.HandleSignup(rr, req)
 
-	identity, _, _ := j.IdentityStore.GetIdentity("email", email, false)
+	identityResp_, _ := j.IdentityStore.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: email, CreateIfMissing: false})
+	var identity *accounts.Identity
+	if identityResp_ != nil { identity = identityResp_.Identity }
 	userID := identity.UserID
 
 	// Reserve username
-	j.UsernameStore.ReserveUsername(username, userID)
+	j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: username, UserID: userID})
 
 	// Create validator with username support
 	validator := localauth.NewCredentialsValidatorWithUsername(
@@ -518,33 +537,40 @@ func TestJourney7_UsernameChange(t *testing.T) {
 	newUsername := "newname"
 
 	// Reserve initial username
-	err := j.UsernameStore.ReserveUsername(oldUsername, userID)
+	_, err := j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: oldUsername, UserID: userID})
 	if err != nil {
 		t.Fatalf("Failed to reserve initial username: %v", err)
 	}
 
 	// Verify it works
-	foundUserID, _ := j.UsernameStore.GetUserByUsername(oldUsername)
+	foundResp, _ := j.UsernameStore.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: oldUsername})
+	foundUserID := ""
+	if foundResp != nil {
+		foundUserID = foundResp.UserID
+	}
 	if foundUserID != userID {
 		t.Error("Initial username should map to user")
 	}
 
 	// Change username
-	err = j.UsernameStore.ChangeUsername(oldUsername, newUsername, userID)
+	_, err = j.UsernameStore.ChangeUsername(context.Background(), &accounts.ChangeUsernameRequest{OldUsername: oldUsername, NewUsername: newUsername, UserID: userID})
 	if err != nil {
 		t.Fatalf("Username change failed: %v", err)
 	}
 
 	// Verify old username NO LONGER works
-	_, err = j.UsernameStore.GetUserByUsername(oldUsername)
-	if err == nil {
+	if _, err := j.UsernameStore.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: oldUsername}); err == nil {
 		t.Error("Old username should NOT exist after change")
 	}
 
 	// Verify new username works
-	foundUserID, err = j.UsernameStore.GetUserByUsername(newUsername)
+	foundResp2, err := j.UsernameStore.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: newUsername})
 	if err != nil {
 		t.Fatalf("New username lookup failed: %v", err)
+	}
+	foundUserID = ""
+	if foundResp2 != nil {
+		foundUserID = foundResp2.UserID
 	}
 	if foundUserID != userID {
 		t.Error("New username should map to same user")
@@ -579,7 +605,9 @@ func TestJourney8_OAuthUserPasswordReset(t *testing.T) {
 
 	// Verify NO local channel exists
 	identityKey := accounts.IdentityKey("email", email)
-	localChannel, _, _ := j.ChannelStore.GetChannel("local", identityKey, false)
+	localChannelResp_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	var localChannel *accounts.Channel
+	if localChannelResp_ != nil { localChannel = localChannelResp_.Channel }
 	if localChannel != nil {
 		t.Fatal("Local channel should NOT exist for OAuth-only user")
 	}
@@ -593,7 +621,9 @@ func TestJourney8_OAuthUserPasswordReset(t *testing.T) {
 	}
 
 	// Verify local channel NOW exists
-	localChannel, _, err = j.ChannelStore.GetChannel("local", identityKey, false)
+	localChannelResp2_, err := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	localChannel = nil
+	if localChannelResp2_ != nil { localChannel = localChannelResp2_.Channel }
 	if err != nil || localChannel == nil {
 		t.Fatal("Local channel should exist after password reset")
 	}
@@ -697,7 +727,9 @@ func TestEdgeCase_OAuthReturnsExistingEmail(t *testing.T) {
 	rr := httptest.NewRecorder()
 	localAuth.HandleSignup(rr, req)
 
-	identity, _, _ := j.IdentityStore.GetIdentity("email", email, false)
+	identityResp_, _ := j.IdentityStore.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: email, CreateIfMissing: false})
+	var identity *accounts.Identity
+	if identityResp_ != nil { identity = identityResp_.Identity }
 	localUserID := identity.UserID
 
 	// OAuth login with same email should link to existing user
@@ -717,8 +749,12 @@ func TestEdgeCase_OAuthReturnsExistingEmail(t *testing.T) {
 
 	// User now has both channels
 	identityKey := accounts.IdentityKey("email", email)
-	localChannel, _, _ := j.ChannelStore.GetChannel("local", identityKey, false)
-	googleChannel, _, _ := j.ChannelStore.GetChannel("google", identityKey, false)
+	localChannelResp_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey, CreateIfMissing: false})
+	var localChannel *accounts.Channel
+	if localChannelResp_ != nil { localChannel = localChannelResp_.Channel }
+	googleChannelResp_, _ := j.ChannelStore.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: "google", IdentityKey: identityKey, CreateIfMissing: false})
+	var googleChannel *accounts.Channel
+	if googleChannelResp_ != nil { googleChannel = googleChannelResp_.Channel }
 
 	if localChannel == nil {
 		t.Error("Local channel should still exist")
@@ -761,19 +797,19 @@ func TestEdgeCase_UsernameAlreadyTaken(t *testing.T) {
 	defer j.Cleanup()
 
 	// User 1 reserves "coolname"
-	err := j.UsernameStore.ReserveUsername("coolname", "user1")
+	_, err := j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "coolname", UserID: "user1"})
 	if err != nil {
 		t.Fatalf("First reservation should succeed: %v", err)
 	}
 
 	// User 2 tries to reserve same name
-	err = j.UsernameStore.ReserveUsername("coolname", "user2")
+	_, err = j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "coolname", UserID: "user2"})
 	if err == nil {
 		t.Error("Should not allow duplicate username")
 	}
 
 	// Case-insensitive: "COOLNAME" should also fail
-	err = j.UsernameStore.ReserveUsername("COOLNAME", "user3")
+	_, err = j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: "COOLNAME", UserID: "user3"})
 	if err == nil {
 		t.Error("Should not allow same username with different case")
 	}
@@ -807,11 +843,13 @@ func TestEdgeCase_AutoDetectEmailVsUsername(t *testing.T) {
 	rr := httptest.NewRecorder()
 	localAuth.HandleSignup(rr, req)
 
-	identity, _, _ := j.IdentityStore.GetIdentity("email", email, false)
+	identityResp_, _ := j.IdentityStore.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: email, CreateIfMissing: false})
+	var identity *accounts.Identity
+	if identityResp_ != nil { identity = identityResp_.Identity }
 	userID := identity.UserID
 
 	// Reserve username
-	j.UsernameStore.ReserveUsername(username, userID)
+	j.UsernameStore.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: username, UserID: userID})
 
 	// Create validator
 	validator := localauth.NewCredentialsValidatorWithUsername(

--- a/stores/fs/fschannel_store.go
+++ b/stores/fs/fschannel_store.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -32,50 +33,57 @@ func (s *FSChannelStore) getChannelPath(provider, identityKey string) (string, e
 	return filepath.Join(s.StoragePath, "channels", filename), nil
 }
 
-func (s *FSChannelStore) GetChannel(provider string, identityKey string, createIfMissing bool) (*accounts.Channel, bool, error) {
-	path, err := s.getChannelPath(provider, identityKey)
+func (s *FSChannelStore) GetChannel(ctx context.Context, req *accounts.GetChannelRequest) (*accounts.GetChannelResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetChannel: req is required")
+	}
+	path, err := s.getChannelPath(req.Provider, req.IdentityKey)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	data, err := os.ReadFile(path)
 
 	if err != nil {
-		if os.IsNotExist(err) && createIfMissing {
+		if os.IsNotExist(err) && req.CreateIfMissing {
 			now := time.Now()
 			channel := &accounts.Channel{
-				Provider:    provider,
-				IdentityKey: identityKey,
+				Provider:    req.Provider,
+				IdentityKey: req.IdentityKey,
 				Credentials: make(map[string]any),
 				Profile:     make(map[string]any),
 				CreatedAt:   now,
 				UpdatedAt:   now,
 				Version:     1,
 			}
-			if err := s.SaveChannel(channel); err != nil {
-				return nil, false, err
+			if _, err := s.SaveChannel(ctx, &accounts.SaveChannelRequest{Channel: channel}); err != nil {
+				return nil, err
 			}
-			return channel, true, nil
+			return &accounts.GetChannelResponse{Channel: channel, NewCreated: true}, nil
 		}
 		if os.IsNotExist(err) {
-			return nil, false, fmt.Errorf("channel not found")
+			return nil, fmt.Errorf("channel not found")
 		}
-		return nil, false, err
+		return nil, err
 	}
 
 	var channel accounts.Channel
 	if err := json.Unmarshal(data, &channel); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return &channel, false, nil
+	return &accounts.GetChannelResponse{Channel: &channel}, nil
 }
 
-func (s *FSChannelStore) SaveChannel(channel *accounts.Channel) error {
+func (s *FSChannelStore) SaveChannel(ctx context.Context, req *accounts.SaveChannelRequest) (*accounts.SaveChannelResponse, error) {
+	if req == nil || req.Channel == nil {
+		return nil, fmt.Errorf("SaveChannel: req.Channel is required")
+	}
+	channel := req.Channel
 	path, err := s.getChannelPath(channel.Provider, channel.IdentityKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
+		return nil, err
 	}
 
 	channel.UpdatedAt = time.Now()
@@ -88,18 +96,23 @@ func (s *FSChannelStore) SaveChannel(channel *accounts.Channel) error {
 
 	data, err := json.MarshalIndent(channel, "", "  ")
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	return writeAtomicFile(path, data)
+	if err := writeAtomicFile(path, data); err != nil {
+		return nil, err
+	}
+	return &accounts.SaveChannelResponse{}, nil
 }
 
-func (s *FSChannelStore) GetChannelsByIdentity(identityKey string) ([]*accounts.Channel, error) {
+func (s *FSChannelStore) GetChannelsByIdentity(ctx context.Context, req *accounts.GetChannelsByIdentityRequest) (*accounts.GetChannelsByIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetChannelsByIdentity: req is required")
+	}
 	channelsDir := filepath.Join(s.StoragePath, "channels")
 	entries, err := os.ReadDir(channelsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []*accounts.Channel{}, nil
+			return &accounts.GetChannelsByIdentityResponse{Channels: []*accounts.Channel{}}, nil
 		}
 		return nil, err
 	}
@@ -109,21 +122,17 @@ func (s *FSChannelStore) GetChannelsByIdentity(identityKey string) ([]*accounts.
 		if entry.IsDir() {
 			continue
 		}
-
 		data, err := os.ReadFile(filepath.Join(channelsDir, entry.Name()))
 		if err != nil {
 			continue
 		}
-
 		var channel accounts.Channel
 		if err := json.Unmarshal(data, &channel); err != nil {
 			continue
 		}
-
-		if channel.IdentityKey == identityKey {
+		if channel.IdentityKey == req.IdentityKey {
 			channels = append(channels, &channel)
 		}
 	}
-
-	return channels, nil
+	return &accounts.GetChannelsByIdentityResponse{Channels: channels}, nil
 }

--- a/stores/fs/fsidentity_store.go
+++ b/stores/fs/fsidentity_store.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -21,89 +22,111 @@ func NewFSIdentityStore(storagePath string) *FSIdentityStore {
 
 func (s *FSIdentityStore) getIdentityPath(identityType, identityValue string) string {
 	key := accounts.IdentityKey(identityType, identityValue)
-	// Use safe filename
-	safeKey := filepath.Base(key) // prevents path traversal
+	safeKey := filepath.Base(key)
 	return filepath.Join(s.StoragePath, "identities", safeKey+".json")
 }
 
-func (s *FSIdentityStore) GetIdentity(identityType, identityValue string, createIfMissing bool) (*accounts.Identity, bool, error) {
-	path := s.getIdentityPath(identityType, identityValue)
+func (s *FSIdentityStore) GetIdentity(ctx context.Context, req *accounts.GetIdentityRequest) (*accounts.GetIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetIdentity: req is required")
+	}
+	path := s.getIdentityPath(req.IdentityType, req.IdentityValue)
 	data, err := os.ReadFile(path)
 
 	if err != nil {
-		if os.IsNotExist(err) && createIfMissing {
+		if os.IsNotExist(err) && req.CreateIfMissing {
 			now := time.Now()
 			identity := &accounts.Identity{
-				Type:      identityType,
-				Value:     identityValue,
-				UserID:    "", // Not assigned yet
+				Type:      req.IdentityType,
+				Value:     req.IdentityValue,
+				UserID:    "",
 				Verified:  false,
 				CreatedAt: now,
 				UpdatedAt: now,
 				Version:   1,
 			}
-			if err := s.SaveIdentity(identity); err != nil {
-				return nil, false, err
+			if _, err := s.SaveIdentity(ctx, &accounts.SaveIdentityRequest{Identity: identity}); err != nil {
+				return nil, err
 			}
-			return identity, true, nil
+			return &accounts.GetIdentityResponse{Identity: identity, NewCreated: true}, nil
 		}
 		if os.IsNotExist(err) {
-			return nil, false, fmt.Errorf("identity not found")
+			return nil, fmt.Errorf("identity not found")
 		}
-		return nil, false, err
+		return nil, err
 	}
 
 	var identity accounts.Identity
 	if err := json.Unmarshal(data, &identity); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return &identity, false, nil
+	return &accounts.GetIdentityResponse{Identity: &identity}, nil
 }
 
-func (s *FSIdentityStore) SaveIdentity(identity *accounts.Identity) error {
+func (s *FSIdentityStore) SaveIdentity(ctx context.Context, req *accounts.SaveIdentityRequest) (*accounts.SaveIdentityResponse, error) {
+	if req == nil || req.Identity == nil {
+		return nil, fmt.Errorf("SaveIdentity: req.Identity is required")
+	}
+	identity := req.Identity
 	path := s.getIdentityPath(identity.Type, identity.Value)
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
+		return nil, err
 	}
-
 	data, err := json.MarshalIndent(identity, "", "  ")
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	return writeAtomicFile(path, data)
+	if err := writeAtomicFile(path, data); err != nil {
+		return nil, err
+	}
+	return &accounts.SaveIdentityResponse{}, nil
 }
 
-func (s *FSIdentityStore) SetUserForIdentity(identityType, identityValue string, newUserId string) error {
-	identity, _, err := s.GetIdentity(identityType, identityValue, false)
-	if err != nil {
-		return err
+func (s *FSIdentityStore) SetUserForIdentity(ctx context.Context, req *accounts.SetUserForIdentityRequest) (*accounts.SetUserForIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("SetUserForIdentity: req is required")
 	}
-
-	identity.UserID = newUserId
+	resp, err := s.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: req.IdentityType, IdentityValue: req.IdentityValue})
+	if err != nil {
+		return nil, err
+	}
+	identity := resp.Identity
+	identity.UserID = req.NewUserID
 	identity.UpdatedAt = time.Now()
 	identity.Version++
-	return s.SaveIdentity(identity)
+	if _, err := s.SaveIdentity(ctx, &accounts.SaveIdentityRequest{Identity: identity}); err != nil {
+		return nil, err
+	}
+	return &accounts.SetUserForIdentityResponse{}, nil
 }
 
-func (s *FSIdentityStore) MarkIdentityVerified(identityType, identityValue string) error {
-	identity, _, err := s.GetIdentity(identityType, identityValue, false)
-	if err != nil {
-		return err
+func (s *FSIdentityStore) MarkIdentityVerified(ctx context.Context, req *accounts.MarkIdentityVerifiedRequest) (*accounts.MarkIdentityVerifiedResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("MarkIdentityVerified: req is required")
 	}
-
+	resp, err := s.GetIdentity(ctx, &accounts.GetIdentityRequest{IdentityType: req.IdentityType, IdentityValue: req.IdentityValue})
+	if err != nil {
+		return nil, err
+	}
+	identity := resp.Identity
 	identity.Verified = true
 	identity.UpdatedAt = time.Now()
 	identity.Version++
-	return s.SaveIdentity(identity)
+	if _, err := s.SaveIdentity(ctx, &accounts.SaveIdentityRequest{Identity: identity}); err != nil {
+		return nil, err
+	}
+	return &accounts.MarkIdentityVerifiedResponse{}, nil
 }
 
-func (s *FSIdentityStore) GetUserIdentities(userId string) ([]*accounts.Identity, error) {
+func (s *FSIdentityStore) GetUserIdentities(ctx context.Context, req *accounts.GetUserIdentitiesRequest) (*accounts.GetUserIdentitiesResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserIdentities: req is required")
+	}
 	identitiesDir := filepath.Join(s.StoragePath, "identities")
 	entries, err := os.ReadDir(identitiesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []*accounts.Identity{}, nil
+			return &accounts.GetUserIdentitiesResponse{Identities: []*accounts.Identity{}}, nil
 		}
 		return nil, err
 	}
@@ -113,21 +136,17 @@ func (s *FSIdentityStore) GetUserIdentities(userId string) ([]*accounts.Identity
 		if entry.IsDir() {
 			continue
 		}
-
 		data, err := os.ReadFile(filepath.Join(identitiesDir, entry.Name()))
 		if err != nil {
 			continue
 		}
-
 		var identity accounts.Identity
 		if err := json.Unmarshal(data, &identity); err != nil {
 			continue
 		}
-
-		if identity.UserID == userId {
+		if identity.UserID == req.UserID {
 			identities = append(identities, &identity)
 		}
 	}
-
-	return identities, nil
+	return &accounts.GetUserIdentitiesResponse{Identities: identities}, nil
 }

--- a/stores/fs/fsuser_store.go
+++ b/stores/fs/fsuser_store.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,7 +11,7 @@ import (
 	"github.com/panyam/oneauth/accounts"
 )
 
-// FSUser implements the oneauth.User interface
+// FSUser implements the accounts.User interface
 type FSUser struct {
 	UserId      string         `json:"user_id"`
 	IsActive    bool           `json:"is_active"`
@@ -39,26 +40,35 @@ func (s *FSUserStore) getUserPath(userId string) (string, error) {
 	return filepath.Join(s.StoragePath, "users", safeID+".json"), nil
 }
 
-func (s *FSUserStore) CreateUser(userId string, isActive bool, profile map[string]any) (accounts.User, error) {
+func (s *FSUserStore) CreateUser(ctx context.Context, req *accounts.CreateUserRequest) (*accounts.CreateUserResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateUser: req is required")
+	}
 	user := &FSUser{
-		UserId:      userId,
-		IsActive:    isActive,
-		UserProfile: profile,
+		UserId:      req.UserID,
+		IsActive:    req.IsActive,
+		UserProfile: req.Profile,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 	}
-	return user, s.SaveUser(user)
+	if _, err := s.SaveUser(ctx, &accounts.SaveUserRequest{User: user}); err != nil {
+		return nil, err
+	}
+	return &accounts.CreateUserResponse{User: user}, nil
 }
 
-func (s *FSUserStore) GetUserById(userId string) (accounts.User, error) {
-	path, err := s.getUserPath(userId)
+func (s *FSUserStore) GetUserById(ctx context.Context, req *accounts.GetUserByIDRequest) (*accounts.GetUserByIDResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserById: req is required")
+	}
+	path, err := s.getUserPath(req.UserID)
 	if err != nil {
 		return nil, err
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("user not found: %s", userId)
+			return nil, fmt.Errorf("user not found: %s", req.UserID)
 		}
 		return nil, err
 	}
@@ -67,19 +77,21 @@ func (s *FSUserStore) GetUserById(userId string) (accounts.User, error) {
 	if err := json.Unmarshal(data, &user); err != nil {
 		return nil, err
 	}
-	return &user, nil
+	return &accounts.GetUserByIDResponse{User: &user}, nil
 }
 
-func (s *FSUserStore) SaveUser(user accounts.User) error {
+func (s *FSUserStore) SaveUser(ctx context.Context, req *accounts.SaveUserRequest) (*accounts.SaveUserResponse, error) {
+	if req == nil || req.User == nil {
+		return nil, fmt.Errorf("SaveUser: req.User is required")
+	}
+	user := req.User
 	fsUser, ok := user.(*FSUser)
 	if !ok {
-		// Convert if it's a different implementation
 		fsUser = &FSUser{
 			UserId:      user.Id(),
 			UserProfile: user.Profile(),
 			UpdatedAt:   time.Now(),
 		}
-		// Try to preserve created_at if it exists in profile
 		if createdAt, ok := user.Profile()["created_at"].(time.Time); ok {
 			fsUser.CreatedAt = createdAt
 		} else {
@@ -91,16 +103,18 @@ func (s *FSUserStore) SaveUser(user accounts.User) error {
 
 	path, err := s.getUserPath(fsUser.UserId)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
+		return nil, err
 	}
 
 	data, err := json.MarshalIndent(fsUser, "", "  ")
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	return writeAtomicFile(path, data)
+	if err := writeAtomicFile(path, data); err != nil {
+		return nil, err
+	}
+	return &accounts.SaveUserResponse{}, nil
 }

--- a/stores/fs/fsusername_store.go
+++ b/stores/fs/fsusername_store.go
@@ -1,82 +1,48 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/panyam/oneauth/accounts"
 )
 
 // FSUsername represents a username reservation stored as JSON
 type FSUsername struct {
-	NormalizedUsername string    `json:"normalized_username"` // Lowercase for lookups
-	Username           string    `json:"username"`            // Original case-preserved
+	NormalizedUsername string    `json:"normalized_username"`
+	Username           string    `json:"username"`
 	UserID             string    `json:"user_id"`
-	Version            int       `json:"version"` // For optimistic concurrency
+	Version            int       `json:"version"`
 	CreatedAt          time.Time `json:"created_at"`
 	UpdatedAt          time.Time `json:"updated_at"`
 }
 
-// FSUsernameStore implements oa.UsernameStore using filesystem storage.
-//
-// # Purpose
-//
-// Provides username uniqueness enforcement and username-based login lookup
-// using JSON files. Each username is stored as a separate file with the
-// normalized (lowercase) username as the filename.
-//
-// # File Structure
-//
-//	{StoragePath}/
-//	└── usernames/
-//	    ├── johndoe.json     # {"username": "JohnDoe", "user_id": "abc123", ...}
-//	    ├── janedoe.json     # {"username": "JaneDoe", "user_id": "xyz789", ...}
-//	    └── ...
-//
-// # Concurrency Model
-//
-// Uses optimistic locking with version numbers. The atomic file write
-// (write to temp, rename) provides basic safety, but concurrent modifications
-// to the same username should be serialized at the application level or
-// will result in last-write-wins behavior.
-//
-// # Setup
-//
-//	usernameStore := fs.NewFSUsernameStore("/var/data/myapp")
-//
-//	localAuth := &oneauth.LocalAuth{
-//	    UsernameStore: usernameStore,
-//	    SignupPolicy: &oneauth.SignupPolicy{
-//	        RequireUsername:       true,
-//	        EnforceUsernameUnique: true,
-//	    },
-//	}
+// FSUsernameStore implements accounts.UsernameStore using filesystem storage.
 type FSUsernameStore struct {
 	StoragePath string
 }
 
-// NewFSUsernameStore creates a new filesystem-backed UsernameStore
 func NewFSUsernameStore(storagePath string) *FSUsernameStore {
 	return &FSUsernameStore{StoragePath: storagePath}
 }
 
-// normalizeUsername converts username to lowercase for case-insensitive lookup
 func (s *FSUsernameStore) normalizeUsername(username string) string {
 	return strings.ToLower(username)
 }
 
-// getUsernamePath returns the file path for a username
 func (s *FSUsernameStore) getUsernamePath(normalizedUsername string) (string, error) {
-	safeName, err := safeName(normalizedUsername)
+	safe, err := safeName(normalizedUsername)
 	if err != nil {
 		return "", fmt.Errorf("invalid username: %w", err)
 	}
-	return filepath.Join(s.StoragePath, "usernames", safeName+".json"), nil
+	return filepath.Join(s.StoragePath, "usernames", safe+".json"), nil
 }
 
-// readUsername reads a username record from disk
 func (s *FSUsernameStore) readUsername(normalizedUsername string) (*FSUsername, error) {
 	path, err := s.getUsernamePath(normalizedUsername)
 	if err != nil {
@@ -85,11 +51,10 @@ func (s *FSUsernameStore) readUsername(normalizedUsername string) (*FSUsername, 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil // Not found
+			return nil, nil
 		}
 		return nil, err
 	}
-
 	var username FSUsername
 	if err := json.Unmarshal(data, &username); err != nil {
 		return nil, err
@@ -97,7 +62,6 @@ func (s *FSUsernameStore) readUsername(normalizedUsername string) (*FSUsername, 
 	return &username, nil
 }
 
-// writeUsername writes a username record to disk atomically
 func (s *FSUsernameStore) writeUsername(username *FSUsername) error {
 	path, err := s.getUsernamePath(username.NormalizedUsername)
 	if err != nil {
@@ -106,185 +70,154 @@ func (s *FSUsernameStore) writeUsername(username *FSUsername) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
-
 	data, err := json.MarshalIndent(username, "", "  ")
 	if err != nil {
 		return err
 	}
-
 	return writeAtomicFile(path, data)
 }
 
-// ReserveUsername reserves a username for a user.
-// Returns error if username is already taken by a different user.
-//
-// # Concurrency
-//
-// Uses file system as implicit lock. The atomic write (temp file + rename)
-// ensures no partial writes, but concurrent reservations of the same username
-// will result in one succeeding (the last to complete the rename).
-func (s *FSUsernameStore) ReserveUsername(username string, userID string) error {
-	normalized := s.normalizeUsername(username)
+func (s *FSUsernameStore) ReserveUsername(ctx context.Context, req *accounts.ReserveUsernameRequest) (*accounts.ReserveUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ReserveUsername: req is required")
+	}
+	normalized := s.normalizeUsername(req.Username)
 
-	// Check if it exists
 	existing, err := s.readUsername(normalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if existing != nil {
-		// Username exists - check if same user
-		if existing.UserID == userID {
-			// Same user - update the case-preserved version if different
-			if existing.Username != username {
-				existing.Username = username
+		if existing.UserID == req.UserID {
+			if existing.Username != req.Username {
+				existing.Username = req.Username
 				existing.Version++
 				existing.UpdatedAt = time.Now()
-				return s.writeUsername(existing)
+				if err := s.writeUsername(existing); err != nil {
+					return nil, err
+				}
 			}
-			return nil
+			return &accounts.ReserveUsernameResponse{}, nil
 		}
-		return fmt.Errorf("username already taken")
+		return nil, fmt.Errorf("username already taken")
 	}
 
-	// Create new reservation
 	now := time.Now()
 	record := &FSUsername{
 		NormalizedUsername: normalized,
-		Username:           username,
-		UserID:             userID,
+		Username:           req.Username,
+		UserID:             req.UserID,
 		Version:            1,
 		CreatedAt:          now,
 		UpdatedAt:          now,
 	}
-	return s.writeUsername(record)
+	if err := s.writeUsername(record); err != nil {
+		return nil, err
+	}
+	return &accounts.ReserveUsernameResponse{}, nil
 }
 
-// GetUserByUsername looks up a userID by username (case-insensitive).
-//
-// # Usage
-//
-// Called by NewCredentialsValidatorWithUsername during login when
-// user enters a username instead of email.
-func (s *FSUsernameStore) GetUserByUsername(username string) (string, error) {
-	normalized := s.normalizeUsername(username)
-
+func (s *FSUsernameStore) GetUserByUsername(ctx context.Context, req *accounts.GetUserByUsernameRequest) (*accounts.GetUserByUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserByUsername: req is required")
+	}
+	normalized := s.normalizeUsername(req.Username)
 	record, err := s.readUsername(normalized)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if record == nil {
-		return "", fmt.Errorf("username not found")
+		return nil, fmt.Errorf("username not found")
 	}
-	return record.UserID, nil
+	return &accounts.GetUserByUsernameResponse{UserID: record.UserID}, nil
 }
 
-// ReleaseUsername removes a username reservation.
-//
-// # When to Use
-//
-// Call this when:
-//   - User deletes their account
-//   - Admin removes a username (e.g., for policy violations)
-func (s *FSUsernameStore) ReleaseUsername(username string) error {
-	normalized := s.normalizeUsername(username)
+func (s *FSUsernameStore) ReleaseUsername(ctx context.Context, req *accounts.ReleaseUsernameRequest) (*accounts.ReleaseUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ReleaseUsername: req is required")
+	}
+	normalized := s.normalizeUsername(req.Username)
 	path, err := s.getUsernamePath(normalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = os.Remove(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
 	}
-	return nil
+	return &accounts.ReleaseUsernameResponse{}, nil
 }
 
-// ChangeUsername atomically changes a username using optimistic concurrency.
-// Returns error if new username is already taken.
-//
-// # Usage
-//
-// Called from a "Change Username" profile page handler.
-//
-// # Concurrency Note
-//
-// This is not fully atomic across files. In a race condition where another
-// process takes the new username between our check and creation, we attempt
-// to restore the old username. For production systems with high concurrency,
-// consider using a database-backed store instead.
-func (s *FSUsernameStore) ChangeUsername(oldUsername, newUsername, userID string) error {
-	oldNormalized := s.normalizeUsername(oldUsername)
-	newNormalized := s.normalizeUsername(newUsername)
+func (s *FSUsernameStore) ChangeUsername(ctx context.Context, req *accounts.ChangeUsernameRequest) (*accounts.ChangeUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ChangeUsername: req is required")
+	}
+	oldNormalized := s.normalizeUsername(req.OldUsername)
+	newNormalized := s.normalizeUsername(req.NewUsername)
 
-	// If same normalized username, just update the case
 	if oldNormalized == newNormalized {
 		existing, err := s.readUsername(oldNormalized)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if existing == nil {
-			return fmt.Errorf("username not found")
+			return nil, fmt.Errorf("username not found")
 		}
-		if existing.UserID != userID {
-			return fmt.Errorf("username not owned by user")
+		if existing.UserID != req.UserID {
+			return nil, fmt.Errorf("username not owned by user")
 		}
-
-		existing.Username = newUsername
+		existing.Username = req.NewUsername
 		existing.Version++
 		existing.UpdatedAt = time.Now()
-		return s.writeUsername(existing)
+		if err := s.writeUsername(existing); err != nil {
+			return nil, err
+		}
+		return &accounts.ChangeUsernameResponse{}, nil
 	}
 
-	// Different username - need to delete old and create new
-
-	// First verify old username exists and belongs to user
 	oldRecord, err := s.readUsername(oldNormalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if oldRecord == nil {
-		return fmt.Errorf("old username not found")
+		return nil, fmt.Errorf("old username not found")
 	}
-	if oldRecord.UserID != userID {
-		return fmt.Errorf("old username not owned by user")
+	if oldRecord.UserID != req.UserID {
+		return nil, fmt.Errorf("old username not owned by user")
 	}
 
-	// Check new username is available
 	newRecord, err := s.readUsername(newNormalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if newRecord != nil {
-		return fmt.Errorf("new username already taken")
+		return nil, fmt.Errorf("new username already taken")
 	}
 
-	// Delete old username file
 	oldPath, err := s.getUsernamePath(oldNormalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
-		return err
+		return nil, err
 	}
 
-	// Create new username
 	now := time.Now()
 	newRecord = &FSUsername{
 		NormalizedUsername: newNormalized,
-		Username:           newUsername,
-		UserID:             userID,
+		Username:           req.NewUsername,
+		UserID:             req.UserID,
 		Version:            1,
 		CreatedAt:          now,
 		UpdatedAt:          now,
 	}
 	if err := s.writeUsername(newRecord); err != nil {
-		// Try to restore the old username
 		oldRecord.Version++
 		oldRecord.UpdatedAt = time.Now()
-		s.writeUsername(oldRecord) // Best effort
-		return fmt.Errorf("failed to create new username: %w", err)
+		_ = s.writeUsername(oldRecord)
+		return nil, fmt.Errorf("failed to create new username: %w", err)
 	}
 
-	return nil
+	return &accounts.ChangeUsernameResponse{}, nil
 }

--- a/stores/fs/security_test.go
+++ b/stores/fs/security_test.go
@@ -64,7 +64,7 @@ func TestSecurity_PathTraversal_UserStore(t *testing.T) {
 
 	for _, tc := range maliciousInputs {
 		t.Run("CreateUser_"+tc.name, func(t *testing.T) {
-			_, err := store.CreateUser(tc.input, true, map[string]any{"name": "evil"})
+			_, err := store.CreateUser(context.Background(), &accounts.CreateUserRequest{UserID: tc.input, IsActive: true, Profile: map[string]any{"name": "evil"}})
 			assert.Error(t, err, "CreateUser should reject malicious userId %q", tc.input)
 
 			// Verify no file was created outside the storage directory
@@ -72,7 +72,7 @@ func TestSecurity_PathTraversal_UserStore(t *testing.T) {
 		})
 
 		t.Run("GetUserById_"+tc.name, func(t *testing.T) {
-			_, err := store.GetUserById(tc.input)
+			_, err := store.GetUserById(context.Background(), &accounts.GetUserByIDRequest{UserID: tc.input})
 			assert.Error(t, err, "GetUserById should reject malicious userId %q", tc.input)
 		})
 	}
@@ -125,17 +125,19 @@ func TestSecurity_PathTraversal_ChannelStore_Provider(t *testing.T) {
 
 	for _, tc := range maliciousInputs {
 		t.Run("SaveChannel_provider_"+tc.name, func(t *testing.T) {
-			err := store.SaveChannel(&accounts.Channel{
+			_, err := store.SaveChannel(context.Background(), &accounts.SaveChannelRequest{Channel: &accounts.Channel{
 				Provider:    tc.input,
 				IdentityKey: "email:test@example.com",
 				Credentials: map[string]any{},
-			})
+			}})
 			assert.Error(t, err, "SaveChannel should reject malicious provider %q", tc.input)
 			assertNoEscape(t, dir, "channels")
 		})
 
 		t.Run("GetChannel_provider_"+tc.name, func(t *testing.T) {
-			_, _, err := store.GetChannel(tc.input, "email:test@example.com", false)
+			_Resp_, err := store.GetChannel(context.Background(), &accounts.GetChannelRequest{Provider: tc.input, IdentityKey: "email:test@example.com", CreateIfMissing: false})
+	var _ *accounts.Channel
+	if _Resp_ != nil { _ = _Resp_.Channel }
 			assert.Error(t, err, "GetChannel should reject malicious provider %q", tc.input)
 		})
 	}
@@ -150,11 +152,11 @@ func TestSecurity_PathTraversal_ChannelStore_IdentityKey(t *testing.T) {
 
 	for _, tc := range maliciousInputs {
 		t.Run("SaveChannel_identityKey_"+tc.name, func(t *testing.T) {
-			err := store.SaveChannel(&accounts.Channel{
+			_, err := store.SaveChannel(context.Background(), &accounts.SaveChannelRequest{Channel: &accounts.Channel{
 				Provider:    "local",
 				IdentityKey: tc.input,
 				Credentials: map[string]any{},
-			})
+			}})
 			assert.Error(t, err, "SaveChannel should reject malicious identityKey %q", tc.input)
 		})
 	}
@@ -205,13 +207,15 @@ func TestSecurity_PathTraversal_UsernameStore(t *testing.T) {
 
 	for _, tc := range maliciousInputs {
 		t.Run("ReserveUsername_"+tc.name, func(t *testing.T) {
-			err := store.ReserveUsername(tc.input, "user123")
+			_, err := store.ReserveUsername(context.Background(), &accounts.ReserveUsernameRequest{Username: tc.input, UserID: "user123"})
 			assert.Error(t, err, "ReserveUsername should reject malicious username %q", tc.input)
 			assertNoEscape(t, dir, "usernames")
 		})
 
 		t.Run("GetUserByUsername_"+tc.name, func(t *testing.T) {
-			_, err := store.GetUserByUsername(tc.input)
+			_Resp_, err := store.GetUserByUsername(context.Background(), &accounts.GetUserByUsernameRequest{Username: tc.input})
+	var _ string
+	if _Resp_ != nil { _ = _Resp_.UserID }
 			assert.Error(t, err, "GetUserByUsername should reject malicious username %q", tc.input)
 		})
 	}
@@ -257,7 +261,7 @@ func TestSecurity_SanitizedInputs_UserStore(t *testing.T) {
 
 	for _, tc := range sanitizedInputs {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := store.CreateUser(tc.input, true, map[string]any{"name": "test"})
+			_, err := store.CreateUser(context.Background(), &accounts.CreateUserRequest{UserID: tc.input, IsActive: true, Profile: map[string]any{"name": "test"}})
 			assert.NoError(t, err, "CreateUser should accept sanitizable input %q", tc.input)
 		})
 	}
@@ -297,7 +301,7 @@ func TestSecurity_PathTraversal_IdentityStore_AlreadySafe(t *testing.T) {
 	// They return "not found" errors (not traversal), which is correct
 	for _, tc := range maliciousInputs {
 		t.Run("GetIdentity_"+tc.name, func(t *testing.T) {
-			_, _, err := store.GetIdentity("email", tc.input, false)
+			_, err := store.GetIdentity(context.Background(), &accounts.GetIdentityRequest{IdentityType: "email", IdentityValue: tc.input, CreateIfMissing: false})
 			// Should either error or return safely within storage dir
 			_ = err
 			assertNoEscape(t, dir, "identities")
@@ -335,7 +339,7 @@ func TestSecurity_DirPermissions(t *testing.T) {
 
 	// Create a user to trigger directory creation
 	userStore := NewFSUserStore(dir)
-	_, err := userStore.CreateUser("testuser", true, map[string]any{"name": "test"})
+	_, err := userStore.CreateUser(context.Background(), &accounts.CreateUserRequest{UserID: "testuser", IsActive: true, Profile: map[string]any{"name": "test"}})
 	require.NoError(t, err)
 
 	// Check the users/ directory permissions
@@ -356,7 +360,7 @@ func TestSecurity_FilePermissions(t *testing.T) {
 
 	// Create a user file
 	userStore := NewFSUserStore(dir)
-	_, err := userStore.CreateUser("testuser", true, map[string]any{"name": "test"})
+	_, err := userStore.CreateUser(context.Background(), &accounts.CreateUserRequest{UserID: "testuser", IsActive: true, Profile: map[string]any{"name": "test"}})
 	require.NoError(t, err)
 
 	// Check the file permissions

--- a/stores/gae/stores.go
+++ b/stores/gae/stores.go
@@ -80,43 +80,49 @@ func (s *UserStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
-func (s *UserStore) CreateUser(userId string, isActive bool, profile map[string]any) (accounts.User, error) {
-	key := s.namespacedKey(KindUser, userId)
+func (s *UserStore) CreateUser(ctx context.Context, req *accounts.CreateUserRequest) (*accounts.CreateUserResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateUser: req is required")
+	}
+	key := s.namespacedKey(KindUser, req.UserID)
 
 	var profileBytes []byte
-	if profile != nil {
-		profileBytes, _ = json.Marshal(profile)
+	if req.Profile != nil {
+		profileBytes, _ = json.Marshal(req.Profile)
 	}
 
 	now := time.Now()
 	entity := &UserEntity{
 		Key:       key,
-		IsActive:  isActive,
+		IsActive:  req.IsActive,
 		Profile:   profileBytes,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
 
-	if _, err := s.client.Put(s.ctx, key, entity); err != nil {
+	if _, err := s.client.Put(ctx, key, entity); err != nil {
 		return nil, err
 	}
 
-	return &GAEUser{
-		UserID:      userId,
-		Active:      isActive,
-		UserProfile: profile,
+	return &accounts.CreateUserResponse{User: &GAEUser{
+		UserID:      req.UserID,
+		Active:      req.IsActive,
+		UserProfile: req.Profile,
 		CreatedAt:   now,
 		UpdatedAt:   now,
-	}, nil
+	}}, nil
 }
 
-func (s *UserStore) GetUserById(userId string) (accounts.User, error) {
-	key := s.namespacedKey(KindUser, userId)
-	log.Println("UserStore Key: ", key, KindUser, userId)
+func (s *UserStore) GetUserById(ctx context.Context, req *accounts.GetUserByIDRequest) (*accounts.GetUserByIDResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserById: req is required")
+	}
+	key := s.namespacedKey(KindUser, req.UserID)
+	log.Println("UserStore Key: ", key, KindUser, req.UserID)
 	var entity UserEntity
-	if err := s.client.Get(s.ctx, key, &entity); err != nil {
+	if err := s.client.Get(ctx, key, &entity); err != nil {
 		if err == datastore.ErrNoSuchEntity {
-			return nil, fmt.Errorf("user not found: %s", userId)
+			return nil, fmt.Errorf("user not found: %s", req.UserID)
 		}
 		return nil, err
 	}
@@ -126,16 +132,20 @@ func (s *UserStore) GetUserById(userId string) (accounts.User, error) {
 		json.Unmarshal(entity.Profile, &profile)
 	}
 
-	return &GAEUser{
-		UserID:      userId,
+	return &accounts.GetUserByIDResponse{User: &GAEUser{
+		UserID:      req.UserID,
 		Active:      entity.IsActive,
 		UserProfile: profile,
 		CreatedAt:   entity.CreatedAt,
 		UpdatedAt:   entity.UpdatedAt,
-	}, nil
+	}}, nil
 }
 
-func (s *UserStore) SaveUser(user accounts.User) error {
+func (s *UserStore) SaveUser(ctx context.Context, req *accounts.SaveUserRequest) (*accounts.SaveUserResponse, error) {
+	if req == nil || req.User == nil {
+		return nil, fmt.Errorf("SaveUser: req.User is required")
+	}
+	user := req.User
 	key := s.namespacedKey(KindUser, user.Id())
 
 	var profileBytes []byte
@@ -143,16 +153,15 @@ func (s *UserStore) SaveUser(user accounts.User) error {
 		profileBytes, _ = json.Marshal(user.Profile())
 	}
 
-	// Get existing to preserve CreatedAt
 	var existing UserEntity
-	err := s.client.Get(s.ctx, key, &existing)
+	err := s.client.Get(ctx, key, &existing)
 	if err != nil && err != datastore.ErrNoSuchEntity {
-		return err
+		return nil, err
 	}
 
 	entity := &UserEntity{
 		Key:       key,
-		IsActive:  true, // Default to true if not specified
+		IsActive:  true,
 		Profile:   profileBytes,
 		CreatedAt: existing.CreatedAt,
 		UpdatedAt: time.Now(),
@@ -161,13 +170,14 @@ func (s *UserStore) SaveUser(user accounts.User) error {
 		entity.CreatedAt = time.Now()
 	}
 
-	// Check if user implements an isActive method via profile
 	if gaeUser, ok := user.(*GAEUser); ok {
 		entity.IsActive = gaeUser.Active
 	}
 
-	_, err = s.client.Put(s.ctx, key, entity)
-	return err
+	if _, err := s.client.Put(ctx, key, entity); err != nil {
+		return nil, err
+	}
+	return &accounts.SaveUserResponse{}, nil
 }
 
 // ============================================================================
@@ -208,66 +218,84 @@ func (s *IdentityStore) identityKeyName(idType, value string) string {
 	return idType + ":" + value
 }
 
-func (s *IdentityStore) GetIdentity(identityType, identityValue string, createIfMissing bool) (*accounts.Identity, bool, error) {
-	key := s.namespacedKey(KindIdentity, s.identityKeyName(identityType, identityValue))
+func (s *IdentityStore) GetIdentity(ctx context.Context, req *accounts.GetIdentityRequest) (*accounts.GetIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetIdentity: req is required")
+	}
+	key := s.namespacedKey(KindIdentity, s.identityKeyName(req.IdentityType, req.IdentityValue))
 	var entity IdentityEntity
-	err := s.client.Get(s.ctx, key, &entity)
+	err := s.client.Get(ctx, key, &entity)
 
 	if err == datastore.ErrNoSuchEntity {
-		if createIfMissing {
+		if req.CreateIfMissing {
 			now := time.Now()
 			entity = IdentityEntity{
 				Key:       key,
-				Type:      identityType,
-				Value:     identityValue,
+				Type:      req.IdentityType,
+				Value:     req.IdentityValue,
 				UserID:    "",
 				Verified:  false,
 				CreatedAt: now,
 				UpdatedAt: now,
 				Version:   1,
 			}
-			if _, err := s.client.Put(s.ctx, key, &entity); err != nil {
-				return nil, false, err
+			if _, err := s.client.Put(ctx, key, &entity); err != nil {
+				return nil, err
 			}
-			return entity.ToIdentity(), true, nil
+			return &accounts.GetIdentityResponse{Identity: entity.ToIdentity(), NewCreated: true}, nil
 		}
-		return nil, false, fmt.Errorf("identity not found")
+		return nil, fmt.Errorf("identity not found")
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return entity.ToIdentity(), false, nil
+	return &accounts.GetIdentityResponse{Identity: entity.ToIdentity()}, nil
 }
 
-func (s *IdentityStore) SaveIdentity(identity *accounts.Identity) error {
+func (s *IdentityStore) SaveIdentity(ctx context.Context, req *accounts.SaveIdentityRequest) (*accounts.SaveIdentityResponse, error) {
+	if req == nil || req.Identity == nil {
+		return nil, fmt.Errorf("SaveIdentity: req.Identity is required")
+	}
+	identity := req.Identity
 	key := s.namespacedKey(KindIdentity, s.identityKeyName(identity.Type, identity.Value))
 	entity := IdentityToEntity(identity, key)
-	_, err := s.client.Put(s.ctx, key, entity)
-	return err
+	if _, err := s.client.Put(ctx, key, entity); err != nil {
+		return nil, err
+	}
+	return &accounts.SaveIdentityResponse{}, nil
 }
 
-func (s *IdentityStore) SetUserForIdentity(identityType, identityValue string, newUserId string) error {
-	key := s.namespacedKey(KindIdentity, s.identityKeyName(identityType, identityValue))
+func (s *IdentityStore) SetUserForIdentity(ctx context.Context, req *accounts.SetUserForIdentityRequest) (*accounts.SetUserForIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("SetUserForIdentity: req is required")
+	}
+	key := s.namespacedKey(KindIdentity, s.identityKeyName(req.IdentityType, req.IdentityValue))
 
-	_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
+	_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 		var entity IdentityEntity
 		if err := tx.Get(key, &entity); err != nil {
 			return err
 		}
-		entity.UserID = newUserId
+		entity.UserID = req.NewUserID
 		entity.UpdatedAt = time.Now()
 		entity.Version++
 		_, err := tx.Put(key, &entity)
 		return err
 	})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &accounts.SetUserForIdentityResponse{}, nil
 }
 
-func (s *IdentityStore) MarkIdentityVerified(identityType, identityValue string) error {
-	key := s.namespacedKey(KindIdentity, s.identityKeyName(identityType, identityValue))
+func (s *IdentityStore) MarkIdentityVerified(ctx context.Context, req *accounts.MarkIdentityVerifiedRequest) (*accounts.MarkIdentityVerifiedResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("MarkIdentityVerified: req is required")
+	}
+	key := s.namespacedKey(KindIdentity, s.identityKeyName(req.IdentityType, req.IdentityValue))
 
-	_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
+	_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 		var entity IdentityEntity
 		if err := tx.Get(key, &entity); err != nil {
 			return err
@@ -278,18 +306,24 @@ func (s *IdentityStore) MarkIdentityVerified(identityType, identityValue string)
 		_, err := tx.Put(key, &entity)
 		return err
 	})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &accounts.MarkIdentityVerifiedResponse{}, nil
 }
 
-func (s *IdentityStore) GetUserIdentities(userId string) ([]*accounts.Identity, error) {
+func (s *IdentityStore) GetUserIdentities(ctx context.Context, req *accounts.GetUserIdentitiesRequest) (*accounts.GetUserIdentitiesResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserIdentities: req is required")
+	}
 	query := datastore.NewQuery(KindIdentity).
-		FilterField("user_id", "=", userId)
+		FilterField("user_id", "=", req.UserID)
 	if s.namespace != "" {
 		query = query.Namespace(s.namespace)
 	}
 
 	var identities []*accounts.Identity
-	it := s.client.Run(s.ctx, query)
+	it := s.client.Run(ctx, query)
 	for {
 		var entity IdentityEntity
 		_, err := it.Next(&entity)
@@ -301,7 +335,7 @@ func (s *IdentityStore) GetUserIdentities(userId string) ([]*accounts.Identity, 
 		}
 		identities = append(identities, entity.ToIdentity())
 	}
-	return identities, nil
+	return &accounts.GetUserIdentitiesResponse{Identities: identities}, nil
 }
 
 // ============================================================================
@@ -342,41 +376,44 @@ func (s *ChannelStore) channelKeyName(provider, identityKey string) string {
 	return provider + ":" + identityKey
 }
 
-func (s *ChannelStore) GetChannel(provider string, identityKey string, createIfMissing bool) (*accounts.Channel, bool, error) {
-	key := s.namespacedKey(KindChannel, s.channelKeyName(provider, identityKey))
+func (s *ChannelStore) GetChannel(ctx context.Context, req *accounts.GetChannelRequest) (*accounts.GetChannelResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetChannel: req is required")
+	}
+	key := s.namespacedKey(KindChannel, s.channelKeyName(req.Provider, req.IdentityKey))
 	var entity ChannelEntity
-	err := s.client.Get(s.ctx, key, &entity)
+	err := s.client.Get(ctx, key, &entity)
 
 	if err == datastore.ErrNoSuchEntity {
-		if createIfMissing {
+		if req.CreateIfMissing {
 			now := time.Now()
 			entity = ChannelEntity{
 				Key:         key,
-				Provider:    provider,
-				IdentityKey: identityKey,
+				Provider:    req.Provider,
+				IdentityKey: req.IdentityKey,
 				Credentials: nil,
 				Profile:     nil,
 				CreatedAt:   now,
 				UpdatedAt:   now,
 				Version:     1,
 			}
-			if _, err := s.client.Put(s.ctx, key, &entity); err != nil {
-				return nil, false, err
+			if _, err := s.client.Put(ctx, key, &entity); err != nil {
+				return nil, err
 			}
-			return &accounts.Channel{
-				Provider:    provider,
-				IdentityKey: identityKey,
+			return &accounts.GetChannelResponse{Channel: &accounts.Channel{
+				Provider:    req.Provider,
+				IdentityKey: req.IdentityKey,
 				Credentials: make(map[string]any),
 				Profile:     make(map[string]any),
 				CreatedAt:   now,
 				UpdatedAt:   now,
 				Version:     1,
-			}, true, nil
+			}, NewCreated: true}, nil
 		}
-		return nil, false, fmt.Errorf("channel not found")
+		return nil, fmt.Errorf("channel not found")
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	var credentials, profile map[string]any
@@ -387,7 +424,7 @@ func (s *ChannelStore) GetChannel(provider string, identityKey string, createIfM
 		json.Unmarshal(entity.Profile, &profile)
 	}
 
-	return &accounts.Channel{
+	return &accounts.GetChannelResponse{Channel: &accounts.Channel{
 		Provider:    entity.Provider,
 		IdentityKey: entity.IdentityKey,
 		Credentials: credentials,
@@ -396,10 +433,14 @@ func (s *ChannelStore) GetChannel(provider string, identityKey string, createIfM
 		UpdatedAt:   entity.UpdatedAt,
 		ExpiresAt:   entity.ExpiresAt,
 		Version:     entity.Version,
-	}, false, nil
+	}}, nil
 }
 
-func (s *ChannelStore) SaveChannel(channel *accounts.Channel) error {
+func (s *ChannelStore) SaveChannel(ctx context.Context, req *accounts.SaveChannelRequest) (*accounts.SaveChannelResponse, error) {
+	if req == nil || req.Channel == nil {
+		return nil, fmt.Errorf("SaveChannel: req.Channel is required")
+	}
+	channel := req.Channel
 	key := s.namespacedKey(KindChannel, s.channelKeyName(channel.Provider, channel.IdentityKey))
 
 	var credBytes, profileBytes []byte
@@ -410,11 +451,10 @@ func (s *ChannelStore) SaveChannel(channel *accounts.Channel) error {
 		profileBytes, _ = json.Marshal(channel.Profile)
 	}
 
-	// Get existing to preserve CreatedAt and increment Version
 	var existing ChannelEntity
-	err := s.client.Get(s.ctx, key, &existing)
+	err := s.client.Get(ctx, key, &existing)
 	if err != nil && err != datastore.ErrNoSuchEntity {
-		return err
+		return nil, err
 	}
 
 	now := time.Now()
@@ -434,19 +474,24 @@ func (s *ChannelStore) SaveChannel(channel *accounts.Channel) error {
 		entity.Version = 1
 	}
 
-	_, err = s.client.Put(s.ctx, key, entity)
-	return err
+	if _, err := s.client.Put(ctx, key, entity); err != nil {
+		return nil, err
+	}
+	return &accounts.SaveChannelResponse{}, nil
 }
 
-func (s *ChannelStore) GetChannelsByIdentity(identityKey string) ([]*accounts.Channel, error) {
+func (s *ChannelStore) GetChannelsByIdentity(ctx context.Context, req *accounts.GetChannelsByIdentityRequest) (*accounts.GetChannelsByIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetChannelsByIdentity: req is required")
+	}
 	query := datastore.NewQuery(KindChannel).
-		FilterField("identity_key", "=", identityKey)
+		FilterField("identity_key", "=", req.IdentityKey)
 	if s.namespace != "" {
 		query = query.Namespace(s.namespace)
 	}
 
 	var channels []*accounts.Channel
-	it := s.client.Run(s.ctx, query)
+	it := s.client.Run(ctx, query)
 	for {
 		var entity ChannelEntity
 		_, err := it.Next(&entity)
@@ -476,7 +521,7 @@ func (s *ChannelStore) GetChannelsByIdentity(identityKey string) ([]*accounts.Ch
 			Version:     entity.Version,
 		})
 	}
-	return channels, nil
+	return &accounts.GetChannelsByIdentityResponse{Channels: channels}, nil
 }
 
 // ============================================================================
@@ -1268,18 +1313,19 @@ func (s *UsernameStore) normalizeUsername(username string) string {
 	return strings.ToLower(username)
 }
 
-func (s *UsernameStore) ReserveUsername(username string, userID string) error {
-	normalizedUsername := s.normalizeUsername(username)
+func (s *UsernameStore) ReserveUsername(ctx context.Context, req *accounts.ReserveUsernameRequest) (*accounts.ReserveUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ReserveUsername: req is required")
+	}
+	normalizedUsername := s.normalizeUsername(req.Username)
 	key := s.namespacedKey(KindUsername, normalizedUsername)
 
-	_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
+	_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 		var existing UsernameEntity
 		err := tx.Get(key, &existing)
 		if err == nil {
-			// Username already exists
-			if existing.UserID == userID {
-				// Same user, just update the original case
-				existing.Username = username
+			if existing.UserID == req.UserID {
+				existing.Username = req.Username
 				_, err = tx.Put(key, &existing)
 				return err
 			}
@@ -1289,67 +1335,81 @@ func (s *UsernameStore) ReserveUsername(username string, userID string) error {
 			return err
 		}
 
-		// Create new username reservation
 		entity := &UsernameEntity{
 			Key:       key,
-			Username:  username,
-			UserID:    userID,
+			Username:  req.Username,
+			UserID:    req.UserID,
 			CreatedAt: time.Now(),
 		}
 		_, err = tx.Put(key, entity)
 		return err
 	})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &accounts.ReserveUsernameResponse{}, nil
 }
 
-func (s *UsernameStore) GetUserByUsername(username string) (string, error) {
-	normalizedUsername := s.normalizeUsername(username)
+func (s *UsernameStore) GetUserByUsername(ctx context.Context, req *accounts.GetUserByUsernameRequest) (*accounts.GetUserByUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserByUsername: req is required")
+	}
+	normalizedUsername := s.normalizeUsername(req.Username)
 	key := s.namespacedKey(KindUsername, normalizedUsername)
 
 	var entity UsernameEntity
-	if err := s.client.Get(s.ctx, key, &entity); err != nil {
+	if err := s.client.Get(ctx, key, &entity); err != nil {
 		if err == datastore.ErrNoSuchEntity {
-			return "", fmt.Errorf("username not found")
+			return nil, fmt.Errorf("username not found")
 		}
-		return "", err
+		return nil, err
 	}
-	return entity.UserID, nil
+	return &accounts.GetUserByUsernameResponse{UserID: entity.UserID}, nil
 }
 
-func (s *UsernameStore) ReleaseUsername(username string) error {
-	normalizedUsername := s.normalizeUsername(username)
+func (s *UsernameStore) ReleaseUsername(ctx context.Context, req *accounts.ReleaseUsernameRequest) (*accounts.ReleaseUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ReleaseUsername: req is required")
+	}
+	normalizedUsername := s.normalizeUsername(req.Username)
 	key := s.namespacedKey(KindUsername, normalizedUsername)
-	return s.client.Delete(s.ctx, key)
+	if err := s.client.Delete(ctx, key); err != nil {
+		return nil, err
+	}
+	return &accounts.ReleaseUsernameResponse{}, nil
 }
 
-func (s *UsernameStore) ChangeUsername(oldUsername, newUsername, userID string) error {
-	oldNormalized := s.normalizeUsername(oldUsername)
-	newNormalized := s.normalizeUsername(newUsername)
+func (s *UsernameStore) ChangeUsername(ctx context.Context, req *accounts.ChangeUsernameRequest) (*accounts.ChangeUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ChangeUsername: req is required")
+	}
+	oldNormalized := s.normalizeUsername(req.OldUsername)
+	newNormalized := s.normalizeUsername(req.NewUsername)
 
-	// If same normalized username, just update the case
 	if oldNormalized == newNormalized {
 		key := s.namespacedKey(KindUsername, oldNormalized)
-		_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
+		_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 			var entity UsernameEntity
 			if err := tx.Get(key, &entity); err != nil {
 				return err
 			}
-			if entity.UserID != userID {
+			if entity.UserID != req.UserID {
 				return fmt.Errorf("username not owned by user")
 			}
-			entity.Username = newUsername
+			entity.Username = req.NewUsername
 			_, err := tx.Put(key, &entity)
 			return err
 		})
-		return err
+		if err != nil {
+			return nil, err
+		}
+		return &accounts.ChangeUsernameResponse{}, nil
 	}
 
-	// Different username - need to atomically release old and reserve new
 	oldKey := s.namespacedKey(KindUsername, oldNormalized)
 	newKey := s.namespacedKey(KindUsername, newNormalized)
 
-	_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
-		// Check old username exists and belongs to user
+	_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 		var oldEntity UsernameEntity
 		if err := tx.Get(oldKey, &oldEntity); err != nil {
 			if err == datastore.ErrNoSuchEntity {
@@ -1357,11 +1417,10 @@ func (s *UsernameStore) ChangeUsername(oldUsername, newUsername, userID string) 
 			}
 			return err
 		}
-		if oldEntity.UserID != userID {
+		if oldEntity.UserID != req.UserID {
 			return fmt.Errorf("old username not owned by user")
 		}
 
-		// Check new username is available
 		var newEntity UsernameEntity
 		err := tx.Get(newKey, &newEntity)
 		if err == nil {
@@ -1371,19 +1430,21 @@ func (s *UsernameStore) ChangeUsername(oldUsername, newUsername, userID string) 
 			return err
 		}
 
-		// Delete old, create new
 		if err := tx.Delete(oldKey); err != nil {
 			return err
 		}
 
 		newEntity = UsernameEntity{
 			Key:       newKey,
-			Username:  newUsername,
-			UserID:    userID,
+			Username:  req.NewUsername,
+			UserID:    req.UserID,
 			CreatedAt: time.Now(),
 		}
 		_, err = tx.Put(newKey, &newEntity)
 		return err
 	})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &accounts.ChangeUsernameResponse{}, nil
 }

--- a/stores/gorm/kidstore_test.go
+++ b/stores/gorm/kidstore_test.go
@@ -6,6 +6,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,33 +14,27 @@ import (
 	"github.com/panyam/oneauth/kidstoretest"
 )
 
-// TestGORMKidStore runs the shared KidStorage conformance suite against
-// the GORM-backed implementation (SQLite by default, PostgreSQL when
-// ONEAUTH_TEST_PGDB is set — same env contract as TestGORMKeyStore).
 func TestGORMKidStore(t *testing.T) {
 	kidstoretest.RunAll(t, func(t *testing.T) keys.KidStorage {
 		return NewKidStore(setupTestDB(t))
 	})
 }
 
-// TestGORMKidStorePersistsAcrossInstances mirrors the FS cross-instance
-// restart test: two KidStore values over the same *gorm.DB see each
-// other's writes, proving the substrate (not just the in-memory handle)
-// holds the grace entry.
 func TestGORMKidStorePersistsAcrossInstances(t *testing.T) {
 	db := setupTestDB(t)
+	ctx := context.Background()
 
 	writer := NewKidStore(db)
-	if err := writer.Add("kid-grace", []byte("retired-secret"), "HS256", "app-1", time.Now().Add(1*time.Hour)); err != nil {
+	if _, err := writer.Add(ctx, &keys.AddKidRequest{Kid: "kid-grace", Key: []byte("retired-secret"), Algorithm: "HS256", ClientID: "app-1", ExpiresAt: time.Now().Add(1 * time.Hour)}); err != nil {
 		t.Fatalf("writer.Add failed: %v", err)
 	}
 
 	reader := NewKidStore(db)
-	rec, err := reader.GetKeyByKid("kid-grace")
+	resp, err := reader.GetKeyByKid(ctx, &keys.GetKeyByKidRequest{Kid: "kid-grace"})
 	if err != nil {
 		t.Fatalf("reader.GetKeyByKid failed: %v", err)
 	}
-	if string(rec.Key.([]byte)) != "retired-secret" {
-		t.Errorf("key material mismatch across instances: got %q", rec.Key)
+	if string(resp.Record.Key.([]byte)) != "retired-secret" {
+		t.Errorf("key material mismatch across instances: got %q", resp.Record.Key)
 	}
 }

--- a/stores/gorm/stores.go
+++ b/stores/gorm/stores.go
@@ -4,6 +4,7 @@
 package gorm
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -55,35 +56,47 @@ func NewUserStore(db *gorm.DB) *UserStore {
 	return &UserStore{db: db}
 }
 
-func (s *UserStore) CreateUser(userId string, isActive bool, profile map[string]any) (accounts.User, error) {
-	model := &UserModel{
-		ID:       userId,
-		IsActive: isActive,
-		Profile:  profile,
+func (s *UserStore) CreateUser(ctx context.Context, req *accounts.CreateUserRequest) (*accounts.CreateUserResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateUser: req is required")
 	}
-	if err := s.db.Create(model).Error; err != nil {
+	model := &UserModel{
+		ID:       req.UserID,
+		IsActive: req.IsActive,
+		Profile:  req.Profile,
+	}
+	if err := s.db.WithContext(ctx).Create(model).Error; err != nil {
 		return nil, err
 	}
-	return &GORMUser{model: model}, nil
+	return &accounts.CreateUserResponse{User: &GORMUser{model: model}}, nil
 }
 
-func (s *UserStore) GetUserById(userId string) (accounts.User, error) {
+func (s *UserStore) GetUserById(ctx context.Context, req *accounts.GetUserByIDRequest) (*accounts.GetUserByIDResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserById: req is required")
+	}
 	var model UserModel
-	if err := s.db.First(&model, "id = ?", userId).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "id = ?", req.UserID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("user not found: %s", userId)
+			return nil, fmt.Errorf("user not found: %s", req.UserID)
 		}
 		return nil, err
 	}
-	return &GORMUser{model: &model}, nil
+	return &accounts.GetUserByIDResponse{User: &GORMUser{model: &model}}, nil
 }
 
-func (s *UserStore) SaveUser(user accounts.User) error {
-	model := &UserModel{
-		ID:      user.Id(),
-		Profile: user.Profile(),
+func (s *UserStore) SaveUser(ctx context.Context, req *accounts.SaveUserRequest) (*accounts.SaveUserResponse, error) {
+	if req == nil || req.User == nil {
+		return nil, fmt.Errorf("SaveUser: req.User is required")
 	}
-	return s.db.Save(model).Error
+	model := &UserModel{
+		ID:      req.User.Id(),
+		Profile: req.User.Profile(),
+	}
+	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
+		return nil, err
+	}
+	return &accounts.SaveUserResponse{}, nil
 }
 
 // =============================================================================
@@ -99,52 +112,76 @@ func NewIdentityStore(db *gorm.DB) *IdentityStore {
 	return &IdentityStore{db: db}
 }
 
-func (s *IdentityStore) GetIdentity(identityType, identityValue string, createIfMissing bool) (*accounts.Identity, bool, error) {
+func (s *IdentityStore) GetIdentity(ctx context.Context, req *accounts.GetIdentityRequest) (*accounts.GetIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetIdentity: req is required")
+	}
 	var model IdentityModel
-	err := s.db.First(&model, "type = ? AND value = ?", identityType, identityValue).Error
+	err := s.db.WithContext(ctx).First(&model, "type = ? AND value = ?", req.IdentityType, req.IdentityValue).Error
 
 	if err == gorm.ErrRecordNotFound {
-		if createIfMissing {
+		if req.CreateIfMissing {
 			model = IdentityModel{
-				Type:     identityType,
-				Value:    identityValue,
+				Type:     req.IdentityType,
+				Value:    req.IdentityValue,
 				UserID:   "",
 				Verified: false,
 			}
-			if err := s.db.Create(&model).Error; err != nil {
-				return nil, false, err
+			if err := s.db.WithContext(ctx).Create(&model).Error; err != nil {
+				return nil, err
 			}
-			return model.ToIdentity(), true, nil
+			return &accounts.GetIdentityResponse{Identity: model.ToIdentity(), NewCreated: true}, nil
 		}
-		return nil, false, fmt.Errorf("identity not found")
+		return nil, fmt.Errorf("identity not found")
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return model.ToIdentity(), false, nil
+	return &accounts.GetIdentityResponse{Identity: model.ToIdentity()}, nil
 }
 
-func (s *IdentityStore) SaveIdentity(identity *accounts.Identity) error {
-	model := IdentityToModel(identity)
-	return s.db.Save(model).Error
+func (s *IdentityStore) SaveIdentity(ctx context.Context, req *accounts.SaveIdentityRequest) (*accounts.SaveIdentityResponse, error) {
+	if req == nil || req.Identity == nil {
+		return nil, fmt.Errorf("SaveIdentity: req.Identity is required")
+	}
+	model := IdentityToModel(req.Identity)
+	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
+		return nil, err
+	}
+	return &accounts.SaveIdentityResponse{}, nil
 }
 
-func (s *IdentityStore) SetUserForIdentity(identityType, identityValue string, newUserId string) error {
-	return s.db.Model(&IdentityModel{}).
-		Where("type = ? AND value = ?", identityType, identityValue).
-		Update("user_id", newUserId).Error
+func (s *IdentityStore) SetUserForIdentity(ctx context.Context, req *accounts.SetUserForIdentityRequest) (*accounts.SetUserForIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("SetUserForIdentity: req is required")
+	}
+	if err := s.db.WithContext(ctx).Model(&IdentityModel{}).
+		Where("type = ? AND value = ?", req.IdentityType, req.IdentityValue).
+		Update("user_id", req.NewUserID).Error; err != nil {
+		return nil, err
+	}
+	return &accounts.SetUserForIdentityResponse{}, nil
 }
 
-func (s *IdentityStore) MarkIdentityVerified(identityType, identityValue string) error {
-	return s.db.Model(&IdentityModel{}).
-		Where("type = ? AND value = ?", identityType, identityValue).
-		Update("verified", true).Error
+func (s *IdentityStore) MarkIdentityVerified(ctx context.Context, req *accounts.MarkIdentityVerifiedRequest) (*accounts.MarkIdentityVerifiedResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("MarkIdentityVerified: req is required")
+	}
+	if err := s.db.WithContext(ctx).Model(&IdentityModel{}).
+		Where("type = ? AND value = ?", req.IdentityType, req.IdentityValue).
+		Update("verified", true).Error; err != nil {
+		return nil, err
+	}
+	return &accounts.MarkIdentityVerifiedResponse{}, nil
 }
 
-func (s *IdentityStore) GetUserIdentities(userId string) ([]*accounts.Identity, error) {
+func (s *IdentityStore) GetUserIdentities(ctx context.Context, req *accounts.GetUserIdentitiesRequest) (*accounts.GetUserIdentitiesResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserIdentities: req is required")
+	}
 	var models []IdentityModel
-	if err := s.db.Where("user_id = ?", userId).Find(&models).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("user_id = ?", req.UserID).Find(&models).Error; err != nil {
 		return nil, err
 	}
 
@@ -152,7 +189,7 @@ func (s *IdentityStore) GetUserIdentities(userId string) ([]*accounts.Identity, 
 	for i, m := range models {
 		identities[i] = m.ToIdentity()
 	}
-	return identities, nil
+	return &accounts.GetUserIdentitiesResponse{Identities: identities}, nil
 }
 
 // =============================================================================
@@ -168,40 +205,52 @@ func NewChannelStore(db *gorm.DB) *ChannelStore {
 	return &ChannelStore{db: db}
 }
 
-func (s *ChannelStore) GetChannel(provider string, identityKey string, createIfMissing bool) (*accounts.Channel, bool, error) {
+func (s *ChannelStore) GetChannel(ctx context.Context, req *accounts.GetChannelRequest) (*accounts.GetChannelResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetChannel: req is required")
+	}
 	var model ChannelModel
-	err := s.db.First(&model, "provider = ? AND identity_key = ?", provider, identityKey).Error
+	err := s.db.WithContext(ctx).First(&model, "provider = ? AND identity_key = ?", req.Provider, req.IdentityKey).Error
 
 	if err == gorm.ErrRecordNotFound {
-		if createIfMissing {
+		if req.CreateIfMissing {
 			model = ChannelModel{
-				Provider:    provider,
-				IdentityKey: identityKey,
+				Provider:    req.Provider,
+				IdentityKey: req.IdentityKey,
 				Credentials: make(JSONMap),
 				Profile:     make(JSONMap),
 			}
-			if err := s.db.Create(&model).Error; err != nil {
-				return nil, false, err
+			if err := s.db.WithContext(ctx).Create(&model).Error; err != nil {
+				return nil, err
 			}
-			return model.ToChannel(), true, nil
+			return &accounts.GetChannelResponse{Channel: model.ToChannel(), NewCreated: true}, nil
 		}
-		return nil, false, fmt.Errorf("channel not found")
+		return nil, fmt.Errorf("channel not found")
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return model.ToChannel(), false, nil
+	return &accounts.GetChannelResponse{Channel: model.ToChannel()}, nil
 }
 
-func (s *ChannelStore) SaveChannel(channel *accounts.Channel) error {
-	model := ChannelToModel(channel)
-	return s.db.Save(model).Error
+func (s *ChannelStore) SaveChannel(ctx context.Context, req *accounts.SaveChannelRequest) (*accounts.SaveChannelResponse, error) {
+	if req == nil || req.Channel == nil {
+		return nil, fmt.Errorf("SaveChannel: req.Channel is required")
+	}
+	model := ChannelToModel(req.Channel)
+	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
+		return nil, err
+	}
+	return &accounts.SaveChannelResponse{}, nil
 }
 
-func (s *ChannelStore) GetChannelsByIdentity(identityKey string) ([]*accounts.Channel, error) {
+func (s *ChannelStore) GetChannelsByIdentity(ctx context.Context, req *accounts.GetChannelsByIdentityRequest) (*accounts.GetChannelsByIdentityResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetChannelsByIdentity: req is required")
+	}
 	var models []ChannelModel
-	if err := s.db.Where("identity_key = ?", identityKey).Find(&models).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("identity_key = ?", req.IdentityKey).Find(&models).Error; err != nil {
 		return nil, err
 	}
 
@@ -209,7 +258,7 @@ func (s *ChannelStore) GetChannelsByIdentity(identityKey string) ([]*accounts.Ch
 	for i, m := range models {
 		channels[i] = m.ToChannel()
 	}
-	return channels, nil
+	return &accounts.GetChannelsByIdentityResponse{Channels: channels}, nil
 }
 
 // =============================================================================
@@ -637,52 +686,50 @@ func (s *UsernameStore) normalizeUsername(username string) string {
 //
 // Uses database unique constraint on primary key. Concurrent inserts for the
 // same username will have one succeed and one fail with a constraint violation.
-func (s *UsernameStore) ReserveUsername(username string, userID string) error {
-	normalized := s.normalizeUsername(username)
+func (s *UsernameStore) ReserveUsername(ctx context.Context, req *accounts.ReserveUsernameRequest) (*accounts.ReserveUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ReserveUsername: req is required")
+	}
+	normalized := s.normalizeUsername(req.Username)
 
-	// First check if it exists
 	var existing UsernameModel
-	err := s.db.First(&existing, "normalized_username = ?", normalized).Error
+	err := s.db.WithContext(ctx).First(&existing, "normalized_username = ?", normalized).Error
 
 	if err == nil {
-		// Username exists - check if same user
-		if existing.UserID == userID {
-			// Same user - update the case-preserved version if different
-			if existing.Username != username {
-				result := s.db.Model(&UsernameModel{}).
+		if existing.UserID == req.UserID {
+			if existing.Username != req.Username {
+				result := s.db.WithContext(ctx).Model(&UsernameModel{}).
 					Where("normalized_username = ? AND version = ?", normalized, existing.Version).
 					Updates(map[string]any{
-						"username": username,
+						"username": req.Username,
 						"version":  existing.Version + 1,
 					})
 				if result.RowsAffected == 0 {
-					return fmt.Errorf("concurrent modification detected, please retry")
+					return nil, fmt.Errorf("concurrent modification detected, please retry")
 				}
 			}
-			return nil
+			return &accounts.ReserveUsernameResponse{}, nil
 		}
-		return fmt.Errorf("username already taken")
+		return nil, fmt.Errorf("username already taken")
 	}
 
 	if err != gorm.ErrRecordNotFound {
-		return err
+		return nil, err
 	}
 
-	// Create new reservation - rely on primary key constraint for uniqueness
 	model := &UsernameModel{
 		NormalizedUsername: normalized,
-		Username:           username,
-		UserID:             userID,
+		Username:           req.Username,
+		UserID:             req.UserID,
 		Version:            1,
 	}
-	if err := s.db.Create(model).Error; err != nil {
-		// Check if it's a duplicate key error (race condition)
+	if err := s.db.WithContext(ctx).Create(model).Error; err != nil {
 		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "UNIQUE") {
-			return fmt.Errorf("username already taken")
+			return nil, fmt.Errorf("username already taken")
 		}
-		return err
+		return nil, err
 	}
-	return nil
+	return &accounts.ReserveUsernameResponse{}, nil
 }
 
 // GetUserByUsername looks up a userID by username (case-insensitive).
@@ -691,29 +738,31 @@ func (s *UsernameStore) ReserveUsername(username string, userID string) error {
 //
 // Called by NewCredentialsValidatorWithUsername during login when
 // user enters a username instead of email.
-func (s *UsernameStore) GetUserByUsername(username string) (string, error) {
-	normalized := s.normalizeUsername(username)
+func (s *UsernameStore) GetUserByUsername(ctx context.Context, req *accounts.GetUserByUsernameRequest) (*accounts.GetUserByUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetUserByUsername: req is required")
+	}
+	normalized := s.normalizeUsername(req.Username)
 
 	var model UsernameModel
-	if err := s.db.First(&model, "normalized_username = ?", normalized).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "normalized_username = ?", normalized).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return "", fmt.Errorf("username not found")
+			return nil, fmt.Errorf("username not found")
 		}
-		return "", err
+		return nil, err
 	}
-	return model.UserID, nil
+	return &accounts.GetUserByUsernameResponse{UserID: model.UserID}, nil
 }
 
-// ReleaseUsername removes a username reservation.
-//
-// # When to Use
-//
-// Call this when:
-//   - User deletes their account
-//   - Admin removes a username (e.g., for policy violations)
-func (s *UsernameStore) ReleaseUsername(username string) error {
-	normalized := s.normalizeUsername(username)
-	return s.db.Delete(&UsernameModel{}, "normalized_username = ?", normalized).Error
+func (s *UsernameStore) ReleaseUsername(ctx context.Context, req *accounts.ReleaseUsernameRequest) (*accounts.ReleaseUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ReleaseUsername: req is required")
+	}
+	normalized := s.normalizeUsername(req.Username)
+	if err := s.db.WithContext(ctx).Delete(&UsernameModel{}, "normalized_username = ?", normalized).Error; err != nil {
+		return nil, err
+	}
+	return &accounts.ReleaseUsernameResponse{}, nil
 }
 
 // ChangeUsername atomically changes a username using optimistic concurrency.
@@ -727,76 +776,71 @@ func (s *UsernameStore) ReleaseUsername(username string) error {
 //
 // Uses version check to detect concurrent modifications. If another process
 // modifies the username between read and update, returns error for retry.
-func (s *UsernameStore) ChangeUsername(oldUsername, newUsername, userID string) error {
-	oldNormalized := s.normalizeUsername(oldUsername)
-	newNormalized := s.normalizeUsername(newUsername)
+func (s *UsernameStore) ChangeUsername(ctx context.Context, req *accounts.ChangeUsernameRequest) (*accounts.ChangeUsernameResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("ChangeUsername: req is required")
+	}
+	oldNormalized := s.normalizeUsername(req.OldUsername)
+	newNormalized := s.normalizeUsername(req.NewUsername)
 
-	// If same normalized username, just update the case
 	if oldNormalized == newNormalized {
 		var existing UsernameModel
-		if err := s.db.First(&existing, "normalized_username = ?", oldNormalized).Error; err != nil {
-			return fmt.Errorf("username not found")
+		if err := s.db.WithContext(ctx).First(&existing, "normalized_username = ?", oldNormalized).Error; err != nil {
+			return nil, fmt.Errorf("username not found")
 		}
-		if existing.UserID != userID {
-			return fmt.Errorf("username not owned by user")
+		if existing.UserID != req.UserID {
+			return nil, fmt.Errorf("username not owned by user")
 		}
 
-		result := s.db.Model(&UsernameModel{}).
+		result := s.db.WithContext(ctx).Model(&UsernameModel{}).
 			Where("normalized_username = ? AND version = ?", oldNormalized, existing.Version).
 			Updates(map[string]any{
-				"username": newUsername,
+				"username": req.NewUsername,
 				"version":  existing.Version + 1,
 			})
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("concurrent modification detected, please retry")
+			return nil, fmt.Errorf("concurrent modification detected, please retry")
 		}
-		return nil
+		return &accounts.ChangeUsernameResponse{}, nil
 	}
 
-	// Different username - need to delete old and create new
-
-	// First verify old username exists and belongs to user
 	var oldModel UsernameModel
-	if err := s.db.First(&oldModel, "normalized_username = ?", oldNormalized).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&oldModel, "normalized_username = ?", oldNormalized).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return fmt.Errorf("old username not found")
+			return nil, fmt.Errorf("old username not found")
 		}
-		return err
+		return nil, err
 	}
-	if oldModel.UserID != userID {
-		return fmt.Errorf("old username not owned by user")
+	if oldModel.UserID != req.UserID {
+		return nil, fmt.Errorf("old username not owned by user")
 	}
 
-	// Check new username is available
 	var newModel UsernameModel
-	err := s.db.First(&newModel, "normalized_username = ?", newNormalized).Error
+	err := s.db.WithContext(ctx).First(&newModel, "normalized_username = ?", newNormalized).Error
 	if err == nil {
-		return fmt.Errorf("new username already taken")
+		return nil, fmt.Errorf("new username already taken")
 	}
 	if err != gorm.ErrRecordNotFound {
-		return err
+		return nil, err
 	}
 
-	// Delete old with version check
-	result := s.db.Where("normalized_username = ? AND version = ?", oldNormalized, oldModel.Version).
+	result := s.db.WithContext(ctx).Where("normalized_username = ? AND version = ?", oldNormalized, oldModel.Version).
 		Delete(&UsernameModel{})
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("concurrent modification detected, please retry")
+		return nil, fmt.Errorf("concurrent modification detected, please retry")
 	}
 
-	// Create new - rely on primary key constraint
 	newModel = UsernameModel{
 		NormalizedUsername: newNormalized,
-		Username:           newUsername,
-		UserID:             userID,
+		Username:           req.NewUsername,
+		UserID:             req.UserID,
 		Version:            1,
 	}
-	if err := s.db.Create(&newModel).Error; err != nil {
-		// Race condition - someone else took the username. Re-create the old one.
+	if err := s.db.WithContext(ctx).Create(&newModel).Error; err != nil {
 		oldModel.Version++
-		s.db.Create(&oldModel) // Best effort to restore
-		return fmt.Errorf("new username already taken")
+		_ = s.db.WithContext(ctx).Create(&oldModel)
+		return nil, fmt.Errorf("new username already taken")
 	}
 
-	return nil
+	return &accounts.ChangeUsernameResponse{}, nil
 }


### PR DESCRIPTION
Second slice of #204. Same pattern as 204a but for the `accounts/` store interfaces (User / Identity / Channel / Username). All tests green.

## What changes

15 methods across 4 interfaces migrated to `(ctx, *XRequest) → (*XResponse, error)`:

- `UserStore`: `CreateUser`, `GetUserById`, `SaveUser`
- `IdentityStore`: `GetIdentity`, `SaveIdentity`, `SetUserForIdentity`, `MarkIdentityVerified`, `GetUserIdentities`
- `ChannelStore`: `GetChannel`, `SaveChannel`, `GetChannelsByIdentity`
- `UsernameStore`: `ReserveUsername`, `GetUserByUsername`, `ReleaseUsername`, `ChangeUsername`

The 3-return-value `GetIdentity` / `GetChannel` collapse to 2-return-value, with `NewCreated bool` on the response struct.

**No aliases** — clean break, same convention as 204a. The GAE backends' `WithContext()` workaround is gone (ctx is now a method parameter).

## Backends migrated

- `stores/fs/{fsuser_store,fsidentity_store,fschannel_store,fsusername_store}.go`
- `stores/gorm/stores.go` (User/Identity/Channel/Username sections)
- `stores/gae/stores.go` (User/Identity/Channel/Username sections)

## Consumers migrated

- `localauth/{helpers,local,signup}.go`
- `federatedauth/{callback,ensure_user}.go`
- Tests across `apiauth/`, `localauth/`, `stores/fs/`

## Verification

- `make test` — all packages green
- `make e2e` (race detector) — green
- Root build + all sub-modules build clean

## Reviewer's guide

1. [accounts/stores.go](https://github.com/panyam/oneauth/pull/221/files#diff-dada5bfe5b94c7e83bc20ef62204923f6bc220810dabf81322395e18200f321d) — start here. New Request/Response types + interface signatures.
2. [stores/fs/fsuser_store.go](https://github.com/panyam/oneauth/pull/221/files#diff-b2b976d66de1adbde823da3ae4731d063896613cfc9c0329bdb54385717b0784) — pick one backend as the worked example; the other 3 backends follow the identical pattern.
3. [localauth/helpers.go](https://github.com/panyam/oneauth/pull/221/files#diff-63b8b2f5e5f3a278e30e87b8c0049b801ee94b76acfdb4b669e8dea1390f9424) — consumer side. Shows the pattern for unwrapping `*GetUserByIDResponse` / `*GetIdentityResponse` / `*GetChannelResponse`.
4. `federatedauth/{callback,ensure_user}.go` — second consumer cluster, same pattern.

Skim: every `_test.go` is mechanical caller migration.

## Out of scope

- Other store interfaces — tracked as #204c (core RefreshToken/APIKey) and #204d (admin AppRegistrationStore + localauth VerificationTokenStore).
- Tag — v0.1.8 after merge (alongside whatever else lands).
