### PR TITLE
refactor(client): thread ctx through ClientCredentials / TokenExchange / JwtBearerGrant (#217a)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -278,7 +279,7 @@ type ClientCredentialsRequest struct {
 // the form-encoded request — including RFC 8707 `resource` indicators
 // and RFC 9396 `authorization_details` when present — and persists the
 // resulting credential.
-func (c *AuthClient) ClientCredentials(req *ClientCredentialsRequest) (*ServerCredential, error) {
+func (c *AuthClient) ClientCredentials(ctx context.Context, req *ClientCredentialsRequest) (*ServerCredential, error) {
 	if req == nil {
 		return nil, fmt.Errorf("ClientCredentials: req is required")
 	}
@@ -312,14 +313,14 @@ func (c *AuthClient) ClientCredentials(req *ClientCredentialsRequest) (*ServerCr
 		err  error
 	)
 	if req.ClientAssertion != nil {
-		cred, err = c.requestTokenFormWithAssertion(tokenEndpoint, data, req.ClientID, tokenEndpoint, *req.ClientAssertion)
+		cred, err = c.requestTokenFormWithAssertion(ctx, tokenEndpoint, data, req.ClientID, tokenEndpoint, *req.ClientAssertion)
 	} else {
 		var asMethods []string
 		if c.cachedASMeta != nil {
 			asMethods = c.cachedASMeta.TokenEndpointAuthMethods
 		}
 		authMethod := SelectAuthMethod(req.ClientSecret, asMethods)
-		cred, err = c.requestTokenForm(tokenEndpoint, data, authMethod, req.ClientID, req.ClientSecret)
+		cred, err = c.requestTokenForm(ctx, tokenEndpoint, data, authMethod, req.ClientID, req.ClientSecret)
 	}
 	if err != nil {
 		return nil, err
@@ -341,8 +342,11 @@ func (c *AuthClient) ClientCredentials(req *ClientCredentialsRequest) (*ServerCr
 //
 // See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
 // See: https://github.com/panyam/oneauth/issues/72
+//
+// Deprecated: use ClientCredentials directly with a context. This wrapper
+// is retained for compatibility and passes context.Background() under the hood.
 func (c *AuthClient) ClientCredentialsToken(clientID, clientSecret string, scopes []string) (*ServerCredential, error) {
-	return c.ClientCredentials(&ClientCredentialsRequest{
+	return c.ClientCredentials(context.Background(), &ClientCredentialsRequest{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Scopes:       scopes,
@@ -355,8 +359,11 @@ func (c *AuthClient) ClientCredentialsToken(clientID, clientSecret string, scope
 // detail parameters.
 //
 // See: https://www.rfc-editor.org/rfc/rfc7523#section-2.2
+//
+// Deprecated: use ClientCredentials directly with a context. This wrapper
+// is retained for compatibility and passes context.Background() under the hood.
 func (c *AuthClient) ClientCredentialsTokenWithAssertion(clientID string, cfg ClientAssertionConfig, scopes []string) (*ServerCredential, error) {
-	return c.ClientCredentials(&ClientCredentialsRequest{
+	return c.ClientCredentials(context.Background(), &ClientCredentialsRequest{
 		ClientID:        clientID,
 		ClientAssertion: &cfg,
 		Scopes:          scopes,
@@ -442,11 +449,11 @@ func (c *AuthClient) refreshTokenLocked(cred *ServerCredential) error {
 // avoid circular auth dependencies when obtaining the initial token.
 //
 // See: https://www.rfc-editor.org/rfc/rfc6749#section-4.4.2
-func (c *AuthClient) requestTokenForm(tokenEndpoint string, data url.Values, authMethod TokenEndpointAuthMethod, clientID, clientSecret string) (*ServerCredential, error) {
+func (c *AuthClient) requestTokenForm(ctx context.Context, tokenEndpoint string, data url.Values, authMethod TokenEndpointAuthMethod, clientID, clientSecret string) (*ServerCredential, error) {
 	// Apply client authentication to form data
 	applyAuthToForm(authMethod, clientID, clientSecret, data)
 
-	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -463,14 +470,14 @@ func (c *AuthClient) requestTokenForm(tokenEndpoint string, data url.Values, aut
 // requestTokenForm. The audience is typically the token endpoint URL
 // (per OIDC Core §9); pass it explicitly so this works with non-default
 // deployments.
-func (c *AuthClient) requestTokenFormWithAssertion(tokenEndpoint string, data url.Values, clientID, audience string, cfg ClientAssertionConfig) (*ServerCredential, error) {
+func (c *AuthClient) requestTokenFormWithAssertion(ctx context.Context, tokenEndpoint string, data url.Values, clientID, audience string, cfg ClientAssertionConfig) (*ServerCredential, error) {
 	assertion, err := MintClientAssertion(clientID, audience, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("mint client_assertion: %w", err)
 	}
 	applyAssertionToForm(clientID, assertion, data)
 
-	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/client/client_credentials_source.go
+++ b/client/client_credentials_source.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -156,7 +157,7 @@ func (s *ClientCredentialsSource) fetchTokenLocked() (*ServerCredential, error) 
 			WithASMetadata(&ASMetadata{TokenEndpoint: s.TokenEndpoint}))
 	}
 
-	cred, err := s.client.ClientCredentials(&ClientCredentialsRequest{
+	cred, err := s.client.ClientCredentials(context.Background(), &ClientCredentialsRequest{
 		ClientID:             s.ClientID,
 		ClientSecret:         s.ClientSecret,
 		ClientAssertion:      s.ClientAssertion,

--- a/client/client_credentials_test.go
+++ b/client/client_credentials_test.go
@@ -10,6 +10,7 @@ package client
 // `authorization_details` (JSON-encoded form value).
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -58,7 +59,7 @@ func TestClientCredentials_ResourceParamSent(t *testing.T) {
 	defer srv.Close()
 
 	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
-	cred, err := c.ClientCredentials(&ClientCredentialsRequest{
+	cred, err := c.ClientCredentials(context.Background(), &ClientCredentialsRequest{
 		ClientID:     "demo",
 		ClientSecret: "shh",
 		Resources:    []string{"https://api.example.com", "https://files.example.com"},
@@ -86,7 +87,7 @@ func TestClientCredentials_AuthorizationDetailsSent(t *testing.T) {
 	defer srv.Close()
 
 	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
-	cred, err := c.ClientCredentials(&ClientCredentialsRequest{
+	cred, err := c.ClientCredentials(context.Background(), &ClientCredentialsRequest{
 		ClientID:             "demo",
 		ClientSecret:         "shh",
 		AuthorizationDetails: want,

--- a/client/jwt_bearer_grant.go
+++ b/client/jwt_bearer_grant.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -44,7 +45,7 @@ type JwtBearerGrantRequest struct {
 
 // JwtBearerGrant performs an RFC 7523 §2.1 jwt-bearer grant exchange.
 // Returns a usable ServerCredential containing the access token.
-func (c *AuthClient) JwtBearerGrant(req *JwtBearerGrantRequest) (*ServerCredential, error) {
+func (c *AuthClient) JwtBearerGrant(ctx context.Context, req *JwtBearerGrantRequest) (*ServerCredential, error) {
 	if req == nil {
 		return nil, fmt.Errorf("JwtBearerGrant: req is required")
 	}
@@ -74,7 +75,7 @@ func (c *AuthClient) JwtBearerGrant(req *JwtBearerGrantRequest) (*ServerCredenti
 		data.Add("resource", r)
 	}
 
-	httpReq, err := c.buildTokenRequest(tokenEndpoint, data, req.ClientID, req.ClientSecret, req.ClientAssertion)
+	httpReq, err := c.buildTokenRequest(ctx, tokenEndpoint, data, req.ClientID, req.ClientSecret, req.ClientAssertion)
 	if err != nil {
 		return nil, err
 	}

--- a/client/jwt_bearer_grant_e2e_test.go
+++ b/client/jwt_bearer_grant_e2e_test.go
@@ -7,6 +7,7 @@ package client_test
 // usable ServerCredential.
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
@@ -52,7 +53,7 @@ func TestJwtBearerGrant_E2E_TrustedIssuerRoundTrip(t *testing.T) {
 
 	c := client.NewAuthClient(srv.URL(), nil,
 		client.WithTokenEndpoint("/api/token"))
-	cred, err := c.JwtBearerGrant(&client.JwtBearerGrantRequest{
+	cred, err := c.JwtBearerGrant(context.Background(), &client.JwtBearerGrantRequest{
 		ClientID:  "demo-client",
 		Assertion: assertion,
 	})

--- a/client/jwt_bearer_grant_test.go
+++ b/client/jwt_bearer_grant_test.go
@@ -7,6 +7,7 @@ package client
 // assertion for an access token.
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -58,7 +59,7 @@ func TestJwtBearerGrant_Roundtrip(t *testing.T) {
 	defer srv.Close()
 
 	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
-	cred, err := c.JwtBearerGrant(&JwtBearerGrantRequest{
+	cred, err := c.JwtBearerGrant(context.Background(), &JwtBearerGrantRequest{
 		ClientID:     "demo",
 		ClientSecret: "shh",
 		Assertion:    "signed-jwt-assertion",
@@ -86,7 +87,7 @@ func TestJwtBearerGrant_ClientAuthBasic(t *testing.T) {
 		TokenEndpoint:            srv.URL + "/token",
 		TokenEndpointAuthMethods: []string{"client_secret_basic"},
 	}))
-	cred, err := c.JwtBearerGrant(&JwtBearerGrantRequest{
+	cred, err := c.JwtBearerGrant(context.Background(), &JwtBearerGrantRequest{
 		ClientID:     "demo",
 		ClientSecret: "shh",
 		Assertion:    "signed-jwt-assertion",
@@ -126,7 +127,7 @@ func TestJwtBearerGrant_ClientAuthPrivateKeyJwt(t *testing.T) {
 		TokenEndpoint:            srv.URL + "/token",
 		TokenEndpointAuthMethods: []string{"private_key_jwt"},
 	}))
-	cred, err := c.JwtBearerGrant(&JwtBearerGrantRequest{
+	cred, err := c.JwtBearerGrant(context.Background(), &JwtBearerGrantRequest{
 		ClientID:  "demo",
 		Assertion: "signed-jwt-assertion",
 		ClientAssertion: &ClientAssertionConfig{

--- a/client/token_exchange.go
+++ b/client/token_exchange.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -90,7 +91,7 @@ type rawTokenExchangeResponse struct {
 // authenticate via shared secret (ClientID + ClientSecret) or via
 // private_key_jwt (ClientID + ClientAssertion). Returns the parsed
 // response including `issued_token_type`.
-func (c *AuthClient) TokenExchange(req *TokenExchangeRequest) (*TokenExchangeResponse, error) {
+func (c *AuthClient) TokenExchange(ctx context.Context, req *TokenExchangeRequest) (*TokenExchangeResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("TokenExchange: req is required")
 	}
@@ -130,7 +131,7 @@ func (c *AuthClient) TokenExchange(req *TokenExchangeRequest) (*TokenExchangeRes
 		data.Set("scope", strings.Join(req.Scope, " "))
 	}
 
-	httpReq, err := c.buildTokenRequest(tokenEndpoint, data, req.ClientID, req.ClientSecret, req.ClientAssertion)
+	httpReq, err := c.buildTokenRequest(ctx, tokenEndpoint, data, req.ClientID, req.ClientSecret, req.ClientAssertion)
 	if err != nil {
 		return nil, err
 	}
@@ -169,14 +170,14 @@ func (c *AuthClient) TokenExchange(req *TokenExchangeRequest) (*TokenExchangeRes
 // non-credential-persisting flows that emit the same form/auth shape
 // as ClientCredentials but return shape-specific responses, so they
 // can't share executeTokenRequest's persistence path.
-func (c *AuthClient) buildTokenRequest(tokenEndpoint string, data url.Values, clientID, clientSecret string, assertion *ClientAssertionConfig) (*http.Request, error) {
+func (c *AuthClient) buildTokenRequest(ctx context.Context, tokenEndpoint string, data url.Values, clientID, clientSecret string, assertion *ClientAssertionConfig) (*http.Request, error) {
 	if assertion != nil {
 		signed, err := MintClientAssertion(clientID, tokenEndpoint, *assertion)
 		if err != nil {
 			return nil, fmt.Errorf("mint client_assertion: %w", err)
 		}
 		applyAssertionToForm(clientID, signed, data)
-		httpReq, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(data.Encode()))
 		if err != nil {
 			return nil, fmt.Errorf("build request: %w", err)
 		}
@@ -189,7 +190,7 @@ func (c *AuthClient) buildTokenRequest(tokenEndpoint string, data url.Values, cl
 	}
 	authMethod := SelectAuthMethod(clientSecret, asMethods)
 	applyAuthToForm(authMethod, clientID, clientSecret, data)
-	httpReq, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}

--- a/client/token_exchange_e2e_test.go
+++ b/client/token_exchange_e2e_test.go
@@ -6,6 +6,7 @@ package client_test
 // and the SDK decodes the issued_token_type-bearing response.
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
@@ -51,7 +52,7 @@ func TestTokenExchange_E2E_JWTSubjectToken(t *testing.T) {
 
 	c := client.NewAuthClient(srv.URL(), nil,
 		client.WithTokenEndpoint("/api/token"))
-	resp, err := c.TokenExchange(&client.TokenExchangeRequest{
+	resp, err := c.TokenExchange(context.Background(), &client.TokenExchangeRequest{
 		ClientID:         "demo-client",
 		SubjectToken:     subjectToken,
 		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",

--- a/client/token_exchange_test.go
+++ b/client/token_exchange_test.go
@@ -5,6 +5,7 @@ package client
 // client SDK.
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -73,7 +74,7 @@ func TestTokenExchange_AllParameters(t *testing.T) {
 	defer srv.Close()
 
 	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
-	resp, err := c.TokenExchange(&TokenExchangeRequest{
+	resp, err := c.TokenExchange(context.Background(), &TokenExchangeRequest{
 		ClientID:           "demo",
 		ClientSecret:       "shh",
 		SubjectToken:       "outer-id-token",
@@ -110,7 +111,7 @@ func TestTokenExchange_MinimalRequest(t *testing.T) {
 	defer srv.Close()
 
 	c := NewAuthClient(srv.URL, nil, WithASMetadata(&ASMetadata{TokenEndpoint: srv.URL + "/token"}))
-	resp, err := c.TokenExchange(&TokenExchangeRequest{
+	resp, err := c.TokenExchange(context.Background(), &TokenExchangeRequest{
 		ClientID:         "demo",
 		ClientSecret:     "shh",
 		SubjectToken:     "outer-token",

--- a/examples/07-client-sdk/walkthrough.go
+++ b/examples/07-client-sdk/walkthrough.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -88,8 +89,11 @@ func runDemo() {
 			authClient := client.NewAuthClient(authServer.URL, nil,
 				client.WithASMetadata(meta))
 
-			cred, err := authClient.ClientCredentialsToken(
-				registeredClientID, registeredSecret, []string{"read"})
+			cred, err := authClient.ClientCredentials(context.Background(), &client.ClientCredentialsRequest{
+				ClientID:     registeredClientID,
+				ClientSecret: registeredSecret,
+				Scopes:       []string{"read"},
+			})
 			if err != nil {
 				return demokit.Errf("token: %v", err)
 			}
@@ -217,8 +221,11 @@ curl -s http://localhost:8082/resource -H "Authorization: Bearer $TOKEN" | jq`).
 
 			kcClient := client.NewAuthClient(kcRealmURL, nil,
 				client.WithASMetadata(kcMeta))
-			cred, err := kcClient.ClientCredentialsToken(
-				kcExampleClientID, kcExampleClientSecret, []string{"openid"})
+			cred, err := kcClient.ClientCredentials(context.Background(), &client.ClientCredentialsRequest{
+				ClientID:     kcExampleClientID,
+				ClientSecret: kcExampleClientSecret,
+				Scopes:       []string{"openid"},
+			})
 			if err != nil {
 				fmt.Printf("    ERROR getting KC token: %v\n", err)
 				return nil

--- a/tests/e2e/authcode_test.go
+++ b/tests/e2e/authcode_test.go
@@ -121,7 +121,11 @@ func TestE2E_ClientCredentials_BasicAuth(t *testing.T) {
 		client.WithTokenEndpoint("/oauth/token"),
 		client.WithASMetadata(meta))
 
-	cred, err := authClient.ClientCredentialsToken(clientID, secret, []string{"read"})
+	cred, err := authClient.ClientCredentials(context.Background(), &client.ClientCredentialsRequest{
+		ClientID:     clientID,
+		ClientSecret: secret,
+		Scopes:       []string{"read"},
+	})
 	require.NoError(t, err, "client_credentials with Basic auth should succeed")
 	assert.Contains(t, cred.AccessToken, "e2e-cc-token-"+clientID)
 }
@@ -156,7 +160,10 @@ func TestE2E_ClientCredentials_PostAuth(t *testing.T) {
 		client.WithTokenEndpoint("/oauth/token"),
 		client.WithASMetadata(meta))
 
-	cred, err := authClient.ClientCredentialsToken(clientID, secret, nil)
+	cred, err := authClient.ClientCredentials(context.Background(), &client.ClientCredentialsRequest{
+		ClientID:     clientID,
+		ClientSecret: secret,
+	})
 	require.NoError(t, err, "client_credentials with post auth should succeed")
 	assert.Contains(t, cred.AccessToken, "e2e-cc-token-"+clientID)
 }

--- a/tests/e2e/private_key_jwt_test.go
+++ b/tests/e2e/private_key_jwt_test.go
@@ -112,10 +112,14 @@ func TestPrivateKeyJWT_E2E_SDKHelper(t *testing.T) {
 	authClient := client.NewAuthClient(env.BaseURL(), store,
 		client.WithTokenEndpoint("/api/token"))
 
-	cred, err := authClient.ClientCredentialsTokenWithAssertion(clientID, client.ClientAssertionConfig{
-		PrivateKey: priv,
-		SigningAlg: "RS256",
-	}, []string{"read"})
+	cred, err := authClient.ClientCredentials(context.Background(), &client.ClientCredentialsRequest{
+		ClientID: clientID,
+		ClientAssertion: &client.ClientAssertionConfig{
+			PrivateKey: priv,
+			SigningAlg: "RS256",
+		},
+		Scopes: []string{"read"},
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, cred.AccessToken)
 }

--- a/tests/e2e/rar_test.go
+++ b/tests/e2e/rar_test.go
@@ -8,6 +8,7 @@ package e2e_test
 // See: https://www.rfc-editor.org/rfc/rfc9396
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -268,7 +269,7 @@ func TestRAR_ClientCredentials_SDKForm(t *testing.T) {
 
 	authClient := client.NewAuthClient(env.BaseURL(), nil,
 		client.WithTokenEndpoint("/api/token"))
-	cred, err := authClient.ClientCredentials(&client.ClientCredentialsRequest{
+	cred, err := authClient.ClientCredentials(context.Background(), &client.ClientCredentialsRequest{
 		ClientID:             clientID,
 		ClientSecret:         clientSecret,
 		Scopes:               []string{"payments"},


### PR DESCRIPTION
## What changes

First of two PRs for #217 — the consumer-facing `client/` SDK adoption of the `(ctx, *Req) → (*Resp, error)` convention used everywhere else in oneauth after the #204 cluster. This slice adds `context.Context` as the first parameter on the three `AuthClient` methods that already accepted a `*Request`:

- `AuthClient.ClientCredentials(ctx, *ClientCredentialsRequest)` (RFC 6749 §4.4)
- `AuthClient.TokenExchange(ctx, *TokenExchangeRequest)` (RFC 8693)
- `AuthClient.JwtBearerGrant(ctx, *JwtBearerGrantRequest)` (RFC 7523 §2.1)

Internal helpers (`requestTokenForm`, `requestTokenFormWithAssertion`, `buildTokenRequest`) plumb ctx through to `http.NewRequestWithContext`, so HTTP cancellation actually works end-to-end now.

The two positional wrappers (`ClientCredentialsToken`, `ClientCredentialsTokenWithAssertion`) get `// Deprecated:` tags and pass `context.Background()` internally — keeps external consumers compiling. In-tree callers (`examples/07-client-sdk`, `tests/e2e/{authcode,private_key_jwt}`) migrated to the new shape.

**Out of scope (covered by #217b):** `Login` + `LoginWithBrowser` Request/Response shapes. Split per the issue's recommendation.

## Reviewer's guide

Read in this order:

1. [client/client.go](https://github.com/panyam/oneauth/pull/225/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `ClientCredentials` signature change + helper plumbing + deprecation tags on the two wrappers.
2. [client/token_exchange.go](https://github.com/panyam/oneauth/pull/225/files#diff-5a787b15620926fc1fad6849644b53996947b72c2b2c4c260ebb0d8e4a48493c) — `TokenExchange` + `buildTokenRequest` ctx threading.
3. [client/jwt_bearer_grant.go](https://github.com/panyam/oneauth/pull/225/files#diff-84b932eb10b14419b115f3671dbf27d557bccf23a18f6d2855675aab10c9f14e) — `JwtBearerGrant` ctx threading (delegates through `buildTokenRequest`).
4. [client/client_credentials_source.go](https://github.com/panyam/oneauth/pull/225/files#diff-8d083e6b912efeb6b0a463ec40b00f3f8aa9ded5b43e1c36449781bfb5bc0f1f) — single-line update: `fetchTokenLocked` now passes `context.Background()` to the new ClientCredentials shape. `ClientCredentialsSource.Token()` itself stays ctx-less for now (its public API is unchanged).

Skim or skip: `client/*_test.go`, `tests/e2e/{authcode,private_key_jwt,rar}_test.go`, [examples/07-client-sdk/walkthrough.go](https://github.com/panyam/oneauth/pull/225/files#diff-51cdbac31f559bfedbd0afb812307cdbdc1d550a5ec26e3a210ac92d7b5eeef9) — mechanical call-site updates.

## Decision log

- **Deprecate the two positional wrappers, don't delete them.** Issue body explicitly says `ClientCredentialsToken` / `ClientCredentialsTokenWithAssertion` can stay as compatibility shims. Removing them is a separate deprecation cycle (different blast radius — they're widely used by external consumers like mcpkit / SEP).
- **`ClientCredentialsSource.Token()` stays ctx-less.** Adding ctx to the source's public API would be a bigger consumer migration than this PR is sized for. The internal `fetchTokenLocked` now passes `context.Background()` to the new `ClientCredentials(ctx, *Req)` shape; a ctx-aware `TokenContext(ctx)` accessor is a candidate for a follow-up if anyone wants it.
- **`http.NewRequestWithContext` instead of `req.WithContext`.** Same net effect; cleaner because we build the request with ctx already attached rather than constructing-then-attaching.

## Risk / blast radius

- **Affects:** every consumer calling `AuthClient.ClientCredentials` / `TokenExchange` / `JwtBearerGrant` directly. mcpkit + SEP both call `ClientCredentials` — coordinated bump expected after this lands and a tag is cut.
- **Tests covering this:** full `client/` unit suite + tests/e2e (-race). Wire format byte-identical pre/post — http.NewRequestWithContext only adds cancellation plumbing, no payload change.
- **Be paranoid about:** the ctx threading on the assertion path (`requestTokenFormWithAssertion` + `buildTokenRequest` when `assertion != nil`). The private_key_jwt assertion is minted from the request data, not from ctx, so ctx cancellation between mint and HTTP-send is the only window — verified by the existing e2e suite.

## Out of scope (deliberately deferred)

- **#217b — `Login` + `LoginWithBrowser` request/response shapes.** Larger, behavior-shaping work; sized as a separate PR.
- **Ctx-aware `ClientCredentialsSource.Token` accessor.** Filed-style follow-up if needed; today's `context.Background()` is functionally identical to current behavior.
- **`exchangeCode` (unexported) + `refreshTokenLocked` (internal)** — issue says leave alone.

## Test plan

- [x] `go test ./...` — root green
- [x] `cd stores/gorm && GOWORK=off go test -race ./...` — green
- [x] `cd stores/gae && GOWORK=off go build ./... && go vet ./...` — green
- [x] `cd cmd/{oneauth-server,demo-hostapp,demo-resource-server} && GOWORK=off go vet ./...` — green
- [x] `go test -race ./tests/e2e/...` — green
- [x] `staticcheck ./...` — no new SA1019 warnings; in-tree deprecated-wrapper callers migrated
