### PR TITLE
chore(examples): add `make note` target — cell-based notebook renderer

### DIFF
--- a/examples/01-client-credentials/Makefile
+++ b/examples/01-client-credentials/Makefile
@@ -17,6 +17,11 @@ demo-plain: ## Run the walkthrough with the plain renderer
 demo-ci: ## Run the walkthrough non-interactively (no pauses)
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note: ## Run the walkthrough in notebook mode (cell-based UI)
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 # Run just the auth server + resource server on real ports. Use this
 # when driving the example from curl, your own client, or a different
 # walkthrough binary.
@@ -27,5 +32,5 @@ serve: ## Start auth server (:8081) + resource server (:8082) and block
 walkthrough: ## Regenerate WALKTHROUGH.md (mermaid + steps + run-it commands)
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/02-resource-token-hs256/Makefile
+++ b/examples/02-resource-token-hs256/Makefile
@@ -15,11 +15,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/03-resource-token-rs256-jwks/Makefile
+++ b/examples/03-resource-token-rs256-jwks/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/04-discovery/Makefile
+++ b/examples/04-discovery/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/05-introspection/Makefile
+++ b/examples/05-introspection/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/06-dynamic-client-registration/Makefile
+++ b/examples/06-dynamic-client-registration/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/07-client-sdk/Makefile
+++ b/examples/07-client-sdk/Makefile
@@ -11,6 +11,11 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
@@ -23,5 +28,5 @@ upkcl:
 downkcl:
 	$(MAKE) -C .. downkcl
 
-.PHONY: demo demo-plain demo-ci serve walkthrough upkcl downkcl
+.PHONY: demo demo-plain demo-ci serve walkthrough upkcl downkcl note
 .DEFAULT_GOAL := demo

--- a/examples/08-rich-authorization-requests/Makefile
+++ b/examples/08-rich-authorization-requests/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/09-key-rotation/Makefile
+++ b/examples/09-key-rotation/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo

--- a/examples/10-security/Makefile
+++ b/examples/10-security/Makefile
@@ -11,11 +11,16 @@ demo-plain:
 demo-ci:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --non-interactive
 
+# Cell-based notebook UI (demokit/notebookbridge). Good for
+# step-through-and-explore demos with persistent output cells.
+note:
+	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --mode=notebook
+
 serve:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --serve
 
 walkthrough:
 	cd ../.. && go run -buildvcs=false ./examples/$(EXAMPLE_DIR)/ --doc md > examples/$(EXAMPLE_DIR)/WALKTHROUGH.md
 
-.PHONY: demo demo-plain demo-ci serve walkthrough
+.PHONY: demo demo-plain demo-ci serve walkthrough note
 .DEFAULT_GOAL := demo


### PR DESCRIPTION
## What changes

Adds a `note` target to every per-example Makefile. It runs the demokit notebook renderer (`--mode=notebook` → `notebookbridge.New()` already wired in `examples/common/SetupRenderer`), giving a fifth interactive option alongside the existing `demo` / `demo-plain` / `demo-ci` / `serve` / `walkthrough` targets.

Per-example invocation:

```bash
cd examples/01-client-credentials && make note
```

Top-level batch: none. Notebook mode is interactive — there's no CI-batch equivalent (matches the existing `demo` target's behavior).

## Reviewer's guide

Read in this order:

1. [examples/01-client-credentials/Makefile](https://github.com/panyam/oneauth/pull/232/files#diff-f9a0418928b55a011ce9ae31f2548d0352aa3d04c8c52f39dc2394a6c607060c) — start here. Canonical Makefile (has the `## help`-comment convention). New `note` target plus `note` added to `.PHONY`.
2. Any other `examples/[0-9][0-9]-*/Makefile` — same edit, less verbose Makefile style.

Skim or skip: 9 of the 10 Makefiles are byte-identical edits.

## Decision log

- **Target named `note`, not `notebook`**: per the user's request — short, typo-resistant, mirrors `demo` more naturally.
- **No top-level batch target in `examples/Makefile`**: notebook mode is interactive (UI loop); no CI equivalent to wire up. Matches the existing `demo` / `serve` precedent of leaving interactive modes off the batch surface.
- **Target uses `--mode=notebook` instead of a new flag**: the dispatcher already exists in `examples/common/SetupRenderer`; nothing to add Go-side.

## Test plan

- [x] `cd examples/01-client-credentials && make note` boots the notebook renderer cleanly on demokit v0.0.25 (verified via short-timeout smoke test that the terminal-altscreen + cursor setup sequence emits without crash).
- [x] All 10 Makefiles carry the new target + `.PHONY` entry — checked by grep.
