### PR TITLE
fix(localauth): close timing-oracle in NewCredentialsValidatorWithUsername (#208) + sweep dead gae WithContext

### DIFF
--- a/localauth/channel_linking_test.go
+++ b/localauth/channel_linking_test.go
@@ -3,6 +3,7 @@
 package localauth_test
 
 import (
+	"time"
 	"github.com/panyam/oneauth/accounts"
 	"context"
 	"github.com/panyam/oneauth/localauth"
@@ -519,6 +520,50 @@ func TestCredentialsValidatorNoUsernameStore(t *testing.T) {
 	_, err := validator("someuser", "password", "username")
 	if err == nil {
 		t.Error("Should fail when UsernameStore is nil")
+	}
+}
+
+// TestCredentialsValidatorWithUsername_TimingOracle verifies the not-found-username
+// path runs a dummy bcrypt comparison, so its wall-clock duration is comparable to
+// a valid-username path. Without the defense, a missing username returns in microseconds
+// while a valid username costs ~bcrypt cost 10 (~30–100 ms), letting an attacker
+// enumerate accounts by timing /auth/login responses.
+//
+// See: https://cwe.mitre.org/data/definitions/208.html
+func TestCredentialsValidatorWithUsername_TimingOracle(t *testing.T) {
+	config, tmpDir := setupAuthStores(t)
+	defer os.RemoveAll(tmpDir)
+
+	validator := localauth.NewCredentialsValidatorWithUsername(
+		config.IdentityStore,
+		config.ChannelStore,
+		config.UserStore,
+		config.UsernameStore,
+	)
+
+	// Lower bound: one bcrypt.DefaultCost comparison takes ~20 ms even on a fast
+	// host. If the dummy comparison was skipped, the not-found path returns in
+	// well under 1 ms — orders of magnitude below this floor.
+	const bcryptFloor = 15 * time.Millisecond
+
+	for _, tc := range []struct {
+		name     string
+		username string
+	}{
+		{"unknown_username", "no-such-user"},
+		{"unknown_email", "ghost@example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			start := time.Now()
+			_, err := validator(tc.username, "any-password", "")
+			elapsed := time.Since(start)
+			if err == nil {
+				t.Fatalf("expected error for missing %s", tc.name)
+			}
+			if elapsed < bcryptFloor {
+				t.Errorf("not-found path returned in %v; expected ≥ %v (dummy bcrypt missing — timing oracle reintroduced)", elapsed, bcryptFloor)
+			}
+		})
 	}
 }
 

--- a/localauth/helpers.go
+++ b/localauth/helpers.go
@@ -309,12 +309,14 @@ func NewCredentialsValidatorWithUsername(identityStore accounts.IdentityStore, c
 			}
 			userResp, err := usernameStore.GetUserByUsername(ctx, &accounts.GetUserByUsernameRequest{Username: username})
 			if err != nil {
+				bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 				return nil, fmt.Errorf("invalid credentials")
 			}
 			userID := userResp.UserID
 
 			idsResp, err := identityStore.GetUserIdentities(ctx, &accounts.GetUserIdentitiesRequest{UserID: userID})
 			if err != nil || len(idsResp.Identities) == 0 {
+				bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 				return nil, fmt.Errorf("invalid credentials")
 			}
 
@@ -326,6 +328,7 @@ func NewCredentialsValidatorWithUsername(identityStore accounts.IdentityStore, c
 				}
 			}
 			if emailIdentity == nil {
+				bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 				return nil, fmt.Errorf("invalid credentials")
 			}
 			identityKey = accounts.IdentityKey("email", emailIdentity.Value)
@@ -335,12 +338,14 @@ func NewCredentialsValidatorWithUsername(identityStore accounts.IdentityStore, c
 
 		chResp, err := channelStore.GetChannel(ctx, &accounts.GetChannelRequest{Provider: "local", IdentityKey: identityKey})
 		if err != nil {
+			bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 			return nil, fmt.Errorf("invalid credentials")
 		}
 		channel := chResp.Channel
 
 		passwordHash, ok := channel.Credentials["password_hash"].(string)
 		if !ok {
+			bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 			return nil, fmt.Errorf("invalid credentials")
 		}
 

--- a/stores/gae/stores.go
+++ b/stores/gae/stores.go
@@ -53,7 +53,6 @@ func (u *GAEUser) Profile() map[string]any { return u.UserProfile }
 type UserStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewUserStore creates a new Datastore-backed UserStore
@@ -61,16 +60,6 @@ func NewUserStore(client *datastore.Client, namespace string) *UserStore {
 	return &UserStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-// WithContext returns a copy of the store with the given context
-func (s *UserStore) WithContext(ctx context.Context) *UserStore {
-	return &UserStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -188,7 +177,6 @@ func (s *UserStore) SaveUser(ctx context.Context, req *accounts.SaveUserRequest)
 type IdentityStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewIdentityStore creates a new Datastore-backed IdentityStore
@@ -196,15 +184,6 @@ func NewIdentityStore(client *datastore.Client, namespace string) *IdentityStore
 	return &IdentityStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-func (s *IdentityStore) WithContext(ctx context.Context) *IdentityStore {
-	return &IdentityStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -346,7 +325,6 @@ func (s *IdentityStore) GetUserIdentities(ctx context.Context, req *accounts.Get
 type ChannelStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewChannelStore creates a new Datastore-backed ChannelStore
@@ -354,15 +332,6 @@ func NewChannelStore(client *datastore.Client, namespace string) *ChannelStore {
 	return &ChannelStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-func (s *ChannelStore) WithContext(ctx context.Context) *ChannelStore {
-	return &ChannelStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -532,7 +501,6 @@ func (s *ChannelStore) GetChannelsByIdentity(ctx context.Context, req *accounts.
 type TokenStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewTokenStore creates a new Datastore-backed TokenStore
@@ -540,15 +508,6 @@ func NewTokenStore(client *datastore.Client, namespace string) *TokenStore {
 	return &TokenStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-func (s *TokenStore) WithContext(ctx context.Context) *TokenStore {
-	return &TokenStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -660,7 +619,6 @@ func (s *TokenStore) DeleteSubjectTokens(ctx context.Context, req *localauth.Del
 type RefreshTokenStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewRefreshTokenStore creates a new Datastore-backed RefreshTokenStore
@@ -668,15 +626,6 @@ func NewRefreshTokenStore(client *datastore.Client, namespace string) *RefreshTo
 	return &RefreshTokenStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-func (s *RefreshTokenStore) WithContext(ctx context.Context) *RefreshTokenStore {
-	return &RefreshTokenStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -1097,7 +1046,6 @@ func (s *RefreshTokenStore) CleanupExpiredTokens(ctx context.Context, req *core.
 type APIKeyStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewAPIKeyStore creates a new Datastore-backed APIKeyStore
@@ -1105,15 +1053,6 @@ func NewAPIKeyStore(client *datastore.Client, namespace string) *APIKeyStore {
 	return &APIKeyStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-func (s *APIKeyStore) WithContext(ctx context.Context) *APIKeyStore {
-	return &APIKeyStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -1350,7 +1289,6 @@ func (s *APIKeyStore) UpdateAPIKeyLastUsed(ctx context.Context, req *core.Update
 type UsernameStore struct {
 	client    *datastore.Client
 	namespace string
-	ctx       context.Context
 }
 
 // NewUsernameStore creates a new Datastore-backed UsernameStore
@@ -1358,15 +1296,6 @@ func NewUsernameStore(client *datastore.Client, namespace string) *UsernameStore
 	return &UsernameStore{
 		client:    client,
 		namespace: namespace,
-		ctx:       context.Background(),
-	}
-}
-
-func (s *UsernameStore) WithContext(ctx context.Context) *UsernameStore {
-	return &UsernameStore{
-		client:    s.client,
-		namespace: s.namespace,
-		ctx:       ctx,
 	}
 }
 


### PR DESCRIPTION
## What changes

Two small independent fixes bundled. Both bounded, both zero wire-format impact.

1. **Closes #208** — `NewCredentialsValidatorWithUsername` had 5 enumerable early-return branches that returned in microseconds on missing usernames, while a valid-username + wrong-password attempt cost ~50ms (one bcrypt). This timing leak let an attacker enumerate accounts. Mirrors the existing dummy-hash defense already present on the sibling `NewCredentialsValidator`. After the fix, all not-found paths run one bcrypt comparison so wall-clock duration is comparable.

2. **Dead `WithContext()` sweep on `stores/gae/`** — pure cleanup deferred from #204c/d. Removes 7 × dead `WithContext()` methods + 7 × dead `ctx` struct fields + 7 × `ctx: context.Background()` constructor initializers. Confirmed dead before removal (zero `s.ctx` reads anywhere in `stores/gae/`; zero external callers of `.WithContext()`).

## Reviewer's guide

Read in this order:

1. [localauth/helpers.go](https://github.com/panyam/oneauth/pull/227/files#diff-63b8b2f5e5f3a278e30e87b8c0049b801ee94b76acfdb4b669e8dea1390f9424) — five `bcrypt.CompareHashAndPassword(dummyBcryptHash, ...)` inserts in `NewCredentialsValidatorWithUsername`. Each guards an early-return that previously leaked timing info. Mirrors the same defense already present in the sibling validator (lines 107, 114).
2. [localauth/channel_linking_test.go](https://github.com/panyam/oneauth/pull/227/files#diff-29a3c863d088046681fa7d7a713f6fa64c9f6607c1e2804cfb8f38516311bd65) — `TestCredentialsValidatorWithUsername_TimingOracle`. Asserts the not-found path takes ≥ 15ms — a hard floor proving the dummy bcrypt ran. Without the fix, the not-found path returns in ~12µs (confirmed red-before-green; included in commit message). `// See:` link to CWE-208.
3. [stores/gae/stores.go](https://github.com/panyam/oneauth/pull/227/files#diff-2c8530602a1cead3e8eb8b59c92358a081544846b91c040987fd6b658d773ba5) — mechanical sweep. ~71 lines removed across 7 stores. No behavior change.

## Diff groups

- **Security fix**: `localauth/helpers.go`, `localauth/channel_linking_test.go`
- **Dead-code sweep**: `stores/gae/stores.go`

## Decision log

- **Bundle vs split**: split was the default recommendation (security fixes deserve isolated audit trails), but per the conversation the user opted to bundle since both are small. The diff groups above keep the intents clearly separable for review.
- **Hard-floor timing assertion over relative parity**: a "≥ 15ms" threshold is unambiguous in CI — bcrypt cost-10 trivially exceeds it (~70ms in practice) while a missing dummy returns in microseconds. A relative-parity test (`assert not-found ≈ wrong-password ± 20%`) would be flakier across CI runner hardware.
- **`usernameStore == nil` branch left untouched**: returns a different error message (`"username login not configured"`) and is a caller configuration error, not a credential probe — not an enumeration oracle.
- **Sweep targets only the dead `WithContext` pattern, not the gorm `s.db.WithContext(ctx)` chain method**: those are gorm's per-query chain calls and are very much alive.

## Risk / blast radius

- **#208**: invalid-username login latency rises from sub-millisecond to ~70ms. Matches `NewCredentialsValidator`'s already-shipped behavior — no surprise to consumers using the sibling.
- **Sweep**: zero behavior change; pure dead-code removal. External breakage limited to any out-of-tree caller of `.WithContext()` on a gae store — none exist in oneauth or known consumers (only the post-#204 internal callers were ever using it, and those moved off in #204c/d).
- **Be paranoid about**: timing test flakiness in CI. Hard floor of 15ms is well below the actual ~70ms cost-10 bcrypt; the margin should survive even on slow runners.

## Before / after

Pre-fix (red):
```
=== RUN   TestCredentialsValidatorWithUsername_TimingOracle/unknown_username
    channel_linking_test.go:564: not-found path returned in 12.292µs; expected ≥ 15ms
--- FAIL: TestCredentialsValidatorWithUsername_TimingOracle/unknown_username
```

Post-fix (green):
```
=== RUN   TestCredentialsValidatorWithUsername_TimingOracle/unknown_username
--- PASS: TestCredentialsValidatorWithUsername_TimingOracle/unknown_username (0.07s)
```

## Out of scope

- Defense audit on `NewCredentialsValidator`'s post-bcrypt branches (issue scopes only to the username variant; the sibling's pre-bcrypt path already implements the defense).
- `cmd/oneauth-server/` or downstream rewiring for the removed `WithContext()` — none exists; grep confirmed.

## Test plan

- [x] `go test ./...` — root green (incl. new timing-oracle test)
- [x] `cd stores/gorm && GOWORK=off go test -race ./...` — green
- [x] `cd stores/gae && GOWORK=off go build ./... && go vet ./...` — green
- [x] `go test -race ./tests/e2e/...` — green
- [x] `staticcheck ./...` — no new warnings
- [x] Red-before-green verified on the new timing test (pre-fix run: 12µs ≪ 15ms floor, fails; post-fix: ~70ms, passes)
