### PR TITLE
refactor(apiauth): remove deprecated APIAuth.* methods, route through TokenIssuer/Validator (#218)

### DIFF
--- a/apiauth/SUMMARY.md
+++ b/apiauth/SUMMARY.md
@@ -11,9 +11,9 @@ JWT-based API authentication: token issuance (login/refresh/client_credentials),
 
 ## Transport-Independent Core (OneAuth)
 
-All transport-agnostic interfaces in this package follow the gRPC-shape convention `MethodName(ctx context.Context, req *XRequest) (*XResponse, error)` — `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`. HTTP handlers are thin wrappers that construct the request type from the HTTP message and format the response. The same shape is used in `admin/` (`ClientRegistrar`, `ClientRegistrationManager`). Convention rationale: issue #110; apiauth adoption: issue #175.
+All transport-agnostic interfaces in this package follow the gRPC-shape convention `MethodName(ctx context.Context, req *XRequest) (*XResponse, error)` — `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`. HTTP handlers are thin wrappers that construct the request type from the HTTP message and format the response. The same shape is used in `admin/` (`ClientRegistrar`, `ClientRegistrationManager`). Convention rationale: issue #110; apiauth adoption: issues #175 and #218.
 
-Legacy positional methods on `APIAuth` (`CreateAccessToken`, `ValidateAccessToken`, `ValidateAccessTokenFull`, `VerifyTokenFunc`) are marked `// Deprecated:` — they remain as the internal implementation backing the HTTP handlers until consolidation lands. Tracked under issue #218.
+`APIAuth` exposes `Issuer() TokenIssuer` and `Validator() TokenValidator` accessors that lazy-build the gRPC-shape implementations from APIAuth's configuration fields — internal HTTP handlers and consumer tests both go through these. The previous positional methods (`CreateAccessToken`, `ValidateAccessToken`, `ValidateAccessTokenFull`, `VerifyTokenFunc`) were removed in issue #218.
 
 The `OneAuth` struct composes focused interfaces for all auth operations without HTTP:
 - **interfaces.go** — `TokenIssuer`, `TokenValidator`, `TokenIntrospector`, `TokenRevoker`, `ClientAuthenticator`, `TokenInfo`

--- a/apiauth/asymmetric_jwt_test.go
+++ b/apiauth/asymmetric_jwt_test.go
@@ -147,12 +147,26 @@ func TestAPIAuth_RS256_Signing(t *testing.T) {
 		JWTIssuer:     "test",
 	}
 
-	tokenStr, _, err := auth.CreateAccessToken("user-rsa", []string{"read"}, nil)
+	tokenStrResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-rsa", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	tokenStr := ""
+
+	var _ int64
+
+	if tokenStrResp != nil { tokenStr = tokenStrResp.Token; _ = tokenStrResp.ExpiresIn }
+
 	if err != nil {
 		t.Fatalf("CreateAccessToken: %v", err)
 	}
 
-	userID, scopes, err := auth.ValidateAccessToken(tokenStr)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+
+	var userID string
+
+	var scopes []string
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; scopes = vresp.Info.Scopes }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessToken: %v", err)
 	}
@@ -177,12 +191,26 @@ func TestAPIAuth_ES256_Signing(t *testing.T) {
 		JWTVerifyKey:  pubKey,
 	}
 
-	tokenStr, _, err := auth.CreateAccessToken("user-ec", []string{"write"}, nil)
+	tokenStrResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-ec", Scopes: []string{"write"}, AuthorizationDetails: nil})
+
+	tokenStr := ""
+
+	var _ int64
+
+	if tokenStrResp != nil { tokenStr = tokenStrResp.Token; _ = tokenStrResp.ExpiresIn }
+
 	if err != nil {
 		t.Fatalf("CreateAccessToken: %v", err)
 	}
 
-	userID, scopes, err := auth.ValidateAccessToken(tokenStr)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+
+	var userID string
+
+	var scopes []string
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; scopes = vresp.Info.Scopes }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessToken: %v", err)
 	}
@@ -208,10 +236,18 @@ func TestAPIAuth_RS256_RejectsHMAC(t *testing.T) {
 	}
 
 	// Create a valid RS256 token, then try to validate with HMAC-configured auth
-	tokenStr, _, _ := auth.CreateAccessToken("user-1", []string{"read"}, nil)
+	tokenStrResp, _ := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	tokenStr := ""
+
+	if tokenStrResp != nil { tokenStr = tokenStrResp.Token }
 
 	hmacAuth := &apiauth.APIAuth{JWTSecretKey: "some-secret"}
-	_, _, err := hmacAuth.ValidateAccessToken(tokenStr)
+	vresp, err := hmacAuth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+	var _ string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	if err == nil {
 		t.Fatal("Expected HMAC auth to reject RS256 token")
 	}
@@ -233,8 +269,19 @@ func TestAPIAuth_ValidateAccessTokenFull_RS256(t *testing.T) {
 		},
 	}
 
-	tokenStr, _, _ := auth.CreateAccessToken("user-1", []string{"read"}, nil)
-	userID, _, custom, err := auth.ValidateAccessTokenFull(tokenStr)
+	tokenStrResp, _ := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+
+	tokenStr := ""
+
+
+	if tokenStrResp != nil { tokenStr = tokenStrResp.Token }
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+	var userID string
+	var _ []string
+	var custom map[string]any
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes; custom = vresp.Info.CustomClaims }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessTokenFull: %v", err)
 	}

--- a/apiauth/audience_test.go
+++ b/apiauth/audience_test.go
@@ -25,6 +25,7 @@ package apiauth_test
 //     Improper Access Control — accepting tokens meant for other services.
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -83,7 +84,14 @@ func TestAudience_WrongAud_Rejected(t *testing.T) {
 	// Token was minted for service-b
 	token := mintToken(t, secret, baseClaims("service-b"))
 
-	_, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	if assert.Error(t, err, "ValidateAccessToken should reject token with wrong audience") {
 		assert.Contains(t, err.Error(), "audience")
 	}
@@ -102,7 +110,16 @@ func TestAudience_WrongAud_Rejected_Full(t *testing.T) {
 
 	token := mintToken(t, secret, baseClaims("service-b"))
 
-	_, _, _, err := auth.ValidateAccessTokenFull(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	var _ map[string]any
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes; _ = vresp.Info.CustomClaims }
+
 	if assert.Error(t, err, "ValidateAccessTokenFull should reject token with wrong audience") {
 		assert.Contains(t, err.Error(), "audience")
 	}
@@ -123,7 +140,14 @@ func TestAudience_MissingAud_Rejected(t *testing.T) {
 	// Token has no aud claim at all
 	token := mintToken(t, secret, baseClaims(""))
 
-	_, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	if assert.Error(t, err, "ValidateAccessToken should reject token missing audience when JWTAudience is configured") {
 		assert.Contains(t, err.Error(), "audience")
 	}
@@ -144,7 +168,14 @@ func TestAudience_CorrectAud_Accepted(t *testing.T) {
 
 	token := mintToken(t, secret, baseClaims("service-a"))
 
-	userID, scopes, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var scopes []string
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; scopes = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 	assert.Contains(t, scopes, "read")
@@ -162,13 +193,20 @@ func TestAudience_NoAudienceConfigured_AcceptsAll(t *testing.T) {
 
 	// Token with some audience — should be accepted
 	token := mintToken(t, secret, baseClaims("any-service"))
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 
 	// Token with no audience — should also be accepted
 	token2 := mintToken(t, secret, baseClaims(""))
-	userID2, _, err := auth.ValidateAccessToken(token2)
+	vresp, err = auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token2})
+	var userID2 string
+	if vresp != nil && vresp.Info != nil { userID2 = vresp.Info.Subject }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID2)
 }
@@ -186,7 +224,16 @@ func TestAudience_CorrectAud_Full(t *testing.T) {
 	claims["tenant"] = "acme"
 	token := mintToken(t, secret, claims)
 
-	userID, _, customClaims, err := auth.ValidateAccessTokenFull(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var _ []string
+
+	var customClaims map[string]any
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes; customClaims = vresp.Info.CustomClaims }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 	assert.Equal(t, "acme", customClaims["tenant"])
@@ -228,7 +275,14 @@ func TestAudience_ArrayAud_Matching_Accepted(t *testing.T) {
 
 	token := mintToken(t, secret, arrayAudClaims([]string{"service-a", "service-b"}))
 
-	userID, scopes, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var scopes []string
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; scopes = vresp.Info.Scopes }
+
 	assert.NoError(t, err, "ValidateAccessToken should accept token with matching audience in array")
 	assert.Equal(t, "user1", userID)
 	assert.Contains(t, scopes, "read")
@@ -249,7 +303,14 @@ func TestAudience_ArrayAud_NotMatching_Rejected(t *testing.T) {
 
 	token := mintToken(t, secret, arrayAudClaims([]string{"service-b", "service-c"}))
 
-	_, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	if assert.Error(t, err, "ValidateAccessToken should reject token when expected audience not in array") {
 		assert.Contains(t, err.Error(), "audience")
 	}
@@ -271,7 +332,16 @@ func TestAudience_ArrayAud_Full_Accepted(t *testing.T) {
 	claims["tenant"] = "acme"
 	token := mintToken(t, secret, claims)
 
-	userID, _, customClaims, err := auth.ValidateAccessTokenFull(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var _ []string
+
+	var customClaims map[string]any
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes; customClaims = vresp.Info.CustomClaims }
+
 	assert.NoError(t, err, "ValidateAccessTokenFull should accept token with matching audience in array")
 	assert.Equal(t, "user1", userID)
 	assert.Equal(t, "acme", customClaims["tenant"])
@@ -291,7 +361,16 @@ func TestAudience_ArrayAud_Full_Rejected(t *testing.T) {
 
 	token := mintToken(t, secret, arrayAudClaims([]string{"service-b"}))
 
-	_, _, _, err := auth.ValidateAccessTokenFull(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	var _ map[string]any
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes; _ = vresp.Info.CustomClaims }
+
 	if assert.Error(t, err, "ValidateAccessTokenFull should reject token when expected audience not in array") {
 		assert.Contains(t, err.Error(), "audience")
 	}
@@ -368,7 +447,14 @@ func TestAudience_EmptyArray_Rejected(t *testing.T) {
 
 	token := mintToken(t, secret, arrayAudClaims([]string{}))
 
-	_, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	if assert.Error(t, err, "ValidateAccessToken should reject token with empty audience array") {
 		assert.Contains(t, err.Error(), "audience")
 	}
@@ -389,7 +475,14 @@ func TestAudience_SingleElementArray_Accepted(t *testing.T) {
 
 	token := mintToken(t, secret, arrayAudClaims([]string{"service-a"}))
 
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err, "ValidateAccessToken should accept single-element array with matching audience")
 	assert.Equal(t, "user1", userID)
 }

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -2,8 +2,6 @@ package apiauth
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -105,6 +103,16 @@ type APIAuth struct {
 	// replay protection for private_key_jwt assertions.
 	lazyAuthenticator     ClientAuthenticator
 	lazyAuthenticatorOnce sync.Once
+
+	// lazyIssuer / lazyValidator cache the gRPC-shape TokenIssuer /
+	// TokenValidator built from APIAuth's configuration. They are the
+	// implementations every HTTP handler dispatches through. Lazy so
+	// callers can populate APIAuth fields after construction (the
+	// existing usage pattern) before any token is minted.
+	lazyIssuer        TokenIssuer
+	lazyIssuerOnce    sync.Once
+	lazyValidator     TokenValidator
+	lazyValidatorOnce sync.Once
 
 	// TrustedAssertionIssuers lists upstream IdPs whose JWT assertions
 	// the token endpoint will accept for the jwt-bearer grant
@@ -273,7 +281,11 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
 	}
 
 	// Create access token (JWT)
-	accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
+	tokResp, err := a.Issuer().CreateAccessToken(r.Context(), &CreateAccessTokenRequest{
+		Subject:              user.Id(),
+		Scopes:               grantedScopes,
+		AuthorizationDetails: req.AuthorizationDetails,
+	})
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -286,7 +298,7 @@ func (a *APIAuth) handlePasswordGrant(w http.ResponseWriter, r *http.Request, re
 	}
 
 	// Return token pair
-	a.tokenResponse(w, accessToken, expiresIn, refreshToken.Token, grantedScopes, req.AuthorizationDetails)
+	a.tokenResponse(w, tokResp.Token, tokResp.ExpiresIn, refreshToken.Token, grantedScopes, req.AuthorizationDetails)
 }
 
 // handleRefreshTokenGrant handles the refresh_token grant type
@@ -340,7 +352,11 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	newRefreshToken := rotResp.Token
 
 	// Create new access token (carry forward authorization_details from original grant)
-	accessToken, expiresIn, err := a.CreateAccessToken(refreshToken.Subject, refreshToken.Scopes, refreshToken.AuthorizationDetails)
+	tokResp, err := a.Issuer().CreateAccessToken(r.Context(), &CreateAccessTokenRequest{
+		Subject:              refreshToken.Subject,
+		Scopes:               refreshToken.Scopes,
+		AuthorizationDetails: refreshToken.AuthorizationDetails,
+	})
 	if err != nil {
 		log.Printf("Error creating access token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -348,7 +364,7 @@ func (a *APIAuth) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	}
 
 	// Return new token pair
-	a.tokenResponse(w, accessToken, expiresIn, newRefreshToken.Token, refreshToken.Scopes, refreshToken.AuthorizationDetails)
+	a.tokenResponse(w, tokResp.Token, tokResp.ExpiresIn, newRefreshToken.Token, refreshToken.Scopes, refreshToken.AuthorizationDetails)
 }
 
 // handleClientCredentialsGrant handles the client_credentials grant type (RFC 6749 §4.4).
@@ -395,7 +411,11 @@ func (a *APIAuth) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Re
 	}
 
 	// Create access token with sub=client_id (no user context)
-	accessToken, expiresIn, err := a.CreateAccessToken(clientID, scopes, req.AuthorizationDetails)
+	tokResp, err := a.Issuer().CreateAccessToken(r.Context(), &CreateAccessTokenRequest{
+		Subject:              clientID,
+		Scopes:               scopes,
+		AuthorizationDetails: req.AuthorizationDetails,
+	})
 	if err != nil {
 		log.Printf("Error creating client_credentials token: %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -403,7 +423,7 @@ func (a *APIAuth) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Re
 	}
 
 	// Return access token only — no refresh token for client_credentials
-	a.tokenResponse(w, accessToken, expiresIn, "", scopes, req.AuthorizationDetails)
+	a.tokenResponse(w, tokResp.Token, tokResp.ExpiresIn, "", scopes, req.AuthorizationDetails)
 }
 
 // authenticateTokenEndpointClient runs whichever auth method the request
@@ -568,288 +588,74 @@ var standardClaims = map[string]bool{
 	"authorization_details": true, // RFC 9396
 }
 
-// CreateAccessToken creates a signed JWT access token. If CustomClaimsFunc is set,
-// its returned claims are merged into the token (standard claims cannot be overridden).
-// authzDetails is an optional RFC 9396 authorization_details array embedded in the JWT.
-//
-// Deprecated: prefer the transport-agnostic TokenIssuer.CreateAccessToken(ctx,
-// *CreateAccessTokenRequest) (*CreateAccessTokenResponse, error) on the OneAuth.Issuer
-// (or NewJWTIssuer-built jwtIssuer). This positional method is retained as the internal
-// implementation that APIAuth's HTTP handlers still call; consolidation tracked under issue 218.
-func (a *APIAuth) CreateAccessToken(userID string, scopes []string, authzDetails []core.AuthorizationDetail) (string, int64, error) {
-	expiry := a.AccessTokenExpiry
-	if expiry == 0 {
-		expiry = core.TokenExpiryAccessToken
-	}
+// Issuer returns the TokenIssuer implementation backing APIAuth's token-mint
+// HTTP handlers. Lazily built from APIAuth's configuration on first call;
+// safe for use after all APIAuth fields are populated.
+func (a *APIAuth) Issuer() TokenIssuer {
+	a.lazyIssuerOnce.Do(func() {
+		a.lazyIssuer = NewJWTIssuer(JWTIssuerConfig{
+			SigningKey:          a.signingKeyForIssuer(),
+			SigningAlg:          a.signingAlg(),
+			Issuer:              a.JWTIssuer,
+			Audience:            a.JWTAudience,
+			AccessExpiry:        a.AccessTokenExpiry,
+			ClientKeyLookup:     a.ClientKeyStore,
+			RefreshStore:        a.RefreshTokenStore,
+			ValidateCredentials: a.ValidateCredentials,
+			GetSubjectScopes:    a.GetSubjectScopes,
+			CustomClaims:        CustomClaimsFunc(a.CustomClaimsFunc),
+		})
+	})
+	return a.lazyIssuer
+}
 
-	now := time.Now()
-	expiresAt := now.Add(expiry)
+// Validator returns the TokenValidator implementation backing APIAuth's
+// token-validation paths (middleware, introspection). Lazily built from
+// APIAuth's configuration on first call.
+func (a *APIAuth) Validator() TokenValidator {
+	a.lazyValidatorOnce.Do(func() {
+		a.lazyValidator = NewJWTValidator(JWTValidatorConfig{
+			SigningKey: a.signingKeyForValidator(),
+			SigningAlg: a.signingAlg(),
+			Blacklist:  a.Blacklist,
+			Issuer:     a.JWTIssuer,
+			Audience:   a.JWTAudience,
+		})
+	})
+	return a.lazyValidator
+}
 
-	// Generate jti (JWT ID) for token blacklisting (RFC 7519 §4.1.7)
-	jti, err := core.GenerateSecureToken()
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to generate jti: %w", err)
+// signingAlg returns APIAuth's effective signing algorithm, defaulting to HS256.
+func (a *APIAuth) signingAlg() string {
+	if a.JWTSigningAlg != "" {
+		return a.JWTSigningAlg
 	}
+	return "HS256"
+}
 
-	claims := jwt.MapClaims{
-		"sub":    userID,
-		"type":   "access",
-		"scopes": scopes,
-		"jti":    jti,
-		"iat":    now.Unix(),
-		"exp":    expiresAt.Unix(),
-	}
-
-	if len(authzDetails) > 0 {
-		claims["authorization_details"] = authzDetails
-	}
-
-	if a.JWTIssuer != "" {
-		claims["iss"] = a.JWTIssuer
-	}
-	if a.JWTAudience != "" {
-		claims["aud"] = a.JWTAudience
-	}
-
-	// Merge custom claims (cannot override standard claims)
-	if a.CustomClaimsFunc != nil {
-		custom, err := a.CustomClaimsFunc(userID, scopes)
-		if err != nil {
-			return "", 0, fmt.Errorf("custom claims func failed: %w", err)
-		}
-		for k, v := range custom {
-			if standardClaims[k] {
-				log.Printf("Warning: CustomClaimsFunc attempted to override standard claim %q (ignored)", k)
-			} else {
-				claims[k] = v
-			}
-		}
-	}
-
-	signingMethod, err := utils.SigningMethodForAlg(a.JWTSigningAlg)
-	if err != nil {
-		return "", 0, fmt.Errorf("invalid signing algorithm: %w", err)
-	}
-
-	// Determine the signing key: asymmetric key takes precedence over JWTSecretKey
-	var signingKey any
+// signingKeyForIssuer returns the key used for signing new tokens.
+// Asymmetric (JWTSigningKey) takes precedence over symmetric (JWTSecretKey).
+func (a *APIAuth) signingKeyForIssuer() any {
 	if a.JWTSigningKey != nil {
-		signingKey = a.JWTSigningKey
-	} else {
-		signingKey = []byte(a.JWTSecretKey)
+		return a.JWTSigningKey
 	}
-
-	token := jwt.NewWithClaims(signingMethod, claims)
-	if kid, kidErr := utils.ComputeKid(signingKey, signingMethod.Alg()); kidErr == nil {
-		token.Header["kid"] = kid
-	}
-	tokenString, err := token.SignedString(signingKey)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to sign token: %w", err)
-	}
-
-	return tokenString, int64(expiry.Seconds()), nil
+	return []byte(a.JWTSecretKey)
 }
 
-// VerifyTokenFunc returns a function that can be used as Middleware.VerifyToken.
-// This allows the Middleware to validate Bearer tokens using the APIAuth's JWT configuration.
-//
-// Deprecated: prefer the transport-agnostic TokenValidator.ValidateToken(ctx,
-// *ValidateTokenRequest) (*ValidateTokenResponse, error) on the OneAuth.Validator.
-// Retained for httpauth.Middleware wiring; consolidation tracked under issue 218.
-func (a *APIAuth) VerifyTokenFunc() func(tokenString string) (userID string, token any, err error) {
-	return func(tokenString string) (string, any, error) {
-		userID, scopes, err := a.ValidateAccessToken(tokenString)
-		if err != nil {
-			return "", nil, err
-		}
-		return userID, scopes, nil
-	}
-}
-
-// ValidateAccessToken validates a JWT access token and returns the claims.
-//
-// Deprecated: prefer the transport-agnostic TokenValidator.ValidateToken(ctx,
-// *ValidateTokenRequest) (*ValidateTokenResponse, error) on the OneAuth.Validator.
-// Retained as the implementation backing the deprecated VerifyTokenFunc;
-// consolidation tracked under issue 218.
-func (a *APIAuth) ValidateAccessToken(tokenString string) (userID string, scopes []string, err error) {
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
-		return a.jwtKeyFunc(token)
-	})
-
-	if err != nil {
-		return "", nil, err
-	}
-
-	if !token.Valid {
-		return "", nil, fmt.Errorf("invalid token")
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return "", nil, fmt.Errorf("invalid claims")
-	}
-
-	// Verify token type: reject if explicitly set to something other than "access"
-	// (prevents OneAuth refresh tokens from being used as access tokens).
-	// External IdP tokens (Keycloak, Auth0) don't include this claim — accepted.
-	if tokenType, ok := claims["type"].(string); ok && tokenType != "access" {
-		return "", nil, fmt.Errorf("invalid token type")
-	}
-
-	// Verify issuer if configured
-	if a.JWTIssuer != "" {
-		if iss, ok := claims["iss"].(string); !ok || iss != a.JWTIssuer {
-			return "", nil, fmt.Errorf("invalid issuer")
-		}
-	}
-
-	// Verify audience if configured (RFC 7519 §4.1.3)
-	// Handles both string and array aud claims (#52)
-	if a.JWTAudience != "" {
-		if !matchesAudience(claims, a.JWTAudience) {
-			return "", nil, fmt.Errorf("invalid audience: expected %q", a.JWTAudience)
-		}
-	}
-
-	// Extract user ID
-	userID, ok = claims["sub"].(string)
-	if !ok || userID == "" {
-		return "", nil, fmt.Errorf("missing subject")
-	}
-
-	// Extract scopes
-	if scopesRaw, ok := claims["scopes"].([]any); ok {
-		scopes = make([]string, 0, len(scopesRaw))
-		for _, s := range scopesRaw {
-			if str, ok := s.(string); ok {
-				scopes = append(scopes, str)
-			}
-		}
-	}
-
-	// Check blacklist if configured (RFC 7519 §4.1.7 jti-based revocation)
-	if a.Blacklist != nil {
-		if jti, ok := claims["jti"].(string); ok && jti != "" {
-			if a.Blacklist.IsRevoked(jti) {
-				return "", nil, fmt.Errorf("token has been revoked")
-			}
-		}
-	}
-
-	return userID, scopes, nil
-}
-
-// ValidateAccessTokenFull validates a JWT access token and returns the standard claims
-// plus any custom claims (non-standard keys) as a separate map.
-//
-// Deprecated: prefer the transport-agnostic TokenValidator.ValidateToken(ctx,
-// *ValidateTokenRequest) (*ValidateTokenResponse, error) on the OneAuth.Validator —
-// its response carries the same standard + custom claims split via TokenInfo.
-// Retained as the implementation backing IntrospectionHandler today; consolidation
-// tracked separately.
-func (a *APIAuth) ValidateAccessTokenFull(tokenString string) (userID string, scopes []string, customClaims map[string]any, err error) {
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
-		return a.jwtKeyFunc(token)
-	})
-
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	if !token.Valid {
-		return "", nil, nil, fmt.Errorf("invalid token")
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return "", nil, nil, fmt.Errorf("invalid claims")
-	}
-
-	// Verify token type: reject if explicitly set to something other than "access"
-	// (prevents OneAuth refresh tokens from being used as access tokens).
-	// External IdP tokens (Keycloak, Auth0) don't include this claim — accepted.
-	if tokenType, ok := claims["type"].(string); ok && tokenType != "access" {
-		return "", nil, nil, fmt.Errorf("invalid token type")
-	}
-
-	// Verify issuer if configured
-	if a.JWTIssuer != "" {
-		if iss, ok := claims["iss"].(string); !ok || iss != a.JWTIssuer {
-			return "", nil, nil, fmt.Errorf("invalid issuer")
-		}
-	}
-
-	// Verify audience if configured (RFC 7519 §4.1.3)
-	// Handles both string and array aud claims (#52)
-	if a.JWTAudience != "" {
-		if !matchesAudience(claims, a.JWTAudience) {
-			return "", nil, nil, fmt.Errorf("invalid audience: expected %q", a.JWTAudience)
-		}
-	}
-
-	// Extract user ID
-	userID, ok = claims["sub"].(string)
-	if !ok || userID == "" {
-		return "", nil, nil, fmt.Errorf("missing subject")
-	}
-
-	// Extract scopes
-	if scopesRaw, ok := claims["scopes"].([]any); ok {
-		scopes = make([]string, 0, len(scopesRaw))
-		for _, s := range scopesRaw {
-			if str, ok := s.(string); ok {
-				scopes = append(scopes, str)
-			}
-		}
-	}
-
-	// Extract custom claims (everything that's not a standard JWT claim)
-	customClaims = make(map[string]any)
-	for k, v := range claims {
-		if !standardClaims[k] {
-			customClaims[k] = v
-		}
-	}
-
-	// Check blacklist if configured
-	if a.Blacklist != nil {
-		if jti, ok := claims["jti"].(string); ok && jti != "" {
-			if a.Blacklist.IsRevoked(jti) {
-				return "", nil, nil, fmt.Errorf("token has been revoked")
-			}
-		}
-	}
-
-	return userID, scopes, customClaims, nil
-}
-
-// jwtKeyFunc is the shared key-selection function for jwt.Parse in APIAuth.
-// It supports both symmetric (HMAC) and asymmetric (RSA/ECDSA) keys.
-func (a *APIAuth) jwtKeyFunc(token *jwt.Token) (any, error) {
-	// Asymmetric: JWTVerifyKey is set
+// signingKeyForValidator returns the key used for verifying token signatures.
+// For asymmetric algorithms, this is the public verification key; for HMAC,
+// the same secret used to sign.
+func (a *APIAuth) signingKeyForValidator() any {
 	if a.JWTVerifyKey != nil {
-		switch a.JWTVerifyKey.(type) {
-		case *rsa.PublicKey:
-			if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v (expected RS256)", token.Header["alg"])
-			}
-		case *ecdsa.PublicKey:
-			if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v (expected ES256)", token.Header["alg"])
-			}
-		default:
-			return nil, fmt.Errorf("unsupported verify key type: %T", a.JWTVerifyKey)
-		}
-		return a.JWTVerifyKey, nil
+		return a.JWTVerifyKey
 	}
-
-	// Symmetric: HMAC with JWTSecretKey
-	if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+	if a.JWTSigningKey != nil {
+		// Asymmetric mode without an explicit verify key — most code paths
+		// pass both, but fall back to the signing key so HS256 holders that
+		// set only JWTSigningKey still work.
+		return a.JWTSigningKey
 	}
-	return []byte(a.JWTSecretKey), nil
+	return []byte(a.JWTSecretKey)
 }
 
 // tokenResponse sends a successful token response

--- a/apiauth/auth_rar_test.go
+++ b/apiauth/auth_rar_test.go
@@ -222,7 +222,14 @@ func TestCreateAccessToken_StandardClaimsGuard_RAR(t *testing.T) {
 		{Type: "legitimate", Actions: []string{"read"}},
 	}
 
-	token, _, err := auth.CreateAccessToken("user-1", []string{"read"}, details)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-1", Scopes: []string{"read"}, AuthorizationDetails: details})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Parse JWT and verify the custom claim was blocked
@@ -264,7 +271,14 @@ func TestIntrospection_WithRAR(t *testing.T) {
 		},
 	}
 
-	token, _, err := auth.CreateAccessToken("user-rar", []string{"payments"}, details)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-rar", Scopes: []string{"payments"}, AuthorizationDetails: details})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Introspect the token
@@ -305,7 +319,14 @@ func TestIntrospection_WithoutRAR(t *testing.T) {
 
 	handler := apiauth.NewIntrospectionHandler(auth, ks)
 
-	token, _, err := auth.CreateAccessToken("user-normal", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-normal", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	rr := postIntrospect(t, handler, token, "resource-server", "rs-secret")

--- a/apiauth/auth_test.go
+++ b/apiauth/auth_test.go
@@ -553,7 +553,9 @@ func TestAPIKeyManagement(t *testing.T) {
 	json.NewDecoder(rr.Body).Decode(&loginResponse)
 
 	// Validate token to get user ID
-	userID, _, _ := apiAuth.ValidateAccessToken(loginResponse.AccessToken)
+	vresp, _ := apiAuth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: loginResponse.AccessToken})
+	var userID string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject }
 
 	var createdKeyID string
 

--- a/apiauth/blacklist_test.go
+++ b/apiauth/blacklist_test.go
@@ -81,10 +81,24 @@ func TestInMemoryBlacklist_Cleanup(t *testing.T) {
 func TestBlacklist_JTIInAccessToken(t *testing.T) {
 	auth := &apiauth.APIAuth{JWTSecretKey: "test-secret"}
 
-	token1, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	token1Resp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token1 := ""
+
+	var _ int64
+
+	if token1Resp != nil { token1 = token1Resp.Token; _ = token1Resp.ExpiresIn }
+
 	require.NoError(t, err)
 
-	token2, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	token2Resp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token2 := ""
+
+	var _ int64
+
+	if token2Resp != nil { token2 = token2Resp.Token; _ = token2Resp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Parse tokens to extract jti
@@ -117,11 +131,22 @@ func TestBlacklist_RevokedTokenRejected(t *testing.T) {
 		Blacklist:    bl,
 	}
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Token should work before revocation
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 
@@ -132,7 +157,11 @@ func TestBlacklist_RevokedTokenRejected(t *testing.T) {
 	bl.Revoke(jti, time.Now().Add(time.Hour))
 
 	// Token should now be rejected
-	_, _, err = auth.ValidateAccessToken(token)
+	vresp, err = auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var _ string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.Error(t, err, "revoked token should be rejected")
 	assert.Contains(t, err.Error(), "revoked")
 }
@@ -146,14 +175,25 @@ func TestBlacklist_NonRevokedTokenAccepted(t *testing.T) {
 		Blacklist:    bl,
 	}
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Revoke a DIFFERENT token
 	bl.Revoke("some-other-jti", time.Now().Add(time.Hour))
 
 	// Our token should still work
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 }
@@ -164,10 +204,24 @@ func TestBlacklist_NoBlacklistConfigured(t *testing.T) {
 	auth := &apiauth.APIAuth{JWTSecretKey: "test-secret"}
 	// No Blacklist field set
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 }
@@ -197,7 +251,13 @@ func TestBlacklist_MiddlewareChecksBlacklist(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token, _, _ := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, _ := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+
+	token := ""
+
+
+	if tokenResp != nil { token = tokenResp.Token }
 
 	// Should work before revocation
 	rr := httptest.NewRecorder()
@@ -230,7 +290,13 @@ func TestBlacklist_ValidateAccessTokenFull_ChecksBlacklist(t *testing.T) {
 		Blacklist:    bl,
 	}
 
-	token, _, _ := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, _ := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+
+	token := ""
+
+
+	if tokenResp != nil { token = tokenResp.Token }
 
 	// Extract and revoke
 	parser := jwt.NewParser()
@@ -238,7 +304,16 @@ func TestBlacklist_ValidateAccessTokenFull_ChecksBlacklist(t *testing.T) {
 	jti := parsed.Claims.(jwt.MapClaims)["jti"].(string)
 	bl.Revoke(jti, time.Now().Add(time.Hour))
 
-	_, _, _, err := auth.ValidateAccessTokenFull(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	var _ map[string]any
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes; _ = vresp.Info.CustomClaims }
+
 	assert.Error(t, err, "ValidateAccessTokenFull should also check blacklist")
 }
 

--- a/apiauth/client_credentials_test.go
+++ b/apiauth/client_credentials_test.go
@@ -75,7 +75,11 @@ func TestClientCredentials_Success(t *testing.T) {
 
 	// Validate the JWT claims
 	token := resp["access_token"].(string)
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	require.NoError(t, err, "minted token should be valid")
 	assert.Equal(t, "test-service", userID, "sub should be the client_id")
 }
@@ -169,7 +173,11 @@ func TestClientCredentials_WithScopes(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 
 	token := resp["access_token"].(string)
-	_, scopes, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var _ string
+	var scopes []string
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; scopes = vresp.Info.Scopes }
+
 	require.NoError(t, err)
 	assert.Contains(t, scopes, "read")
 	assert.Contains(t, scopes, "write")

--- a/apiauth/custom_claims_test.go
+++ b/apiauth/custom_claims_test.go
@@ -32,13 +32,22 @@ func TestCustomClaimsFunc_RoundTrip(t *testing.T) {
 	}
 
 	// Mint a token using the exported method
-	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read", "write"}, nil)
+	tokenResp, err := apiAuth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-123", Scopes: []string{"read", "write"}, AuthorizationDetails: nil})
+	token := ""
+	var _ int64
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
 
 	// Validate and extract custom claims
-	userID, scopes, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	vresp, err := apiAuth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var scopes []string
+	var customClaims map[string]any
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; scopes = vresp.Info.Scopes; customClaims = vresp.Info.CustomClaims }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
 	}
@@ -73,12 +82,28 @@ func TestCustomClaimsFunc_Nil(t *testing.T) {
 		// CustomClaimsFunc is nil
 	}
 
-	token, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"}, nil)
+	tokenResp, err := apiAuth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-123", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
 
-	userID, scopes, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	vresp, err := apiAuth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var scopes []string
+
+	var customClaims map[string]any
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; scopes = vresp.Info.Scopes; customClaims = vresp.Info.CustomClaims }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
 	}
@@ -104,7 +129,8 @@ func TestCustomClaimsFunc_Error(t *testing.T) {
 		},
 	}
 
-	_, _, err := apiAuth.CreateAccessToken("user-123", []string{"read"}, nil)
+	_, err := apiAuth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-123", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
 	if err == nil {
 		t.Fatal("Expected error from CreateAccessToken when CustomClaimsFunc fails")
 	}
@@ -125,12 +151,28 @@ func TestCustomClaimsFunc_NoOverrideStandard(t *testing.T) {
 		},
 	}
 
-	token, _, err := apiAuth.CreateAccessToken("real-user", []string{"read"}, nil)
+	tokenResp, err := apiAuth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "real-user", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
 
-	userID, _, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	vresp, err := apiAuth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var userID string
+
+	var _ []string
+
+	var customClaims map[string]any
+
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes; customClaims = vresp.Info.CustomClaims }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
 	}
@@ -329,12 +371,28 @@ func TestValidateAccessTokenFull_StandardClaimsExcluded(t *testing.T) {
 		},
 	}
 
-	token, _, err := apiAuth.CreateAccessToken("user-1", []string{"read"}, nil)
+	tokenResp, err := apiAuth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	if err != nil {
 		t.Fatalf("CreateAccessToken failed: %v", err)
 	}
 
-	_, _, customClaims, err := apiAuth.ValidateAccessTokenFull(token)
+	vresp, err := apiAuth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+
+	var _ string
+
+	var _ []string
+
+	var customClaims map[string]any
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes; customClaims = vresp.Info.CustomClaims }
+
 	if err != nil {
 		t.Fatalf("ValidateAccessTokenFull failed: %v", err)
 	}

--- a/apiauth/introspection.go
+++ b/apiauth/introspection.go
@@ -59,21 +59,22 @@ func (ai *apiauthIntrospector) Introspect(ctx context.Context, req *IntrospectRe
 		return nil, fmt.Errorf("IntrospectRequest is required")
 	}
 	tokenString := req.Token
-	userID, scopes, _, err := ai.auth.ValidateAccessTokenFull(tokenString)
+	validateResp, err := ai.auth.Validator().ValidateToken(ctx, &ValidateTokenRequest{Token: tokenString})
 	if err != nil {
 		return &IntrospectResponse{Result: &IntrospectionResult{Active: false}}, nil
 	}
+	info := validateResp.Info
 
 	rawClaims := parseRawJWTClaims(tokenString)
 
 	result := &IntrospectionResult{
 		Active:    true,
-		Sub:       userID,
+		Sub:       info.Subject,
 		TokenType: "access_token",
 	}
 
-	if len(scopes) > 0 {
-		result.Scope = joinScopes(scopes)
+	if len(info.Scopes) > 0 {
+		result.Scope = joinScopes(info.Scopes)
 	}
 
 	if rawClaims != nil {

--- a/apiauth/introspection_test.go
+++ b/apiauth/introspection_test.go
@@ -78,7 +78,11 @@ func postIntrospect(t *testing.T, handler http.Handler, token, clientID, clientS
 // mintIntrospectionToken creates a signed access token for testing.
 func mintIntrospectionToken(t *testing.T, auth *apiauth.APIAuth, userID string, scopes []string) string {
 	t.Helper()
-	token, _, err := auth.CreateAccessToken(userID, scopes, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: userID, Scopes: scopes, AuthorizationDetails: nil})
+	token := ""
+	var _ int64
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 	return token
 }

--- a/apiauth/jwt_bearer_grant.go
+++ b/apiauth/jwt_bearer_grant.go
@@ -228,7 +228,11 @@ func (a *APIAuth) handleJwtBearerGrant(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	accessToken, expiresIn, err := a.CreateAccessToken(subject, scopes, req.AuthorizationDetails)
+	tokResp, err := a.Issuer().CreateAccessToken(r.Context(), &CreateAccessTokenRequest{
+		Subject:              subject,
+		Scopes:               scopes,
+		AuthorizationDetails: req.AuthorizationDetails,
+	})
 	if err != nil {
 		log.Printf("Error creating access token (jwt-bearer grant): %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -239,5 +243,5 @@ func (a *APIAuth) handleJwtBearerGrant(w http.ResponseWriter, r *http.Request, r
 	// itself is the renewable credential (re-issued by the upstream
 	// IdP and re-presented). Returning a refresh token would muddle
 	// session semantics.
-	a.tokenResponse(w, accessToken, expiresIn, "", scopes, req.AuthorizationDetails)
+	a.tokenResponse(w, tokResp.Token, tokResp.ExpiresIn, "", scopes, req.AuthorizationDetails)
 }

--- a/apiauth/oneauth.go
+++ b/apiauth/oneauth.go
@@ -63,6 +63,11 @@ type OneAuthConfig struct {
 	ValidateCredentials CredentialsValidator    // validates username/password
 	GetSubjectScopes    core.GetSubjectScopesFunc // returns allowed scopes for the subject (user ID or client_id)
 
+	// CustomClaims is called during access-token issuance to inject additional
+	// non-standard claims into the JWT. Standard JWT claims (sub, iss, aud,
+	// exp, iat, type, scopes, jti, authorization_details) cannot be overridden.
+	CustomClaims CustomClaimsFunc
+
 	// Hooks — lifecycle callbacks
 	Hooks Hooks
 }
@@ -86,6 +91,7 @@ func NewOneAuth(cfg OneAuthConfig) *OneAuth {
 		RefreshStore:        cfg.RefreshStore,
 		ValidateCredentials: cfg.ValidateCredentials,
 		GetSubjectScopes:    cfg.GetSubjectScopes,
+		CustomClaims:        cfg.CustomClaims,
 		Hooks:               cfg.Hooks.Token,
 	})
 

--- a/apiauth/private_key_jwt_test.go
+++ b/apiauth/private_key_jwt_test.go
@@ -150,7 +150,13 @@ func TestPrivateKeyJWT_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	require.NotEmpty(t, resp["access_token"], "expected access_token")
 
-	sub, _, err := f.auth.ValidateAccessToken(resp["access_token"].(string))
+	vresp, err := f.auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: resp["access_token"].(string)})
+
+
+	var sub string
+
+
+	if vresp != nil && vresp.Info != nil { sub = vresp.Info.Subject }
 	require.NoError(t, err)
 	assert.Equal(t, f.clientID, sub, "minted token sub MUST equal client_id")
 }

--- a/apiauth/revocation_test.go
+++ b/apiauth/revocation_test.go
@@ -84,7 +84,11 @@ func TestRevocation_AccessToken(t *testing.T) {
 	revHandler, auth, introHandler := setupRevocation(t)
 
 	// Mint an access token
-	token, _, err := auth.CreateAccessToken("user-1", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+	token := ""
+	var _ int64
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Verify it's active via introspection
@@ -136,7 +140,11 @@ func TestRevocation_NoHint(t *testing.T) {
 	revHandler, auth, introHandler := setupRevocation(t)
 
 	// Mint an access token and revoke with no hint
-	token, _, err := auth.CreateAccessToken("user-2", []string{"write"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-2", Scopes: []string{"write"}, AuthorizationDetails: nil})
+	token := ""
+	var _ int64
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	rr := postRevoke(t, revHandler, token, "", "revoke-client", "revoke-client-secret")
@@ -154,7 +162,13 @@ func TestRevocation_NoHint(t *testing.T) {
 func TestRevocation_AlreadyRevoked(t *testing.T) {
 	revHandler, auth, _ := setupRevocation(t)
 
-	token, _, _ := auth.CreateAccessToken("user-3", []string{"read"}, nil)
+	tokenResp, _ := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user-3", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+
+	token := ""
+
+
+	if tokenResp != nil { token = tokenResp.Token }
 
 	// Revoke twice — both should succeed
 	rr := postRevoke(t, revHandler, token, "access_token", "revoke-client", "revoke-client-secret")

--- a/apiauth/security_test.go
+++ b/apiauth/security_test.go
@@ -134,11 +134,22 @@ func TestSecurity_ExpiredToken_Rejected(t *testing.T) {
 	secret := "test-secret-key-for-jwt"
 	auth := &apiauth.APIAuth{JWTSecretKey: secret}
 
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+
+	token := ""
+
+	var _ int64
+
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	require.NoError(t, err)
 
 	// Validate immediately — should work
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 
@@ -152,7 +163,14 @@ func TestSecurity_ExpiredToken_Rejected(t *testing.T) {
 	})
 	expiredStr, _ := expired.SignedString([]byte(secret))
 
-	_, _, err = auth.ValidateAccessToken(expiredStr)
+	vresp, err = auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: expiredStr})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.Error(t, err, "expired tokens must be rejected")
 }
 
@@ -174,7 +192,14 @@ func TestSecurity_RefreshTokenType_RejectedAsAccess(t *testing.T) {
 	})
 	tokenStr, _ := token.SignedString([]byte(secret))
 
-	_, _, err := auth.ValidateAccessToken(tokenStr)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.Error(t, err, "refresh-type tokens must be rejected by access token validator")
 	assert.Contains(t, err.Error(), "invalid token type")
 }
@@ -195,7 +220,14 @@ func TestSecurity_MissingSub_Rejected(t *testing.T) {
 	})
 	tokenStr, _ := token.SignedString([]byte(secret))
 
-	_, _, err := auth.ValidateAccessToken(tokenStr)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.Error(t, err, "tokens without sub claim must be rejected")
 	assert.Contains(t, err.Error(), "missing subject")
 }
@@ -222,7 +254,14 @@ func TestSecurity_WrongIssuer_Rejected(t *testing.T) {
 	})
 	tokenStr, _ := token.SignedString([]byte(secret))
 
-	_, _, err := auth.ValidateAccessToken(tokenStr)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: tokenStr})
+
+	var _ string
+
+	var _ []string
+
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.Error(t, err, "tokens with wrong issuer must be rejected")
 	assert.Contains(t, err.Error(), "invalid issuer")
 }
@@ -239,20 +278,32 @@ func TestSecurity_EmptySigningKey_Errors(t *testing.T) {
 	// CreateAccessToken with empty key should still produce a token
 	// (jwt library allows it), but validation should use the same empty key.
 	// The real risk is key misconfiguration — this documents current behavior.
-	token, _, err := auth.CreateAccessToken("user1", []string{"read"}, nil)
+	tokenResp, err := auth.Issuer().CreateAccessToken(context.Background(), &apiauth.CreateAccessTokenRequest{Subject: "user1", Scopes: []string{"read"}, AuthorizationDetails: nil})
+	token := ""
+	var _ int64
+	if tokenResp != nil { token = tokenResp.Token; _ = tokenResp.ExpiresIn }
+
 	if err != nil {
 		// If it errors on creation, that's fine — fail-safe
 		return
 	}
 
 	// If it produces a token, it should at least be verifiable with the same empty key
-	userID, _, err := auth.ValidateAccessToken(token)
+	vresp, err := auth.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var userID string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { userID = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", userID)
 
 	// But it must NOT be verifiable with a different key
 	auth2 := &apiauth.APIAuth{JWTSecretKey: "different-key"}
-	_, _, err = auth2.ValidateAccessToken(token)
+	vresp, err = auth2.Validator().ValidateToken(context.Background(), &apiauth.ValidateTokenRequest{Token: token})
+	var _ string
+	var _ []string
+	if vresp != nil && vresp.Info != nil { _ = vresp.Info.Subject; _ = vresp.Info.Scopes }
+
 	assert.Error(t, err, "token signed with empty key must not validate with different key")
 }
 

--- a/apiauth/token_exchange_grant.go
+++ b/apiauth/token_exchange_grant.go
@@ -118,7 +118,11 @@ func (a *APIAuth) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	accessToken, expiresIn, err := a.CreateAccessToken(subject, scopes, req.AuthorizationDetails)
+	tokResp, err := a.Issuer().CreateAccessToken(r.Context(), &CreateAccessTokenRequest{
+		Subject:              subject,
+		Scopes:               scopes,
+		AuthorizationDetails: req.AuthorizationDetails,
+	})
 	if err != nil {
 		log.Printf("Error creating access token (token-exchange grant): %v", err)
 		a.errorResponse(w, "server_error", "Failed to create token", http.StatusInternalServerError)
@@ -129,9 +133,9 @@ func (a *APIAuth) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 	// tokenResponse helper omits issued_token_type, which RFC 8693 §2.2
 	// REQUIRES. Encode the response inline.
 	resp := core.TokenPair{
-		AccessToken:          accessToken,
+		AccessToken:          tokResp.Token,
 		TokenType:            "Bearer",
-		ExpiresIn:            expiresIn,
+		ExpiresIn:            tokResp.ExpiresIn,
 		Scope:                core.JoinScopes(scopes),
 		AuthorizationDetails: req.AuthorizationDetails,
 		IssuedTokenType:      requestedType,

--- a/apiauth/token_validator.go
+++ b/apiauth/token_validator.go
@@ -3,6 +3,7 @@ package apiauth
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -15,32 +16,45 @@ import (
 
 // jwtValidator implements TokenValidator using local JWT validation.
 // Dependencies are explicit and minimal: KeyLookup (read-only), Blacklist,
-// issuer/audience config, and security hooks.
+// issuer/audience config, and security hooks. SigningKey is an optional
+// self-validation fallback (used when no KeyLookup is configured or the
+// token's kid / client_id doesn't resolve through it) — supports the
+// "APIAuth holds its own key" mode that doesn't need a KeyStore.
 type jwtValidator struct {
-	keyLookup keys.KeyLookup
-	blacklist core.TokenBlacklist
-	issuer    string
-	audience  string
-	hooks     SecurityHooks
+	keyLookup  keys.KeyLookup
+	signingKey any
+	signingAlg string
+	blacklist  core.TokenBlacklist
+	issuer     string
+	audience   string
+	hooks      SecurityHooks
 }
 
 // JWTValidatorConfig configures a jwtValidator.
 type JWTValidatorConfig struct {
 	KeyLookup keys.KeyLookup
-	Blacklist core.TokenBlacklist
-	Issuer    string
-	Audience  string
-	Hooks     SecurityHooks
+	// SigningKey is an optional fallback used when KeyLookup is nil or the
+	// token's kid / client_id does not resolve through it. For HS256, supply
+	// []byte; for RS256/ES256, supply the verification key (*rsa.PublicKey,
+	// *ecdsa.PublicKey) directly.
+	SigningKey any
+	SigningAlg string
+	Blacklist  core.TokenBlacklist
+	Issuer     string
+	Audience   string
+	Hooks      SecurityHooks
 }
 
 // NewJWTValidator creates a TokenValidator that validates JWTs locally.
 func NewJWTValidator(cfg JWTValidatorConfig) TokenValidator {
 	return &jwtValidator{
-		keyLookup: cfg.KeyLookup,
-		blacklist: cfg.Blacklist,
-		issuer:    cfg.Issuer,
-		audience:  cfg.Audience,
-		hooks:     cfg.Hooks,
+		keyLookup:  cfg.KeyLookup,
+		signingKey: cfg.SigningKey,
+		signingAlg: cfg.SigningAlg,
+		blacklist:  cfg.Blacklist,
+		issuer:     cfg.Issuer,
+		audience:   cfg.Audience,
+		hooks:      cfg.Hooks,
 	}
 }
 
@@ -182,46 +196,66 @@ func (v *jwtValidator) CheckAuthorizationDetails(ctx context.Context, req *Check
 
 // resolveKey finds the appropriate signing key for a JWT token.
 func (v *jwtValidator) resolveKey(token *jwt.Token) (any, error) {
-	if v.keyLookup == nil {
-		return nil, fmt.Errorf("no key store configured")
-	}
-
-	// Try kid-based lookup first
-	if kid, ok := token.Header["kid"].(string); ok && kid != "" {
-		kidResp, err := v.keyLookup.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
-		if err == nil && kidResp != nil && kidResp.Record != nil {
-			rec := kidResp.Record
-			if token.Header["alg"] != rec.Algorithm {
-				v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
-				return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
-			}
-			// Cross-check kid owner vs client_id claim
-			if rec.ClientID != "" {
-				if claims, ok := token.Claims.(jwt.MapClaims); ok {
-					if claimClientID, _ := claims["client_id"].(string); claimClientID != "" && claimClientID != rec.ClientID {
-						return nil, fmt.Errorf("kid owner %q does not match client_id claim %q", rec.ClientID, claimClientID)
-					}
-				}
-			}
-			return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)
-		}
-	}
-
-	// Fall back to client_id claim
-	if claims, ok := token.Claims.(jwt.MapClaims); ok {
-		if clientID, ok := claims["client_id"].(string); ok && clientID != "" {
-			getResp, err := v.keyLookup.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
-			if err == nil && getResp != nil && getResp.Record != nil {
-				rec := getResp.Record
+	// Try kid-based lookup first (only when a KeyLookup is configured)
+	if v.keyLookup != nil {
+		if kid, ok := token.Header["kid"].(string); ok && kid != "" {
+			kidResp, err := v.keyLookup.GetKeyByKid(context.Background(), &keys.GetKeyByKidRequest{Kid: kid})
+			if err == nil && kidResp != nil && kidResp.Record != nil {
+				rec := kidResp.Record
 				if token.Header["alg"] != rec.Algorithm {
 					v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
 					return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
 				}
+				// Cross-check kid owner vs client_id claim
+				if rec.ClientID != "" {
+					if claims, ok := token.Claims.(jwt.MapClaims); ok {
+						if claimClientID, _ := claims["client_id"].(string); claimClientID != "" && claimClientID != rec.ClientID {
+							return nil, fmt.Errorf("kid owner %q does not match client_id claim %q", rec.ClientID, claimClientID)
+						}
+					}
+				}
 				return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)
+			}
+		}
+
+		// Fall back to client_id claim
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			if clientID, ok := claims["client_id"].(string); ok && clientID != "" {
+				getResp, err := v.keyLookup.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID})
+				if err == nil && getResp != nil && getResp.Record != nil {
+					rec := getResp.Record
+					if token.Header["alg"] != rec.Algorithm {
+						v.hooks.fireOnAlgorithmMismatch(rec.Algorithm, fmt.Sprintf("%v", token.Header["alg"]))
+						return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", rec.Algorithm, token.Header["alg"])
+					}
+					return utils.DecodeVerifyKey(rec.Key, rec.Algorithm)
+				}
 			}
 		}
 	}
 
+	// Self-validation fallback: the validator was configured with its own
+	// SigningKey (typical APIAuth shape — one key, no KeyStore).
+	if v.signingKey != nil {
+		switch k := v.signingKey.(type) {
+		case []byte:
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return k, nil
+		default:
+			// Asymmetric key — type-check against the token's alg before returning.
+			if v.signingAlg != "" && token.Header["alg"] != v.signingAlg {
+				v.hooks.fireOnAlgorithmMismatch(v.signingAlg, fmt.Sprintf("%v", token.Header["alg"]))
+				return nil, fmt.Errorf("algorithm mismatch: expected %s, got %v", v.signingAlg, token.Header["alg"])
+			}
+			return v.signingKey, nil
+		}
+	}
+
+	if v.keyLookup == nil {
+		return nil, fmt.Errorf("no key store configured")
+	}
 	return nil, fmt.Errorf("no key found for token")
 }
 
@@ -236,8 +270,15 @@ type jwtIssuer struct {
 	refreshStore        core.RefreshTokenStore
 	validateCredentials CredentialsValidator
 	getSubjectScopes    core.GetSubjectScopesFunc
+	customClaims        CustomClaimsFunc
 	hooks               TokenHooks
 }
+
+// CustomClaimsFunc is called during access-token issuance to inject additional
+// non-standard claims. Returning a claim key that collides with a standard JWT
+// claim (sub, iss, aud, exp, iat, type, scopes, jti, authorization_details)
+// is ignored with a log warning — standard claims are owned by the issuer.
+type CustomClaimsFunc func(subject string, scopes []string) (map[string]any, error)
 
 // JWTIssuerConfig configures a jwtIssuer.
 type JWTIssuerConfig struct {
@@ -250,6 +291,7 @@ type JWTIssuerConfig struct {
 	RefreshStore        core.RefreshTokenStore  // for refresh_token grant
 	ValidateCredentials CredentialsValidator // for password grant
 	GetSubjectScopes    core.GetSubjectScopesFunc // for password grant (optional)
+	CustomClaims        CustomClaimsFunc       // optional per-token custom-claim injection
 	Hooks               TokenHooks
 }
 
@@ -269,6 +311,7 @@ func NewJWTIssuer(cfg JWTIssuerConfig) TokenIssuer {
 		refreshStore:        cfg.RefreshStore,
 		validateCredentials: cfg.ValidateCredentials,
 		getSubjectScopes:    cfg.GetSubjectScopes,
+		customClaims:        cfg.CustomClaims,
 		hooks:               cfg.Hooks,
 	}
 }
@@ -305,6 +348,20 @@ func (i *jwtIssuer) CreateAccessToken(ctx context.Context, req *CreateAccessToke
 	}
 	if i.audience != "" {
 		claims["aud"] = i.audience
+	}
+
+	if i.customClaims != nil {
+		custom, err := i.customClaims(subject, scopes)
+		if err != nil {
+			return nil, fmt.Errorf("custom claims func failed: %w", err)
+		}
+		for k, v := range custom {
+			if standardClaims[k] {
+				log.Printf("Warning: CustomClaimsFunc attempted to override standard claim %q (ignored)", k)
+				continue
+			}
+			claims[k] = v
+		}
 	}
 
 	signingMethod, err := utils.SigningMethodForAlg(i.signingAlg)


### PR DESCRIPTION
## What changes

Closes #218. Deletes the four `// Deprecated:` positional methods on `APIAuth` (`CreateAccessToken`, `ValidateAccessToken`, `ValidateAccessTokenFull`, `VerifyTokenFunc`) and routes every internal HTTP handler through `APIAuth.Issuer()` / `APIAuth.Validator()` — lazy-built accessors that return the gRPC-shape `TokenIssuer` / `TokenValidator`. Single internal cleanup PR. Wire format byte-identical.

## Reviewer's guide

Read in this order:

1. [apiauth/token_validator.go](https://github.com/panyam/oneauth/pull/224/files#diff-f9f7b35ad6cff7153c60ca3233a9dbd16b3c3dc4eb2f443916b6d6c9bb71e0e9) — start here. Two surface additions: `CustomClaimsFunc` field on `JWTIssuerConfig`+`jwtIssuer` (closes the only behavioral gap APIAuth had over the gRPC-shape issuer), and `SigningKey`/`SigningAlg` self-validation fallback on `JWTValidatorConfig`+`jwtValidator` (supports APIAuth's single-key, no-KeyStore mode through the new validator).
2. [apiauth/auth.go](https://github.com/panyam/oneauth/pull/224/files#diff-6f548dbab24d0609200ec2c43738d8d522c8f3d3b5b288eae95c1dc06b239bf8) — `Issuer()` / `Validator()` accessors + the **378-line deletion** of the four deprecated methods + the now-orphaned `jwtKeyFunc` helper.
3. `apiauth/{introspection,token_exchange_grant,jwt_bearer_grant}.go` — 4 production call sites swapped to the new accessors. Plus 3 sites in [apiauth/auth.go](https://github.com/panyam/oneauth/pull/224/files#diff-6f548dbab24d0609200ec2c43738d8d522c8f3d3b5b288eae95c1dc06b239bf8) (password / refresh / client_credentials grants).
4. [apiauth/oneauth.go](https://github.com/panyam/oneauth/pull/224/files#diff-a3675db2368b4a23a1a7eb6f927806614f2ddf909e29dea8c64a51d1d0ebe845) — `CustomClaims` field added to `OneAuthConfig` and threaded into the issuer.
5. `apiauth/*_test.go` (11 files) — mechanical migration of ~63 call sites to `auth.Issuer().CreateAccessToken(ctx, &Req{...})` / `auth.Validator().ValidateToken(ctx, &Req{...})`.

Skim or skip: [apiauth/SUMMARY.md](https://github.com/panyam/oneauth/pull/224/files#diff-f3bbacfca08d00c3458076319ba481fec63aa40f5488dd2adf1254e38b90986e) (one-paragraph doc update — drops the "legacy positional methods remain" note).

## Decision log

- **Lazy accessors via `sync.Once`, not a constructor.** APIAuth has no `NewAPIAuth` factory — callers populate fields directly. Adding one now would have broken every consumer's composition pattern. `sync.Once` means the issuer/validator are materialized on first use, after all fields are set.
- **Embed via accessor, don't make `APIAuth` implement `TokenIssuer`/`TokenValidator` directly.** Implementing the interfaces directly would have forced `APIAuth` to expose `PasswordGrant` / `ClientCredentials` / `TokenExchange` / `JwtBearerGrant` as method-level surfaces. Those live on `jwtIssuer` today and `APIAuth`'s HTTP handlers already drive them — re-exposing on `APIAuth` would have been bloat with no payoff.
- **Validator gained `SigningKey` fallback** rather than auto-wiring a synthetic `InMemoryKeyStore`. The fallback keeps the validator's contract simple ("look up by kid/client_id first, then fall back to my own configured key") and avoids leaking a synthetic clientID like `"_apiauth_self"` into anyone's debug logs.
- **`CustomClaimsFunc` is now a first-class capability of `jwtIssuer`.** Previously only `APIAuth.CreateAccessToken` honored it; tokens minted via `OneAuth.Issuer.CreateAccessToken` silently dropped custom claims. After this PR, both paths support it via the same `cfg.CustomClaims` plumbing. Small bonus capability on `OneAuthConfig`.

## Risk / blast radius

- **Affects:** every consumer importing oneauth at < v0.1.7 that called the four deprecated `APIAuth.*` methods directly. In-tree: just the apiauth package and the keys/kid test. Out-of-tree: deprecation comments have been in place since #175; this is the removal phase.
- **Tests covering this:** full apiauth suite (~657 assertions) — all unchanged. e2e (-race), stores/gorm (-race), staticcheck — green. **Assertion count: 657 → 657 (added: 0, removed/weakened: 0).**
- **Be paranoid about:** the `CustomClaimsFunc` move from APIAuth to jwtIssuer. Verified by running the unmodified `apiauth/custom_claims_test.go` cases against the new wiring — all pass including the "standard claims cannot be overridden" log-warn path.

## Before / after

The diff is symbol consolidation, not behavioral change. The most visible delta:

```diff
- accessToken, expiresIn, err := a.CreateAccessToken(user.Id(), grantedScopes, req.AuthorizationDetails)
+ tokResp, err := a.Issuer().CreateAccessToken(r.Context(), &CreateAccessTokenRequest{
+     Subject:              user.Id(),
+     Scopes:               grantedScopes,
+     AuthorizationDetails: req.AuthorizationDetails,
+ })
```

Wire-format token bytes (header, claims, signature) identical pre/post.

## Out of scope (deliberately deferred)

- **#217 — `client/` SDK convention adoption** (sibling). Pure consumer-facing work; not coupled to this server-side cleanup.
- **`httpauth.Middleware.VerifyToken` callback signature** stays as-is. The deleted method here was `APIAuth.VerifyTokenFunc()` — an adapter that returned such a function. Consumers wiring `httpauth.Middleware.VerifyToken` should construct an `apiauth.APIMiddleware` directly (or wrap `auth.Validator().ValidateToken`).
- **Standalone tests for `CustomClaims` on `OneAuth.Issuer`** — covered transitively by the existing `apiauth/custom_claims_test.go` cases, which now exercise the same code path via APIAuth's lazy issuer.

## Test plan

- [x] `go test ./...` — root green (assertion count unchanged)
- [x] `cd stores/gorm && GOWORK=off go test -race ./...` — green
- [x] `cd stores/gae && GOWORK=off go build ./... && go vet ./...` — green
- [x] `cd cmd/{oneauth-server,demo-hostapp,demo-resource-server} && GOWORK=off go vet ./...` — green
- [x] `go test -race ./tests/e2e/...` — green
- [x] `staticcheck ./...` — no SA1019 warnings introduced
