### PR TITLE
refactor(client): reshape Login + LoginWithBrowser to (ctx, *Req) shape (#217b)

### DIFF
--- a/client/SUMMARY.md
+++ b/client/SUMMARY.md
@@ -3,8 +3,8 @@
 Go client library for OAuth 2.0 authentication: browser-based login (authorization code + PKCE), headless login, client_credentials, AS metadata discovery, credential storage, and automatic token refresh.
 
 ## Contents
-- **client.go** — `AuthClient` (token management, `Login`, `ClientCredentialsToken`, `ClientCredentialsTokenWithAssertion`, `GetToken`, auto-refresh transport), `WithASMetadata`, `WithTokenEndpoint`, `WithHTTPClient`
-- **browser_login.go** — `LoginWithBrowser` (authorization code + PKCE flow, RFC 8252), `FollowRedirects` (headless HTTP redirect mode), `BrowserLoginConfig` (with `ClientSecret` for confidential clients, `TokenEndpointAuthMethods` for explicit endpoint auth method override, `ClientAssertion` for `private_key_jwt`)
+- **client.go** — `AuthClient` (token management, `Login`, `ClientCredentials`, `GetToken`, auto-refresh transport), `WithASMetadata`, `WithTokenEndpoint`, `WithHTTPClient`. `ClientCredentialsToken` / `ClientCredentialsTokenWithAssertion` retained as `// Deprecated:` compat wrappers.
+- **browser_login.go** — `LoginWithBrowser` (authorization code + PKCE flow, RFC 8252), `FollowRedirects` (headless HTTP redirect mode), `BrowserLoginRequest` (with `ClientSecret` for confidential clients, `TokenEndpointAuthMethods` for explicit endpoint auth method override, `ClientAssertion` for `private_key_jwt`)
 - **auth_method.go** — `TokenEndpointAuthMethod` type, `SelectAuthMethod` (negotiates `client_secret_basic` vs `client_secret_post` vs `none` from AS metadata), `applyAuthToForm`
 - **private_key_jwt.go** — `AuthMethodPrivateKeyJWT` constant, `ClientAssertionConfig`, `MintClientAssertion` (RFC 7523 §2.2 / OIDC Core §9 assertion minter — fresh `jti` + bounded lifetime per call)
 - **discovery.go** — `ASMetadata`, `DiscoverAS` (RFC 8414 + OIDC Discovery fallback), `DiscoveryOption`
@@ -26,6 +26,7 @@ Go client library for OAuth 2.0 authentication: browser-based login (authorizati
 ## Recent Changes
 - **Client-side DCR + validation utilities (mcpkit#158)** — `RegisterClient` (client-side RFC 7591 DCR caller), `ValidateHTTPS`/`IsLocalhost`/`ValidateCIMDURL` (OAuth endpoint validation), `ClientCredentialsSource` (RFC 6749 §4.4 grant wrapper with caching). Pushed down from mcpkit/ext/auth as pure-OAuth reusable code. See oneauth#78.
 - **DCR `application_type` (mcpkit#440)** — added `ApplicationType` to `ClientRegistrationRequest` per OpenID Connect Dynamic Client Registration 1.0. `omitempty` so existing oneauth callers stay wire-compatible; consumers whose spec requires it (MCP per SEP-837) set it explicitly to `"native"` or `"web"`.
+- **gRPC-shape convention (#217)** — `AuthClient` token-acquisition methods all follow `MethodName(ctx context.Context, req *XRequest) (..., error)`: `Login(ctx, *LoginRequest)`, `ClientCredentials(ctx, *ClientCredentialsRequest)`, `TokenExchange(ctx, *TokenExchangeRequest)`, `JwtBearerGrant(ctx, *JwtBearerGrantRequest)`, `LoginWithBrowser(ctx, *BrowserLoginRequest)`. Matches the convention adopted across `apiauth/`, `admin/`, and store-layer interfaces (#175 / #172 / #204).
 
 ## Dependencies
 `core/` is imported for `UnionScopes`. Otherwise standalone with only stdlib + `stretchr/testify` (testing).

--- a/client/browser_login.go
+++ b/client/browser_login.go
@@ -16,9 +16,9 @@ import (
 	"time"
 )
 
-// BrowserLoginConfig configures the authorization code + PKCE flow
-// for CLI and headless clients.
-type BrowserLoginConfig struct {
+// BrowserLoginRequest configures the authorization code + PKCE flow
+// for CLI and headless clients (RFC 8252 + RFC 7636).
+type BrowserLoginRequest struct {
 	// AuthorizationEndpoint is the AS authorization URL.
 	// If empty, auto-discovered via DiscoverAS(serverURL) using the
 	// AuthClient's server URL.
@@ -116,7 +116,11 @@ type callbackResult struct {
 //
 // See: https://www.rfc-editor.org/rfc/rfc8252 (OAuth 2.0 for Native Apps)
 // See: https://www.rfc-editor.org/rfc/rfc7636 (PKCE)
-func (c *AuthClient) LoginWithBrowser(cfg BrowserLoginConfig) (*ServerCredential, error) {
+func (c *AuthClient) LoginWithBrowser(ctx context.Context, req *BrowserLoginRequest) (*ServerCredential, error) {
+	if req == nil {
+		return nil, fmt.Errorf("LoginWithBrowser: req is required")
+	}
+	cfg := *req
 	if cfg.ClientID == "" {
 		return nil, fmt.Errorf("ClientID is required")
 	}
@@ -240,14 +244,18 @@ func (c *AuthClient) LoginWithBrowser(cfg BrowserLoginConfig) (*ServerCredential
 		return nil, fmt.Errorf("failed to open browser (URL: %s): %w", authURL, err)
 	}
 
-	// Wait for callback or timeout
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	// Wait for callback or timeout — derive from the caller's ctx so
+	// upstream cancellation aborts the browser-login flow too.
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var result callbackResult
 	select {
 	case result = <-resultCh:
-	case <-ctx.Done():
+	case <-waitCtx.Done():
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, fmt.Errorf("login timed out after %s", timeout)
 	}
 
@@ -270,7 +278,7 @@ func (c *AuthClient) LoginWithBrowser(cfg BrowserLoginConfig) (*ServerCredential
 		httpClient = http.DefaultClient
 	}
 
-	cred, err := c.exchangeCode(exchangeCodeParams{
+	cred, err := c.exchangeCode(ctx, exchangeCodeParams{
 		HTTPClient:    httpClient,
 		TokenEndpoint: tokenEndpoint,
 		Code:          result.Code,
@@ -324,7 +332,7 @@ type exchangeCodeParams struct {
 	Assertion *ClientAssertionConfig
 }
 
-func (c *AuthClient) exchangeCode(p exchangeCodeParams) (*ServerCredential, error) {
+func (c *AuthClient) exchangeCode(ctx context.Context, p exchangeCodeParams) (*ServerCredential, error) {
 	data := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {p.Code},
@@ -349,7 +357,7 @@ func (c *AuthClient) exchangeCode(p exchangeCodeParams) (*ServerCredential, erro
 		applyAuthToForm(p.AuthMethod, p.ClientID, p.ClientSecret, data)
 	}
 
-	req, err := http.NewRequest("POST", p.TokenEndpoint, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", p.TokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build token request: %w", err)
 	}
@@ -457,7 +465,7 @@ func containsString(slice []string, val string) bool {
 //
 // Usage:
 //
-//	cred, err := authClient.LoginWithBrowser(client.BrowserLoginConfig{
+//	cred, err := authClient.LoginWithBrowser(ctx, &client.BrowserLoginRequest{
 //	    ClientID:    "my-cli",
 //	    OpenBrowser: client.FollowRedirects(nil),
 //	})

--- a/client/browser_login_test.go
+++ b/client/browser_login_test.go
@@ -13,6 +13,7 @@ package client
 //   - See: https://github.com/panyam/oneauth/issues/54
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -144,7 +145,7 @@ func TestLoginWithBrowser_FullFlow(t *testing.T) {
 	authClient := NewAuthClient(authSrv.URL, store)
 
 	var capturedAuthURL string
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Scopes:   []string{"openid", "read"},
 		Timeout:  5 * time.Second,
@@ -185,7 +186,7 @@ func TestLoginWithBrowser_Timeout(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Timeout:  500 * time.Millisecond,
 		OpenBrowser: func(url string) error {
@@ -225,7 +226,7 @@ func TestLoginWithBrowser_StateMismatch(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(srv.URL, store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Timeout:  2 * time.Second,
 		OpenBrowser: func(authURL string) error {
@@ -244,7 +245,7 @@ func TestLoginWithBrowser_MissingClientID(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient("http://localhost", store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{})
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ClientID")
 }
@@ -272,7 +273,7 @@ func TestLoginWithBrowser_AuthorizationError(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(srv.URL, store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Timeout:  2 * time.Second,
 		OpenBrowser: func(authURL string) error {
@@ -292,7 +293,7 @@ func TestLoginWithBrowser_ExplicitEndpoints(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:              "test-cli",
 		AuthorizationEndpoint: authSrv.URL + "/authorize",
 		TokenEndpoint:         authSrv.URL + "/token",
@@ -322,7 +323,7 @@ func TestFollowRedirects_FullFlow(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:    "test-cli",
 		Scopes:      []string{"openid", "read"},
 		Timeout:     5 * time.Second,
@@ -351,7 +352,7 @@ func TestFollowRedirects_WithCustomHTTPClient(t *testing.T) {
 	authClient := NewAuthClient(authSrv.URL, store)
 
 	customClient := &http.Client{Timeout: 10 * time.Second}
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:    "test-cli",
 		Timeout:     5 * time.Second,
 		OpenBrowser: FollowRedirects(customClient),
@@ -387,7 +388,7 @@ func TestFollowRedirects_AuthorizationError(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(srv.URL, store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:    "test-cli",
 		Timeout:     2 * time.Second,
 		OpenBrowser: FollowRedirects(nil),
@@ -433,7 +434,7 @@ func TestLoginWithBrowser_PKCENotSupported(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(srv.URL, store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Timeout:  2 * time.Second,
 		OpenBrowser: func(url string) error {
@@ -466,7 +467,7 @@ func TestLoginWithBrowser_PKCEWrongMethod(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(srv.URL, store)
 
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Timeout:  2 * time.Second,
 		OpenBrowser: func(url string) error {
@@ -490,7 +491,7 @@ func TestLoginWithBrowser_PKCESkippedWithExplicitEndpoints(t *testing.T) {
 	authClient := NewAuthClient(authSrv.URL, store)
 
 	// Explicit endpoints — no discovery, no PKCE check
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:              "test-cli",
 		AuthorizationEndpoint: authSrv.URL + "/authorize",
 		TokenEndpoint:         authSrv.URL + "/token",
@@ -521,7 +522,7 @@ func TestLoginWithBrowser_ResourceParameter(t *testing.T) {
 	authClient := NewAuthClient(authSrv.URL, store)
 
 	var capturedAuthURL string
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		Resource: "https://api.example.com",
 		Timeout:  5 * time.Second,
@@ -657,7 +658,7 @@ func TestLoginWithBrowser_ConfidentialClient_BasicAuth(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:     "confidential-app",
 		ClientSecret: "app-secret",
 		Timeout:      5 * time.Second,
@@ -681,7 +682,7 @@ func TestLoginWithBrowser_ConfidentialClient_PostAuth(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:     "confidential-app",
 		ClientSecret: "app-secret",
 		Timeout:      5 * time.Second,
@@ -705,7 +706,7 @@ func TestLoginWithBrowser_PublicClient_NoneAuth(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:    "public-app",
 		Timeout:     5 * time.Second,
 		OpenBrowser: FollowRedirects(nil),
@@ -717,7 +718,7 @@ func TestLoginWithBrowser_PublicClient_NoneAuth(t *testing.T) {
 }
 
 // =============================================================================
-// #74 — TokenEndpointAuthMethods in BrowserLoginConfig
+// #74 — TokenEndpointAuthMethods in BrowserLoginRequest
 // =============================================================================
 
 // TestLoginWithBrowser_ExplicitEndpoints_PostAuth verifies that when explicit
@@ -738,7 +739,7 @@ func TestLoginWithBrowser_ExplicitEndpoints_PostAuth(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:                 "confidential-app",
 		ClientSecret:             "app-secret",
 		AuthorizationEndpoint:    authSrv.URL + "/authorize",
@@ -767,7 +768,7 @@ func TestLoginWithBrowser_ExplicitEndpoints_DefaultsToBasic(t *testing.T) {
 	store := newMockCredentialStore()
 	authClient := NewAuthClient(authSrv.URL, store)
 
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:              "confidential-app",
 		ClientSecret:          "app-secret",
 		AuthorizationEndpoint: authSrv.URL + "/authorize",
@@ -800,7 +801,7 @@ func TestLoginWithBrowser_ExplicitEndpoints_MethodsOverrideDiscovery(t *testing.
 	// Without explicit TokenEndpointAuthMethods, discovery would return both
 	// and SelectAuthMethod would pick basic (preferred). But we override to
 	// post-only, proving the config field takes effect.
-	cred, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:                 "confidential-app",
 		ClientSecret:             "app-secret",
 		AuthorizationEndpoint:    authSrv.URL + "/authorize",
@@ -824,7 +825,7 @@ func TestLoginWithBrowser_NoResourceParameter(t *testing.T) {
 	authClient := NewAuthClient(authSrv.URL, store)
 
 	var capturedAuthURL string
-	_, err := authClient.LoginWithBrowser(BrowserLoginConfig{
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID: "test-cli",
 		// No Resource set
 		Timeout: 5 * time.Second,

--- a/client/client.go
+++ b/client/client.go
@@ -205,25 +205,51 @@ func (c *AuthClient) GetCredential() (*ServerCredential, error) {
 	return c.store.GetCredential(c.serverURL)
 }
 
-// Login authenticates with username/password and stores the credential
-func (c *AuthClient) Login(username, password, scope string) (*ServerCredential, error) {
+// LoginRequest is the input to AuthClient.Login. It carries the
+// resource-owner password credentials grant inputs (RFC 6749 §4.3).
+// The ClientID defaults to "cli" if unset, matching the oneauth /api/token
+// endpoint's expected value for first-party CLI clients.
+type LoginRequest struct {
+	// Username is the resource-owner identifier (email / username).
+	Username string
+
+	// Password is the resource-owner secret.
+	Password string
+
+	// Scope is the requested OAuth scope (space-delimited).
+	Scope string
+
+	// ClientID identifies the client. Defaults to "cli" when empty.
+	ClientID string
+}
+
+// Login authenticates with username/password (RFC 6749 §4.3 resource-owner
+// password credentials grant) and stores the resulting credential.
+func (c *AuthClient) Login(ctx context.Context, req *LoginRequest) (*ServerCredential, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Login: req is required")
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	req := OAuth2TokenRequest{
+	clientID := req.ClientID
+	if clientID == "" {
+		clientID = "cli"
+	}
+	tokReq := OAuth2TokenRequest{
 		GrantType: "password",
-		Username:  username,
-		Password:  password,
-		Scope:     scope,
-		ClientID:  "cli",
+		Username:  req.Username,
+		Password:  req.Password,
+		Scope:     req.Scope,
+		ClientID:  clientID,
 	}
 
-	cred, err := c.requestToken(req)
+	cred, err := c.requestToken(ctx, tokReq)
 	if err != nil {
 		return nil, err
 	}
 
-	cred.UserEmail = username
+	cred.UserEmail = req.Username
 
 	if err := c.store.SetCredential(c.serverURL, cred); err != nil {
 		return nil, fmt.Errorf("failed to store credential: %w", err)
@@ -405,7 +431,7 @@ func (c *AuthClient) refreshTokenLocked(cred *ServerCredential) error {
 		ClientID:     "cli",
 	}
 
-	newCred, err := c.requestToken(req)
+	newCred, err := c.requestToken(context.Background(), req)
 	if err != nil {
 		return err
 	}
@@ -535,7 +561,7 @@ func (c *AuthClient) executeTokenRequest(req *http.Request) (*ServerCredential, 
 // requestToken makes a token request to the server using JSON encoding.
 // This is the legacy path used by Login and refreshTokenLocked for the
 // oneauth-specific /auth/cli/token endpoint.
-func (c *AuthClient) requestToken(req OAuth2TokenRequest) (*ServerCredential, error) {
+func (c *AuthClient) requestToken(ctx context.Context, req OAuth2TokenRequest) (*ServerCredential, error) {
 	tokenURL := c.serverURL + c.tokenEndpoint
 
 	jsonBody, err := json.Marshal(req)
@@ -543,9 +569,15 @@ func (c *AuthClient) requestToken(req OAuth2TokenRequest) (*ServerCredential, er
 		return nil, fmt.Errorf("failed to encode request: %w", err)
 	}
 
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", tokenURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
 	// Use base transport directly to avoid auth loop
 	httpClient := &http.Client{Transport: c.baseTransport}
-	resp, err := httpClient.Post(tokenURL, "application/json", bytes.NewReader(jsonBody))
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}

--- a/client/client_http_test.go
+++ b/client/client_http_test.go
@@ -3,6 +3,7 @@ package client
 // Tests for the AuthClient HTTP interactions: login, token refresh, auth transport, and custom configuration options.
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -43,7 +44,7 @@ func TestAuthClient_Login_Success(t *testing.T) {
 	store := newMockCredentialStore()
 	client := NewAuthClient(server.URL, store)
 
-	cred, err := client.Login("user@example.com", "password123", "read write")
+	cred, err := client.Login(context.Background(), &LoginRequest{Username: "user@example.com", Password: "password123", Scope: "read write"})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
 	}
@@ -82,7 +83,7 @@ func TestAuthClient_Login_InvalidCredentials(t *testing.T) {
 	store := newMockCredentialStore()
 	client := NewAuthClient(server.URL, store)
 
-	_, err := client.Login("user@example.com", "wrong-password", "read write")
+	_, err := client.Login(context.Background(), &LoginRequest{Username: "user@example.com", Password: "wrong-password", Scope: "read write"})
 	if err == nil {
 		t.Fatal("Login() should have failed with invalid credentials")
 	}
@@ -353,7 +354,7 @@ func TestAuthClient_WithCustomTokenEndpoint(t *testing.T) {
 	store := newMockCredentialStore()
 	client := NewAuthClient(server.URL, store, WithTokenEndpoint("/custom/token"))
 
-	_, err := client.Login("user@example.com", "password", "")
+	_, err := client.Login(context.Background(), &LoginRequest{Username: "user@example.com", Password: "password", Scope: ""})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
 	}

--- a/client/client_nil_test.go
+++ b/client/client_nil_test.go
@@ -9,6 +9,7 @@ package client
 // See: https://github.com/panyam/oneauth/issues/76
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -82,7 +83,7 @@ func TestAuthClient_NilStore_Login(t *testing.T) {
 	defer server.Close()
 
 	c := NewAuthClient(server.URL, nil)
-	cred, err := c.Login("user", "pass", "")
+	cred, err := c.Login(context.Background(), &LoginRequest{Username: "user", Password: "pass", Scope: ""})
 	require.NoError(t, err)
 	assert.Equal(t, "test-token", cred.AccessToken)
 
@@ -125,7 +126,7 @@ func TestAuthClient_NilStore_LoginWithBrowser(t *testing.T) {
 	authSrv := mockAuthServer(t)
 
 	c := NewAuthClient(authSrv.URL, nil)
-	cred, err := c.LoginWithBrowser(BrowserLoginConfig{
+	cred, err := c.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
 		ClientID:    "test-cli",
 		Scopes:      []string{"openid"},
 		Timeout:     10 * time.Second,

--- a/tests/e2e/authcode_test.go
+++ b/tests/e2e/authcode_test.go
@@ -48,7 +48,7 @@ func TestE2E_AuthCodePKCE_HeadlessFlow(t *testing.T) {
 	authClient := client.NewAuthClient(env.BaseURL(), store,
 		client.WithTokenEndpoint("/oauth/token"))
 
-	cred, err := authClient.LoginWithBrowser(client.BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &client.BrowserLoginRequest{
 		ClientID:    "e2e-public-client",
 		Scopes:      []string{"openid", "read"},
 		Timeout:     5 * time.Second,
@@ -232,7 +232,7 @@ func TestE2E_AuthCodePKCE_ExplicitEndpoints_WithAuthMethods(t *testing.T) {
 
 	// Simulate MCPKit flow: caller already discovered endpoints + auth methods
 	// via PRM→AS metadata, and passes them explicitly.
-	cred, err := authClient.LoginWithBrowser(client.BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &client.BrowserLoginRequest{
 		ClientID:                 "e2e-public-client",
 		Scopes:                   []string{"openid", "read"},
 		AuthorizationEndpoint:    env.BaseURL() + "/authorize",
@@ -280,7 +280,7 @@ func TestE2E_AuthCodePKCE_ExplicitEndpoints_ConfidentialClient(t *testing.T) {
 	authClient := client.NewAuthClient(env.BaseURL(), store,
 		client.WithTokenEndpoint("/oauth/token"))
 
-	cred, err := authClient.LoginWithBrowser(client.BrowserLoginConfig{
+	cred, err := authClient.LoginWithBrowser(context.Background(), &client.BrowserLoginRequest{
 		ClientID:                 clientID,
 		ClientSecret:             secret,
 		Scopes:                   []string{"read"},


### PR DESCRIPTION
## What changes

Closes **#217**. Second slice — finishes the gRPC-shape convention adoption in the consumer-facing `client/` SDK that #217a started. Two methods reshape:

```diff
- AuthClient.Login(username, password, scope) (*ServerCredential, error)
+ AuthClient.Login(ctx context.Context, req *LoginRequest) (*ServerCredential, error)

- AuthClient.LoginWithBrowser(cfg BrowserLoginConfig) (*ServerCredential, error)
+ AuthClient.LoginWithBrowser(ctx context.Context, req *BrowserLoginRequest) (*ServerCredential, error)
```

`BrowserLoginConfig` is renamed to **`BrowserLoginRequest`** — it was a request struct in spirit; the rename makes that explicit and aligns with every other `*Request` type the SDK now uses (`ClientCredentialsRequest`, `TokenExchangeRequest`, `JwtBearerGrantRequest`, `LoginRequest`).

After this PR every token-acquisition surface on `AuthClient` follows `MethodName(ctx, *XRequest) → (..., error)`.

## Reviewer's guide

Read in this order:

1. [client/client.go](https://github.com/panyam/oneauth/pull/226/files#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09) — `LoginRequest` definition + reshaped `Login` + `requestToken` gained ctx (now uses `http.NewRequestWithContext`) + `refreshTokenLocked` passes `context.Background()` since it's invoked from a RoundTripper.
2. [client/browser_login.go](https://github.com/panyam/oneauth/pull/226/files#diff-d5734d6e88ef6fa1ad180d1a3759f873c04caa9fea8d60123ec6c06db9d0db3e) — `BrowserLoginConfig` → `BrowserLoginRequest` rename + reshaped `LoginWithBrowser` + `exchangeCode` gained ctx + the internal `context.WithTimeout` now derives from the caller's ctx so upstream cancellation aborts the browser-login wait.
3. [client/SUMMARY.md](https://github.com/panyam/oneauth/pull/226/files#diff-3a46ff406dca6db0306228beb6a581b19e9373c5f02d6f413012ed95a05fd13c) — documents the convention across the SDK surface.

Skim or skip: `client/{browser_login,client_http,client_nil}_test.go`, [tests/e2e/authcode_test.go](https://github.com/panyam/oneauth/pull/226/files#diff-e26ea27bb7c386b1a3b183497776d64e2effe142bdabd643ff7648d00ce01fdf) — mechanical call-site updates (4 `Login` sites, ~18 `LoginWithBrowser` sites).

## Decision log

- **Clean break, no wrappers.** Go has no method overloading, so `Login(username, password, scope)` and `Login(ctx, *LoginRequest)` cannot coexist on the same receiver. The issue's "keep the old as a thin wrapper" plan isn't expressible in Go. Per agreement on the discussion thread, choosing the cleanest path: delete the old surface, migrate the in-tree callers (4 + ~18). External consumers (mcpkit, SEP) get a one-shot migration on the next oneauth version bump — matches 217a's pattern.
- **No `LoginResponse` / `BrowserLoginResponse` wrappers.** Symmetric with 217a where `ClientCredentials` returns `*ServerCredential` directly without a wrapper. Single-value returns get unwrapped; the convention's payoff is request normalization. Forward-compat headroom is fine to add later if a response actually gains additional fields.
- **`BrowserLoginConfig` → `BrowserLoginRequest` rename, not just a type alias.** The old name was a holdover from before the convention work. Type-aliasing it would be dead weight; in-tree callers all migrated.
- **Internal `context.WithTimeout` derives from caller's ctx.** Previously rooted at `context.Background()`. New behavior: cancellation propagates from caller through to the browser-login wait. This is the only meaningful behavior change in the PR; everything else is signature reshape.

## Risk / blast radius

- **Affects:** every consumer calling `AuthClient.Login` / `AuthClient.LoginWithBrowser` directly. In-tree migrated. External callers (mcpkit, SEP) will need a one-shot update on the next oneauth bump.
- **Tests covering this:** full `client/` unit suite + `tests/e2e/authcode_test.go` (browser-login end-to-end with race detector). Wire format byte-identical pre/post.
- **Be paranoid about:** the timeout-context derivation. The new `context.WithTimeout(ctx, timeout)` returns a context that cancels on EITHER the caller cancelling OR the timeout firing. The select statement distinguishes "caller cancelled" (returns `ctx.Err()`) from "timeout fired" (returns the timeout error) — verified by manual code review since browser-login is interactive and hard to e2e for timeouts in CI.

## Out of scope (deliberately deferred)

- **Ctx-aware `ClientCredentialsSource.Token` accessor** — covered briefly in 217a's PR description; still deferred. The internal `fetchTokenLocked` passes `context.Background()` to the new ctx-aware methods; a public `TokenContext(ctx)` is a candidate follow-up.
- **`ClientCredentialsToken` / `ClientCredentialsTokenWithAssertion`** — already marked `// Deprecated:` in 217a; full removal can wait until consumers migrate.

## Test plan

- [x] `go test ./...` — root green
- [x] `cd stores/gorm && GOWORK=off go test -race ./...` — green
- [x] `cd stores/gae && GOWORK=off go build ./...` — green
- [x] `go test -race ./tests/e2e/...` — green (includes browser-login end-to-end coverage)
- [x] `staticcheck ./...` — no new warnings introduced (two pre-existing `option.WithCredentialsFile` warnings in `stores/gae/*_test.go` untouched by this PR)
