### PR TITLE
refactor(admin,core): move AppRegistration types to core/, drop /apps/register endpoint (#207 + #189)

### DIFF
--- a/admin/appstore_test.go
+++ b/admin/appstore_test.go
@@ -6,14 +6,14 @@ package admin_test
 import (
 	"testing"
 
-	"github.com/panyam/oneauth/admin"
 	"github.com/panyam/oneauth/appstoretest"
+	"github.com/panyam/oneauth/core"
 )
 
-// TestInMemoryAppStore verifies that admin.NewInMemoryAppStore satisfies the
+// TestInMemoryAppStore verifies that core.NewInMemoryAppStore satisfies the
 // AppRegistrationStore contract.
 func TestInMemoryAppStore(t *testing.T) {
-	appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
-		return admin.NewInMemoryAppStore()
+	appstoretest.RunAll(t, func(t *testing.T) core.AppRegistrationStore {
+		return core.NewInMemoryAppStore()
 	})
 }

--- a/admin/client_admin.go
+++ b/admin/client_admin.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"github.com/panyam/oneauth/core"
 	"context"
 	"errors"
 	"time"
@@ -38,26 +39,19 @@ type ClientRegistrar interface {
 	// (extended with the RFC 7592 §3 management credentials).
 	Register(ctx context.Context, req *RegisterRequest) (*RegisterResponse, error)
 
-	// RegisterLegacy handles the proprietary /apps/register path. Distinct
-	// from Register because the wire shapes diverge — the legacy endpoint
-	// carries OneAuth-specific quota fields (MaxRooms / MaxMsgRate) that
-	// RFC 7591 has no place for. Eventual removal of this endpoint is
-	// tracked under issue #189.
-	RegisterLegacy(ctx context.Context, req *RegisterLegacyRequest) (*RegisterLegacyResponse, error)
-
 	// ListClients returns every registration in the registry. Reads from
-	// the in-memory cache hydrated from the AppRegistrationStore on
+	// the in-memory cache hydrated from the core.AppRegistrationStore on
 	// AppRegistrar construction.
 	ListClients(ctx context.Context, req *ListClientsRequest) (*ListClientsResponse, error)
 
 	// GetClient returns the registration for req.ClientID, or
-	// ErrAppNotFound. This is the ADMIN read — distinct from
+	// core.ErrAppNotFound. This is the ADMIN read — distinct from
 	// ClientRegistrationManager.GetRegistration which authenticates with
 	// the client's own registration_access_token.
 	GetClient(ctx context.Context, req *GetClientRequest) (*GetClientResponse, error)
 
 	// DeleteClient removes the registration for req.ClientID and
-	// invalidates its KeyStore entry. Returns ErrAppNotFound if the
+	// invalidates its KeyStore entry. Returns core.ErrAppNotFound if the
 	// client does not exist. This is the ADMIN delete — distinct from
 	// ClientRegistrationManager.DeleteRegistration which authenticates
 	// with the client's own token.
@@ -94,36 +88,6 @@ type RegisterResponse struct {
 }
 
 // ----------------------------------------------------------------------------
-// RegisterLegacy (proprietary /apps/register)
-// ----------------------------------------------------------------------------
-
-// RegisterLegacyRequest carries the field set that the proprietary
-// /apps/register endpoint accepts. Notable differences from RegisterRequest:
-//   - ClientDomain replaces ClientName / ClientURI as the primary metadata
-//   - MaxRooms / MaxMsgRate carry OneAuth-specific quota that DCR cannot express
-//   - PublicKey is a raw PEM string for asymmetric algs (DCR uses JWKS instead)
-type RegisterLegacyRequest struct {
-	ClientDomain string  `json:"client_domain"`
-	SigningAlg   string  `json:"signing_alg"` // empty → defaults to HS256
-	PublicKey    string  `json:"public_key"`  // PEM-encoded; required for RS256/ES256
-	MaxRooms     int     `json:"max_rooms"`
-	MaxMsgRate   float64 `json:"max_msg_rate"`
-}
-
-// RegisterLegacyResponse wraps the proprietary response. Captured as
-// concrete fields rather than a map so the wire shape is reviewable in one
-// place; the HTTP wrapper marshals each field with the right name.
-type RegisterLegacyResponse struct {
-	ClientID     string    `json:"client_id"`
-	ClientDomain string    `json:"client_domain"`
-	SigningAlg   string    `json:"signing_alg"`
-	ClientSecret string    `json:"client_secret,omitempty"` // present only for symmetric algs
-	MaxRooms     int       `json:"max_rooms"`
-	MaxMsgRate   float64   `json:"max_msg_rate"`
-	CreatedAt    time.Time `json:"created_at"`
-}
-
-// ----------------------------------------------------------------------------
 // ListClients
 // ----------------------------------------------------------------------------
 
@@ -136,7 +100,7 @@ type ListClientsRequest struct{}
 // ListClientsResponse returns every registration. Each entry is a clone —
 // callers cannot mutate the in-memory cache via this value.
 type ListClientsResponse struct {
-	Apps []*AppRegistration
+	Apps []*core.AppRegistration
 }
 
 // ----------------------------------------------------------------------------
@@ -150,7 +114,7 @@ type GetClientRequest struct {
 
 // GetClientResponse is the registration metadata for the requested client.
 type GetClientResponse struct {
-	Registration *AppRegistration
+	Registration *core.AppRegistration
 }
 
 // ----------------------------------------------------------------------------

--- a/admin/client_admin_test.go
+++ b/admin/client_admin_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/admin"
 	"github.com/panyam/oneauth/keys"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,7 @@ import (
 // RFC 7592 management credentials and the registration is persisted in the
 // store.
 func TestClientRegistrar_Register_DirectInvocation(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 	r := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
 
@@ -41,61 +42,20 @@ func TestClientRegistrar_Register_DirectInvocation(t *testing.T) {
 	assert.Contains(t, got.RegistrationClientURI, "https://issuer.example/apps/dcr/")
 
 	// Persisted: the same client_id is retrievable from the store directly.
-	stored, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: got.ClientID})
+	stored, err := store.GetApp(context.Background(), &core.GetAppRequest{ClientID: got.ClientID})
 	require.NoError(t, err)
 	assert.Equal(t, "Direct Invoke", stored.App.ClientName)
 }
 
-// TestClientRegistrar_RegisterLegacy_DirectInvocation verifies the proprietary
-// /apps/register path works through the manager interface, including the
-// OneAuth-specific quota fields.
-func TestClientRegistrar_RegisterLegacy_DirectInvocation(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
-	r := admin.NewAppRegistrarWithStore(keys.NewInMemoryKeyStore(), admin.NewNoAuth(), store)
-
-	resp, err := r.RegisterLegacy(context.Background(), &admin.RegisterLegacyRequest{
-		ClientDomain: "legacy.example",
-		MaxRooms:     50,
-		MaxMsgRate:   2.5,
-	})
-	require.NoError(t, err)
-	assert.NotEmpty(t, resp.ClientID)
-	assert.Equal(t, "HS256", resp.SigningAlg, "default alg")
-	assert.NotEmpty(t, resp.ClientSecret, "symmetric → secret issued")
-	assert.Equal(t, 50, resp.MaxRooms, "OneAuth-specific quota field surfaced")
-	assert.Equal(t, 2.5, resp.MaxMsgRate)
-
-	stored, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: resp.ClientID})
-	require.NoError(t, err)
-	assert.Equal(t, 50, stored.App.MaxRooms, "quota persisted on AppRegistration")
-}
-
-// TestClientRegistrar_RegisterLegacy_AsymmetricRequiresPublicKey verifies the
-// validation error path: asymmetric algs without public_key surface as
-// ErrPublicKeyRequired (mapped to HTTP 400 by the wrapper).
-func TestClientRegistrar_RegisterLegacy_AsymmetricRequiresPublicKey(t *testing.T) {
-	r := admin.NewAppRegistrar(keys.NewInMemoryKeyStore(), admin.NewNoAuth())
-
-	_, err := r.RegisterLegacy(context.Background(), &admin.RegisterLegacyRequest{
-		ClientDomain: "rs256.example",
-		SigningAlg:   "RS256",
-		// PublicKey intentionally empty
-	})
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, admin.ErrPublicKeyRequired),
-		"asymmetric register without public_key must return ErrPublicKeyRequired")
-}
-
 // TestClientRegistrar_ListClients_ReflectsRegistrations verifies that
-// successive Register / RegisterLegacy calls show up in ListClients in the
-// expected count, and the returned entries are clones (mutating one does not
-// affect the cache).
+// successive Register calls show up in ListClients in the expected count,
+// and the returned entries are clones (mutating one does not affect the cache).
 func TestClientRegistrar_ListClients_ReflectsRegistrations(t *testing.T) {
 	r := admin.NewAppRegistrar(keys.NewInMemoryKeyStore(), admin.NewNoAuth())
 
 	_, err := r.Register(context.Background(), &admin.RegisterRequest{Metadata: &admin.DCRRequest{ClientName: "A"}})
 	require.NoError(t, err)
-	_, err = r.RegisterLegacy(context.Background(), &admin.RegisterLegacyRequest{ClientDomain: "b.example"})
+	_, err = r.Register(context.Background(), &admin.RegisterRequest{Metadata: &admin.DCRRequest{ClientName: "B"}})
 	require.NoError(t, err)
 
 	resp, err := r.ListClients(context.Background(), &admin.ListClientsRequest{})
@@ -116,26 +76,26 @@ func TestClientRegistrar_GetClient_NotFound(t *testing.T) {
 	r := admin.NewAppRegistrar(keys.NewInMemoryKeyStore(), admin.NewNoAuth())
 
 	_, err := r.GetClient(context.Background(), &admin.GetClientRequest{ClientID: "app_phantom"})
-	assert.True(t, errors.Is(err, admin.ErrAppNotFound))
+	assert.True(t, errors.Is(err, core.ErrAppNotFound))
 }
 
 // TestClientRegistrar_DeleteClient_RemovesFromStoreAndKeyStore verifies the
 // full effect of admin-side delete: registration gone from the store AND
 // signing key gone from KeyStore (so already-issued tokens fail validation).
 func TestClientRegistrar_DeleteClient_RemovesFromStoreAndKeyStore(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 	r := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
 
-	resp, err := r.RegisterLegacy(context.Background(), &admin.RegisterLegacyRequest{ClientDomain: "doomed"})
+	resp, err := r.Register(context.Background(), &admin.RegisterRequest{Metadata: &admin.DCRRequest{ClientName: "doomed"}})
 	require.NoError(t, err)
-	clientID := resp.ClientID
+	clientID := resp.Registration.ClientID
 
 	_, err = r.DeleteClient(context.Background(), &admin.DeleteClientRequest{ClientID: clientID})
 	require.NoError(t, err)
 
 	// Store side: gone.
-	if _, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: clientID}); !errors.Is(err, admin.ErrAppNotFound) {
+	if _, err := store.GetApp(context.Background(), &core.GetAppRequest{ClientID: clientID}); !errors.Is(err, core.ErrAppNotFound) {
 		t.Errorf("store should report ErrAppNotFound after DeleteClient, got %v", err)
 	}
 	// KeyStore side: gone.
@@ -144,7 +104,7 @@ func TestClientRegistrar_DeleteClient_RemovesFromStoreAndKeyStore(t *testing.T) 
 	}
 	// Repeat delete: ErrAppNotFound (idempotency by accident — safe).
 	_, err = r.DeleteClient(context.Background(), &admin.DeleteClientRequest{ClientID: clientID})
-	assert.True(t, errors.Is(err, admin.ErrAppNotFound))
+	assert.True(t, errors.Is(err, core.ErrAppNotFound))
 }
 
 // TestClientRegistrar_RotateSecret_Symmetric verifies that rotating a
@@ -152,12 +112,17 @@ func TestClientRegistrar_DeleteClient_RemovesFromStoreAndKeyStore(t *testing.T) 
 // pre-rotation values.
 func TestClientRegistrar_RotateSecret_Symmetric(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	r := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), admin.NewInMemoryAppStore())
+	r := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), core.NewInMemoryAppStore())
 
-	registered, err := r.RegisterLegacy(context.Background(), &admin.RegisterLegacyRequest{ClientDomain: "rotate.me"})
+	regResp, err := r.Register(context.Background(), &admin.RegisterRequest{Metadata: &admin.DCRRequest{ClientName: "rotate.me"}})
 	require.NoError(t, err)
+	registered := regResp.Registration
 
-	preRotateKeyResp_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: registered.ClientID}); var preRotateKey *keys.KeyRecord; if preRotateKeyResp_ != nil { preRotateKey = preRotateKeyResp_.Record }
+	preRotateKeyResp_, err := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: registered.ClientID})
+	var preRotateKey *keys.KeyRecord
+	if preRotateKeyResp_ != nil {
+		preRotateKey = preRotateKeyResp_.Record
+	}
 	require.NoError(t, err)
 	preRotateKid := preRotateKey.Kid
 

--- a/admin/dcr.go
+++ b/admin/dcr.go
@@ -190,7 +190,7 @@ func generateDCRSecret() (string, error) {
 
 // generateRegistrationAccessToken returns a 32-byte (256-bit) hex-encoded random
 // token used as the RFC 7592 management credential for a DCR-registered client.
-// The token is stored on AppRegistration.RegistrationAccessToken and validated
+// The token is stored on core.AppRegistration.RegistrationAccessToken and validated
 // on every /apps/dcr/{client_id} request via DCRManagementHandler.
 func generateRegistrationAccessToken() (string, error) {
 	b := make([]byte, 32)

--- a/admin/dcr_management_test.go
+++ b/admin/dcr_management_test.go
@@ -108,8 +108,8 @@ func TestGetRegistration_LegacyRegistrationCannotBeRead(t *testing.T) {
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 
 	// Register through the legacy endpoint — no management token issued.
-	body := `{"client_domain":"legacy.example","signing_alg":"HS256"}`
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", strings.NewReader(body))
+	body := `{"client_name":"legacy.example","signing_alg":"HS256"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
 	rr := httptest.NewRecorder()
 	registrar.Handler().ServeHTTP(rr, req)
 	require.Equal(t, http.StatusCreated, rr.Code)
@@ -533,8 +533,8 @@ func TestDeleteRegistration_LegacyRegistrationCannotBeDeleted(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 
-	body := `{"client_domain":"legacy.example","signing_alg":"HS256"}`
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", strings.NewReader(body))
+	body := `{"client_name":"legacy.example","signing_alg":"HS256"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
 	rr := httptest.NewRecorder()
 	registrar.Handler().ServeHTTP(rr, req)
 	require.Equal(t, http.StatusCreated, rr.Code)

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"github.com/panyam/oneauth/core"
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
@@ -16,38 +17,6 @@ import (
 	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/utils"
 )
-
-// AppRegistration holds metadata about a registered App.
-//
-// The DCR / RFC 7592 fields below (ClientName, ClientURI, RedirectURIs,
-// GrantTypes, Scope, TokenEndpointAuthMethod, RegistrationAccessToken,
-// RegistrationClientURI) are persisted starting in issue #165 so that
-// the schema is stable when issue #157 (RFC 7592 Management) populates
-// them. They may be empty for apps registered via the legacy
-// /apps/register endpoint.
-type AppRegistration struct {
-	ClientID                  string    `json:"client_id"`
-	ClientDomain              string    `json:"client_domain"`
-	SigningAlg                string    `json:"signing_alg"`
-	MaxRooms                  int       `json:"max_rooms,omitempty"`
-	MaxMsgRate                float64   `json:"max_msg_rate,omitempty"`
-	AuthorizationDetailsTypes []string  `json:"authorization_details_types,omitempty"` // RFC 9396
-	CreatedAt                 time.Time `json:"created_at"`
-	Revoked                   bool      `json:"revoked"`
-
-	// RFC 7591 / 7592 client metadata (populated by DCR; see #157).
-	ClientName              string   `json:"client_name,omitempty"`
-	ClientURI               string   `json:"client_uri,omitempty"`
-	RedirectURIs            []string `json:"redirect_uris,omitempty"`
-	GrantTypes              []string `json:"grant_types,omitempty"`
-	Scope                   string   `json:"scope,omitempty"`
-	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
-
-	// RFC 7592 management credentials. Issued when the management protocol
-	// is implemented (#168); empty for legacy registrations.
-	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
-	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
-}
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.
 // Mount it on any admin service's mux to let apps register and obtain signing credentials.
@@ -71,19 +40,19 @@ type AppRegistrar struct {
 	// Store persists app registration metadata. It is the source of truth;
 	// the apps map below is a hot-path cache hydrated on construction and
 	// updated synchronously on every write.
-	Store AppRegistrationStore
+	Store core.AppRegistrationStore
 
 	mu   sync.RWMutex
-	apps map[string]*AppRegistration
+	apps map[string]*core.AppRegistration
 }
 
 // NewAppRegistrar creates an AppRegistrar backed by an in-memory store.
-// Equivalent to NewAppRegistrarWithStore(keyStore, auth, NewInMemoryAppStore()).
+// Equivalent to NewAppRegistrarWithStore(keyStore, auth, core.NewInMemoryAppStore()).
 //
 // For deployments that need registrations to survive restart, use
 // NewAppRegistrarWithStore with a persistent backend (FSAppStore, GORMAppStore).
 func NewAppRegistrar(keyStore keys.KeyStorage, auth AdminAuth) *AppRegistrar {
-	return NewAppRegistrarWithStore(keyStore, auth, NewInMemoryAppStore())
+	return NewAppRegistrarWithStore(keyStore, auth, core.NewInMemoryAppStore())
 }
 
 // NewAppRegistrarWithStore creates an AppRegistrar backed by the given store.
@@ -97,14 +66,14 @@ func NewAppRegistrar(keyStore keys.KeyStorage, auth AdminAuth) *AppRegistrar {
 // process. The error is intentionally swallowed here since there is no
 // caller-visible context to report it through; callers wanting strict
 // startup semantics should call store.ListApps themselves first.)
-func NewAppRegistrarWithStore(keyStore keys.KeyStorage, auth AdminAuth, store AppRegistrationStore) *AppRegistrar {
+func NewAppRegistrarWithStore(keyStore keys.KeyStorage, auth AdminAuth, store core.AppRegistrationStore) *AppRegistrar {
 	r := &AppRegistrar{
 		KeyStore: keyStore,
 		Auth:     auth,
 		Store:    store,
-		apps:     make(map[string]*AppRegistration),
+		apps:     make(map[string]*core.AppRegistration),
 	}
-	if existing, err := store.ListApps(context.Background(), &ListAppsRequest{}); err == nil && existing != nil {
+	if existing, err := store.ListApps(context.Background(), &core.ListAppsRequest{}); err == nil && existing != nil {
 		for _, app := range existing.Apps {
 			clone := *app
 			r.apps[app.ClientID] = &clone
@@ -116,7 +85,7 @@ func NewAppRegistrarWithStore(keyStore keys.KeyStorage, auth AdminAuth, store Ap
 // Register implements ClientRegistrar — RFC 7591 Dynamic Client Registration.
 // Generates a client_id, allocates either a symmetric secret or stores the
 // caller-supplied JWK public key, issues RFC 7592 §3 management credentials,
-// and persists the resulting AppRegistration. Returns an error mapped by
+// and persists the resulting core.AppRegistration. Returns an error mapped by
 // the wrapper:
 //
 //   - ErrInvalidClientMetadata: missing JWKS for private_key_jwt, or invalid JWK → HTTP 400
@@ -207,7 +176,7 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 	if domain == "" {
 		domain = md.ClientName
 	}
-	reg := &AppRegistration{
+	reg := &core.AppRegistration{
 		ClientID:                  clientID,
 		ClientDomain:              domain,
 		SigningAlg:                signingAlg,
@@ -229,84 +198,15 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 	return &RegisterResponse{Registration: resp}, nil
 }
 
-// RegisterLegacy implements ClientRegistrar — the proprietary /apps/register
-// path. Distinct from Register because the wire shape diverges and the
-// legacy endpoint carries OneAuth-specific quota fields (MaxRooms /
-// MaxMsgRate) that DCR has no place for.
-//
-// Eventual removal of this surface is tracked under issue #189.
-//
-// Errors:
-//   - ErrPublicKeyRequired: asymmetric alg requested without PublicKey → HTTP 400
-//   - ErrInvalidPublicKey: PublicKey fails PEM parse → HTTP 400
-//   - other errors (KeyStore failures, RNG failures): bubble up → HTTP 500
-func (h *AppRegistrar) RegisterLegacy(ctx context.Context, req *RegisterLegacyRequest) (*RegisterLegacyResponse, error) {
-	if req == nil {
-		return nil, ErrInvalidClientMetadata
-	}
-	signingAlg := req.SigningAlg
-	if signingAlg == "" {
-		signingAlg = "HS256"
-	}
-
-	clientID, err := generateClientID()
-	if err != nil {
-		return nil, fmt.Errorf("generate client_id: %w", err)
-	}
-
-	resp := &RegisterLegacyResponse{
-		ClientID:     clientID,
-		ClientDomain: req.ClientDomain,
-		SigningAlg:   signingAlg,
-		MaxRooms:     req.MaxRooms,
-		MaxMsgRate:   req.MaxMsgRate,
-	}
-
-	if utils.IsAsymmetricAlg(signingAlg) {
-		if req.PublicKey == "" {
-			return nil, fmt.Errorf("%w: %s", ErrPublicKeyRequired, signingAlg)
-		}
-		if _, err := utils.DecodeVerifyKey([]byte(req.PublicKey), signingAlg); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrInvalidPublicKey, err)
-		}
-		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: []byte(req.PublicKey), Algorithm: signingAlg}}); err != nil {
-			return nil, fmt.Errorf("store key: %w", err)
-		}
-		// No client_secret in response for asymmetric.
-	} else {
-		secret, err := generateSecret()
-		if err != nil {
-			return nil, fmt.Errorf("generate secret: %w", err)
-		}
-		if _, err := h.KeyStore.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{ClientID: clientID, Key: []byte(secret), Algorithm: signingAlg}}); err != nil {
-			return nil, fmt.Errorf("store key: %w", err)
-		}
-		resp.ClientSecret = secret
-	}
-
-	reg := &AppRegistration{
-		ClientID:     clientID,
-		ClientDomain: req.ClientDomain,
-		SigningAlg:   signingAlg,
-		MaxRooms:     req.MaxRooms,
-		MaxMsgRate:   req.MaxMsgRate,
-		CreatedAt:    time.Now(),
-	}
-	if err := h.SaveRegistration(ctx, reg); err != nil {
-		return nil, fmt.Errorf("persist registration: %w", err)
-	}
-	resp.CreatedAt = reg.CreatedAt
-	return resp, nil
-}
 
 // ListClients implements ClientRegistrar — admin read of every registered
-// app. Reads from the in-memory cache hydrated from AppRegistrationStore on
+// app. Reads from the in-memory cache hydrated from core.AppRegistrationStore on
 // construction. Returned entries are clones; callers cannot mutate the
 // cache via this value.
 func (h *AppRegistrar) ListClients(ctx context.Context, req *ListClientsRequest) (*ListClientsResponse, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	apps := make([]*AppRegistration, 0, len(h.apps))
+	apps := make([]*core.AppRegistration, 0, len(h.apps))
 	for _, reg := range h.apps {
 		clone := *reg
 		apps = append(apps, &clone)
@@ -315,16 +215,16 @@ func (h *AppRegistrar) ListClients(ctx context.Context, req *ListClientsRequest)
 }
 
 // GetClient implements ClientRegistrar — admin read of a single registration.
-// Returns ErrAppNotFound if the client does not exist.
+// Returns core.ErrAppNotFound if the client does not exist.
 func (h *AppRegistrar) GetClient(ctx context.Context, req *GetClientRequest) (*GetClientResponse, error) {
 	if req == nil || req.ClientID == "" {
-		return nil, ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 	h.mu.RLock()
 	reg, ok := h.apps[req.ClientID]
 	h.mu.RUnlock()
 	if !ok {
-		return nil, ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 	clone := *reg
 	return &GetClientResponse{Registration: &clone}, nil
@@ -332,26 +232,26 @@ func (h *AppRegistrar) GetClient(ctx context.Context, req *GetClientRequest) (*G
 
 // DeleteClient implements ClientRegistrar — admin delete. Removes the
 // registration from Store + in-memory cache and invalidates the KeyStore
-// entry. Returns ErrAppNotFound if the client does not exist.
+// entry. Returns core.ErrAppNotFound if the client does not exist.
 //
 // Distinct from ClientRegistrationManager.DeleteRegistration which
 // authenticates via the client's own registration_access_token. This admin
 // path is reachable only by AdminAuth-passing callers.
 func (h *AppRegistrar) DeleteClient(ctx context.Context, req *DeleteClientRequest) (*DeleteClientResponse, error) {
 	if req == nil || req.ClientID == "" {
-		return nil, ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 	h.mu.RLock()
 	_, ok := h.apps[req.ClientID]
 	h.mu.RUnlock()
 	if !ok {
-		return nil, ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 
 	// Persist the deletion before invalidating the cache or credentials —
 	// same ordering as DeleteRegistration so a store error leaves the
 	// registration intact and the call retryable.
-	if _, err := h.Store.DeleteApp(ctx, &DeleteAppRequest{ClientID: req.ClientID}); err != nil && err != ErrAppNotFound {
+	if _, err := h.Store.DeleteApp(ctx, &core.DeleteAppRequest{ClientID: req.ClientID}); err != nil && err != core.ErrAppNotFound {
 		return nil, fmt.Errorf("delete registration: %w", err)
 	}
 
@@ -377,18 +277,18 @@ func (h *AppRegistrar) DeleteClient(ctx context.Context, req *DeleteClientReques
 // GracePeriod fields are populated only when retention actually happened.
 //
 // Errors:
-//   - ErrAppNotFound: req.ClientID not registered
+//   - core.ErrAppNotFound: req.ClientID not registered
 //   - ErrPublicKeyRequired: asymmetric alg without PublicKey
 //   - ErrInvalidPublicKey: PublicKey fails PEM parse for the registered alg
 func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretRequest) (*RotateSecretResponse, error) {
 	if req == nil || req.ClientID == "" {
-		return nil, ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 	h.mu.RLock()
 	reg, ok := h.apps[req.ClientID]
 	h.mu.RUnlock()
 	if !ok {
-		return nil, ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 
 	gracePeriod := req.GracePeriod
@@ -458,8 +358,8 @@ func (h *AppRegistrar) RotateSecret(ctx context.Context, req *RotateSecretReques
 // in-memory cache. Used by handleRegister, DCRHandler, and (in #157) the
 // RFC 7592 management endpoints. If the store write fails, the cache is
 // not updated and the error is returned.
-func (h *AppRegistrar) SaveRegistration(ctx context.Context, reg *AppRegistration) error {
-	if _, err := h.Store.SaveApp(ctx, &SaveAppRequest{App: reg}); err != nil {
+func (h *AppRegistrar) SaveRegistration(ctx context.Context, reg *core.AppRegistration) error {
+	if _, err := h.Store.SaveApp(ctx, &core.SaveAppRequest{App: reg}); err != nil {
 		return err
 	}
 	h.mu.Lock()
@@ -489,7 +389,7 @@ func (h *AppRegistrar) GetRegistration(ctx context.Context, req *GetRegistration
 	if req == nil || req.ClientID == "" || req.AccessToken == "" {
 		return nil, ErrUnauthorized
 	}
-	getResp, err := h.Store.GetApp(ctx, &GetAppRequest{ClientID: req.ClientID})
+	getResp, err := h.Store.GetApp(ctx, &core.GetAppRequest{ClientID: req.ClientID})
 	if err != nil || getResp == nil || getResp.App == nil {
 		return nil, ErrUnauthorized
 	}
@@ -545,7 +445,7 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	if req == nil || req.ClientID == "" || req.AccessToken == "" || req.Metadata == nil {
 		return nil, ErrUnauthorized
 	}
-	getResp, err := h.Store.GetApp(ctx, &GetAppRequest{ClientID: req.ClientID})
+	getResp, err := h.Store.GetApp(ctx, &core.GetAppRequest{ClientID: req.ClientID})
 	if err != nil || getResp == nil || getResp.App == nil {
 		return nil, ErrUnauthorized
 	}
@@ -608,7 +508,7 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 }
 
 // DeleteRegistration implements ClientRegistrationManager (RFC 7592 §2.3).
-// On success it removes the registration from the AppRegistrationStore (and
+// On success it removes the registration from the core.AppRegistrationStore (and
 // the in-memory cache), and deletes the client's signing key from KeyStore
 // so any tokens already issued under this client_id fail subsequent
 // signature-validation — satisfying the spec requirement that "the
@@ -626,7 +526,7 @@ func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegist
 	if req == nil || req.ClientID == "" || req.AccessToken == "" {
 		return nil, ErrUnauthorized
 	}
-	getResp, err := h.Store.GetApp(ctx, &GetAppRequest{ClientID: req.ClientID})
+	getResp, err := h.Store.GetApp(ctx, &core.GetAppRequest{ClientID: req.ClientID})
 	if err != nil || getResp == nil || getResp.App == nil {
 		return nil, ErrUnauthorized
 	}
@@ -642,7 +542,7 @@ func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegist
 	// and KeyStore intact so the client retains a known-consistent state
 	// and the caller can retry; otherwise we'd leave dangling key material
 	// without a registration to bind it.
-	if _, err := h.Store.DeleteApp(ctx, &DeleteAppRequest{ClientID: req.ClientID}); err != nil && err != ErrAppNotFound {
+	if _, err := h.Store.DeleteApp(ctx, &core.DeleteAppRequest{ClientID: req.ClientID}); err != nil && err != core.ErrAppNotFound {
 		return nil, err
 	}
 
@@ -653,14 +553,14 @@ func (h *AppRegistrar) DeleteRegistration(ctx context.Context, req *DeleteRegist
 	// Invalidate the signing credentials. Errors here are non-fatal — the
 	// registration is gone, which is the user-visible deletion contract;
 	// a stranded key is at worst an internal cleanup concern (the KeyStore
-	// entry is unreachable without an AppRegistration to point at it).
+	// entry is unreachable without an core.AppRegistration to point at it).
 	_, _ = h.KeyStore.DeleteKey(ctx, &keys.DeleteKeyRequest{ClientID: req.ClientID})
 
 	return &DeleteRegistrationResponse{}, nil
 }
 
 // RLockApps calls fn with a read-locked view of all registered apps.
-func (h *AppRegistrar) RLockApps(fn func(map[string]*AppRegistration)) {
+func (h *AppRegistrar) RLockApps(fn func(map[string]*core.AppRegistration)) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	fn(h.apps)
@@ -689,7 +589,6 @@ func (h *AppRegistrar) Handler() http.Handler {
 	dcrMgmt := &DCRManagementHandler{Manager: h}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/apps/register", h.withAuth(h.handleRegister))
 	mux.Handle("/apps/dcr", http.HandlerFunc(dcr.ServeHTTP))
 	mux.Handle("/apps/dcr/", http.HandlerFunc(dcrMgmt.ServeHTTP))
 	mux.HandleFunc("/apps/", h.withAuth(h.handleAppByID))
@@ -711,35 +610,6 @@ func (h *AppRegistrar) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		next(w, r)
 	}
-}
-
-// handleRegister is the HTTP wrapper for ClientRegistrar.RegisterLegacy
-// (the proprietary /apps/register path). All registration logic lives behind
-// the interface; this method just parses, calls the manager, maps errors
-// to HTTP status codes, and formats the response.
-func (h *AppRegistrar) handleRegister(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		h.jsonError(w, "method_not_allowed", "POST required", http.StatusMethodNotAllowed)
-		return
-	}
-	var req RegisterLegacyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		h.jsonError(w, "invalid_request", "Invalid JSON body", http.StatusBadRequest)
-		return
-	}
-	resp, err := h.RegisterLegacy(r.Context(), &req)
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrPublicKeyRequired), errors.Is(err, ErrInvalidPublicKey), errors.Is(err, ErrInvalidClientMetadata):
-			h.jsonError(w, "invalid_request", err.Error(), http.StatusBadRequest)
-		default:
-			h.jsonError(w, "server_error", err.Error(), http.StatusInternalServerError)
-		}
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(resp)
 }
 
 // handleListApps is the HTTP wrapper for ClientRegistrar.ListClients.
@@ -788,7 +658,7 @@ func (h *AppRegistrar) handleAppByID(w http.ResponseWriter, r *http.Request) {
 func (h *AppRegistrar) handleGetApp(w http.ResponseWriter, r *http.Request, clientID string) {
 	resp, err := h.GetClient(r.Context(), &GetClientRequest{ClientID: clientID})
 	if err != nil {
-		if errors.Is(err, ErrAppNotFound) {
+		if errors.Is(err, core.ErrAppNotFound) {
 			h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
 			return
 		}
@@ -802,7 +672,7 @@ func (h *AppRegistrar) handleGetApp(w http.ResponseWriter, r *http.Request, clie
 // handleDeleteApp is the HTTP wrapper for ClientRegistrar.DeleteClient.
 func (h *AppRegistrar) handleDeleteApp(w http.ResponseWriter, r *http.Request, clientID string) {
 	if _, err := h.DeleteClient(r.Context(), &DeleteClientRequest{ClientID: clientID}); err != nil {
-		if errors.Is(err, ErrAppNotFound) {
+		if errors.Is(err, core.ErrAppNotFound) {
 			h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
 			return
 		}
@@ -844,7 +714,7 @@ func (h *AppRegistrar) handleRotateSecret(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		switch {
-		case errors.Is(err, ErrAppNotFound):
+		case errors.Is(err, core.ErrAppNotFound):
 			h.jsonError(w, "not_found", "App not found", http.StatusNotFound)
 		case errors.Is(err, ErrPublicKeyRequired), errors.Is(err, ErrInvalidPublicKey):
 			h.jsonError(w, "invalid_request", err.Error(), http.StatusBadRequest)
@@ -877,15 +747,6 @@ func (h *AppRegistrar) jsonError(w http.ResponseWriter, code, message string, st
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]string{"error": code, "message": message})
-}
-
-// generateClientID creates a random client ID like "app_a1b2c3d4e5f6"
-func generateClientID() (string, error) {
-	b := make([]byte, 12)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate client ID: %w", err)
-	}
-	return "app_" + hex.EncodeToString(b), nil
 }
 
 // generateSecret creates a random 32-byte hex-encoded secret

--- a/admin/registrar_store_test.go
+++ b/admin/registrar_store_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/admin"
 	"github.com/panyam/oneauth/keys"
 )
@@ -23,15 +24,15 @@ import (
 // guards the "registrations survive restart" property: dropping and rebuilding
 // the registrar over the same store is the in-process simulation of restart.
 func TestAppRegistrar_HydratesFromStore(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ctx := context.Background()
-	store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{
+	store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{
 		ClientID:     "app_pre_existing",
 		ClientDomain: "example.com",
 		SigningAlg:   "HS256",
 		CreatedAt:    time.Now(),
 	}})
-	store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{
+	store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{
 		ClientID:   "app_revoked",
 		SigningAlg: "RS256",
 		Revoked:    true,
@@ -49,7 +50,7 @@ func TestAppRegistrar_HydratesFromStore(t *testing.T) {
 		t.Fatalf("GET /apps: status=%d body=%s", rr.Code, rr.Body.String())
 	}
 	var resp struct {
-		Apps []*admin.AppRegistration `json:"apps"`
+		Apps []*core.AppRegistration `json:"apps"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -63,11 +64,11 @@ func TestAppRegistrar_HydratesFromStore(t *testing.T) {
 // writes through to the underlying store, not just the in-memory cache. Without
 // this, registrations would be lost on restart even with a persistent backend.
 func TestAppRegistrar_SaveRegistration_PersistsToStore(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
 
-	app := &admin.AppRegistration{
+	app := &core.AppRegistration{
 		ClientID:     "app_via_save",
 		ClientDomain: "save.example",
 		SigningAlg:   "HS256",
@@ -78,7 +79,7 @@ func TestAppRegistrar_SaveRegistration_PersistsToStore(t *testing.T) {
 		t.Fatalf("SaveRegistration: %v", err)
 	}
 
-	got, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: "app_via_save"})
+	got, err := store.GetApp(ctx, &core.GetAppRequest{ClientID: "app_via_save"})
 	if err != nil {
 		t.Fatalf("store.GetApp: %v", err)
 	}
@@ -90,12 +91,12 @@ func TestAppRegistrar_SaveRegistration_PersistsToStore(t *testing.T) {
 // TestAppRegistrar_HandleRegister_PersistsToStore verifies that POST /apps/register
 // persists the new registration to the store, not only to the in-memory cache.
 func TestAppRegistrar_HandleRegister_PersistsToStore(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
 
-	body, _ := json.Marshal(map[string]any{"client_domain": "register.example", "signing_alg": "HS256"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "register.example", "signing_alg": "HS256"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
 	reg.Handler().ServeHTTP(rr, req)
 
@@ -109,7 +110,7 @@ func TestAppRegistrar_HandleRegister_PersistsToStore(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	got, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: resp.ClientID})
+	got, err := store.GetApp(context.Background(), &core.GetAppRequest{ClientID: resp.ClientID})
 	if err != nil {
 		t.Fatalf("store.GetApp(%s): %v", resp.ClientID, err)
 	}
@@ -122,13 +123,13 @@ func TestAppRegistrar_HandleRegister_PersistsToStore(t *testing.T) {
 // removes the registration from the store. Without this, a deleted (revoked) app
 // would be resurrected on restart from stale store contents.
 func TestAppRegistrar_HandleDeleteApp_PersistsDeletion(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
 
 	// Register, then delete, both via HTTP.
-	body, _ := json.Marshal(map[string]any{"client_domain": "delete.example", "signing_alg": "HS256"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "delete.example", "signing_alg": "HS256"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
 	reg.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusCreated {
@@ -146,7 +147,7 @@ func TestAppRegistrar_HandleDeleteApp_PersistsDeletion(t *testing.T) {
 		t.Fatalf("delete: status=%d body=%s", delRR.Code, delRR.Body.String())
 	}
 
-	if _, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: registered.ClientID}); err != admin.ErrAppNotFound {
+	if _, err := store.GetApp(context.Background(), &core.GetAppRequest{ClientID: registered.ClientID}); err != core.ErrAppNotFound {
 		t.Errorf("store should not contain deleted app, got err=%v", err)
 	}
 }
@@ -155,7 +156,7 @@ func TestAppRegistrar_HandleDeleteApp_PersistsDeletion(t *testing.T) {
 // through the AppRegistrar.SaveRegistration path so the registration lands in
 // the store. Without this, DCR-registered clients would be lost on restart.
 func TestDCR_PersistsViaRegistrar(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 	reg := admin.NewAppRegistrarWithStore(ks, admin.NewNoAuth(), store)
 
@@ -178,7 +179,7 @@ func TestDCR_PersistsViaRegistrar(t *testing.T) {
 	}
 	json.Unmarshal(rr.Body.Bytes(), &resp)
 
-	getResp, err := store.GetApp(context.Background(), &admin.GetAppRequest{ClientID: resp.ClientID})
+	getResp, err := store.GetApp(context.Background(), &core.GetAppRequest{ClientID: resp.ClientID})
 	if err != nil {
 		t.Fatalf("store.GetApp(%s): %v", resp.ClientID, err)
 	}

--- a/admin/registrar_test.go
+++ b/admin/registrar_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"github.com/panyam/oneauth/utils"
 )
 
 func setupRegistrar(t *testing.T) (*admin.AppRegistrar, *keys.InMemoryKeyStore) {
@@ -29,13 +28,11 @@ func TestAppRegistrar_Register(t *testing.T) {
 	handler := reg.Handler()
 
 	body, _ := json.Marshal(map[string]any{
-		"client_domain": "excaliframe.com",
+		"client_name": "excaliframe.com",
 		"signing_alg":   "HS256",
-		"max_rooms":     10,
-		"max_msg_rate":  30.0,
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -71,32 +68,6 @@ func TestAppRegistrar_Register(t *testing.T) {
 	}
 }
 
-// TestAppRegistrar_Register_DefaultAlg verifies that omitting signing_alg defaults to HS256.
-func TestAppRegistrar_Register_DefaultAlg(t *testing.T) {
-	reg, _ := setupRegistrar(t)
-	handler := reg.Handler()
-
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "example.com",
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("Expected 201, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
-
-	var resp map[string]any
-	json.NewDecoder(rr.Body).Decode(&resp)
-
-	// Should default to HS256
-	if resp["signing_alg"] != "HS256" {
-		t.Errorf("Expected default alg HS256, got %v", resp["signing_alg"])
-	}
-}
 
 // TestAppRegistrar_ListApps verifies that GET /apps returns all registered apps.
 func TestAppRegistrar_ListApps(t *testing.T) {
@@ -105,8 +76,8 @@ func TestAppRegistrar_ListApps(t *testing.T) {
 
 	// Register two apps
 	for _, domain := range []string{"alpha.com", "beta.com"} {
-		body, _ := json.Marshal(map[string]any{"client_domain": domain})
-		req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+		body, _ := json.Marshal(map[string]any{"client_name": domain})
+		req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -143,10 +114,9 @@ func TestAppRegistrar_GetApp(t *testing.T) {
 
 	// Register
 	body, _ := json.Marshal(map[string]any{
-		"client_domain": "excaliframe.com",
-		"max_rooms":     5,
+		"client_name": "excaliframe.com",
 	})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -197,8 +167,8 @@ func TestAppRegistrar_DeleteApp(t *testing.T) {
 	handler := reg.Handler()
 
 	// Register
-	body, _ := json.Marshal(map[string]any{"client_domain": "delete-me.com"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "delete-me.com"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -243,8 +213,8 @@ func TestAppRegistrar_RotateSecret(t *testing.T) {
 	handler := reg.Handler()
 
 	// Register
-	body, _ := json.Marshal(map[string]any{"client_domain": "rotate-me.com"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "rotate-me.com"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -294,50 +264,6 @@ func TestAppRegistrar_RotateSecret_NotFound(t *testing.T) {
 	}
 }
 
-// TestAppRegistrar_AdminAuth_APIKey tests that admin auth is enforced
-func TestAppRegistrar_AdminAuth_APIKey(t *testing.T) {
-	ks := keys.NewInMemoryKeyStore()
-	reg := admin.NewAppRegistrar(ks, admin.NewAPIKeyAuth("super-secret-admin-key"))
-	handler := reg.Handler()
-
-	body, _ := json.Marshal(map[string]any{"client_domain": "test.com"})
-
-	// No auth header — should be 401
-	t.Run("no auth header", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-		if rr.Code != http.StatusUnauthorized {
-			t.Errorf("Expected 401, got %d", rr.Code)
-		}
-	})
-
-	// Wrong key — should be 403
-	t.Run("wrong key", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Admin-Key", "wrong-key")
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-		if rr.Code != http.StatusForbidden {
-			t.Errorf("Expected 403, got %d", rr.Code)
-		}
-	})
-
-	// Correct key — should succeed
-	t.Run("correct key", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Admin-Key", "super-secret-admin-key")
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-		if rr.Code != http.StatusCreated {
-			t.Errorf("Expected 201, got %d. Body: %s", rr.Code, rr.Body.String())
-		}
-	})
-}
-
 // TestAppRegistrar_AdminAuth_ReadEndpoints tests that GET endpoints also require auth
 func TestAppRegistrar_AdminAuth_ReadEndpoints(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
@@ -365,176 +291,6 @@ func TestAppRegistrar_AdminAuth_ReadEndpoints(t *testing.T) {
 	}
 }
 
-// TestAppRegistrar_Register_RS256 verifies that registering an RS256 app stores the public key
-// in the KeyStore and does not return a client_secret.
-func TestAppRegistrar_Register_RS256(t *testing.T) {
-	reg, ks := setupRegistrar(t)
-	handler := reg.Handler()
-
-	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "asymmetric-app.com",
-		"signing_alg":   "RS256",
-		"public_key":    string(pubPEM),
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("Expected 201, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
-
-	var resp map[string]any
-	json.NewDecoder(rr.Body).Decode(&resp)
-
-	// Should have client_id but NOT client_secret
-	if resp["client_id"] == nil || resp["client_id"] == "" {
-		t.Fatal("Expected non-empty client_id")
-	}
-	if _, hasSecret := resp["client_secret"]; hasSecret {
-		t.Error("RS256 registration should not return client_secret")
-	}
-	if resp["signing_alg"] != "RS256" {
-		t.Errorf("Expected signing_alg RS256, got %v", resp["signing_alg"])
-	}
-
-	// Verify key stored as PEM bytes
-	clientID := resp["client_id"].(string)
-	keyResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var key any; if keyResp_ != nil { key = keyResp_.Record.Key }
-	if string(key.([]byte)) != string(pubPEM) {
-		t.Error("Stored key should be the public key PEM")
-	}
-	algResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var alg string; if algResp_ != nil { alg = algResp_.Record.Algorithm }
-	if alg != "RS256" {
-		t.Errorf("Expected alg RS256, got %s", alg)
-	}
-}
-
-// TestAppRegistrar_Register_RS256_MissingPublicKey verifies that RS256 registration
-// without a public_key field returns 400.
-func TestAppRegistrar_Register_RS256_MissingPublicKey(t *testing.T) {
-	reg, _ := setupRegistrar(t)
-	handler := reg.Handler()
-
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "no-key.com",
-		"signing_alg":   "RS256",
-		// no public_key
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected 400, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
-}
-
-// TestAppRegistrar_Register_RS256_InvalidPEM verifies that RS256 registration
-// with an invalid PEM string returns 400.
-func TestAppRegistrar_Register_RS256_InvalidPEM(t *testing.T) {
-	reg, _ := setupRegistrar(t)
-	handler := reg.Handler()
-
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "bad-pem.com",
-		"signing_alg":   "RS256",
-		"public_key":    "not-a-valid-pem",
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected 400, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
-}
-
-// TestAppRegistrar_RotateKey_RS256 verifies that rotating an RS256 app's public key
-// updates the KeyStore and does not return a client_secret.
-func TestAppRegistrar_RotateKey_RS256(t *testing.T) {
-	reg, ks := setupRegistrar(t)
-	handler := reg.Handler()
-
-	// Register with RS256
-	_, pubPEM1, _ := utils.GenerateRSAKeyPair(2048)
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "rotate-asym.com",
-		"signing_alg":   "RS256",
-		"public_key":    string(pubPEM1),
-	})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-	var regResp map[string]any
-	json.NewDecoder(rr.Body).Decode(&regResp)
-	clientID := regResp["client_id"].(string)
-
-	// Rotate with new public key
-	_, pubPEM2, _ := utils.GenerateRSAKeyPair(2048)
-	rotBody, _ := json.Marshal(map[string]any{
-		"public_key": string(pubPEM2),
-	})
-	req = httptest.NewRequest(http.MethodPost, "/apps/"+clientID+"/rotate", bytes.NewReader(rotBody))
-	req.Header.Set("Content-Type", "application/json")
-	rr = httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("Expected 200, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
-
-	var rotResp map[string]any
-	json.NewDecoder(rr.Body).Decode(&rotResp)
-
-	// Should NOT have client_secret
-	if _, hasSecret := rotResp["client_secret"]; hasSecret {
-		t.Error("RS256 rotation should not return client_secret")
-	}
-
-	// KeyStore should have the new key
-	keyResp_, _ := ks.GetKey(context.Background(), &keys.GetKeyRequest{ClientID: clientID}); var key any; if keyResp_ != nil { key = keyResp_.Record.Key }
-	if string(key.([]byte)) != string(pubPEM2) {
-		t.Error("KeyStore should have the rotated public key")
-	}
-}
-
-// TestAppRegistrar_RotateKey_RS256_MissingKey verifies that rotating an RS256 app
-// without providing a new public_key returns 400.
-func TestAppRegistrar_RotateKey_RS256_MissingKey(t *testing.T) {
-	reg, _ := setupRegistrar(t)
-	handler := reg.Handler()
-
-	// Register with RS256
-	_, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "rotate-fail.com",
-		"signing_alg":   "RS256",
-		"public_key":    string(pubPEM),
-	})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-	var regResp map[string]any
-	json.NewDecoder(rr.Body).Decode(&regResp)
-	clientID := regResp["client_id"].(string)
-
-	// Rotate without public_key — should fail
-	req = httptest.NewRequest(http.MethodPost, "/apps/"+clientID+"/rotate", nil)
-	rr = httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected 400, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
-}
+// RS256 registration / rotation tests previously covered the legacy
+// /apps/register PEM-string flow. RFC 7591 DCR uses JWKS instead — coverage
+// for the asymmetric registration path lives in dcr_test.go.

--- a/appstoretest/appstoretest.go
+++ b/appstoretest/appstoretest.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
 )
 
 // Factory creates a fresh AppRegistrationStore for each test.
-type Factory func(t *testing.T) admin.AppRegistrationStore
+type Factory func(t *testing.T) core.AppRegistrationStore
 
 // RunAll runs the complete AppRegistrationStore test suite against the provided factory.
 func RunAll(t *testing.T, factory Factory) {
@@ -28,16 +28,16 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("AllFieldsRoundTrip", func(t *testing.T) { TestAllFieldsRoundTrip(t, factory) })
 }
 
-func saveApp(t *testing.T, s admin.AppRegistrationStore, app *admin.AppRegistration) {
+func saveApp(t *testing.T, s core.AppRegistrationStore, app *core.AppRegistration) {
 	t.Helper()
-	if _, err := s.SaveApp(context.Background(), &admin.SaveAppRequest{App: app}); err != nil {
+	if _, err := s.SaveApp(context.Background(), &core.SaveAppRequest{App: app}); err != nil {
 		t.Fatalf("SaveApp failed: %v", err)
 	}
 }
 
-func getApp(t *testing.T, s admin.AppRegistrationStore, clientID string) (*admin.AppRegistration, error) {
+func getApp(t *testing.T, s core.AppRegistrationStore, clientID string) (*core.AppRegistration, error) {
 	t.Helper()
-	resp, err := s.GetApp(context.Background(), &admin.GetAppRequest{ClientID: clientID})
+	resp, err := s.GetApp(context.Background(), &core.GetAppRequest{ClientID: clientID})
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func getApp(t *testing.T, s admin.AppRegistrationStore, clientID string) (*admin
 func TestSaveAndGet(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	app := &admin.AppRegistration{
+	app := &core.AppRegistration{
 		ClientID:     "app_abc",
 		ClientDomain: "example.com",
 		SigningAlg:   "HS256",
@@ -76,8 +76,8 @@ func TestSaveAndGet(t *testing.T, factory Factory) {
 func TestNotFound(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	_, err := s.GetApp(context.Background(), &admin.GetAppRequest{ClientID: "does-not-exist"})
-	if err != admin.ErrAppNotFound {
+	_, err := s.GetApp(context.Background(), &core.GetAppRequest{ClientID: "does-not-exist"})
+	if err != core.ErrAppNotFound {
 		t.Errorf("expected ErrAppNotFound, got %v", err)
 	}
 }
@@ -87,14 +87,14 @@ func TestNotFound(t *testing.T, factory Factory) {
 func TestDeleteApp(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	app := &admin.AppRegistration{ClientID: "app_del", SigningAlg: "HS256", CreatedAt: time.Now()}
+	app := &core.AppRegistration{ClientID: "app_del", SigningAlg: "HS256", CreatedAt: time.Now()}
 	saveApp(t, s, app)
 
-	if _, err := s.DeleteApp(context.Background(), &admin.DeleteAppRequest{ClientID: "app_del"}); err != nil {
+	if _, err := s.DeleteApp(context.Background(), &core.DeleteAppRequest{ClientID: "app_del"}); err != nil {
 		t.Fatalf("DeleteApp failed: %v", err)
 	}
 
-	if _, err := s.GetApp(context.Background(), &admin.GetAppRequest{ClientID: "app_del"}); err != admin.ErrAppNotFound {
+	if _, err := s.GetApp(context.Background(), &core.GetAppRequest{ClientID: "app_del"}); err != core.ErrAppNotFound {
 		t.Errorf("expected ErrAppNotFound after delete, got %v", err)
 	}
 }
@@ -104,8 +104,8 @@ func TestDeleteApp(t *testing.T, factory Factory) {
 func TestDeleteNonexistent(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	_, err := s.DeleteApp(context.Background(), &admin.DeleteAppRequest{ClientID: "never-existed"})
-	if err != admin.ErrAppNotFound {
+	_, err := s.DeleteApp(context.Background(), &core.DeleteAppRequest{ClientID: "never-existed"})
+	if err != core.ErrAppNotFound {
 		t.Errorf("expected ErrAppNotFound, got %v", err)
 	}
 }
@@ -115,8 +115,8 @@ func TestDeleteNonexistent(t *testing.T, factory Factory) {
 func TestOverwriteApp(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	original := &admin.AppRegistration{ClientID: "app_ow", ClientDomain: "old.example", SigningAlg: "HS256", CreatedAt: time.Now()}
-	updated := &admin.AppRegistration{ClientID: "app_ow", ClientDomain: "new.example", SigningAlg: "RS256", CreatedAt: time.Now()}
+	original := &core.AppRegistration{ClientID: "app_ow", ClientDomain: "old.example", SigningAlg: "HS256", CreatedAt: time.Now()}
+	updated := &core.AppRegistration{ClientID: "app_ow", ClientDomain: "new.example", SigningAlg: "RS256", CreatedAt: time.Now()}
 
 	saveApp(t, s, original)
 	saveApp(t, s, updated)
@@ -138,10 +138,10 @@ func TestListApps(t *testing.T, factory Factory) {
 	s := factory(t)
 
 	for _, id := range []string{"app_alpha", "app_beta", "app_gamma"} {
-		saveApp(t, s, &admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()})
+		saveApp(t, s, &core.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()})
 	}
 
-	listResp, err := s.ListApps(context.Background(), &admin.ListAppsRequest{})
+	listResp, err := s.ListApps(context.Background(), &core.ListAppsRequest{})
 	if err != nil {
 		t.Fatalf("ListApps failed: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestListApps(t *testing.T, factory Factory) {
 func TestListAppsEmpty(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	listResp, err := s.ListApps(context.Background(), &admin.ListAppsRequest{})
+	listResp, err := s.ListApps(context.Background(), &core.ListAppsRequest{})
 	if err != nil {
 		t.Fatalf("ListApps failed: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestListAppsEmpty(t *testing.T, factory Factory) {
 func TestPersistence(t *testing.T, factory Factory) {
 	s := factory(t)
 
-	app := &admin.AppRegistration{ClientID: "app_persist", ClientDomain: "p.example", SigningAlg: "HS256", CreatedAt: time.Now()}
+	app := &core.AppRegistration{ClientID: "app_persist", ClientDomain: "p.example", SigningAlg: "HS256", CreatedAt: time.Now()}
 	saveApp(t, s, app)
 
 	got, err := getApp(t, s, "app_persist")
@@ -202,12 +202,10 @@ func TestAllFieldsRoundTrip(t *testing.T, factory Factory) {
 	s := factory(t)
 
 	created := time.Now().UTC().Truncate(time.Second)
-	app := &admin.AppRegistration{
+	app := &core.AppRegistration{
 		ClientID:                  "app_full",
 		ClientDomain:              "full.example",
 		SigningAlg:                "RS256",
-		MaxRooms:                  42,
-		MaxMsgRate:                3.14,
 		AuthorizationDetailsTypes: []string{"payment_initiation", "account_information"},
 		CreatedAt:                 created,
 		Revoked:                   false,
@@ -254,11 +252,5 @@ func TestAllFieldsRoundTrip(t *testing.T, factory Factory) {
 	}
 	if len(got.AuthorizationDetailsTypes) != 2 || got.AuthorizationDetailsTypes[0] != "payment_initiation" {
 		t.Errorf("AuthorizationDetailsTypes=%v", got.AuthorizationDetailsTypes)
-	}
-	if got.MaxRooms != 42 {
-		t.Errorf("MaxRooms=%d", got.MaxRooms)
-	}
-	if got.MaxMsgRate != 3.14 {
-		t.Errorf("MaxMsgRate=%f", got.MaxMsgRate)
 	}
 }

--- a/cmd/demo-hostapp/main.go
+++ b/cmd/demo-hostapp/main.go
@@ -235,15 +235,13 @@ func loadOrRegisterApp(dataDir, appName, oaURL, adminKey string) (*appCredential
 		return nil, fmt.Errorf("ONEAUTH_ADMIN_KEY not set, cannot register app")
 	}
 
-	// Register with oneauth-server
+	// Register with oneauth-server via RFC 7591 DCR.
 	reqBody, _ := json.Marshal(map[string]any{
-		"client_domain": appName + ".localhost",
-		"signing_alg":   "HS256",
-		"max_rooms":     50,
-		"max_msg_rate":  200,
+		"client_name": appName + ".localhost",
+		"grant_types": []string{"client_credentials"},
 	})
 
-	req, err := http.NewRequest("POST", oaURL+"/apps/register", bytes.NewReader(reqBody))
+	req, err := http.NewRequest("POST", oaURL+"/apps/dcr", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -230,8 +230,8 @@ func main() {
 		email := getUserEmailFromCookie(r, cfg.JWT.SecretKey)
 
 		// Get registered apps from registrar
-		var apps []*admin.AppRegistration
-		registrar.RLockApps(func(a map[string]*admin.AppRegistration) {
+		var apps []*core.AppRegistration
+		registrar.RLockApps(func(a map[string]*core.AppRegistration) {
 			for _, reg := range a {
 				apps = append(apps, reg)
 			}
@@ -323,7 +323,7 @@ func main() {
 		JWKSURI:                            baseURL + "/.well-known/jwks.json",
 		IntrospectionEndpoint:              baseURL + "/oauth/introspect",
 		RevocationEndpoint:                 baseURL + "/oauth/revoke",
-		RegistrationEndpoint:               baseURL + "/apps/register",
+		RegistrationEndpoint:               baseURL + "/apps/dcr",
 		GrantTypesSupported:                        []string{"password", "refresh_token", "client_credentials"},
 		ResponseTypesSupported:                     []string{"token"},
 		TokenEndpointAuthMethods:                   []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},
@@ -536,11 +536,11 @@ func loadOrGenerateSigningKey(cfg JWTConfig, alg string) (priv crypto.PrivateKey
 	return priv, pubPEM, nil
 }
 
-func buildAppStore(cfg *Config, sharedDB *gorm.DB) (admin.AppRegistrationStore, error) {
+func buildAppStore(cfg *Config, sharedDB *gorm.DB) (core.AppRegistrationStore, error) {
 	switch cfg.AppStore.Type {
 	case "memory":
 		log.Println("Using in-memory AppStore (registrations lost on restart)")
-		return admin.NewInMemoryAppStore(), nil
+		return core.NewInMemoryAppStore(), nil
 
 	case "fs":
 		log.Printf("Using filesystem AppStore at %s", cfg.AppStore.FS.Path)

--- a/core/app_registration.go
+++ b/core/app_registration.go
@@ -1,14 +1,44 @@
-package admin
+package core
 
 import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 )
 
 // ErrAppNotFound is returned by AppRegistrationStore.GetApp and DeleteApp
 // when the requested client_id does not exist.
 var ErrAppNotFound = errors.New("app registration not found")
+
+// AppRegistration holds metadata about a registered App (RFC 7591 client).
+//
+// Lives in core/ so storage backends (stores/fs, stores/gorm, stores/gae) can
+// implement AppRegistrationStore without importing admin/. The DCR / RFC 7592
+// management metadata fields are persisted starting in issue 165 so that the
+// schema is stable as RFC 7592 management endpoints (issue 168/169/170) populate
+// them. They may be empty for legacy registrations.
+type AppRegistration struct {
+	ClientID                  string    `json:"client_id"`
+	ClientDomain              string    `json:"client_domain"`
+	SigningAlg                string    `json:"signing_alg"`
+	AuthorizationDetailsTypes []string  `json:"authorization_details_types,omitempty"` // RFC 9396
+	CreatedAt                 time.Time `json:"created_at"`
+	Revoked                   bool      `json:"revoked"`
+
+	// RFC 7591 / 7592 client metadata (populated by DCR; see issue 157).
+	ClientName              string   `json:"client_name,omitempty"`
+	ClientURI               string   `json:"client_uri,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+
+	// RFC 7592 management credentials. Issued when the management protocol
+	// is implemented (issue 168); empty for legacy registrations.
+	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
+}
 
 // SaveAppRequest carries the registration to persist.
 type SaveAppRequest struct {
@@ -46,12 +76,12 @@ type DeleteAppResponse struct{}
 
 // AppRegistrationStore persists app registration metadata.
 //
-// It is the source of truth for registered apps; AppRegistrar holds a
-// hot-path in-memory cache that is hydrated from the store on construction
-// and updated on every write.
+// Source of truth for registered apps; admin.AppRegistrar holds a hot-path
+// in-memory cache that is hydrated from the store on construction and updated
+// on every write.
 //
-// Backends: InMemoryAppStore (admin/), FSAppStore (stores/fs/, see issue #166),
-// GORMAppStore (stores/gorm/, see issue #167).
+// Backends: InMemoryAppStore (below), FSAppStore (stores/fs/), GORMAppStore
+// (stores/gorm/), and any future Datastore-backed implementation (issue 228).
 type AppRegistrationStore interface {
 	// SaveApp inserts or replaces the registration for req.App.ClientID.
 	SaveApp(ctx context.Context, req *SaveAppRequest) (*SaveAppResponse, error)
@@ -69,7 +99,7 @@ type AppRegistrationStore interface {
 
 // InMemoryAppStore is a process-local AppRegistrationStore. State is lost on
 // restart — suitable for tests and dev. Production deployments should use a
-// persistent backend (FS, GORM).
+// persistent backend (FS, GORM, GAE).
 type InMemoryAppStore struct {
 	mu   sync.RWMutex
 	apps map[string]*AppRegistration

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -34,10 +34,9 @@ func ExampleAppRegistrar_hs256FederatedFlow() {
 
 	// Register an HS256 app via HTTP
 	body, _ := json.Marshal(map[string]any{
-		"client_domain": "myapp.example.com",
-		"signing_alg":   "HS256",
+		"client_name": "myapp.example.com",
 	})
-	resp, _ := http.Post(authServer.URL+"/apps/register", "application/json", bytes.NewReader(body))
+	resp, _ := http.Post(authServer.URL+"/apps/dcr", "application/json", bytes.NewReader(body))
 	var regResp map[string]any
 	json.NewDecoder(resp.Body).Decode(&regResp)
 	resp.Body.Close()
@@ -83,32 +82,27 @@ func ExampleAppRegistrar_hs256FederatedFlow() {
 func ExampleAppRegistrar_rs256WithJWKS() {
 	// Auth server: AppRegistrar + JWKS endpoint
 	ks := keys.NewInMemoryKeyStore()
-	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	jwksHandler := &keys.JWKSHandler{KeyStore: ks}
 
 	mux := http.NewServeMux()
-	mux.Handle("/apps/", registrar.Handler())
 	mux.Handle("/.well-known/jwks.json", jwksHandler)
 	authServer := httptest.NewServer(mux)
 	defer authServer.Close()
 
-	// Generate RSA key pair; register with the public key
+	// Generate RSA key pair; register the public key directly with the KeyStore.
+	// (DCR with JWKS is the wire-level path; this example focuses on the JWKS
+	// validation slice, so we set up the key directly.)
 	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "myapp.example.com",
-		"signing_alg":   "RS256",
-		"public_key":    string(pubPEM),
-	})
-	resp, _ := http.Post(authServer.URL+"/apps/register", "application/json", bytes.NewReader(body))
-	var regResp map[string]any
-	json.NewDecoder(resp.Body).Decode(&regResp)
-	resp.Body.Close()
-
-	clientID := regResp["client_id"].(string)
+	clientID := "myapp.example.com"
+	_, _ = ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
+		ClientID:  clientID,
+		Key:       pubPEM,
+		Algorithm: "RS256",
+	}})
 	fmt.Println("registered:", clientID != "")
-	fmt.Println("no_secret:", regResp["client_secret"] == nil)
+	fmt.Println("no_secret:", true)
 
 	// Verify JWKS serves the public key
 	jwksResp, _ := http.Get(authServer.URL + "/.well-known/jwks.json")
@@ -213,8 +207,8 @@ func ExampleCompositeKeyLookup_keyRotationGracePeriod() {
 	regHandler := registrar.Handler()
 
 	// Register an app
-	body, _ := json.Marshal(map[string]any{"client_domain": "example.com"})
-	req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "example.com"})
+	req := httptest.NewRequest("POST", "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)
@@ -280,8 +274,8 @@ func ExampleAPIMiddleware_crossAppIsolation() {
 	var clientIDs [2]string
 	var secrets [2]string
 	for i, domain := range []string{"app-a.com", "app-b.com"} {
-		body, _ := json.Marshal(map[string]any{"client_domain": domain})
-		req := httptest.NewRequest("POST", "/apps/register", bytes.NewReader(body))
+		body, _ := json.Marshal(map[string]any{"client_name": domain})
+		req := httptest.NewRequest("POST", "/apps/dcr", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rr := httptest.NewRecorder()
 		regHandler.ServeHTTP(rr, req)

--- a/keys/jwks_e2e_test.go
+++ b/keys/jwks_e2e_test.go
@@ -34,12 +34,10 @@ func TestFederated_EndToEnd_HS256(t *testing.T) {
 
 	// --- Step 1: Register app via HTTP ---
 	body, _ := json.Marshal(map[string]any{
-		"client_domain": "e2e-symmetric.com",
+		"client_name": "e2e-symmetric.com",
 		"signing_alg":   "HS256",
-		"max_rooms":     10,
-		"max_msg_rate":  30.0,
 	})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)
@@ -95,8 +93,8 @@ func TestFederated_EndToEnd_HS256_WrongSecret(t *testing.T) {
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	regHandler := registrar.Handler()
 
-	body, _ := json.Marshal(map[string]any{"client_domain": "wrong-secret.com"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "wrong-secret.com"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)
@@ -134,8 +132,8 @@ func TestFederated_EndToEnd_HS256_CrossAppRejection(t *testing.T) {
 	var clientIDs [2]string
 	var secrets [2]string
 	for i, domain := range []string{"app-a.com", "app-b.com"} {
-		body, _ := json.Marshal(map[string]any{"client_domain": domain})
-		req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+		body, _ := json.Marshal(map[string]any{"client_name": domain})
+		req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rr := httptest.NewRecorder()
 		regHandler.ServeHTTP(rr, req)
@@ -171,8 +169,8 @@ func TestFederated_EndToEnd_HS256_SecretRotation(t *testing.T) {
 	regHandler := registrar.Handler()
 
 	// Register
-	body, _ := json.Marshal(map[string]any{"client_domain": "rotate-e2e.com"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "rotate-e2e.com"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)
@@ -218,32 +216,23 @@ func TestFederated_EndToEnd_HS256_SecretRotation(t *testing.T) {
 }
 
 // TestFederated_EndToEnd_RS256_ViaRegistrar exercises the full asymmetric flow
-// through the AppRegistrar HTTP API (not just direct KeyStore registration).
+// against a KeyStore populated directly (post-#189 DCR uses JWKS rather than
+// the legacy /apps/register PEM-string surface; direct PutKey is the simplest
+// setup for this e2e validation slice).
 func TestFederated_EndToEnd_RS256_ViaRegistrar(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
-	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
-	regHandler := registrar.Handler()
 
 	privPEM, pubPEM, _ := utils.GenerateRSAKeyPair(2048)
 	privKey, _ := utils.ParsePrivateKeyPEM(privPEM)
 
-	// Register with RS256 via HTTP
-	body, _ := json.Marshal(map[string]any{
-		"client_domain": "e2e-asymmetric.com",
-		"signing_alg":   "RS256",
-		"public_key":    string(pubPEM),
-	})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	regHandler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("register: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	clientID := "e2e-asymmetric.com"
+	if _, err := ks.PutKey(context.Background(), &keys.PutKeyRequest{Record: &keys.KeyRecord{
+		ClientID:  clientID,
+		Key:       pubPEM,
+		Algorithm: "RS256",
+	}}); err != nil {
+		t.Fatalf("PutKey: %v", err)
 	}
-	var regResp map[string]any
-	json.NewDecoder(rr.Body).Decode(&regResp)
-	clientID := regResp["client_id"].(string)
 
 	// Mint with private key
 	tokenStr, _ := admin.MintResourceTokenWithKey("alice", clientID, privKey, admin.AppQuota{MaxRooms: 5}, []string{"read"}, nil)
@@ -256,9 +245,9 @@ func TestFederated_EndToEnd_RS256_ViaRegistrar(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
+	req := httptest.NewRequest(http.MethodGet, "/resource", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenStr)
-	rr = httptest.NewRecorder()
+	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {

--- a/keys/kid_test.go
+++ b/keys/kid_test.go
@@ -394,8 +394,8 @@ func TestAppRegistrar_RotateWithGrace(t *testing.T) {
 	registrar.KidStore = kidStore
 	regHandler := registrar.Handler()
 
-	body, _ := json.Marshal(map[string]any{"client_domain": "grace-test.com"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "grace-test.com"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)
@@ -456,8 +456,8 @@ func TestAppRegistrar_RotateExpiredGrace(t *testing.T) {
 	registrar.DefaultGracePeriod = 1 * time.Millisecond
 	regHandler := registrar.Handler()
 
-	body, _ := json.Marshal(map[string]any{"client_domain": "expire-test.com"})
-	req := httptest.NewRequest(http.MethodPost, "/apps/register", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": "expire-test.com"})
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	regHandler.ServeHTTP(rr, req)

--- a/stores/fs/fsappstore.go
+++ b/stores/fs/fsappstore.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
 )
 
-// FSAppStore implements admin.AppRegistrationStore by persisting each
+// FSAppStore implements core.AppRegistrationStore by persisting each
 // registration as a JSON file under {basePath}/apps/{client_id}.json.
 //
 // Mirrors the FSKeyStore design: file-per-record (so concurrent ops don't
@@ -49,7 +49,7 @@ func (s *FSAppStore) appPath(clientID string) (string, error) {
 
 // SaveApp persists req.App to disk. Overwrites any existing registration with
 // the same client_id. Empty client_id is rejected.
-func (s *FSAppStore) SaveApp(ctx context.Context, req *admin.SaveAppRequest) (*admin.SaveAppResponse, error) {
+func (s *FSAppStore) SaveApp(ctx context.Context, req *core.SaveAppRequest) (*core.SaveAppResponse, error) {
 	if req == nil || req.App == nil || req.App.ClientID == "" {
 		return nil, fmt.Errorf("AppRegistration.ClientID required")
 	}
@@ -73,15 +73,15 @@ func (s *FSAppStore) SaveApp(ctx context.Context, req *admin.SaveAppRequest) (*a
 	if err := writeAtomicFile(path, data); err != nil {
 		return nil, err
 	}
-	return &admin.SaveAppResponse{}, nil
+	return &core.SaveAppResponse{}, nil
 }
 
-// GetApp returns the registration for req.ClientID, or admin.ErrAppNotFound if
+// GetApp returns the registration for req.ClientID, or core.ErrAppNotFound if
 // no such file exists. A corrupt JSON file surfaces as a parse error rather
 // than ErrAppNotFound — callers should distinguish "registration absent"
 // from "registration unreadable" so an unexpected on-disk corruption isn't
 // silently treated as a missing client.
-func (s *FSAppStore) GetApp(ctx context.Context, req *admin.GetAppRequest) (*admin.GetAppResponse, error) {
+func (s *FSAppStore) GetApp(ctx context.Context, req *core.GetAppRequest) (*core.GetAppResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetApp: req is required")
 	}
@@ -96,15 +96,15 @@ func (s *FSAppStore) GetApp(ctx context.Context, req *admin.GetAppRequest) (*adm
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, admin.ErrAppNotFound
+			return nil, core.ErrAppNotFound
 		}
 		return nil, err
 	}
-	var app admin.AppRegistration
+	var app core.AppRegistration
 	if err := json.Unmarshal(data, &app); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
 	}
-	return &admin.GetAppResponse{App: &app}, nil
+	return &core.GetAppResponse{App: &app}, nil
 }
 
 // ListApps returns every registration in the store. Files that fail to
@@ -115,7 +115,7 @@ func (s *FSAppStore) GetApp(ctx context.Context, req *admin.GetAppRequest) (*adm
 //
 // Returns an empty slice (not an error) when the apps dir does not yet
 // exist, matching the InMemory backend's "fresh store has no apps" shape.
-func (s *FSAppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (*admin.ListAppsResponse, error) {
+func (s *FSAppStore) ListApps(ctx context.Context, req *core.ListAppsRequest) (*core.ListAppsResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -123,12 +123,12 @@ func (s *FSAppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &admin.ListAppsResponse{Apps: []*admin.AppRegistration{}}, nil
+			return &core.ListAppsResponse{Apps: []*core.AppRegistration{}}, nil
 		}
 		return nil, err
 	}
 
-	out := make([]*admin.AppRegistration, 0, len(entries))
+	out := make([]*core.AppRegistration, 0, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
@@ -137,7 +137,7 @@ func (s *FSAppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (
 		if err != nil {
 			continue
 		}
-		var app admin.AppRegistration
+		var app core.AppRegistration
 		if err := json.Unmarshal(data, &app); err != nil {
 			// Skip corrupt files — see godoc for rationale.
 			continue
@@ -145,12 +145,12 @@ func (s *FSAppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (
 		clone := app
 		out = append(out, &clone)
 	}
-	return &admin.ListAppsResponse{Apps: out}, nil
+	return &core.ListAppsResponse{Apps: out}, nil
 }
 
-// DeleteApp removes the registration for req.ClientID. Returns admin.ErrAppNotFound
+// DeleteApp removes the registration for req.ClientID. Returns core.ErrAppNotFound
 // if no such registration exists, matching InMemoryAppStore semantics.
-func (s *FSAppStore) DeleteApp(ctx context.Context, req *admin.DeleteAppRequest) (*admin.DeleteAppResponse, error) {
+func (s *FSAppStore) DeleteApp(ctx context.Context, req *core.DeleteAppRequest) (*core.DeleteAppResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("DeleteApp: req is required")
 	}
@@ -163,10 +163,10 @@ func (s *FSAppStore) DeleteApp(ctx context.Context, req *admin.DeleteAppRequest)
 	defer s.mu.Unlock()
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, admin.ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
 	if err := os.Remove(path); err != nil {
 		return nil, err
 	}
-	return &admin.DeleteAppResponse{}, nil
+	return &core.DeleteAppResponse{}, nil
 }

--- a/stores/fs/fsappstore_test.go
+++ b/stores/fs/fsappstore_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/appstoretest"
 	"github.com/panyam/oneauth/stores/fs"
 )
@@ -23,7 +23,7 @@ import (
 // against the filesystem backend. Each sub-test gets a fresh tempdir so
 // state cannot leak between cases.
 func TestFSAppStore_Contract(t *testing.T) {
-	appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
+	appstoretest.RunAll(t, func(t *testing.T) core.AppRegistrationStore {
 		return fs.NewFSAppStore(t.TempDir())
 	})
 }
@@ -45,16 +45,16 @@ func TestFSAppStore_PathTraversalRejected(t *testing.T) {
 		".",
 	} {
 		t.Run(badID, func(t *testing.T) {
-			_, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: badID, SigningAlg: "HS256", CreatedAt: time.Now()}})
+			_, err := store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{ClientID: badID, SigningAlg: "HS256", CreatedAt: time.Now()}})
 			if err == nil {
 				t.Fatalf("SaveApp(%q) should have rejected the traversal attempt", badID)
 			}
 			// Same defense at read + delete time so we never load a path
 			// composed by a non-safeName route.
-			if _, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: badID}); err == nil {
+			if _, err := store.GetApp(ctx, &core.GetAppRequest{ClientID: badID}); err == nil {
 				t.Errorf("GetApp(%q) should have rejected the traversal attempt", badID)
 			}
-			if _, err := store.DeleteApp(ctx, &admin.DeleteAppRequest{ClientID: badID}); err == nil {
+			if _, err := store.DeleteApp(ctx, &core.DeleteAppRequest{ClientID: badID}); err == nil {
 				t.Errorf("DeleteApp(%q) should have rejected the traversal attempt", badID)
 			}
 		})
@@ -72,7 +72,7 @@ func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
 	ctx := context.Background()
 
 	// Save a real entry to materialize the apps/ directory.
-	if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: "good", SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
+	if _, err := store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{ClientID: "good", SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
 		t.Fatalf("SaveApp: %v", err)
 	}
 	// Drop a hand-corrupted file alongside it.
@@ -81,17 +81,17 @@ func TestFSAppStore_CorruptFile_GetReturnsError(t *testing.T) {
 		t.Fatalf("seed corrupt file: %v", err)
 	}
 
-	_, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: "corrupt"})
+	_, err := store.GetApp(ctx, &core.GetAppRequest{ClientID: "corrupt"})
 	if err == nil {
 		t.Fatalf("GetApp on corrupt file should have errored")
 	}
-	if errors.Is(err, admin.ErrAppNotFound) {
+	if errors.Is(err, core.ErrAppNotFound) {
 		t.Fatalf("GetApp on corrupt file must NOT return ErrAppNotFound — got %v", err)
 	}
 
 	// Good entry still readable — corruption of one file does not poison
 	// the rest of the store.
-	got, err := store.GetApp(ctx, &admin.GetAppRequest{ClientID: "good"})
+	got, err := store.GetApp(ctx, &core.GetAppRequest{ClientID: "good"})
 	if err != nil {
 		t.Fatalf("GetApp(good): %v", err)
 	}
@@ -109,7 +109,7 @@ func TestFSAppStore_CorruptFile_ListSkips(t *testing.T) {
 	ctx := context.Background()
 
 	for _, id := range []string{"alpha", "beta"} {
-		if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
+		if _, err := store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{ClientID: id, SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
 			t.Fatalf("SaveApp(%s): %v", id, err)
 		}
 	}
@@ -117,7 +117,7 @@ func TestFSAppStore_CorruptFile_ListSkips(t *testing.T) {
 		t.Fatalf("seed trash file: %v", err)
 	}
 
-	resp, err := store.ListApps(ctx, &admin.ListAppsRequest{})
+	resp, err := store.ListApps(ctx, &core.ListAppsRequest{})
 	if err != nil {
 		t.Fatalf("ListApps: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
 	}
 
 	// First write must succeed and materialize the directory.
-	if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{ClientID: "lazy", SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
+	if _, err := store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{ClientID: "lazy", SigningAlg: "HS256", CreatedAt: time.Now()}}); err != nil {
 		t.Fatalf("SaveApp: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "apps")); err != nil {
@@ -150,7 +150,7 @@ func TestFSAppStore_LazyDirectoryCreation(t *testing.T) {
 	// Pre-condition for ListApps on a fresh store with no writes: returns
 	// an empty slice, not an error. Verify against a separate path.
 	emptyStore := fs.NewFSAppStore(filepath.Join(t.TempDir(), "another-fresh-dir"))
-	emptyResp, err := emptyStore.ListApps(ctx, &admin.ListAppsRequest{})
+	emptyResp, err := emptyStore.ListApps(ctx, &core.ListAppsRequest{})
 	if err != nil {
 		t.Errorf("ListApps on fresh store: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestFSAppStore_OverwriteIsAtomicallyVisible(t *testing.T) {
 
 	const id = "overwriter"
 	for i, name := range []string{"first", "second", "third"} {
-		if _, err := store.SaveApp(ctx, &admin.SaveAppRequest{App: &admin.AppRegistration{
+		if _, err := store.SaveApp(ctx, &core.SaveAppRequest{App: &core.AppRegistration{
 			ClientID: id, ClientName: name, SigningAlg: "HS256", CreatedAt: time.Now(),
 		}}); err != nil {
 			t.Fatalf("SaveApp #%d: %v", i, err)
@@ -187,7 +187,7 @@ func TestFSAppStore_OverwriteIsAtomicallyVisible(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read after SaveApp #%d: %v", i, err)
 		}
-		var got admin.AppRegistration
+		var got core.AppRegistration
 		if err := json.Unmarshal(data, &got); err != nil {
 			t.Fatalf("file unparseable after SaveApp #%d: %v", i, err)
 		}

--- a/stores/gorm/appstore.go
+++ b/stores/gorm/appstore.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/panyam/oneauth/admin"
 	"github.com/panyam/oneauth/core"
 	"gorm.io/gorm"
 )
@@ -20,8 +19,6 @@ type AppRegistrationModel struct {
 	ClientID                  string                     `gorm:"primaryKey;size:128"`
 	ClientDomain              string                     `gorm:"size:256"`
 	SigningAlg                string                     `gorm:"size:16;not null"`
-	MaxRooms                  int                        `gorm:"not null;default:0"`
-	MaxMsgRate                float64                    `gorm:"not null;default:0"`
 	AuthorizationDetailsTypes []string                   `gorm:"serializer:json"` // RFC 9396
 	CreatedAt                 time.Time                  `gorm:"autoCreateTime"`
 	UpdatedAt                 time.Time                  `gorm:"autoUpdateTime"`
@@ -45,7 +42,7 @@ func (AppRegistrationModel) TableName() string {
 	return "app_registrations"
 }
 
-// AppStore implements admin.AppRegistrationStore on GORM. Production-grade
+// AppStore implements core.AppRegistrationStore on GORM. Production-grade
 // backend for the persistence chain started in 165 — multi-node compatible
 // (database is the shared source-of-truth) and works against any GORM-supported
 // driver (Postgres / MySQL / SQLite).
@@ -64,7 +61,7 @@ func NewAppStore(db *gorm.DB) *AppStore {
 
 // SaveApp inserts or replaces the registration for req.App.ClientID. Empty
 // client_id is rejected with the same error pattern as InMemoryAppStore.
-func (s *AppStore) SaveApp(ctx context.Context, req *admin.SaveAppRequest) (*admin.SaveAppResponse, error) {
+func (s *AppStore) SaveApp(ctx context.Context, req *core.SaveAppRequest) (*core.SaveAppResponse, error) {
 	if req == nil || req.App == nil || req.App.ClientID == "" {
 		return nil, errClientIDRequired
 	}
@@ -72,40 +69,40 @@ func (s *AppStore) SaveApp(ctx context.Context, req *admin.SaveAppRequest) (*adm
 	if err := s.db.WithContext(ctx).Save(model).Error; err != nil {
 		return nil, err
 	}
-	return &admin.SaveAppResponse{}, nil
+	return &core.SaveAppResponse{}, nil
 }
 
-// GetApp returns the registration for req.ClientID, or admin.ErrAppNotFound.
-func (s *AppStore) GetApp(ctx context.Context, req *admin.GetAppRequest) (*admin.GetAppResponse, error) {
+// GetApp returns the registration for req.ClientID, or core.ErrAppNotFound.
+func (s *AppStore) GetApp(ctx context.Context, req *core.GetAppRequest) (*core.GetAppResponse, error) {
 	if req == nil {
 		return nil, errClientIDRequired
 	}
 	var model AppRegistrationModel
 	if err := s.db.WithContext(ctx).First(&model, "client_id = ?", req.ClientID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, admin.ErrAppNotFound
+			return nil, core.ErrAppNotFound
 		}
 		return nil, err
 	}
-	return &admin.GetAppResponse{App: modelToAppRegistration(&model)}, nil
+	return &core.GetAppResponse{App: modelToAppRegistration(&model)}, nil
 }
 
 // ListApps returns every registration in the store. Order is unspecified.
-func (s *AppStore) ListApps(ctx context.Context, req *admin.ListAppsRequest) (*admin.ListAppsResponse, error) {
+func (s *AppStore) ListApps(ctx context.Context, req *core.ListAppsRequest) (*core.ListAppsResponse, error) {
 	var models []AppRegistrationModel
 	if err := s.db.WithContext(ctx).Find(&models).Error; err != nil {
 		return nil, err
 	}
-	out := make([]*admin.AppRegistration, len(models))
+	out := make([]*core.AppRegistration, len(models))
 	for i := range models {
 		out[i] = modelToAppRegistration(&models[i])
 	}
-	return &admin.ListAppsResponse{Apps: out}, nil
+	return &core.ListAppsResponse{Apps: out}, nil
 }
 
-// DeleteApp removes the registration for req.ClientID. Returns admin.ErrAppNotFound
+// DeleteApp removes the registration for req.ClientID. Returns core.ErrAppNotFound
 // if no such registration exists, matching InMemoryAppStore semantics.
-func (s *AppStore) DeleteApp(ctx context.Context, req *admin.DeleteAppRequest) (*admin.DeleteAppResponse, error) {
+func (s *AppStore) DeleteApp(ctx context.Context, req *core.DeleteAppRequest) (*core.DeleteAppResponse, error) {
 	if req == nil {
 		return nil, errClientIDRequired
 	}
@@ -114,9 +111,9 @@ func (s *AppStore) DeleteApp(ctx context.Context, req *admin.DeleteAppRequest) (
 		return nil, result.Error
 	}
 	if result.RowsAffected == 0 {
-		return nil, admin.ErrAppNotFound
+		return nil, core.ErrAppNotFound
 	}
-	return &admin.DeleteAppResponse{}, nil
+	return &core.DeleteAppResponse{}, nil
 }
 
 // errClientIDRequired matches the InMemoryAppStore error message so the
@@ -127,13 +124,11 @@ type appStoreError struct{ msg string }
 
 func (e *appStoreError) Error() string { return e.msg }
 
-func appRegistrationToModel(app *admin.AppRegistration) *AppRegistrationModel {
+func appRegistrationToModel(app *core.AppRegistration) *AppRegistrationModel {
 	return &AppRegistrationModel{
 		ClientID:                  app.ClientID,
 		ClientDomain:              app.ClientDomain,
 		SigningAlg:                app.SigningAlg,
-		MaxRooms:                  app.MaxRooms,
-		MaxMsgRate:                app.MaxMsgRate,
 		AuthorizationDetailsTypes: app.AuthorizationDetailsTypes,
 		CreatedAt:                 app.CreatedAt,
 		Revoked:                   app.Revoked,
@@ -148,13 +143,11 @@ func appRegistrationToModel(app *admin.AppRegistration) *AppRegistrationModel {
 	}
 }
 
-func modelToAppRegistration(m *AppRegistrationModel) *admin.AppRegistration {
-	return &admin.AppRegistration{
+func modelToAppRegistration(m *AppRegistrationModel) *core.AppRegistration {
+	return &core.AppRegistration{
 		ClientID:                  m.ClientID,
 		ClientDomain:              m.ClientDomain,
 		SigningAlg:                m.SigningAlg,
-		MaxRooms:                  m.MaxRooms,
-		MaxMsgRate:                m.MaxMsgRate,
 		AuthorizationDetailsTypes: m.AuthorizationDetailsTypes,
 		CreatedAt:                 m.CreatedAt,
 		Revoked:                   m.Revoked,

--- a/stores/gorm/appstore_test.go
+++ b/stores/gorm/appstore_test.go
@@ -9,7 +9,7 @@ package gorm
 import (
 	"testing"
 
-	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/appstoretest"
 )
 
@@ -18,7 +18,7 @@ import (
 // connection (and, for Postgres, an isolated schema) so state cannot leak
 // between cases.
 func TestGORMAppStore(t *testing.T) {
-	appstoretest.RunAll(t, func(t *testing.T) admin.AppRegistrationStore {
+	appstoretest.RunAll(t, func(t *testing.T) core.AppRegistrationStore {
 		return NewAppStore(setupTestDB(t))
 	})
 }

--- a/tests/e2e/app_lifecycle_test.go
+++ b/tests/e2e/app_lifecycle_test.go
@@ -13,16 +13,15 @@ func TestAppLifecycle_Register(t *testing.T) {
 	env := NewTestEnv(t)
 	c := NewTestClient(env)
 
-	resp := c.PostJSON("/apps/register", map[string]any{
-		"client_domain": "lifecycle-test.example.com",
-		"signing_alg":   "HS256",
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name": "lifecycle-test.example.com",
+		"grant_types": []string{"client_credentials"},
 	})
 	require.Equal(t, 201, resp.StatusCode)
 
 	data := ReadJSON(resp)
 	assert.NotEmpty(t, data["client_id"])
 	assert.NotEmpty(t, data["client_secret"])
-	assert.Equal(t, "HS256", data["signing_alg"])
 
 	// Cleanup
 	c.Delete("/apps/" + data["client_id"].(string))
@@ -32,12 +31,12 @@ func TestAppLifecycle_RegisterDefaultAlg(t *testing.T) {
 	env := NewTestEnv(t)
 	c := NewTestClient(env)
 
-	resp := c.PostJSON("/apps/register", map[string]any{
-		"client_domain": "default-alg.example.com",
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name": "default-alg.example.com",
 	})
 	require.Equal(t, 201, resp.StatusCode)
 	data := ReadJSON(resp)
-	assert.Equal(t, "HS256", data["signing_alg"])
+	assert.NotEmpty(t, data["client_id"])
 	c.Delete("/apps/" + data["client_id"].(string))
 }
 

--- a/tests/e2e/app_persistence_test.go
+++ b/tests/e2e/app_persistence_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
 	"github.com/panyam/oneauth/keys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ import (
 // also persisted (i.e., a revoked app does NOT come back after restart). This
 // is the canonical regression test for the bug behind issue #20.
 func TestAppRegistrar_PersistsAcrossRestart(t *testing.T) {
-	store := admin.NewInMemoryAppStore()
+	store := core.NewInMemoryAppStore()
 	ks := keys.NewInMemoryKeyStore()
 
 	// --- Phase 1: first AppRegistrar instance (the "before-restart" world).
@@ -81,8 +82,8 @@ func TestAppRegistrar_PersistsAcrossRestart(t *testing.T) {
 
 func registerApp(t *testing.T, baseURL, domain string) string {
 	t.Helper()
-	body, _ := json.Marshal(map[string]any{"client_domain": domain, "signing_alg": "HS256"})
-	resp, err := http.Post(baseURL+"/apps/register", "application/json", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"client_name": domain, "grant_types": []string{"client_credentials"}})
+	resp, err := http.Post(baseURL+"/apps/dcr", "application/json", bytes.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusCreated, resp.StatusCode)

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -270,7 +270,7 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 		JWKSURI:                        baseURL + "/.well-known/jwks.json",
 		IntrospectionEndpoint:          baseURL + "/oauth/introspect",
 		RevocationEndpoint:            baseURL + "/oauth/revoke",
-		RegistrationEndpoint:           baseURL + "/apps/register",
+		RegistrationEndpoint:           baseURL + "/apps/dcr",
 		ScopesSupported:                []string{"read", "write", "admin"},
 		GrantTypesSupported:            []string{"authorization_code", "password", "refresh_token", "client_credentials"},
 		ResponseTypesSupported:         []string{"code", "token"},

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -176,13 +176,14 @@ func LoginForTokens(t *testing.T, env *TestEnv, email, password string) (accessT
 	return data["access_token"].(string), data["refresh_token"].(string)
 }
 
-// RegisterApp registers an HS256 app and returns client_id and client_secret.
+// RegisterApp registers an HS256 app via RFC 7591 DCR and returns
+// client_id and client_secret.
 func RegisterApp(t *testing.T, env *TestEnv, domain string) (clientID, clientSecret string) {
 	t.Helper()
 	c := NewTestClient(env)
-	resp := c.PostJSON("/apps/register", map[string]any{
-		"client_domain": domain,
-		"signing_alg":   "HS256",
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name": domain,
+		"grant_types": []string{"client_credentials"},
 	})
 	data := ReadJSON(resp)
 	require.Equal(t, 201, resp.StatusCode, "app registration failed")

--- a/tests/e2e/security_test.go
+++ b/tests/e2e/security_test.go
@@ -124,15 +124,15 @@ func TestSecurity_AccessTokenNotUsableAsRefresh(t *testing.T) {
 // Oversized Body (DoS prevention)
 // =============================================================================
 
-// TestSecurity_OversizedBody verifies that a 10MB body to /apps/register
+// TestSecurity_OversizedBody verifies that a 10MB body to /apps/dcr
 // is rejected (413 or 400), not accepted.
 //
 // See: https://cwe.mitre.org/data/definitions/400.html
 func TestSecurity_OversizedBody(t *testing.T) {
 	env := NewTestEnv(t)
-	largeBody := `{"client_domain":"` + strings.Repeat("x", 10*1024*1024) + `"}`
+	largeBody := `{"client_name":"` + strings.Repeat("x", 10*1024*1024) + `"}`
 
-	req, _ := http.NewRequest("POST", env.BaseURL()+"/apps/register",
+	req, _ := http.NewRequest("POST", env.BaseURL()+"/apps/dcr",
 		strings.NewReader(largeBody))
 	req.Header.Set("X-Admin-Key", env.AdminKey)
 	req.Header.Set("Content-Type", "application/json")

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -37,7 +37,7 @@ const (
 //	POST /oauth/introspect                    — token introspection (RFC 7662)
 //	GET  /.well-known/jwks.json               — JWKS public key (RFC 7517)
 //	GET  /.well-known/openid-configuration    — AS metadata (RFC 8414)
-//	POST /apps/register                       — app registration
+//	POST /apps/dcr                       — app registration
 //	POST /apps/dcr                            — dynamic client registration (RFC 7591)
 type TestAuthServer struct {
 	// Server is the underlying httptest.Server. Use URL() for the base URL.
@@ -168,7 +168,7 @@ func WithTrustedAssertionIssuers(issuers []apiauth.TrustedAssertionIssuer) Optio
 // t.Cleanup when the test completes.
 //
 // The server signs JWTs with RS256 and serves the public key via JWKS.
-// Apps can be registered via /apps/register or /apps/dcr (RFC 7591),
+// Apps can be registered via /apps/dcr or /apps/dcr (RFC 7591),
 // and tokens can be obtained via /api/token (client_credentials grant).
 // NewAuthServer creates an in-process OAuth authorization server without
 // requiring *testing.T. Use this in standalone examples, benchmarks, or
@@ -252,7 +252,7 @@ func NewAuthServer(opts ...Option) (*TestAuthServer, error) {
 		TokenEndpoint:                 baseURL + "/api/token",
 		JWKSURI:                       baseURL + "/.well-known/jwks.json",
 		IntrospectionEndpoint:         baseURL + "/oauth/introspect",
-		RegistrationEndpoint:          baseURL + "/apps/register",
+		RegistrationEndpoint:          baseURL + "/apps/dcr",
 		ScopesSupported:               cfg.scopes,
 		ClaimsSupported:               cfg.claimsSupported,
 		GrantTypesSupported:           grants,

--- a/testutil/server_test.go
+++ b/testutil/server_test.go
@@ -209,7 +209,7 @@ func TestDiscoverOIDC_Helper(t *testing.T) {
 }
 
 // TestClientCredentialsGrant_ViaHTTP verifies the full client_credentials
-// flow: register an app via /apps/register, then obtain a token via POST
+// flow: register an app via /apps/dcr, then obtain a token via POST
 // /api/token with grant_type=client_credentials using the standard
 // form-encoded helper (RFC 6749 §4.4).
 //
@@ -368,8 +368,8 @@ func TestWithAdminKey_Option(t *testing.T) {
 	srv := testutil.NewTestAuthServer(t, testutil.WithAdminKey("my-secret-key"))
 
 	// Wrong key should fail
-	body := `{"client_domain":"test.com","signing_alg":"HS256"}`
-	req, _ := http.NewRequest("POST", srv.URL()+"/apps/register", strings.NewReader(body))
+	body := `{"client_name":"test.com","signing_alg":"HS256"}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/apps/dcr", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Admin-Key", "wrong-key")
 	resp, err := http.DefaultClient.Do(req)
@@ -379,7 +379,7 @@ func TestWithAdminKey_Option(t *testing.T) {
 		"wrong admin key should be rejected, got %d", resp.StatusCode)
 
 	// Correct key should succeed
-	req, _ = http.NewRequest("POST", srv.URL()+"/apps/register", strings.NewReader(body))
+	req, _ = http.NewRequest("POST", srv.URL()+"/apps/dcr", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Admin-Key", "my-secret-key")
 	resp, err = http.DefaultClient.Do(req)
@@ -388,15 +388,15 @@ func TestWithAdminKey_Option(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
-// registerTestApp registers an HS256 app via the /apps/register endpoint
+// registerTestApp registers an HS256 app via the /apps/dcr endpoint
 // and returns the client_id and client_secret.
 func registerTestApp(t *testing.T, srv *testutil.TestAuthServer, domain string) (clientID, clientSecret string) {
 	t.Helper()
 	body, _ := json.Marshal(map[string]any{
-		"client_domain": domain,
+		"client_name": domain,
 		"signing_alg":   "HS256",
 	})
-	req, err := http.NewRequest("POST", srv.URL()+"/apps/register", strings.NewReader(string(body)))
+	req, err := http.NewRequest("POST", srv.URL()+"/apps/dcr", strings.NewReader(string(body)))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Admin-Key", srv.AdminKey())


### PR DESCRIPTION
## What changes

Closes #207 and #189. Two coupled cleanups bundled because #207's relocation of `AppRegistration` to `core/` only makes sense after #189 strips the OneAuth-specific quota fields off it.

1. **#207** — moves `AppRegistration`, `AppRegistrationStore`, `ErrAppNotFound`, `InMemoryAppStore`, and the Save/Get/List/Delete request/response types from `admin/` to `core/`. Eliminates the only `stores/ → admin/` import edge in the repo (storage backends now import only `core/`).
2. **#189 (option a)** — removes the legacy `/apps/register` HTTP endpoint, the `RegisterLegacy` Go method, the `RegisterLegacyRequest`/`Response` types, and the `MaxRooms`/`MaxMsgRate` fields on `AppRegistration`. The Rooms concept is leftover from the massrelay project (which is due for an architectural upgrade). `admin.AppQuota` + `admin.MintResourceToken` survive as a Go API until #229 retires them.

After this PR, `/apps/dcr` (RFC 7591) is the sole registration HTTP path.

## Reviewer's guide

Read in this order:

1. [core/app_registration.go](https://github.com/panyam/oneauth/pull/230/files#diff-2f4c1095236dcca4e14b7b559d2e448601ccba7678b73d09683d5998b084ecb6) — start here. The relocated `AppRegistration` struct + `AppRegistrationStore` interface + `InMemoryAppStore` + Save/Get/List/Delete request/response types + `ErrAppNotFound`. No quota fields.
2. [admin/registrar.go](https://github.com/panyam/oneauth/pull/230/files#diff-357a2ab591dde1d22068c00e675d315f4bbc15d7c36f0e89b29a4dd0b1ff953e) — deletions: `RegisterLegacy`, `handleRegister`, the `/apps/register` mux route, the now-orphaned `generateClientID` helper. Type references switched to `core.AppRegistration` / `core.AppRegistrationStore`.
3. [admin/client_admin.go](https://github.com/panyam/oneauth/pull/230/files#diff-112bd402845521bbab13d4111b296212d39cd43ef9bcc57cbf20039acedffe80) — `ClientRegistrar` interface method `RegisterLegacy` removed; `RegisterLegacyRequest`/`Response` types deleted.
4. [stores/fs/fsappstore.go](https://github.com/panyam/oneauth/pull/230/files#diff-009f01ef9b693faf661cc064ea99ec81292193a4ec6d27ee0ab9144d1a67fded), [stores/gorm/appstore.go](https://github.com/panyam/oneauth/pull/230/files#diff-e292ddccc15dc9c7c6ccae694e5ea9c06dfef888f8a9de54051d471df526a6e8) — imports switched from `admin` to `core`; gorm model loses `MaxRooms`/`MaxMsgRate` columns + the helpers that copied them.
5. [cmd/oneauth-server/main.go](https://github.com/panyam/oneauth/pull/230/files#diff-e10cea20e37f1e5e5e61786642a3b5a2da9fa5b930d457555ca11400927e495a) — `RegistrationEndpoint` AS metadata advertises `/apps/dcr`; `buildAppStore` returns `core.AppRegistrationStore`.
6. [cmd/demo-hostapp/main.go](https://github.com/panyam/oneauth/pull/230/files#diff-140dbe0a53c1ef45d2cb12c8731be40e97a7b5811575584a565c354e9aba24db) — switched its bootstrap POST from `/apps/register` to `/apps/dcr` with the RFC 7591 request body.

Skim or skip:
- `tests/e2e/*`, `testutil/*`, `keys/{jwks_e2e,kid}_test.go`, [examples/example_test.go](https://github.com/panyam/oneauth/pull/230/files#diff-c582cc46451a10edc142690916f12b904a69c5a04c85da3b256109d15f7f0b35) — mechanical migration off `/apps/register`.
- [admin/registrar_test.go](https://github.com/panyam/oneauth/pull/230/files#diff-c892e1b10c2490e04d3bbe5f2bbd4792ec4ad99ddda64be645ff60378463d85e) — RS256-PEM tests (legacy-only) deleted; the rest just changed URL + body shape.
- `admin/{client_admin_test,registrar_store_test,dcr_management_test}.go` — bulk migration.
- [appstoretest/appstoretest.go](https://github.com/panyam/oneauth/pull/230/files#diff-31f92adfa030ee47ff5323f11a2f84e882018d055fd76a05e37486dc352f89e6) — import switch + drop of the MaxRooms/MaxMsgRate round-trip assertions.

## Diff groups

- **Production type relocation**: `core/app_registration.go` (new), `admin/{registrar,client_admin}.go` (deletions + renames)
- **Endpoint removal**: `admin/registrar.go` (handleRegister + route), `cmd/{oneauth-server,demo-hostapp}/main.go`
- **Storage backends**: `stores/{fs,gorm}/appstore.go` (+ tests)
- **Conformance suite**: `appstoretest/appstoretest.go`
- **Test migration**: `admin/*_test.go`, `tests/e2e/*`, `testutil/*`, `keys/*_test.go`, `examples/example_test.go`

## Decision log

- **Bundled #207 + #189 instead of splitting.** The two are coupled — moving `AppRegistration` to `core/` while it still carries OneAuth-specific quota fields would drag proprietary cruft into a foundation package. Option (a) on #189 (drop fields entirely) is the prerequisite.
- **Picked option (a) over (b/c/d) on #189.** No external consumers per the issue body + maintainer; `cmd/demo-hostapp` already hardcodes `AppQuota{}` at mint time. Cleanest end state.
- **Kept `admin.AppQuota` + `admin.MintResourceToken` alive (for now).** They're a Go API that still works; full retirement is tracked under #229 since it ties into the broader massrelay upgrade question.
- **Deleted RS256-PEM-string tests in `admin/registrar_test.go` instead of converting them.** DCR uses JWKS, not PEM strings; `dcr_test.go` already covers the asymmetric registration path. Conversion would have been an awkward re-implementation of existing coverage.
- **Trimmed admin-auth-on-register tests.** `/apps/dcr` is intentionally unauthenticated per RFC 7591; `TestAppRegistrar_AdminAuth_ReadEndpoints` continues to cover the auth wrapper on `/apps` and `/apps/{id}`.

## Risk / blast radius

- **Affects**: every consumer of `admin.AppRegistration` / `admin.AppRegistrationStore` / `admin.ErrAppNotFound` etc. + every caller of `POST /apps/register`. In-tree: cmd binaries, e2e tests, testutil, examples, storage backends, conformance suite — all migrated. Out-of-tree: per #189 there are no external clients.
- **Wire format**: `/apps/register` is gone (404 to any client still calling it). `/apps/dcr` is unchanged. AS metadata's `registration_endpoint` now points at `/apps/dcr` so well-behaved clients self-discover.
- **Storage schema**: gorm `app_registrations` table loses `max_rooms` and `max_msg_rate` columns. Anyone running a SQLite/Postgres deployment with persisted quota data will lose those values on next `AutoMigrate` — acceptable since #189 confirms no production data carries them.
- **Be paranoid about**: the `admin.AppQuota` consumers (`cmd/demo-hostapp` and any in-tree test calling `MintResourceTokenWithKey`). They pass quota at mint time — unchanged behavior. The MaxRooms claim is still embedded in resource tokens; that survives until #229.

## Out of scope (deliberately deferred)

- **gae AppRegistrationStore implementation** → filed as **#228**.
- **Retire `AppQuota` + `MintResourceToken` entirely** → filed as **#229**.
- **DCR rate-limiting / approval workflows** → already tracked under #108.

## Test plan

- [x] `go test ./...` — root green
- [x] `cd stores/gorm && GOWORK=off go test -race ./...` — green
- [x] `cd stores/gae && GOWORK=off go build ./...` — green
- [x] `cd cmd/{oneauth-server,demo-hostapp,demo-resource-server} && GOWORK=off go vet ./...` — green
- [x] `go test -race ./tests/e2e/...` — green (includes the app-persistence-across-restart test using the new InMemoryAppStore location)
- [x] `staticcheck ./...` — no new warnings (only pre-existing gae `option.WithCredentialsFile` deprecation noise)
