### PR TITLE
refactor(admin,localauth): migrate AppRegistrationStore + VerificationTokenStore to (ctx, *Req) shape (#204d)

### DIFF
--- a/admin/appstore.go
+++ b/admin/appstore.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"errors"
 	"sync"
 )
@@ -8,6 +9,40 @@ import (
 // ErrAppNotFound is returned by AppRegistrationStore.GetApp and DeleteApp
 // when the requested client_id does not exist.
 var ErrAppNotFound = errors.New("app registration not found")
+
+// SaveAppRequest carries the registration to persist.
+type SaveAppRequest struct {
+	App *AppRegistration
+}
+
+// SaveAppResponse is empty; SaveApp returns only an error signal.
+type SaveAppResponse struct{}
+
+// GetAppRequest carries the client_id to look up.
+type GetAppRequest struct {
+	ClientID string
+}
+
+// GetAppResponse wraps the requested registration.
+type GetAppResponse struct {
+	App *AppRegistration
+}
+
+// ListAppsRequest is empty; ListApps takes no parameters.
+type ListAppsRequest struct{}
+
+// ListAppsResponse wraps every registration in the store. Order is unspecified.
+type ListAppsResponse struct {
+	Apps []*AppRegistration
+}
+
+// DeleteAppRequest carries the client_id to remove.
+type DeleteAppRequest struct {
+	ClientID string
+}
+
+// DeleteAppResponse is empty; DeleteApp returns only an error signal.
+type DeleteAppResponse struct{}
 
 // AppRegistrationStore persists app registration metadata.
 //
@@ -18,18 +53,18 @@ var ErrAppNotFound = errors.New("app registration not found")
 // Backends: InMemoryAppStore (admin/), FSAppStore (stores/fs/, see issue #166),
 // GORMAppStore (stores/gorm/, see issue #167).
 type AppRegistrationStore interface {
-	// SaveApp inserts or replaces the registration for app.ClientID.
-	SaveApp(app *AppRegistration) error
+	// SaveApp inserts or replaces the registration for req.App.ClientID.
+	SaveApp(ctx context.Context, req *SaveAppRequest) (*SaveAppResponse, error)
 
-	// GetApp returns the registration for clientID, or ErrAppNotFound.
-	GetApp(clientID string) (*AppRegistration, error)
+	// GetApp returns the registration for req.ClientID, or ErrAppNotFound.
+	GetApp(ctx context.Context, req *GetAppRequest) (*GetAppResponse, error)
 
 	// ListApps returns every registration in the store. Order is unspecified.
-	ListApps() ([]*AppRegistration, error)
+	ListApps(ctx context.Context, req *ListAppsRequest) (*ListAppsResponse, error)
 
-	// DeleteApp removes the registration for clientID. Returns ErrAppNotFound
+	// DeleteApp removes the registration for req.ClientID. Returns ErrAppNotFound
 	// if no such registration exists.
-	DeleteApp(clientID string) error
+	DeleteApp(ctx context.Context, req *DeleteAppRequest) (*DeleteAppResponse, error)
 }
 
 // InMemoryAppStore is a process-local AppRegistrationStore. State is lost on
@@ -45,29 +80,32 @@ func NewInMemoryAppStore() *InMemoryAppStore {
 	return &InMemoryAppStore{apps: make(map[string]*AppRegistration)}
 }
 
-func (s *InMemoryAppStore) SaveApp(app *AppRegistration) error {
-	if app == nil || app.ClientID == "" {
-		return errors.New("AppRegistration.ClientID required")
+func (s *InMemoryAppStore) SaveApp(ctx context.Context, req *SaveAppRequest) (*SaveAppResponse, error) {
+	if req == nil || req.App == nil || req.App.ClientID == "" {
+		return nil, errors.New("AppRegistration.ClientID required")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	clone := *app
-	s.apps[app.ClientID] = &clone
-	return nil
+	clone := *req.App
+	s.apps[req.App.ClientID] = &clone
+	return &SaveAppResponse{}, nil
 }
 
-func (s *InMemoryAppStore) GetApp(clientID string) (*AppRegistration, error) {
+func (s *InMemoryAppStore) GetApp(ctx context.Context, req *GetAppRequest) (*GetAppResponse, error) {
+	if req == nil {
+		return nil, errors.New("GetApp: req is required")
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	app, ok := s.apps[clientID]
+	app, ok := s.apps[req.ClientID]
 	if !ok {
 		return nil, ErrAppNotFound
 	}
 	clone := *app
-	return &clone, nil
+	return &GetAppResponse{App: &clone}, nil
 }
 
-func (s *InMemoryAppStore) ListApps() ([]*AppRegistration, error) {
+func (s *InMemoryAppStore) ListApps(ctx context.Context, req *ListAppsRequest) (*ListAppsResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]*AppRegistration, 0, len(s.apps))
@@ -75,15 +113,18 @@ func (s *InMemoryAppStore) ListApps() ([]*AppRegistration, error) {
 		clone := *app
 		out = append(out, &clone)
 	}
-	return out, nil
+	return &ListAppsResponse{Apps: out}, nil
 }
 
-func (s *InMemoryAppStore) DeleteApp(clientID string) error {
+func (s *InMemoryAppStore) DeleteApp(ctx context.Context, req *DeleteAppRequest) (*DeleteAppResponse, error) {
+	if req == nil {
+		return nil, errors.New("DeleteApp: req is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.apps[clientID]; !ok {
-		return ErrAppNotFound
+	if _, ok := s.apps[req.ClientID]; !ok {
+		return nil, ErrAppNotFound
 	}
-	delete(s.apps, clientID)
-	return nil
+	delete(s.apps, req.ClientID)
+	return &DeleteAppResponse{}, nil
 }

--- a/admin/client_admin_test.go
+++ b/admin/client_admin_test.go
@@ -41,9 +41,9 @@ func TestClientRegistrar_Register_DirectInvocation(t *testing.T) {
 	assert.Contains(t, got.RegistrationClientURI, "https://issuer.example/apps/dcr/")
 
 	// Persisted: the same client_id is retrievable from the store directly.
-	stored, err := store.GetApp(got.ClientID)
+	stored, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: got.ClientID})
 	require.NoError(t, err)
-	assert.Equal(t, "Direct Invoke", stored.ClientName)
+	assert.Equal(t, "Direct Invoke", stored.App.ClientName)
 }
 
 // TestClientRegistrar_RegisterLegacy_DirectInvocation verifies the proprietary
@@ -65,9 +65,9 @@ func TestClientRegistrar_RegisterLegacy_DirectInvocation(t *testing.T) {
 	assert.Equal(t, 50, resp.MaxRooms, "OneAuth-specific quota field surfaced")
 	assert.Equal(t, 2.5, resp.MaxMsgRate)
 
-	stored, err := store.GetApp(resp.ClientID)
+	stored, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: resp.ClientID})
 	require.NoError(t, err)
-	assert.Equal(t, 50, stored.MaxRooms, "quota persisted on AppRegistration")
+	assert.Equal(t, 50, stored.App.MaxRooms, "quota persisted on AppRegistration")
 }
 
 // TestClientRegistrar_RegisterLegacy_AsymmetricRequiresPublicKey verifies the
@@ -135,7 +135,7 @@ func TestClientRegistrar_DeleteClient_RemovesFromStoreAndKeyStore(t *testing.T) 
 	require.NoError(t, err)
 
 	// Store side: gone.
-	if _, err := store.GetApp(clientID); !errors.Is(err, admin.ErrAppNotFound) {
+	if _, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: clientID}); !errors.Is(err, admin.ErrAppNotFound) {
 		t.Errorf("store should report ErrAppNotFound after DeleteClient, got %v", err)
 	}
 	// KeyStore side: gone.

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -104,8 +104,8 @@ func NewAppRegistrarWithStore(keyStore keys.KeyStorage, auth AdminAuth, store Ap
 		Store:    store,
 		apps:     make(map[string]*AppRegistration),
 	}
-	if existing, err := store.ListApps(); err == nil {
-		for _, app := range existing {
+	if existing, err := store.ListApps(context.Background(), &ListAppsRequest{}); err == nil && existing != nil {
+		for _, app := range existing.Apps {
 			clone := *app
 			r.apps[app.ClientID] = &clone
 		}
@@ -222,7 +222,7 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 		RegistrationAccessToken:   regAccessToken,
 		RegistrationClientURI:     regClientURI,
 	}
-	if err := h.SaveRegistration(reg); err != nil {
+	if err := h.SaveRegistration(ctx, reg); err != nil {
 		return nil, fmt.Errorf("persist registration: %w", err)
 	}
 
@@ -292,7 +292,7 @@ func (h *AppRegistrar) RegisterLegacy(ctx context.Context, req *RegisterLegacyRe
 		MaxMsgRate:   req.MaxMsgRate,
 		CreatedAt:    time.Now(),
 	}
-	if err := h.SaveRegistration(reg); err != nil {
+	if err := h.SaveRegistration(ctx, reg); err != nil {
 		return nil, fmt.Errorf("persist registration: %w", err)
 	}
 	resp.CreatedAt = reg.CreatedAt
@@ -351,7 +351,7 @@ func (h *AppRegistrar) DeleteClient(ctx context.Context, req *DeleteClientReques
 	// Persist the deletion before invalidating the cache or credentials —
 	// same ordering as DeleteRegistration so a store error leaves the
 	// registration intact and the call retryable.
-	if err := h.Store.DeleteApp(req.ClientID); err != nil && err != ErrAppNotFound {
+	if _, err := h.Store.DeleteApp(ctx, &DeleteAppRequest{ClientID: req.ClientID}); err != nil && err != ErrAppNotFound {
 		return nil, fmt.Errorf("delete registration: %w", err)
 	}
 
@@ -458,8 +458,8 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 // in-memory cache. Used by handleRegister, DCRHandler, and (in #157) the
 // RFC 7592 management endpoints. If the store write fails, the cache is
 // not updated and the error is returned.
-func (h *AppRegistrar) SaveRegistration(reg *AppRegistration) error {
-	if err := h.Store.SaveApp(reg); err != nil {
+func (h *AppRegistrar) SaveRegistration(ctx context.Context, reg *AppRegistration) error {
+	if _, err := h.Store.SaveApp(ctx, &SaveAppRequest{App: reg}); err != nil {
 		return err
 	}
 	h.mu.Lock()
@@ -489,10 +489,11 @@ func (h *AppRegistrar) GetRegistration(ctx context.Context, req *GetRegistration
 	if req == nil || req.ClientID == "" || req.AccessToken == "" {
 		return nil, ErrUnauthorized
 	}
-	reg, err := h.Store.GetApp(req.ClientID)
-	if err != nil || reg == nil {
+	getResp, err := h.Store.GetApp(ctx, &GetAppRequest{ClientID: req.ClientID})
+	if err != nil || getResp == nil || getResp.App == nil {
 		return nil, ErrUnauthorized
 	}
+	reg := getResp.App
 	if reg.RegistrationAccessToken == "" {
 		return nil, ErrUnauthorized
 	}
@@ -544,10 +545,11 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	if req == nil || req.ClientID == "" || req.AccessToken == "" || req.Metadata == nil {
 		return nil, ErrUnauthorized
 	}
-	reg, err := h.Store.GetApp(req.ClientID)
-	if err != nil || reg == nil {
+	getResp, err := h.Store.GetApp(ctx, &GetAppRequest{ClientID: req.ClientID})
+	if err != nil || getResp == nil || getResp.App == nil {
 		return nil, ErrUnauthorized
 	}
+	reg := getResp.App
 	if reg.RegistrationAccessToken == "" {
 		return nil, ErrUnauthorized
 	}
@@ -584,7 +586,7 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	reg.ClientDomain = domain
 	reg.RegistrationAccessToken = newToken
 
-	if err := h.SaveRegistration(reg); err != nil {
+	if err := h.SaveRegistration(ctx, reg); err != nil {
 		return nil, err
 	}
 	return &UpdateRegistrationResponse{
@@ -624,10 +626,11 @@ func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegist
 	if req == nil || req.ClientID == "" || req.AccessToken == "" {
 		return nil, ErrUnauthorized
 	}
-	reg, err := h.Store.GetApp(req.ClientID)
-	if err != nil || reg == nil {
+	getResp, err := h.Store.GetApp(ctx, &GetAppRequest{ClientID: req.ClientID})
+	if err != nil || getResp == nil || getResp.App == nil {
 		return nil, ErrUnauthorized
 	}
+	reg := getResp.App
 	if reg.RegistrationAccessToken == "" {
 		return nil, ErrUnauthorized
 	}
@@ -639,7 +642,7 @@ func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegist
 	// and KeyStore intact so the client retains a known-consistent state
 	// and the caller can retry; otherwise we'd leave dangling key material
 	// without a registration to bind it.
-	if err := h.Store.DeleteApp(req.ClientID); err != nil && err != ErrAppNotFound {
+	if _, err := h.Store.DeleteApp(ctx, &DeleteAppRequest{ClientID: req.ClientID}); err != nil && err != ErrAppNotFound {
 		return nil, err
 	}
 

--- a/admin/registrar_store_test.go
+++ b/admin/registrar_store_test.go
@@ -7,6 +7,7 @@ package admin_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -23,18 +24,19 @@ import (
 // the registrar over the same store is the in-process simulation of restart.
 func TestAppRegistrar_HydratesFromStore(t *testing.T) {
 	store := admin.NewInMemoryAppStore()
-	store.SaveApp(&admin.AppRegistration{
+	ctx := context.Background()
+	store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{
 		ClientID:     "app_pre_existing",
 		ClientDomain: "example.com",
 		SigningAlg:   "HS256",
 		CreatedAt:    time.Now(),
-	})
-	store.SaveApp(&admin.AppRegistration{
+	}})
+	store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{
 		ClientID:   "app_revoked",
 		SigningAlg: "RS256",
 		Revoked:    true,
 		CreatedAt:  time.Now(),
-	})
+	}})
 
 	ks := keys.NewInMemoryKeyStore()
 	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
@@ -71,16 +73,17 @@ func TestAppRegistrar_SaveRegistration_PersistsToStore(t *testing.T) {
 		SigningAlg:   "HS256",
 		CreatedAt:    time.Now(),
 	}
-	if err := reg.SaveRegistration(app); err != nil {
+	ctx := context.Background()
+	if err := reg.SaveRegistration(ctx, app); err != nil {
 		t.Fatalf("SaveRegistration: %v", err)
 	}
 
-	got, err := store.GetApp("app_via_save")
+	got, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: "app_via_save"})
 	if err != nil {
 		t.Fatalf("store.GetApp: %v", err)
 	}
-	if got.ClientDomain != "save.example" {
-		t.Errorf("ClientDomain=%q, want save.example", got.ClientDomain)
+	if got.App.ClientDomain != "save.example" {
+		t.Errorf("ClientDomain=%q, want save.example", got.App.ClientDomain)
 	}
 }
 
@@ -106,12 +109,12 @@ func TestAppRegistrar_HandleRegister_PersistsToStore(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	got, err := store.GetApp(resp.ClientID)
+	got, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: resp.ClientID})
 	if err != nil {
 		t.Fatalf("store.GetApp(%s): %v", resp.ClientID, err)
 	}
-	if got.ClientDomain != "register.example" {
-		t.Errorf("ClientDomain=%q, want register.example", got.ClientDomain)
+	if got.App.ClientDomain != "register.example" {
+		t.Errorf("ClientDomain=%q, want register.example", got.App.ClientDomain)
 	}
 }
 
@@ -143,7 +146,7 @@ func TestAppRegistrar_HandleDeleteApp_PersistsDeletion(t *testing.T) {
 		t.Fatalf("delete: status=%d body=%s", delRR.Code, delRR.Body.String())
 	}
 
-	if _, err := store.GetApp(registered.ClientID); err != admin.ErrAppNotFound {
+	if _, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: registered.ClientID}); err != admin.ErrAppNotFound {
 		t.Errorf("store should not contain deleted app, got err=%v", err)
 	}
 }
@@ -175,10 +178,11 @@ func TestDCR_PersistsViaRegistrar(t *testing.T) {
 	}
 	json.Unmarshal(rr.Body.Bytes(), &resp)
 
-	got, err := store.GetApp(resp.ClientID)
+	getResp, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: resp.ClientID})
 	if err != nil {
 		t.Fatalf("store.GetApp(%s): %v", resp.ClientID, err)
 	}
+	got := getResp.App
 	if got.ClientName != "DCR Test App" {
 		t.Errorf("ClientName=%q, want DCR Test App", got.ClientName)
 	}

--- a/apiauth/auth_flows_test.go
+++ b/apiauth/auth_flows_test.go
@@ -254,10 +254,11 @@ func TestEmailVerificationFlow(t *testing.T) {
 	testEmail := "verify@example.com"
 
 	// Create a verification token
-	token, err := tokenStore.CreateToken("testuser123", testEmail, localauth.VerificationTypeEmail, 24*time.Hour)
+	tokenResp, err := tokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "testuser123", Email: testEmail, Type: localauth.VerificationTypeEmail, ExpiryDuration: 24*time.Hour})
 	if err != nil {
 		t.Fatalf("Failed to create token: %v", err)
 	}
+	token := tokenResp.Token
 
 	// Create identity (unverified)
 	identity := &accounts.Identity{
@@ -378,10 +379,11 @@ func TestPasswordResetFlow(t *testing.T) {
 	})
 
 	// Create a reset token manually for testing
-	resetToken, err := tokenStore.CreateToken("", testEmail, localauth.VerificationTypePasswordReset, 1*time.Hour)
+	resetTokenResp, err := tokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: testEmail, Type: localauth.VerificationTypePasswordReset, ExpiryDuration: 1*time.Hour})
 	if err != nil {
 		t.Fatalf("Failed to create reset token: %v", err)
 	}
+	resetToken := resetTokenResp.Token
 
 	t.Run("reset password with valid token", func(t *testing.T) {
 		form := url.Values{}
@@ -430,10 +432,11 @@ func TestPasswordResetFlow(t *testing.T) {
 
 	t.Run("reset password with weak password", func(t *testing.T) {
 		// Create new token for this test
-		newToken, err := tokenStore.CreateToken("", testEmail, localauth.VerificationTypePasswordReset, 1*time.Hour)
+		newTokenResp, err := tokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: testEmail, Type: localauth.VerificationTypePasswordReset, ExpiryDuration: 1*time.Hour})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		newToken := newTokenResp.Token
 
 		form := url.Values{}
 		form.Set("token", newToken.Token)

--- a/appstoretest/appstoretest.go
+++ b/appstoretest/appstoretest.go
@@ -4,6 +4,7 @@
 package appstoretest
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
@@ -27,6 +28,22 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("AllFieldsRoundTrip", func(t *testing.T) { TestAllFieldsRoundTrip(t, factory) })
 }
 
+func saveApp(t *testing.T, s admin.AppRegistrationStore, app *admin.AppRegistration) {
+	t.Helper()
+	if _, err := s.SaveApp(context.Background(), &admin.SaveAppRequest{App: app}); err != nil {
+		t.Fatalf("SaveApp failed: %v", err)
+	}
+}
+
+func getApp(t *testing.T, s admin.AppRegistrationStore, clientID string) (*admin.AppRegistration, error) {
+	t.Helper()
+	resp, err := s.GetApp(context.Background(), &admin.GetAppRequest{ClientID: clientID})
+	if err != nil {
+		return nil, err
+	}
+	return resp.App, nil
+}
+
 // TestSaveAndGet verifies that SaveApp followed by GetApp returns the saved registration.
 func TestSaveAndGet(t *testing.T, factory Factory) {
 	s := factory(t)
@@ -38,11 +55,9 @@ func TestSaveAndGet(t *testing.T, factory Factory) {
 		CreatedAt:    time.Now().UTC().Truncate(time.Second),
 	}
 
-	if err := s.SaveApp(app); err != nil {
-		t.Fatalf("SaveApp failed: %v", err)
-	}
+	saveApp(t, s, app)
 
-	got, err := s.GetApp("app_abc")
+	got, err := getApp(t, s, "app_abc")
 	if err != nil {
 		t.Fatalf("GetApp failed: %v", err)
 	}
@@ -61,7 +76,7 @@ func TestSaveAndGet(t *testing.T, factory Factory) {
 func TestNotFound(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	_, err := s.GetApp("does-not-exist")
+	_, err := s.GetApp(context.Background(), &admin.GetAppRequest{ClientID: "does-not-exist"})
 	if err != admin.ErrAppNotFound {
 		t.Errorf("expected ErrAppNotFound, got %v", err)
 	}
@@ -73,15 +88,13 @@ func TestDeleteApp(t *testing.T, factory Factory) {
 	s := factory(t)
 
 	app := &admin.AppRegistration{ClientID: "app_del", SigningAlg: "HS256", CreatedAt: time.Now()}
-	if err := s.SaveApp(app); err != nil {
-		t.Fatalf("SaveApp failed: %v", err)
-	}
+	saveApp(t, s, app)
 
-	if err := s.DeleteApp("app_del"); err != nil {
+	if _, err := s.DeleteApp(context.Background(), &admin.DeleteAppRequest{ClientID: "app_del"}); err != nil {
 		t.Fatalf("DeleteApp failed: %v", err)
 	}
 
-	if _, err := s.GetApp("app_del"); err != admin.ErrAppNotFound {
+	if _, err := s.GetApp(context.Background(), &admin.GetAppRequest{ClientID: "app_del"}); err != admin.ErrAppNotFound {
 		t.Errorf("expected ErrAppNotFound after delete, got %v", err)
 	}
 }
@@ -91,7 +104,7 @@ func TestDeleteApp(t *testing.T, factory Factory) {
 func TestDeleteNonexistent(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	err := s.DeleteApp("never-existed")
+	_, err := s.DeleteApp(context.Background(), &admin.DeleteAppRequest{ClientID: "never-existed"})
 	if err != admin.ErrAppNotFound {
 		t.Errorf("expected ErrAppNotFound, got %v", err)
 	}
@@ -105,14 +118,10 @@ func TestOverwriteApp(t *testing.T, factory Factory) {
 	original := &admin.AppRegistration{ClientID: "app_ow", ClientDomain: "old.example", SigningAlg: "HS256", CreatedAt: time.Now()}
 	updated := &admin.AppRegistration{ClientID: "app_ow", ClientDomain: "new.example", SigningAlg: "RS256", CreatedAt: time.Now()}
 
-	if err := s.SaveApp(original); err != nil {
-		t.Fatalf("SaveApp original failed: %v", err)
-	}
-	if err := s.SaveApp(updated); err != nil {
-		t.Fatalf("SaveApp updated failed: %v", err)
-	}
+	saveApp(t, s, original)
+	saveApp(t, s, updated)
 
-	got, err := s.GetApp("app_ow")
+	got, err := getApp(t, s, "app_ow")
 	if err != nil {
 		t.Fatalf("GetApp failed: %v", err)
 	}
@@ -129,15 +138,14 @@ func TestListApps(t *testing.T, factory Factory) {
 	s := factory(t)
 
 	for _, id := range []string{"app_alpha", "app_beta", "app_gamma"} {
-		if err := s.SaveApp(&admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
-			t.Fatalf("SaveApp %s failed: %v", id, err)
-		}
+		saveApp(t, s, &admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()})
 	}
 
-	apps, err := s.ListApps()
+	listResp, err := s.ListApps(context.Background(), &admin.ListAppsRequest{})
 	if err != nil {
 		t.Fatalf("ListApps failed: %v", err)
 	}
+	apps := listResp.Apps
 	if len(apps) != 3 {
 		t.Fatalf("expected 3 apps, got %d", len(apps))
 	}
@@ -160,12 +168,12 @@ func TestListApps(t *testing.T, factory Factory) {
 func TestListAppsEmpty(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	apps, err := s.ListApps()
+	listResp, err := s.ListApps(context.Background(), &admin.ListAppsRequest{})
 	if err != nil {
 		t.Fatalf("ListApps failed: %v", err)
 	}
-	if len(apps) != 0 {
-		t.Errorf("expected 0 apps, got %d", len(apps))
+	if len(listResp.Apps) != 0 {
+		t.Errorf("expected 0 apps, got %d", len(listResp.Apps))
 	}
 }
 
@@ -176,11 +184,9 @@ func TestPersistence(t *testing.T, factory Factory) {
 	s := factory(t)
 
 	app := &admin.AppRegistration{ClientID: "app_persist", ClientDomain: "p.example", SigningAlg: "HS256", CreatedAt: time.Now()}
-	if err := s.SaveApp(app); err != nil {
-		t.Fatalf("SaveApp failed: %v", err)
-	}
+	saveApp(t, s, app)
 
-	got, err := s.GetApp("app_persist")
+	got, err := getApp(t, s, "app_persist")
 	if err != nil {
 		t.Fatalf("GetApp after save failed: %v", err)
 	}
@@ -215,11 +221,9 @@ func TestAllFieldsRoundTrip(t *testing.T, factory Factory) {
 		RegistrationClientURI:     "https://issuer.example/apps/dcr/app_full",
 	}
 
-	if err := s.SaveApp(app); err != nil {
-		t.Fatalf("SaveApp failed: %v", err)
-	}
+	saveApp(t, s, app)
 
-	got, err := s.GetApp("app_full")
+	got, err := getApp(t, s, "app_full")
 	if err != nil {
 		t.Fatalf("GetApp failed: %v", err)
 	}

--- a/keys/kid_test.go
+++ b/keys/kid_test.go
@@ -89,16 +89,20 @@ func TestMintResourceTokenWithKey_RSA_HasKid(t *testing.T) {
 }
 
 func TestCreateAccessToken_HasKid(t *testing.T) {
-	auth := &apiauth.APIAuth{
-		JWTSecretKey: "my-secret",
-	}
-	tokenStr, _, err := auth.CreateAccessToken("user-1", []string{"read"}, nil)
+	issuer := apiauth.NewJWTIssuer(apiauth.JWTIssuerConfig{
+		SigningKey: []byte("my-secret"),
+		SigningAlg: "HS256",
+	})
+	resp, err := issuer.CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{
+		Subject: "user-1",
+		Scopes:  []string{"read"},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	parser := jwt.NewParser()
-	parsed, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	parsed, _, err := parser.ParseUnverified(resp.Token, jwt.MapClaims{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/localauth/helpers.go
+++ b/localauth/helpers.go
@@ -136,10 +136,11 @@ func NewCredentialsValidator(identityStore accounts.IdentityStore, channelStore 
 func NewVerifyEmailFunc(identityStore accounts.IdentityStore, tokenStore VerificationTokenStore) VerifyEmailFunc {
 	return func(token string) error {
 		ctx := context.Background()
-		verToken, err := tokenStore.GetToken(token)
+		getResp, err := tokenStore.GetToken(ctx, &GetVerificationTokenRequest{Token: token})
 		if err != nil {
 			return fmt.Errorf("invalid or expired token")
 		}
+		verToken := getResp.Token
 
 		if verToken.Type != VerificationTypeEmail {
 			return fmt.Errorf("invalid token type")
@@ -149,7 +150,7 @@ func NewVerifyEmailFunc(identityStore accounts.IdentityStore, tokenStore Verific
 			return fmt.Errorf("failed to verify email: %w", err)
 		}
 
-		if err := tokenStore.DeleteToken(token); err != nil {
+		if _, err := tokenStore.DeleteToken(ctx, &DeleteVerificationTokenRequest{Token: token}); err != nil {
 			log.Printf("Warning: failed to delete token: %v", err)
 		}
 

--- a/localauth/local.go
+++ b/localauth/local.go
@@ -330,13 +330,18 @@ func (a *LocalAuth) HandleForgotPassword(w http.ResponseWriter, r *http.Request)
 	// Generate reset token
 	// Note: We need UserID for CreateToken, but we don't want to reveal if email exists
 	// For security, always return success even if email doesn't exist
-	token, err := a.TokenStore.CreateToken("", email, VerificationTypePasswordReset, VerificationExpiryPasswordReset)
+	createResp, err := a.TokenStore.CreateToken(r.Context(), &CreateVerificationTokenRequest{
+		Subject:        "",
+		Email:          email,
+		Type:           VerificationTypePasswordReset,
+		ExpiryDuration: VerificationExpiryPasswordReset,
+	})
 	if err != nil {
 		log.Printf("Error creating reset token: %v", err)
 		// Still return success to avoid revealing if email exists
 	} else {
 		// Send reset email
-		resetLink := fmt.Sprintf("%s/auth/reset-password?token=%s", a.BaseURL, token.Token)
+		resetLink := fmt.Sprintf("%s/auth/reset-password?token=%s", a.BaseURL, createResp.Token.Token)
 		if err := a.EmailSender.SendPasswordResetEmail(email, resetLink); err != nil {
 			log.Printf("Error sending reset email: %v", err)
 		}
@@ -378,7 +383,7 @@ func (a *LocalAuth) HandleResetPasswordForm(w http.ResponseWriter, r *http.Reque
 
 	// Verify token exists and is valid
 	if a.TokenStore != nil {
-		if _, err := a.TokenStore.GetToken(token); err != nil {
+		if _, err := a.TokenStore.GetToken(r.Context(), &GetVerificationTokenRequest{Token: token}); err != nil {
 			http.Error(w, "Invalid or expired token", http.StatusBadRequest)
 			return
 		}
@@ -426,11 +431,12 @@ func (a *LocalAuth) HandleResetPassword(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Validate token
-	authToken, err := a.TokenStore.GetToken(token)
+	getResp, err := a.TokenStore.GetToken(r.Context(), &GetVerificationTokenRequest{Token: token})
 	if err != nil {
 		a.resetPasswordError(w, r, token, "Invalid or expired reset link")
 		return
 	}
+	authToken := getResp.Token
 
 	if authToken.Type != VerificationTypePasswordReset {
 		a.resetPasswordError(w, r, token, "Invalid token type")
@@ -450,7 +456,7 @@ func (a *LocalAuth) HandleResetPassword(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Delete the token (one-time use)
-	if err := a.TokenStore.DeleteToken(token); err != nil {
+	if _, err := a.TokenStore.DeleteToken(r.Context(), &DeleteVerificationTokenRequest{Token: token}); err != nil {
 		log.Printf("Warning: failed to delete token: %v", err)
 	}
 

--- a/localauth/local_test.go
+++ b/localauth/local_test.go
@@ -3,7 +3,7 @@
 package localauth_test
 
 import (
-	"github.com/panyam/oneauth/localauth"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,9 +12,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/panyam/oneauth/accounts"
+	"github.com/panyam/oneauth/localauth"
 	"github.com/panyam/oneauth/stores/fs"
 	"golang.org/x/oauth2"
-	"github.com/panyam/oneauth/accounts"
 )
 
 // testAuthService wraps the stores for testing
@@ -237,13 +239,14 @@ func TestTokenExpiry(t *testing.T) {
 	defer cleanup(t, tmpDir)
 
 	// Create an expired token
-	token, err := service.TokenStore.CreateToken("testuser", "test@example.com", localauth.VerificationTypeEmail, -1*time.Hour)
+	tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "testuser", Email: "test@example.com", Type: localauth.VerificationTypeEmail, ExpiryDuration: -1*time.Hour})
 	if err != nil {
 		t.Fatalf("Failed to create token: %v", err)
 	}
+	token := tokenResp.Token
 
 	// Try to get the token - should fail
-	_, err = service.TokenStore.GetToken(token.Token)
+	_, err = service.TokenStore.GetToken(context.Background(), &localauth.GetVerificationTokenRequest{Token: token.Token})
 	if err == nil {
 		t.Error("Expected error for expired token")
 	}
@@ -550,10 +553,11 @@ func TestResetPasswordForm(t *testing.T) {
 		localAuth, service, _, tmpDir := setupPasswordResetAuth(t)
 		defer cleanup(t, tmpDir)
 
-		token, err := service.TokenStore.CreateToken("", "reset@example.com", localauth.VerificationTypePasswordReset, localauth.VerificationExpiryPasswordReset)
+		tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: "reset@example.com", Type: localauth.VerificationTypePasswordReset, ExpiryDuration: localauth.VerificationExpiryPasswordReset})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		token := tokenResp.Token
 
 		req := httptest.NewRequest(http.MethodGet, "/auth/reset-password?token="+token.Token, nil)
 		rr := httptest.NewRecorder()
@@ -592,10 +596,11 @@ func TestResetPasswordForm(t *testing.T) {
 
 		localAuth.ResetPasswordURL = "/reset-password"
 
-		token, err := service.TokenStore.CreateToken("", "reset@example.com", localauth.VerificationTypePasswordReset, localauth.VerificationExpiryPasswordReset)
+		tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: "reset@example.com", Type: localauth.VerificationTypePasswordReset, ExpiryDuration: localauth.VerificationExpiryPasswordReset})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		token := tokenResp.Token
 
 		req := httptest.NewRequest(http.MethodGet, "/auth/reset-password?token="+token.Token, nil)
 		rr := httptest.NewRecorder()
@@ -640,10 +645,11 @@ func TestResetPassword(t *testing.T) {
 		defer cleanup(t, tmpDir)
 
 		// Create a valid reset token
-		token, err := service.TokenStore.CreateToken("", "reset@example.com", localauth.VerificationTypePasswordReset, localauth.VerificationExpiryPasswordReset)
+		tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: "reset@example.com", Type: localauth.VerificationTypePasswordReset, ExpiryDuration: localauth.VerificationExpiryPasswordReset})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		token := tokenResp.Token
 
 		form := url.Values{}
 		form.Set("token", token.Token)
@@ -668,7 +674,7 @@ func TestResetPassword(t *testing.T) {
 		}
 
 		// Token should be deleted after use
-		_, err = service.TokenStore.GetToken(token.Token)
+		_, err = service.TokenStore.GetToken(context.Background(), &localauth.GetVerificationTokenRequest{Token: token.Token})
 		if err == nil {
 			t.Error("Expected token to be deleted after use")
 		}
@@ -680,10 +686,11 @@ func TestResetPassword(t *testing.T) {
 
 		localAuth.ResetPasswordURL = "/reset-password"
 
-		token, err := service.TokenStore.CreateToken("", "reset@example.com", localauth.VerificationTypePasswordReset, localauth.VerificationExpiryPasswordReset)
+		tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: "reset@example.com", Type: localauth.VerificationTypePasswordReset, ExpiryDuration: localauth.VerificationExpiryPasswordReset})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		token := tokenResp.Token
 
 		form := url.Values{}
 		form.Set("token", token.Token)
@@ -733,10 +740,11 @@ func TestResetPassword(t *testing.T) {
 		localAuth, service, _, tmpDir := setupPasswordResetAuth(t)
 		defer cleanup(t, tmpDir)
 
-		token, err := service.TokenStore.CreateToken("", "reset@example.com", localauth.VerificationTypePasswordReset, localauth.VerificationExpiryPasswordReset)
+		tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: "reset@example.com", Type: localauth.VerificationTypePasswordReset, ExpiryDuration: localauth.VerificationExpiryPasswordReset})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		token := tokenResp.Token
 
 		form := url.Values{}
 		form.Set("token", token.Token)
@@ -779,10 +787,11 @@ func TestResetPassword(t *testing.T) {
 		defer cleanup(t, tmpDir)
 
 		// Create an expired token
-		token, err := service.TokenStore.CreateToken("", "reset@example.com", localauth.VerificationTypePasswordReset, -1*time.Hour)
+		tokenResp, err := service.TokenStore.CreateToken(context.Background(), &localauth.CreateVerificationTokenRequest{Subject: "", Email: "reset@example.com", Type: localauth.VerificationTypePasswordReset, ExpiryDuration: -1*time.Hour})
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
+		token := tokenResp.Token
 
 		form := url.Values{}
 		form.Set("token", token.Token)

--- a/localauth/signup.go
+++ b/localauth/signup.go
@@ -74,11 +74,16 @@ func (a *LocalAuth) HandleSignup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if primaryEmail != "" && a.EmailSender != nil && a.TokenStore != nil && a.BaseURL != "" {
-		token, err := a.TokenStore.CreateToken(user.Id(), primaryEmail, VerificationTypeEmail, VerificationExpiryEmail)
+		createResp, err := a.TokenStore.CreateToken(r.Context(), &CreateVerificationTokenRequest{
+			Subject:        user.Id(),
+			Email:          primaryEmail,
+			Type:           VerificationTypeEmail,
+			ExpiryDuration: VerificationExpiryEmail,
+		})
 		if err != nil {
 			log.Println("error creating verification token: ", err)
 		} else {
-			verificationLink := fmt.Sprintf("%s/auth/verify-email?token=%s", a.BaseURL, token.Token)
+			verificationLink := fmt.Sprintf("%s/auth/verify-email?token=%s", a.BaseURL, createResp.Token.Token)
 			if err := a.EmailSender.SendVerificationEmail(primaryEmail, verificationLink); err != nil {
 				log.Println("error sending verification email: ", err)
 			}

--- a/localauth/verification.go
+++ b/localauth/verification.go
@@ -1,6 +1,9 @@
 package localauth
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // VerificationType is the kind of email/phone-mediated verification token
 // issued by localauth (e.g. signup email-verify, password-reset).
@@ -46,11 +49,46 @@ func (t *VerificationToken) IsValid(expectedType VerificationType) bool {
 	return t.Type == expectedType && !t.IsExpired()
 }
 
+// CreateVerificationTokenRequest carries the inputs for issuing a verification
+// token. Subject may be empty for password-reset flows where the AS does not
+// want to reveal whether the email belongs to a registered user.
+type CreateVerificationTokenRequest struct {
+	Subject        string
+	Email          string
+	Type           VerificationType
+	ExpiryDuration time.Duration
+}
+
+type CreateVerificationTokenResponse struct {
+	Token *VerificationToken
+}
+
+type GetVerificationTokenRequest struct {
+	Token string
+}
+
+type GetVerificationTokenResponse struct {
+	Token *VerificationToken
+}
+
+type DeleteVerificationTokenRequest struct {
+	Token string
+}
+
+type DeleteVerificationTokenResponse struct{}
+
+type DeleteSubjectVerificationTokensRequest struct {
+	Subject string
+	Type    VerificationType
+}
+
+type DeleteSubjectVerificationTokensResponse struct{}
+
 // VerificationTokenStore manages localauth verification tokens (signup
 // email-verify, password-reset). Renamed from core.TokenStore.
 type VerificationTokenStore interface {
-	CreateToken(subject, email string, tokenType VerificationType, expiryDuration time.Duration) (*VerificationToken, error)
-	GetToken(token string) (*VerificationToken, error)
-	DeleteToken(token string) error
-	DeleteSubjectTokens(subject string, tokenType VerificationType) error
+	CreateToken(ctx context.Context, req *CreateVerificationTokenRequest) (*CreateVerificationTokenResponse, error)
+	GetToken(ctx context.Context, req *GetVerificationTokenRequest) (*GetVerificationTokenResponse, error)
+	DeleteToken(ctx context.Context, req *DeleteVerificationTokenRequest) (*DeleteVerificationTokenResponse, error)
+	DeleteSubjectTokens(ctx context.Context, req *DeleteSubjectVerificationTokensRequest) (*DeleteSubjectVerificationTokensResponse, error)
 }

--- a/stores/fs/fsappstore.go
+++ b/stores/fs/fsappstore.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -46,39 +47,45 @@ func (s *FSAppStore) appPath(clientID string) (string, error) {
 	return filepath.Join(s.appsDir(), safeID+".json"), nil
 }
 
-// SaveApp persists app to disk. Overwrites any existing registration with
+// SaveApp persists req.App to disk. Overwrites any existing registration with
 // the same client_id. Empty client_id is rejected.
-func (s *FSAppStore) SaveApp(app *admin.AppRegistration) error {
-	if app == nil || app.ClientID == "" {
-		return fmt.Errorf("AppRegistration.ClientID required")
+func (s *FSAppStore) SaveApp(ctx context.Context, req *admin.SaveAppRequest) (*admin.SaveAppResponse, error) {
+	if req == nil || req.App == nil || req.App.ClientID == "" {
+		return nil, fmt.Errorf("AppRegistration.ClientID required")
 	}
 
-	path, err := s.appPath(app.ClientID)
+	path, err := s.appPath(req.App.ClientID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := os.MkdirAll(s.appsDir(), 0700); err != nil {
-		return fmt.Errorf("create apps dir: %w", err)
+		return nil, fmt.Errorf("create apps dir: %w", err)
 	}
 
-	data, err := json.MarshalIndent(app, "", "  ")
+	data, err := json.MarshalIndent(req.App, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal AppRegistration: %w", err)
+		return nil, fmt.Errorf("marshal AppRegistration: %w", err)
 	}
-	return writeAtomicFile(path, data)
+	if err := writeAtomicFile(path, data); err != nil {
+		return nil, err
+	}
+	return &admin.SaveAppResponse{}, nil
 }
 
-// GetApp returns the registration for clientID, or admin.ErrAppNotFound if
+// GetApp returns the registration for req.ClientID, or admin.ErrAppNotFound if
 // no such file exists. A corrupt JSON file surfaces as a parse error rather
 // than ErrAppNotFound — callers should distinguish "registration absent"
 // from "registration unreadable" so an unexpected on-disk corruption isn't
 // silently treated as a missing client.
-func (s *FSAppStore) GetApp(clientID string) (*admin.AppRegistration, error) {
-	path, err := s.appPath(clientID)
+func (s *FSAppStore) GetApp(ctx context.Context, req *admin.GetAppRequest) (*admin.GetAppResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetApp: req is required")
+	}
+	path, err := s.appPath(req.ClientID)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +104,7 @@ func (s *FSAppStore) GetApp(clientID string) (*admin.AppRegistration, error) {
 	if err := json.Unmarshal(data, &app); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
 	}
-	return &app, nil
+	return &admin.GetAppResponse{App: &app}, nil
 }
 
 // ListApps returns every registration in the store. Files that fail to
@@ -108,7 +115,7 @@ func (s *FSAppStore) GetApp(clientID string) (*admin.AppRegistration, error) {
 //
 // Returns an empty slice (not an error) when the apps dir does not yet
 // exist, matching the InMemory backend's "fresh store has no apps" shape.
-func (s *FSAppStore) ListApps() ([]*admin.AppRegistration, error) {
+func (s *FSAppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (*admin.ListAppsResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -116,7 +123,7 @@ func (s *FSAppStore) ListApps() ([]*admin.AppRegistration, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []*admin.AppRegistration{}, nil
+			return &admin.ListAppsResponse{Apps: []*admin.AppRegistration{}}, nil
 		}
 		return nil, err
 	}
@@ -135,26 +142,31 @@ func (s *FSAppStore) ListApps() ([]*admin.AppRegistration, error) {
 			// Skip corrupt files — see godoc for rationale.
 			continue
 		}
-		// Take address of a fresh copy; ranging by value re-uses the loop var.
 		clone := app
 		out = append(out, &clone)
 	}
-	return out, nil
+	return &admin.ListAppsResponse{Apps: out}, nil
 }
 
-// DeleteApp removes the registration for clientID. Returns admin.ErrAppNotFound
+// DeleteApp removes the registration for req.ClientID. Returns admin.ErrAppNotFound
 // if no such registration exists, matching InMemoryAppStore semantics.
-func (s *FSAppStore) DeleteApp(clientID string) error {
-	path, err := s.appPath(clientID)
+func (s *FSAppStore) DeleteApp(ctx context.Context, req *admin.DeleteAppRequest) (*admin.DeleteAppResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteApp: req is required")
+	}
+	path, err := s.appPath(req.ClientID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return admin.ErrAppNotFound
+		return nil, admin.ErrAppNotFound
 	}
-	return os.Remove(path)
+	if err := os.Remove(path); err != nil {
+		return nil, err
+	}
+	return &admin.DeleteAppResponse{}, nil
 }

--- a/stores/fs/fsappstore_test.go
+++ b/stores/fs/fsappstore_test.go
@@ -6,6 +6,7 @@
 package fs_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -33,6 +34,7 @@ func TestFSAppStore_Contract(t *testing.T) {
 // regressions in that contract.
 func TestFSAppStore_PathTraversalRejected(t *testing.T) {
 	store := fs.NewFSAppStore(t.TempDir())
+	ctx := context.Background()
 
 	for _, badID := range []string{
 		"../etc/passwd",
@@ -43,16 +45,16 @@ func TestFSAppStore_PathTraversalRejected(t *testing.T) {
 		".",
 	} {
 		t.Run(badID, func(t *testing.T) {
-			err := store.SaveApp(&admin.AppRegistration{ClientID: badID, SigningAlg: "HS256", CreatedAt: time.Now()})
+			_, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: badID, SigningAlg: "HS256", CreatedAt: time.Now()}})
 			if err == nil {
 				t.Fatalf("SaveApp(%q) should have rejected the traversal attempt", badID)
 			}
 			// Same defense at read + delete time so we never load a path
 			// composed by a non-safeName route.
-			if _, err := store.GetApp(badID); err == nil {
+			if _, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: badID}); err == nil {
 				t.Errorf("GetApp(%q) should have rejected the traversal attempt", badID)
 			}
-			if err := store.DeleteApp(badID); err == nil {
+			if _, err := store.DeleteApp(ctx, &admin.DeleteAppRequest{ClientID: badID}); err == nil {
 				t.Errorf("DeleteApp(%q) should have rejected the traversal attempt", badID)
 			}
 		})
@@ -67,9 +69,10 @@ func TestFSAppStore_PathTraversalRejected(t *testing.T) {
 func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	store := fs.NewFSAppStore(dir)
+	ctx := context.Background()
 
 	// Save a real entry to materialize the apps/ directory.
-	if err := store.SaveApp(&admin.AppRegistration{ClientID: "good", SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+	if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: "good", SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
 		t.Fatalf("SaveApp: %v", err)
 	}
 	// Drop a hand-corrupted file alongside it.
@@ -78,7 +81,7 @@ func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
 		t.Fatalf("seed corrupt file: %v", err)
 	}
 
-	_, err := store.GetApp("corrupt")
+	_, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: "corrupt"})
 	if err == nil {
 		t.Fatalf("GetApp on corrupt file should have errored")
 	}
@@ -88,12 +91,12 @@ func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
 
 	// Good entry still readable — corruption of one file does not poison
 	// the rest of the store.
-	got, err := store.GetApp("good")
+	got, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: "good"})
 	if err != nil {
 		t.Fatalf("GetApp(good): %v", err)
 	}
-	if got.ClientID != "good" {
-		t.Errorf("ClientID=%q, want good", got.ClientID)
+	if got.App.ClientID != "good" {
+		t.Errorf("ClientID=%q, want good", got.App.ClientID)
 	}
 }
 
@@ -103,9 +106,10 @@ func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
 func TestFSAppStore_CorruptFile_ListSkips(t *testing.T) {
 	dir := t.TempDir()
 	store := fs.NewFSAppStore(dir)
+	ctx := context.Background()
 
 	for _, id := range []string{"alpha", "beta"} {
-		if err := store.SaveApp(&admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+		if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
 			t.Fatalf("SaveApp(%s): %v", id, err)
 		}
 	}
@@ -113,12 +117,12 @@ func TestFSAppStore_CorruptFile_ListSkips(t *testing.T) {
 		t.Fatalf("seed trash file: %v", err)
 	}
 
-	apps, err := store.ListApps()
+	resp, err := store.ListApps(ctx, &admin.ListAppsRequest{})
 	if err != nil {
 		t.Fatalf("ListApps: %v", err)
 	}
-	if len(apps) != 2 {
-		t.Errorf("expected 2 apps (corrupt file skipped), got %d", len(apps))
+	if len(resp.Apps) != 2 {
+		t.Errorf("expected 2 apps (corrupt file skipped), got %d", len(resp.Apps))
 	}
 }
 
@@ -128,6 +132,7 @@ func TestFSAppStore_CorruptFile_ListSkips(t *testing.T) {
 func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "does-not-exist-yet", "nor-this")
 	store := fs.NewFSAppStore(dir)
+	ctx := context.Background()
 
 	// Pre-condition: the directory does not exist.
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
@@ -135,7 +140,7 @@ func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
 	}
 
 	// First write must succeed and materialize the directory.
-	if err := store.SaveApp(&admin.AppRegistration{ClientID: "lazy", SigningAlg: "HS256", CreatedAt: time.Now()}); err != nil {
+	if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: "lazy", SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
 		t.Fatalf("SaveApp: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "apps")); err != nil {
@@ -145,12 +150,12 @@ func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
 	// Pre-condition for ListApps on a fresh store with no writes: returns
 	// an empty slice, not an error. Verify against a separate path.
 	emptyStore := fs.NewFSAppStore(filepath.Join(t.TempDir(), "another-fresh-dir"))
-	apps, err := emptyStore.ListApps()
+	emptyResp, err := emptyStore.ListApps(ctx, &admin.ListAppsRequest{})
 	if err != nil {
 		t.Errorf("ListApps on fresh store: %v", err)
 	}
-	if len(apps) != 0 {
-		t.Errorf("ListApps on fresh store should return empty slice, got %d entries", len(apps))
+	if len(emptyResp.Apps) != 0 {
+		t.Errorf("ListApps on fresh store should return empty slice, got %d entries", len(emptyResp.Apps))
 	}
 }
 
@@ -164,12 +169,13 @@ func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
 func TestFSAppStore_OverwriteIsAtomicallyVisible(t *testing.T) {
 	dir := t.TempDir()
 	store := fs.NewFSAppStore(dir)
+	ctx := context.Background()
 
 	const id = "overwriter"
 	for i, name := range []string{"first", "second", "third"} {
-		if err := store.SaveApp(&admin.AppRegistration{
+		if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{
 			ClientID: id, ClientName: name, SigningAlg: "HS256", CreatedAt: time.Now(),
-		}); err != nil {
+		}}); err != nil {
 			t.Fatalf("SaveApp #%d: %v", i, err)
 		}
 

--- a/stores/fs/fstoken_store.go
+++ b/stores/fs/fstoken_store.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -29,7 +30,10 @@ func (s *FSTokenStore) getTokenPath(token string) (string, error) {
 	return filepath.Join(s.StoragePath, "tokens", safeToken+".json"), nil
 }
 
-func (s *FSTokenStore) CreateToken(subject, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
+func (s *FSTokenStore) CreateToken(ctx context.Context, req *localauth.CreateVerificationTokenRequest) (*localauth.CreateVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateToken: req is required")
+	}
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -37,11 +41,11 @@ func (s *FSTokenStore) CreateToken(subject, email string, tokenType localauth.Ve
 
 	verToken := &localauth.VerificationToken{
 		Token:     token,
-		Type:      tokenType,
-		Subject:    subject,
-		Email:     email,
+		Type:      req.Type,
+		Subject:   req.Subject,
+		Email:     req.Email,
 		CreatedAt: time.Now(),
-		ExpiresAt: time.Now().Add(expiryDuration),
+		ExpiresAt: time.Now().Add(req.ExpiryDuration),
 	}
 
 	path, err := s.getTokenPath(token)
@@ -61,11 +65,14 @@ func (s *FSTokenStore) CreateToken(subject, email string, tokenType localauth.Ve
 		return nil, err
 	}
 
-	return verToken, nil
+	return &localauth.CreateVerificationTokenResponse{Token: verToken}, nil
 }
 
-func (s *FSTokenStore) GetToken(token string) (*localauth.VerificationToken, error) {
-	path, err := s.getTokenPath(token)
+func (s *FSTokenStore) GetToken(ctx context.Context, req *localauth.GetVerificationTokenRequest) (*localauth.GetVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetToken: req is required")
+	}
+	path, err := s.getTokenPath(req.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -82,36 +89,43 @@ func (s *FSTokenStore) GetToken(token string) (*localauth.VerificationToken, err
 		return nil, err
 	}
 
-	// Check if token is expired
 	if verToken.IsExpired() {
-		// Auto-delete expired token
-		_ = s.DeleteToken(token)
+		_, _ = s.DeleteToken(ctx, &localauth.DeleteVerificationTokenRequest{Token: req.Token})
 		return nil, fmt.Errorf("token expired")
 	}
 
-	return &verToken, nil
+	return &localauth.GetVerificationTokenResponse{Token: &verToken}, nil
 }
 
-func (s *FSTokenStore) DeleteToken(token string) error {
-	path, err := s.getTokenPath(token)
+func (s *FSTokenStore) DeleteToken(ctx context.Context, req *localauth.DeleteVerificationTokenRequest) (*localauth.DeleteVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteToken: req is required")
+	}
+	path, err := s.getTokenPath(req.Token)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = os.Remove(path)
 	if os.IsNotExist(err) {
-		return nil // Already deleted
+		return &localauth.DeleteVerificationTokenResponse{}, nil
 	}
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &localauth.DeleteVerificationTokenResponse{}, nil
 }
 
-func (s *FSTokenStore) DeleteSubjectTokens(subject string, tokenType localauth.VerificationType) error {
+func (s *FSTokenStore) DeleteSubjectTokens(ctx context.Context, req *localauth.DeleteSubjectVerificationTokensRequest) (*localauth.DeleteSubjectVerificationTokensResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteSubjectTokens: req is required")
+	}
 	tokensDir := filepath.Join(s.StoragePath, "tokens")
 	entries, err := os.ReadDir(tokensDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return &localauth.DeleteSubjectVerificationTokensResponse{}, nil
 		}
-		return err
+		return nil, err
 	}
 
 	for _, entry := range entries {
@@ -129,10 +143,10 @@ func (s *FSTokenStore) DeleteSubjectTokens(subject string, tokenType localauth.V
 			continue
 		}
 
-		if verToken.Subject == subject && verToken.Type == tokenType {
+		if verToken.Subject == req.Subject && verToken.Type == req.Type {
 			_ = os.Remove(filepath.Join(tokensDir, entry.Name()))
 		}
 	}
 
-	return nil
+	return &localauth.DeleteSubjectVerificationTokensResponse{}, nil
 }

--- a/stores/fs/security_test.go
+++ b/stores/fs/security_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/panyam/oneauth/accounts"
 	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/keys"
+	"github.com/panyam/oneauth/localauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -178,13 +179,13 @@ func TestSecurity_PathTraversal_TokenStore(t *testing.T) {
 
 	for _, tc := range maliciousInputs {
 		t.Run("GetToken_"+tc.name, func(t *testing.T) {
-			_, err := store.GetToken(tc.input)
+			_, err := store.GetToken(context.Background(), &localauth.GetVerificationTokenRequest{Token: tc.input})
 			assert.Error(t, err, "GetToken should reject malicious token %q", tc.input)
 		})
 
 		t.Run("DeleteToken_"+tc.name, func(t *testing.T) {
 			// DeleteToken should not follow traversal paths
-			err := store.DeleteToken(tc.input)
+			_, err := store.DeleteToken(context.Background(), &localauth.DeleteVerificationTokenRequest{Token: tc.input})
 			// May return "not found" error which is fine — as long as it doesn't
 			// delete files outside the storage directory
 			_ = err

--- a/stores/gae/stores.go
+++ b/stores/gae/stores.go
@@ -558,7 +558,10 @@ func (s *TokenStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
-func (s *TokenStore) CreateToken(subject, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
+func (s *TokenStore) CreateToken(ctx context.Context, req *localauth.CreateVerificationTokenRequest) (*localauth.CreateVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateToken: req is required")
+	}
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -568,31 +571,34 @@ func (s *TokenStore) CreateToken(subject, email string, tokenType localauth.Veri
 	now := time.Now()
 	entity := &VerificationTokenEntity{
 		Key:       key,
-		Type:      tokenType,
-		Subject:   subject,
-		Email:     email,
+		Type:      req.Type,
+		Subject:   req.Subject,
+		Email:     req.Email,
 		CreatedAt: now,
-		ExpiresAt: now.Add(expiryDuration),
+		ExpiresAt: now.Add(req.ExpiryDuration),
 	}
 
-	if _, err := s.client.Put(s.ctx, key, entity); err != nil {
+	if _, err := s.client.Put(ctx, key, entity); err != nil {
 		return nil, err
 	}
 
-	return &localauth.VerificationToken{
+	return &localauth.CreateVerificationTokenResponse{Token: &localauth.VerificationToken{
 		Token:     token,
-		Type:      tokenType,
-		Subject:   subject,
-		Email:     email,
+		Type:      req.Type,
+		Subject:   req.Subject,
+		Email:     req.Email,
 		CreatedAt: now,
-		ExpiresAt: now.Add(expiryDuration),
-	}, nil
+		ExpiresAt: now.Add(req.ExpiryDuration),
+	}}, nil
 }
 
-func (s *TokenStore) GetToken(token string) (*localauth.VerificationToken, error) {
-	key := s.namespacedKey(KindAuthToken, token)
+func (s *TokenStore) GetToken(ctx context.Context, req *localauth.GetVerificationTokenRequest) (*localauth.GetVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetToken: req is required")
+	}
+	key := s.namespacedKey(KindAuthToken, req.Token)
 	var entity VerificationTokenEntity
-	if err := s.client.Get(s.ctx, key, &entity); err != nil {
+	if err := s.client.Get(ctx, key, &entity); err != nil {
 		if err == datastore.ErrNoSuchEntity {
 			return nil, fmt.Errorf("token not found")
 		}
@@ -601,37 +607,49 @@ func (s *TokenStore) GetToken(token string) (*localauth.VerificationToken, error
 
 	authToken := entity.ToVerificationToken()
 	if authToken.IsExpired() {
-		_ = s.DeleteToken(token)
+		_, _ = s.DeleteToken(ctx, &localauth.DeleteVerificationTokenRequest{Token: req.Token})
 		return nil, fmt.Errorf("token expired")
 	}
 
-	return authToken, nil
+	return &localauth.GetVerificationTokenResponse{Token: authToken}, nil
 }
 
-func (s *TokenStore) DeleteToken(token string) error {
-	key := s.namespacedKey(KindAuthToken, token)
-	return s.client.Delete(s.ctx, key)
+func (s *TokenStore) DeleteToken(ctx context.Context, req *localauth.DeleteVerificationTokenRequest) (*localauth.DeleteVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteToken: req is required")
+	}
+	key := s.namespacedKey(KindAuthToken, req.Token)
+	if err := s.client.Delete(ctx, key); err != nil {
+		return nil, err
+	}
+	return &localauth.DeleteVerificationTokenResponse{}, nil
 }
 
-func (s *TokenStore) DeleteSubjectTokens(subject string, tokenType localauth.VerificationType) error {
+func (s *TokenStore) DeleteSubjectTokens(ctx context.Context, req *localauth.DeleteSubjectVerificationTokensRequest) (*localauth.DeleteSubjectVerificationTokensResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteSubjectTokens: req is required")
+	}
 	query := datastore.NewQuery(KindAuthToken).
-		FilterField("subject", "=", subject).
-		FilterField("type", "=", string(tokenType)).
+		FilterField("subject", "=", req.Subject).
+		FilterField("type", "=", string(req.Type)).
 		KeysOnly()
 	if s.namespace != "" {
 		query = query.Namespace(s.namespace)
 	}
 
-	keys, err := s.client.GetAll(s.ctx, query, nil)
+	keys, err := s.client.GetAll(ctx, query, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(keys) == 0 {
-		return nil
+		return &localauth.DeleteSubjectVerificationTokensResponse{}, nil
 	}
 
-	return s.client.DeleteMulti(s.ctx, keys)
+	if err := s.client.DeleteMulti(ctx, keys); err != nil {
+		return nil, err
+	}
+	return &localauth.DeleteSubjectVerificationTokensResponse{}, nil
 }
 
 // ============================================================================

--- a/stores/gorm/appstore.go
+++ b/stores/gorm/appstore.go
@@ -4,6 +4,7 @@
 package gorm
 
 import (
+	"context"
 	"time"
 
 	"github.com/panyam/oneauth/admin"
@@ -61,52 +62,61 @@ func NewAppStore(db *gorm.DB) *AppStore {
 	return &AppStore{db: db}
 }
 
-// SaveApp inserts or replaces the registration for app.ClientID. Empty
+// SaveApp inserts or replaces the registration for req.App.ClientID. Empty
 // client_id is rejected with the same error pattern as InMemoryAppStore.
-func (s *AppStore) SaveApp(app *admin.AppRegistration) error {
-	if app == nil || app.ClientID == "" {
-		return errClientIDRequired
+func (s *AppStore) SaveApp(ctx context.Context, req *admin.SaveAppRequest) (*admin.SaveAppResponse, error) {
+	if req == nil || req.App == nil || req.App.ClientID == "" {
+		return nil, errClientIDRequired
 	}
-	model := appRegistrationToModel(app)
-	return s.db.Save(model).Error
+	model := appRegistrationToModel(req.App)
+	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
+		return nil, err
+	}
+	return &admin.SaveAppResponse{}, nil
 }
 
-// GetApp returns the registration for clientID, or admin.ErrAppNotFound.
-func (s *AppStore) GetApp(clientID string) (*admin.AppRegistration, error) {
+// GetApp returns the registration for req.ClientID, or admin.ErrAppNotFound.
+func (s *AppStore) GetApp(ctx context.Context, req *admin.GetAppRequest) (*admin.GetAppResponse, error) {
+	if req == nil {
+		return nil, errClientIDRequired
+	}
 	var model AppRegistrationModel
-	if err := s.db.First(&model, "client_id = ?", clientID).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "client_id = ?", req.ClientID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, admin.ErrAppNotFound
 		}
 		return nil, err
 	}
-	return modelToAppRegistration(&model), nil
+	return &admin.GetAppResponse{App: modelToAppRegistration(&model)}, nil
 }
 
 // ListApps returns every registration in the store. Order is unspecified.
-func (s *AppStore) ListApps() ([]*admin.AppRegistration, error) {
+func (s *AppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (*admin.ListAppsResponse, error) {
 	var models []AppRegistrationModel
-	if err := s.db.Find(&models).Error; err != nil {
+	if err := s.db.WithContext(ctx).Find(&models).Error; err != nil {
 		return nil, err
 	}
 	out := make([]*admin.AppRegistration, len(models))
 	for i := range models {
 		out[i] = modelToAppRegistration(&models[i])
 	}
-	return out, nil
+	return &admin.ListAppsResponse{Apps: out}, nil
 }
 
-// DeleteApp removes the registration for clientID. Returns admin.ErrAppNotFound
+// DeleteApp removes the registration for req.ClientID. Returns admin.ErrAppNotFound
 // if no such registration exists, matching InMemoryAppStore semantics.
-func (s *AppStore) DeleteApp(clientID string) error {
-	result := s.db.Delete(&AppRegistrationModel{}, "client_id = ?", clientID)
+func (s *AppStore) DeleteApp(ctx context.Context, req *admin.DeleteAppRequest) (*admin.DeleteAppResponse, error) {
+	if req == nil {
+		return nil, errClientIDRequired
+	}
+	result := s.db.WithContext(ctx).Delete(&AppRegistrationModel{}, "client_id = ?", req.ClientID)
 	if result.Error != nil {
-		return result.Error
+		return nil, result.Error
 	}
 	if result.RowsAffected == 0 {
-		return admin.ErrAppNotFound
+		return nil, admin.ErrAppNotFound
 	}
-	return nil
+	return &admin.DeleteAppResponse{}, nil
 }
 
 // errClientIDRequired matches the InMemoryAppStore error message so the

--- a/stores/gorm/stores.go
+++ b/stores/gorm/stores.go
@@ -274,7 +274,10 @@ func NewTokenStore(db *gorm.DB) *TokenStore {
 	return &TokenStore{db: db}
 }
 
-func (s *TokenStore) CreateToken(subject, email string, tokenType localauth.VerificationType, expiryDuration time.Duration) (*localauth.VerificationToken, error) {
+func (s *TokenStore) CreateToken(ctx context.Context, req *localauth.CreateVerificationTokenRequest) (*localauth.CreateVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateToken: req is required")
+	}
 	token, err := core.GenerateSecureToken()
 	if err != nil {
 		return nil, err
@@ -282,22 +285,25 @@ func (s *TokenStore) CreateToken(subject, email string, tokenType localauth.Veri
 
 	model := &VerificationTokenModel{
 		Token:     token,
-		Type:      tokenType,
-		Subject:   subject,
-		Email:     email,
-		ExpiresAt: time.Now().Add(expiryDuration),
+		Type:      req.Type,
+		Subject:   req.Subject,
+		Email:     req.Email,
+		ExpiresAt: time.Now().Add(req.ExpiryDuration),
 	}
 
-	if err := s.db.Create(model).Error; err != nil {
+	if err := s.db.WithContext(ctx).Create(model).Error; err != nil {
 		return nil, err
 	}
 
-	return model.ToVerificationToken(), nil
+	return &localauth.CreateVerificationTokenResponse{Token: model.ToVerificationToken()}, nil
 }
 
-func (s *TokenStore) GetToken(token string) (*localauth.VerificationToken, error) {
+func (s *TokenStore) GetToken(ctx context.Context, req *localauth.GetVerificationTokenRequest) (*localauth.GetVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetToken: req is required")
+	}
 	var model VerificationTokenModel
-	if err := s.db.First(&model, "token = ?", token).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "token = ?", req.Token).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, fmt.Errorf("token not found")
 		}
@@ -306,19 +312,31 @@ func (s *TokenStore) GetToken(token string) (*localauth.VerificationToken, error
 
 	verToken := model.ToVerificationToken()
 	if verToken.IsExpired() {
-		_ = s.DeleteToken(token)
+		_, _ = s.DeleteToken(ctx, &localauth.DeleteVerificationTokenRequest{Token: req.Token})
 		return nil, fmt.Errorf("token expired")
 	}
 
-	return verToken, nil
+	return &localauth.GetVerificationTokenResponse{Token: verToken}, nil
 }
 
-func (s *TokenStore) DeleteToken(token string) error {
-	return s.db.Delete(&VerificationTokenModel{}, "token = ?", token).Error
+func (s *TokenStore) DeleteToken(ctx context.Context, req *localauth.DeleteVerificationTokenRequest) (*localauth.DeleteVerificationTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteToken: req is required")
+	}
+	if err := s.db.WithContext(ctx).Delete(&VerificationTokenModel{}, "token = ?", req.Token).Error; err != nil {
+		return nil, err
+	}
+	return &localauth.DeleteVerificationTokenResponse{}, nil
 }
 
-func (s *TokenStore) DeleteSubjectTokens(subject string, tokenType localauth.VerificationType) error {
-	return s.db.Delete(&VerificationTokenModel{}, "subject = ? AND type = ?", subject, tokenType).Error
+func (s *TokenStore) DeleteSubjectTokens(ctx context.Context, req *localauth.DeleteSubjectVerificationTokensRequest) (*localauth.DeleteSubjectVerificationTokensResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("DeleteSubjectTokens: req is required")
+	}
+	if err := s.db.WithContext(ctx).Delete(&VerificationTokenModel{}, "subject = ? AND type = ?", req.Subject, req.Type).Error; err != nil {
+		return nil, err
+	}
+	return &localauth.DeleteSubjectVerificationTokensResponse{}, nil
 }
 
 // =============================================================================


### PR DESCRIPTION
## What changes

Closes out the **#204 store-layer convention migration**. Applies the gRPC-shape `MethodName(ctx context.Context, req *XRequest) (*XResponse, error)` convention to the last two store interfaces in the cluster:

- `admin.AppRegistrationStore` (4 methods)
- `localauth.VerificationTokenStore` (4 methods)

This is the final slice — combined with 204a (`keys/`), 204b (`accounts/`), and 204c (`core/` token stores), every store-layer interface now follows the convention. No aliases; clean break per the agreed plan.

## Reviewer's guide

Read in this order:

1. [admin/appstore.go](https://github.com/panyam/oneauth/pull/223/files#diff-8bfa58e6ab7dd9c7c6db058243c587396ba6d49dd172b2a4e02599df98a63835) — start here. Request/response types + new `AppRegistrationStore` interface + `InMemoryAppStore` impl. Note the request structs name fields after the entity (`App`, `ClientID`) rather than positional args.
2. [localauth/verification.go](https://github.com/panyam/oneauth/pull/223/files#diff-c24ba625110c15425b59700cbe321421caf3543af33bbef801487ac45b053652) — companion interface for verification tokens.
3. [admin/registrar.go](https://github.com/panyam/oneauth/pull/223/files#diff-357a2ab591dde1d22068c00e675d315f4bbc15d7c36f0e89b29a4dd0b1ff953e) — biggest consumer. `SaveRegistration` gained a `ctx` parameter (previously took only `*AppRegistration`); every `Store.X` call threads `ctx` through. The Get/Delete sites have to unwrap `getResp.App` before reading fields like `RegistrationAccessToken`.
4. `localauth/{signup,local,helpers}.go` — middleware/handlers thread `r.Context()` through every `TokenStore` call.
5. `stores/fs/{fsappstore,fstoken_store}.go` — first backend, easiest to skim.
6. `stores/gorm/{appstore,stores.go}` — second backend; mostly s/db.X/s.db.WithContext(ctx).X/ + request/response wrap.
7. [stores/gae/stores.go](https://github.com/panyam/oneauth/pull/223/files#diff-2c8530602a1cead3e8eb8b59c92358a081544846b91c040987fd6b658d773ba5) — third backend (TokenStore only — AppRegistrationStore isn't backed by gae). Same WithContext-kept-for-compat pattern as 204c.

Skim or skip: [appstoretest/appstoretest.go](https://github.com/panyam/oneauth/pull/223/files#diff-31f92adfa030ee47ff5323f11a2f84e882018d055fd76a05e37486dc352f89e6), `admin/{client_admin,registrar_store}_test.go`, `stores/fs/{fsappstore,security}_test.go`, [localauth/local_test.go](https://github.com/panyam/oneauth/pull/223/files#diff-bb05b4d3693ed570f536010958684cafaf80a96f2a7f650a64d90ada2f41931e), [apiauth/auth_flows_test.go](https://github.com/panyam/oneauth/pull/223/files#diff-1d6db1550a21dd0a07f13bc321be60f054a973db55efa00754175841366f2235) — mechanical call-site updates.

## Diff groups

- Production: `admin/{appstore,registrar}.go`, `localauth/{verification,local,signup,helpers}.go`, `stores/{fs,gorm,gae}/*`
- Conformance suite: `appstoretest/appstoretest.go`
- Tests: `admin/{client_admin,registrar_store}_test.go`, `stores/fs/{fsappstore,security}_test.go`, `localauth/local_test.go`, `apiauth/auth_flows_test.go`

## Decision log

- **`SaveRegistration` gained a `ctx` parameter** rather than keeping its old signature and using `context.Background()` internally. Only 3 in-tree call sites needed updates (handleRegister, RegisterLegacy, UpdateRegistration), and the parameter is properly forwarded through to the store now.
- **No aliases.** Same as 204a/b/c — clean break is fine while oneauth is single-consumer.
- **Conformance suite `appstoretest`** got two small helpers (`saveApp`, `getApp`) to avoid every test having to wrap/unwrap the request and response structs. Pure DX — doesn't change what's tested.
- **gae TokenStore keeps `WithContext()` + `ctx` field** for consistency with the rest of the gae package after 204b/c. Dead-code sweep is a follow-up.

## Risk / blast radius

- Affects every consumer of `admin.AppRegistrationStore` or `localauth.VerificationTokenStore`. Outside this repo: any external consumer that built against these surfaces (currently just `panyam/oneauth` itself + the in-tree `cmd/oneauth-server` reference deployment).
- Tests covering this: full `admin` + `localauth` + `apiauth` suites + e2e suite (-race) + gorm conformance.
- Be paranoid about: the `AppRegistrar.SaveRegistration` ctx threading — three call sites (Register, RegisterLegacy, UpdateRegistration) each pass their own `ctx`. A miss here would silently degrade to `context.Background()` semantics if the signature reverted.

## Out of scope (deliberately deferred)

- **Dead `WithContext()` + `ctx` field on gae stores** — covered by #204 follow-ups. Single cleanup PR after all four 204 slices land.
- **`gae/stores.go` doesn't have an AppRegistrationStore yet** (issue #167's GAE half) — out of scope; the admin interface migration here just doesn't touch a gae file because no gae impl exists.

## Test plan

- [x] `go test ./...` — root green
- [x] `cd stores/gorm && GOWORK=off go test -race ./...` — green
- [x] `cd stores/gae && GOWORK=off go build ./... && go vet ./...` — green
- [x] `cd cmd/{oneauth-server,demo-hostapp,demo-resource-server} && GOWORK=off go vet ./...` — green
- [x] `go test -race ./tests/e2e/...` — green
