### PR TITLE
feat(stores/gae): GAEAppStore implementing core.AppRegistrationStore (closes 228)

### DIFF
--- a/cmd/oneauth-server/config.go
+++ b/cmd/oneauth-server/config.go
@@ -24,9 +24,10 @@ type Config struct {
 // (issue 167 — closes parent 20). Mirrors KeyStoreConfig so deployments
 // see consistent shape.
 type AppStoreConfig struct {
-	Type string     `yaml:"type"` // memory, fs, gorm (defaults to memory)
+	Type string     `yaml:"type"` // memory, fs, gorm, gae (defaults to memory)
 	FS   FSConfig   `yaml:"fs"`
 	GORM GORMConfig `yaml:"gorm"`
+	GAE  GAEConfig  `yaml:"gae"`
 }
 
 // UserStoresConfig configures persistent stores for users, identities, channels, tokens.

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -565,6 +565,15 @@ func buildAppStore(cfg *Config, sharedDB *gorm.DB) (core.AppRegistrationStore, e
 		log.Printf("Using GORM AppStore (driver=%s)", cfg.AppStore.GORM.Driver)
 		return gormstore.NewAppStore(db), nil
 
+	case "gae":
+		ctx := context.Background()
+		client, err := datastore.NewClient(ctx, cfg.AppStore.GAE.Project)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("Using GAE Datastore AppStore (project=%s, namespace=%s)", cfg.AppStore.GAE.Project, cfg.AppStore.GAE.Namespace)
+		return gaestore.NewAppStore(client, cfg.AppStore.GAE.Namespace), nil
+
 	default:
 		return nil, fmt.Errorf("unknown app_store type: %s", cfg.AppStore.Type)
 	}

--- a/stores/gae/.design.yaml
+++ b/stores/gae/.design.yaml
@@ -1,8 +1,8 @@
 package: gae
-purpose: Google Cloud Datastore-backed implementations of oneauth's account/identity/channel/token/key/username stores, with namespacing, JSON-blob payloads, and transactional rotation/revocation flows.
+purpose: Google Cloud Datastore-backed implementations of oneauth's account/identity/channel/token/key/username and app-registration stores, all sharing a single `namespace` + `NameKey(Kind, name, nil)` pattern.
 language: go
-last_rebuilt: 1fdddf397a0df7dcf0037de53891635664d8372f
-last_rebuilt_at: 2026-05-27T20:17:38Z
+last_rebuilt: 57a84270971b503a5e26dec841a214d21228c212
+last_rebuilt_at: 2026-05-30T00:00:00Z
 entities:
   - name: UserEntity
     kind: struct
@@ -40,6 +40,10 @@ entities:
     kind: struct
     role: Datastore model for kid→key grace entries (KidKey kind) — kid is the key name, ExpiresAt unindexed.
     why: Grace store for verification during key rotation; CleanExpired scans in Go because Datastore can't combine "not zero" with "less than".
+  - name: AppRegistrationEntity
+    kind: struct
+    role: Datastore model for DCR app registrations (AppRegistration kind) — client_id is the key name, every field noindex, CreatedAt stored as unix nanos.
+    why: All fields noindex sidesteps Datastore's 1500-byte property index limit (which would reject long registration_client_uri values or large redirect_uris arrays); unix-nano CreatedAt avoids the microsecond truncation Datastore applies to time.Time properties so the conformance suite's equality check passes.
   - name: GAEUser
     kind: struct
     role: Concrete accounts.User implementation returned by UserStore — id, profile, active flag, timestamps.
@@ -80,53 +84,86 @@ entities:
     kind: struct
     role: keys.KidStorage implementation — Add / Remove (idempotent) / GetKeyByKid (honours ExpiresAt) / CleanExpired for the kid-grace store; GetKey deliberately returns ErrKeyNotFound.
     why: Verification-only grace cache for old kids during rotation; intentionally not a primary-key store.
-  - name: WithContext-shim
-    kind: idiom
-    role: Every store exposes a `WithContext(ctx)` clone method that returns a copy with an embedded ctx field.
-    why: Backward-compat shim after #204c/d — every request method now takes ctx as a parameter, so the embedded field is unread. The shim survives to keep older call sites compiling.
+  - name: GAEAppStore
+    kind: struct
+    role: core.AppRegistrationStore implementation — SaveApp / GetApp / ListApps / DeleteApp over the AppRegistration kind, completing the gae parity story with FS and GORM.
+    why: New in this PR; shared Datastore client + namespace pattern means cmd/oneauth-server can switch backends by swapping a single dial and reusing the appstoretest conformance suite.
+  - name: NewUserStore
+    kind: func
+    role: Constructor — returns a UserStore bound to a datastore client + namespace.
+    why: Constructor-injection of the shared *datastore.Client keeps the store agnostic to dial/credentials wiring.
+  - name: NewIdentityStore
+    kind: func
+    role: Constructor — returns an IdentityStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewChannelStore
+    kind: func
+    role: Constructor — returns a ChannelStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewTokenStore
+    kind: func
+    role: Constructor — returns a TokenStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewRefreshTokenStore
+    kind: func
+    role: Constructor — returns a RefreshTokenStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewAPIKeyStore
+    kind: func
+    role: Constructor — returns an APIKeyStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewUsernameStore
+    kind: func
+    role: Constructor — returns a UsernameStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewKeyStore
+    kind: func
+    role: Constructor — returns a GAEKeyStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewKidStore
+    kind: func
+    role: Constructor — returns a GAEKidStore bound to a datastore client + namespace.
+    why: Same shared-client pattern across every store in this package.
+  - name: NewAppStore
+    kind: func
+    role: Constructor — returns a GAEAppStore bound to a datastore client + namespace.
+    why: Same shared-client pattern; lets cmd/oneauth-server slot the gae app backend in with a one-line dial just like every other store here.
+  - name: IdentityToEntity
+    kind: func
+    role: Converts a public accounts.Identity into an IdentityEntity bound to the supplied key.
+    why: Per-row Datastore key cannot be derived from the value alone (it depends on namespace), so callers must pass the key in.
+  - name: VerificationTokenToEntity
+    kind: func
+    role: Converts a localauth.VerificationToken into a VerificationTokenEntity bound to the supplied key.
+    why: Same key-injection pattern as IdentityToEntity for namespace-aware writes.
+  - name: IdentityEntity.ToIdentity
+    kind: method
+    role: Round-trips an IdentityEntity back into accounts.Identity (no key fields).
+    why: Public store API hands out interface values, never entity structs.
+  - name: VerificationTokenEntity.ToVerificationToken
+    kind: method
+    role: Round-trips a VerificationTokenEntity back into localauth.VerificationToken (token name carried as Key.Name).
+    why: Public store API hands out interface values, never entity structs.
+  - name: GAEUser.Id
+    kind: method
+    role: accounts.User implementation — returns the UserID.
+    why: Implements the User interface as a plain struct (no DB round-trip on read).
+  - name: GAEUser.Profile
+    kind: method
+    role: accounts.User implementation — returns the user profile map.
+    why: Implements the User interface as a plain struct (no DB round-trip on read).
   - name: Kind constants
-    kind: const-group
-    role: KindUser / KindIdentity / KindChannel / KindAuthToken / KindRefreshToken / KindAPIKey / KindUsername / KindSigningKey / KindKidKey.
+    kind: const
+    role: KindUser / KindIdentity / KindChannel / KindAuthToken / KindRefreshToken / KindAPIKey / KindUsername / KindSigningKey / KindKidKey / KindAppRegistration.
     why: Single source of truth for Datastore kind names referenced from queries, keys, and tests.
 depends_on:
-  - path: ../../accounts
-    uses:
-      - accounts.User
-      - accounts.UserStore
-      - accounts.Identity
-      - accounts.IdentityStore
-      - accounts.Channel
-      - accounts.ChannelStore
-      - accounts.UsernameStore
   - path: ../../core
-    uses:
-      - core.TokenStore
-      - core.RefreshToken
-      - core.RefreshTokenStore
-      - core.APIKey
-      - core.APIKeyStore
-      - core.AuthorizationDetail
-      - core.GenerateSecureToken
-      - core.GenerateAPIKeyID
-      - core.GenerateAPIKeySecret
-      - core.TokenExpiryRefreshToken
-      - core.ErrTokenNotFound
-      - core.ErrTokenReused
-      - core.ErrTokenExpired
-      - core.ErrTokenRevoked
-      - core.ErrAPIKeyNotFound
+    entities: [AppRegistration, AppRegistrationStore, SaveAppRequest, SaveAppResponse, GetAppRequest, GetAppResponse, ListAppsRequest, ListAppsResponse, DeleteAppRequest, DeleteAppResponse, ErrAppNotFound, RefreshToken, RefreshTokenStore, CreateRefreshTokenRequest, CreateRefreshTokenResponse, GetRefreshTokenRequest, GetRefreshTokenResponse, RotateRefreshTokenRequest, RotateRefreshTokenResponse, RevokeRefreshTokenRequest, RevokeRefreshTokenResponse, RevokeSubjectTokensRequest, RevokeSubjectTokensResponse, RevokeTokenFamilyRequest, RevokeTokenFamilyResponse, GetSubjectTokensRequest, GetSubjectTokensResponse, CleanupExpiredTokensRequest, CleanupExpiredTokensResponse, APIKey, APIKeyStore, CreateAPIKeyRequest, CreateAPIKeyResponse, GetAPIKeyByIDRequest, GetAPIKeyByIDResponse, ValidateAPIKeyRequest, ValidateAPIKeyResponse, RevokeAPIKeyRequest, RevokeAPIKeyResponse, ListSubjectAPIKeysRequest, ListSubjectAPIKeysResponse, UpdateAPIKeyLastUsedRequest, UpdateAPIKeyLastUsedResponse, ErrAPIKeyNotFound, ErrTokenNotFound, ErrTokenExpired, ErrTokenRevoked, ErrTokenReused, GenerateSecureToken, GenerateAPIKeyID, GenerateAPIKeySecret, TokenExpiryRefreshToken, AuthorizationDetail]
   - path: ../../keys
-    uses:
-      - keys.KeyStorage
-      - keys.KidStorage
-      - keys.KeyRecord
-      - keys.ErrKeyNotFound
-      - keys.ErrKidNotFound
-      - keys.ErrAlgorithmMismatch
-  - path: ../../localauth
-    uses:
-      - localauth.VerificationType
-      - localauth.VerificationToken
+    entities: [KeyStorage, KidStorage, KeyRecord, PutKeyRequest, PutKeyResponse, GetKeyRequest, GetKeyResponse, GetKeyByKidRequest, GetKeyByKidResponse, DeleteKeyRequest, DeleteKeyResponse, ListKeyIDsRequest, ListKeyIDsResponse, AddKidRequest, AddKidResponse, RemoveKidRequest, RemoveKidResponse, CleanExpiredRequest, CleanExpiredResponse, ErrKeyNotFound, ErrKidNotFound, ErrAlgorithmMismatch]
   - path: ../../utils
-    uses:
-      - utils.ComputeKid
+    entities: [ComputeKid]
+  - path: ../../accounts
+    entities: [User, UserStore, IdentityStore, ChannelStore, UsernameStore, Identity, Channel, CreateUserRequest, CreateUserResponse, GetUserByIDRequest, GetUserByIDResponse, SaveUserRequest, SaveUserResponse, GetIdentityRequest, GetIdentityResponse, SaveIdentityRequest, SaveIdentityResponse, SetUserForIdentityRequest, SetUserForIdentityResponse, MarkIdentityVerifiedRequest, MarkIdentityVerifiedResponse, GetUserIdentitiesRequest, GetUserIdentitiesResponse, GetChannelRequest, GetChannelResponse, SaveChannelRequest, SaveChannelResponse, GetChannelsByIdentityRequest, GetChannelsByIdentityResponse, ReserveUsernameRequest, ReserveUsernameResponse, GetUserByUsernameRequest, GetUserByUsernameResponse, ReleaseUsernameRequest, ReleaseUsernameResponse, ChangeUsernameRequest, ChangeUsernameResponse]
+  - path: ../../localauth
+    entities: [VerificationToken, VerificationType, CreateVerificationTokenRequest, CreateVerificationTokenResponse, GetVerificationTokenRequest, GetVerificationTokenResponse, DeleteVerificationTokenRequest, DeleteVerificationTokenResponse, DeleteSubjectVerificationTokensRequest, DeleteSubjectVerificationTokensResponse]

--- a/stores/gae/DESIGN.md
+++ b/stores/gae/DESIGN.md
@@ -1,20 +1,11 @@
 # gae
 
-Google Cloud Datastore-backed implementation of every persistence interface OneAuth needs: signing keys, kid-grace entries, users, identities, channels, verification tokens, refresh tokens, API keys, and username reservations. Each store is an independent struct (no god object) that takes a `*datastore.Client` plus a per-tenant namespace, and every method already follows the request-response shape — `(ctx, *XRequest) → (*XResponse, error)`. The legacy `WithContext(ctx)` clone method is retained for backward compatibility but is now dead code: `ctx` flows through the call parameter, and the embedded `s.ctx` field is never read. The package is its own Go sub-module so consumers that don't run on GCP don't pay the Datastore dependency cost.
-
-Two stylistic conventions thread through the file:
-
-- **JSON-in-noindex-blob for sub-records.** Anything map- or slice-shaped (`profile`, `credentials`, `device_info`, `scopes`, `authorization_details`) is `json.Marshal`-ed into a `[]byte` field tagged `datastore:"...,noindex"`. This keeps schema churn out of Datastore indexes and side-steps Datastore's flat-property model. Top-level scalars that callers actually filter on (`subject`, `family`, `identity_key`, `kid`, `revoked`, `expires_at`) stay indexed.
-- **Composite key names instead of ancestor keys.** Identity keys are `"type:value"`, channel keys are `"provider:identityKey"`, username keys are the lowercased username. No entity groups are used, so every write is a single-key write and queries are flat (no strong-consistency window to worry about).
+Google Cloud Datastore implementations of oneauth's storage interfaces — accounts (User / Identity / Channel / Username), credentials (verification tokens, refresh tokens, API keys), signing-key material (`keys.KeyStorage` + `keys.KidStorage`), and as of this PR DCR app registrations (`core.AppRegistrationStore`). Every store takes the same `(*datastore.Client, namespace)` pair and routes through `datastore.NameKey(Kind, name, nil)` with `key.Namespace = s.namespace`, so a single Datastore client services all of oneauth in one project and tests can sandbox themselves to a per-suite namespace. All files carry the `//go:build !wasm` tag because the cloud Datastore client is not available under wasm.
 
 ## Contents
 
 - [Entities](#entities)
 - [Flows](#flows)
-  - [Refresh-token rotation with reuse detection](#refresh-token-rotation-with-reuse-detection)
-  - [Username reservation with case-insensitive normalisation](#username-reservation-with-case-insensitive-normalisation)
-  - [Kid grace-store cleanup](#kid-grace-store-cleanup)
-  - [Verification-token lookup with lazy expiry](#verification-token-lookup-with-lazy-expiry)
 - [Gotchas](#gotchas)
 - [Depends on](#depends-on)
 
@@ -22,172 +13,117 @@ Two stylistic conventions thread through the file:
 
 | Entity | Kind | Role | Why |
 |---|---|---|---|
-| `UserEntity` | struct | Datastore model for the `User` kind — `IsActive`, JSON `profile` blob, timestamps, version. | Persistent shape decoupled from the public `accounts.User` interface so JSON profiles can be unindexed. |
-| `IdentityEntity` | struct | Datastore model for the `Identity` kind — keyed `"type:value"`, indexed `user_id` for reverse lookup. | `IdentityStore.GetUserIdentities` is a reverse query, so `user_id` is the only field that must stay indexed. |
-| `ChannelEntity` | struct | Datastore model for the `Channel` kind — keyed `"provider:identityKey"`, JSON `credentials`/`profile`. | One row per `(provider, identityKey)` lets `identity_key` be queried to fan-out "all channels for this identity". |
-| `VerificationTokenEntity` | struct | Datastore model for the `AuthToken` kind — token string is the key name. | Direct key lookup avoids any index; bulk delete is filterable by `subject` + `type`. |
-| `RefreshTokenEntity` | struct | Datastore model for the `RefreshToken` kind — token-hash key, `family` + `generation`, JSON `scopes` and `authorization_details` (RFC 9396). | Hash-keyed for O(1) lookup; indexed `family` so a reuse attack can revoke the whole family. |
-| `APIKeyEntity` | struct | Datastore model for the `APIKey` kind — `KeyID` is the key, bcrypt `KeyHash` unindexed, `HasExpiry` flag. | `HasExpiry` avoids ambiguity around `time.Time` zero values when an API key has no expiry. |
-| `UsernameEntity` | struct | Datastore model for the `Username` kind — keyed by lowercased username, original case preserved in a field. | Case-insensitive uniqueness via normalised key, while still allowing the original casing to be displayed. |
-| `SigningKeyEntity` | struct | Datastore model for the `SigningKey` kind — clientID key, indexed `kid`. | Two-way lookup (by clientID for signing, by `kid` for verification) on the same row. |
-| `KidKeyEntity` | struct | Datastore model for the `KidKey` kind — `kid` is the key, `ExpiresAt` unindexed. | Grace store for verification during key rotation; cleanup scans in Go because Datastore can't combine "not zero" with "less than". |
-| `GAEUser` | struct | Concrete `accounts.User` implementation returned by `UserStore`. | Plain DTO returned from `CreateUser`/`GetUserById`; `SaveUser` checks this type to read back `IsActive`. |
-| `UserStore` | struct | `accounts.UserStore` impl — `UserStore.CreateUser`, `UserStore.GetUserById`, `UserStore.SaveUser`. | Maps the public store interface onto a single `User` kind. |
-| `IdentityStore` | struct | `accounts.IdentityStore` impl — `IdentityStore.GetIdentity`, `IdentityStore.SaveIdentity`, `IdentityStore.SetUserForIdentity`, `IdentityStore.MarkIdentityVerified`, `IdentityStore.GetUserIdentities`. | Transactions on `SetUserForIdentity`/`MarkIdentityVerified` keep `Version` monotonic. |
-| `ChannelStore` | struct | `accounts.ChannelStore` impl — `ChannelStore.GetChannel`, `ChannelStore.SaveChannel`, `ChannelStore.GetChannelsByIdentity`. | Composite key plus indexed `identity_key` for the fan-out query. |
-| `TokenStore` | struct | `core.TokenStore` impl for localauth verification tokens — `TokenStore.CreateToken`, `TokenStore.GetToken` (auto-deletes expired), `TokenStore.DeleteToken`, `TokenStore.DeleteSubjectTokens`. | Keys-only filter + `DeleteMulti` gives a single batched purge for "all reset tokens for this subject". |
-| `RefreshTokenStore` | struct | `core.RefreshTokenStore` impl — `RefreshTokenStore.CreateRefreshToken`, `RefreshTokenStore.GetRefreshToken`, `RefreshTokenStore.RotateRefreshToken`, `RefreshTokenStore.RevokeRefreshToken`, `RefreshTokenStore.RevokeSubjectTokens`, `RefreshTokenStore.RevokeTokenFamily`, `RefreshTokenStore.GetSubjectTokens`, `RefreshTokenStore.CleanupExpiredTokens`. | Implements RFC 6749 §10.4 rotation with family-wide revocation on reuse. |
-| `APIKeyStore` | struct | `core.APIKeyStore` impl — `APIKeyStore.CreateAPIKey`, `APIKeyStore.GetAPIKeyByID`, `APIKeyStore.ValidateAPIKey`, `APIKeyStore.RevokeAPIKey`, `APIKeyStore.ListSubjectAPIKeys`, `APIKeyStore.UpdateAPIKeyLastUsed`. | Tracks both `KeyID` (lookup) and a bcrypt hash of the secret (validation); `HasExpiry` flag avoids `omitempty` time.Time pitfalls. |
-| `UsernameStore` | struct | `accounts.UsernameStore` impl — `UsernameStore.ReserveUsername`, `UsernameStore.GetUserByUsername`, `UsernameStore.ReleaseUsername`, `UsernameStore.ChangeUsername`. | `ChangeUsername` does Get-then-Put in one transaction to prevent races between two users grabbing the same name. |
-| `GAEKeyStore` | struct | `keys.KeyStorage` impl — `GAEKeyStore.PutKey`, `GAEKeyStore.GetKey`, `GAEKeyStore.GetKeyByKid`, `GAEKeyStore.DeleteKey`, `GAEKeyStore.ListKeyIDs`. | One row per client; either direction (clientID or `kid`) resolves a key. |
-| `GAEKidStore` | struct | `keys.KidStorage` impl — `GAEKidStore.Add`, `GAEKidStore.Remove` (idempotent), `GAEKidStore.GetKeyByKid` (honours `ExpiresAt`), `GAEKidStore.CleanExpired`; `GAEKidStore.GetKey` deliberately returns `ErrKeyNotFound`. | Verification-only grace cache for old kids during rotation; intentionally not a primary-key store. |
-| `Kind` constants | const-group | `KindUser`, `KindIdentity`, `KindChannel`, `KindAuthToken`, `KindRefreshToken`, `KindAPIKey`, `KindUsername`, `KindSigningKey`, `KindKidKey`. | Single source of truth for Datastore kind names referenced from queries, keys, and tests. |
-| `WithContext` shim | idiom | Every store still exposes a `Store.WithContext(ctx)` clone method. | Backward-compat shim after #204c/d — `ctx` already flows through the request methods, so this is now dead code that survives only to keep old call sites compiling. |
+| `UserEntity` | struct | Datastore model for users (User kind) — IsActive flag, JSON profile blob (noindex), timestamps, version. | Persistent shape decoupled from `accounts.User` so JSON profiles can be unindexed. |
+| `IdentityEntity` | struct | Datastore model for identities (Identity kind) — keyed by `"type:value"`, indexed `user_id` for reverse lookups. | Allows `GetUserIdentities` reverse-index queries while keeping the key human-readable. |
+| `ChannelEntity` | struct | Datastore model for auth channels (Channel kind) — keyed by `"provider:identityKey"`, carries credentials/profile JSON. | One row per (provider, identity); indexed `identity_key` enables "all channels for this identity". |
+| `VerificationTokenEntity` | struct | Datastore model for localauth verification tokens (AuthToken kind) — token is the key name. | Direct key lookup avoids indexes; bulk delete is filterable by subject + type. |
+| `RefreshTokenEntity` | struct | Datastore model for refresh tokens — token-hash key, family/generation, JSON scopes + RFC 9396 `authorization_details`. | Hash-keyed for O(1) lookup; family field indexed so a reuse attack can revoke the whole family. |
+| `APIKeyEntity` | struct | Datastore model for API keys — KeyID is the key, bcrypt KeyHash unindexed, HasExpiry flag. | `HasExpiry` bool avoids omitempty pitfalls on `time.Time` zero-value when `ExpiresAt` is unset. |
+| `UsernameEntity` | struct | Datastore model for username→userID reservations — keyed by lowercased username, original case preserved in a field. | Case-insensitive uniqueness via normalised key, but original casing is retained for display. |
+| `SigningKeyEntity` | struct | Datastore model for per-client signing keys (SigningKey kind) — clientID key, kid indexed for JWKS lookup. | Two-way lookup (by clientID for signing, by kid for verification) on the same row. |
+| `KidKeyEntity` | struct | Datastore model for kid→key grace entries (KidKey kind) — kid is the key name, `ExpiresAt` unindexed. | Grace store for verification during key rotation; `CleanExpired` scans in Go because Datastore can't combine "not zero" with "less than". |
+| `AppRegistrationEntity` | struct | Datastore model for DCR app registrations (AppRegistration kind) — client_id is the key name, every field `noindex`, CreatedAt stored as unix nanos. | All fields `noindex` sidesteps Datastore's 1500-byte property index limit (which would reject long `registration_client_uri` values or large `redirect_uris` arrays); unix-nano `CreatedAt` avoids the microsecond truncation Datastore applies to `time.Time` properties so the conformance suite's equality check passes. |
+| `GAEUser` | struct | Concrete `accounts.User` returned by `UserStore` — id, profile, active flag, timestamps. | Plain DTO returned from CreateUser/GetUserById; `SaveUser` type-asserts on this to read back `IsActive`. |
+| `UserStore` | struct | `accounts.UserStore` impl — CreateUser / GetUserById / SaveUser keyed by userId in the configured namespace. | Maps the public store interface onto a single User kind. |
+| `IdentityStore` | struct | `accounts.IdentityStore` impl — Get/Save identities, set UserID, mark verified, reverse-lookup by user_id. | Transactions guard `SetUserForIdentity` and `MarkIdentityVerified` to keep `Version` monotonic. |
+| `ChannelStore` | struct | `accounts.ChannelStore` impl — Get/Save channels and list channels for an identity key. | Single Channel kind with composite name plus indexed `identity_key` for fan-out. |
+| `TokenStore` | struct | `core.TokenStore` impl for localauth verification tokens — CreateToken / GetToken (auto-deletes if expired) / DeleteToken / DeleteSubjectTokens. | Keys-only filter + `DeleteMulti` gives a single batched purge for "all reset tokens for this subject". |
+| `RefreshTokenStore` | struct | `core.RefreshTokenStore` impl — Create / Get / Rotate (transactional, reuse-detection) / Revoke{Refresh,Subject,Family} / GetSubjectTokens / CleanupExpired. | Implements RFC 6749 §10.4 refresh-token rotation with family-wide revocation on reuse. |
+| `APIKeyStore` | struct | `core.APIKeyStore` impl — Create (bcrypt hash, `"oa_keyid_secret"` format) / GetByID / Validate / Revoke / ListSubject / UpdateLastUsed. | Tracks both KeyID (lookup) and a bcrypt hash of the secret (validation); `HasExpiry` flag avoids omitempty on `time.Time`. |
+| `UsernameStore` | struct | `accounts.UsernameStore` impl — Reserve / Get / Release / Change with case-insensitive normalisation. | `ChangeUsername` runs Get-then-Put in one transaction to prevent races between two users grabbing the same name. |
+| `GAEKeyStore` | struct | `keys.KeyStorage` impl — PutKey / GetKey / GetKeyByKid / DeleteKey / ListKeyIDs over the SigningKey kind. | One row per client lets either direction (clientID or kid) resolve a key via composite indexing. |
+| `GAEKidStore` | struct | `keys.KidStorage` impl — Add / Remove (idempotent) / GetKeyByKid (honours `ExpiresAt`) / CleanExpired; `GetKey` deliberately returns `ErrKeyNotFound`. | Verification-only grace cache for old kids during rotation; intentionally not a primary-key store. |
+| `GAEAppStore` | struct | `core.AppRegistrationStore` impl — SaveApp / GetApp / ListApps / DeleteApp over the AppRegistration kind. | New in this PR; shared client + namespace pattern means `cmd/oneauth-server` can swap backends with one line and reuse the `appstoretest` conformance suite. |
+| `NewUserStore` | func | Constructor — returns a `UserStore` bound to a datastore client + namespace. | Constructor injection of the shared `*datastore.Client` keeps the store agnostic to dial/credentials wiring. |
+| `NewIdentityStore` | func | Constructor — returns an `IdentityStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewChannelStore` | func | Constructor — returns a `ChannelStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewTokenStore` | func | Constructor — returns a `TokenStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewRefreshTokenStore` | func | Constructor — returns a `RefreshTokenStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewAPIKeyStore` | func | Constructor — returns an `APIKeyStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewUsernameStore` | func | Constructor — returns a `UsernameStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewKeyStore` | func | Constructor — returns a `GAEKeyStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewKidStore` | func | Constructor — returns a `GAEKidStore` bound to a datastore client + namespace. | Same shared-client pattern across every store in this package. |
+| `NewAppStore` | func | Constructor — returns a `GAEAppStore` bound to a datastore client + namespace. | Same shared-client pattern; lets `cmd/oneauth-server` slot the gae app backend in with a one-line dial just like every other store here. |
+| `IdentityToEntity` | func | Converts a public `accounts.Identity` into an `IdentityEntity` bound to the supplied key. | Datastore key depends on namespace, so callers must pass it in rather than have the converter derive it. |
+| `VerificationTokenToEntity` | func | Converts a `localauth.VerificationToken` into a `VerificationTokenEntity` bound to the supplied key. | Same key-injection pattern as `IdentityToEntity` for namespace-aware writes. |
+| `IdentityEntity.ToIdentity` | method | Round-trips an `IdentityEntity` back into `accounts.Identity` (no key fields). | Public store API hands out interface values, never entity structs. |
+| `VerificationTokenEntity.ToVerificationToken` | method | Round-trips a `VerificationTokenEntity` back into `localauth.VerificationToken` (token name carried as `Key.Name`). | Public store API hands out interface values, never entity structs. |
+| `GAEUser.Id` | method | `accounts.User` impl — returns the UserID. | Implements the `User` interface as a plain struct (no DB round-trip on read). |
+| `GAEUser.Profile` | method | `accounts.User` impl — returns the user profile map. | Implements the `User` interface as a plain struct (no DB round-trip on read). |
+| `KindUser`, `KindIdentity`, `KindChannel`, `KindAuthToken`, `KindRefreshToken`, `KindAPIKey`, `KindUsername`, `KindSigningKey`, `KindKidKey`, `KindAppRegistration` | const | Datastore "kind" names for every entity type in this package. | Single source of truth referenced from queries, keys, and tests. |
 
 ## Flows
 
 ### Refresh-token rotation with reuse detection
 
-`RefreshTokenStore.RotateRefreshToken` is the centerpiece: a single Datastore transaction that revokes the old token and writes the next-generation token while preserving `Family`, plus an out-of-transaction family revocation if reuse is detected. Holding the old-revoke and new-create in one `RunInTransaction` closure is what makes the rotation atomic — neither side is observable on its own.
-
-```mermaid
-sequenceDiagram
-    participant Caller as apiauth.OneAuth
-    participant Store as RefreshTokenStore
-    participant Tx as Datastore Tx
-    participant DS as Datastore
-
-    Caller->>Store: RotateRefreshToken(ctx, oldToken)
-    Store->>Store: hashToken(oldToken)
-    Store->>Tx: RunInTransaction
-    Tx->>DS: Get(oldHash)
-    alt ErrNoSuchEntity
-        Tx-->>Store: ErrTokenNotFound
-    else Already revoked
-        Tx-->>Store: ErrTokenReused
-        Store->>DS: Get(oldHash) (outside tx, read family)
-        Store->>Store: RevokeTokenFamily(family)
-        Store-->>Caller: nil, ErrTokenReused
-    else Expired
-        Tx-->>Store: ErrTokenExpired
-    else Valid
-        Tx->>DS: Put(old: Revoked=true, RevokedAt=now)
-        Store->>Store: GenerateSecureToken()
-        Tx->>DS: Put(new: Generation+1, same Family)
-        Tx-->>Store: ok
-        Store-->>Caller: newRefreshToken, nil
-    end
-```
-
-### Username reservation with case-insensitive normalisation
-
-`UsernameStore.ReserveUsername` and `UsernameStore.ChangeUsername` collapse the same lowercased username to the same key, while still preserving the original casing in the entity body.
-
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant US as UsernameStore
-    participant Tx as Datastore Tx
+    participant RTS as RefreshTokenStore
+    participant TX as Datastore Tx
+    participant DS as Datastore
 
-    Caller->>US: ReserveUsername(ctx, "Alice", uid)
-    US->>US: normalize → "alice"
-    US->>Tx: RunInTransaction
-    Tx->>Tx: Get("alice")
-    alt Exists, same userID
-        Tx->>Tx: Put({Username:"Alice", UserID:uid})
-        Tx-->>US: nil
-    else Exists, different userID
-        Tx-->>US: "username already taken"
-    else Not found
-        Tx->>Tx: Put(new UsernameEntity)
-        Tx-->>US: nil
+    Caller->>RTS: RotateRefreshToken(oldToken)
+    RTS->>RTS: hash := sha256(oldToken)
+    RTS->>TX: RunInTransaction(key=hash)
+    TX->>DS: Get(key)
+    alt entity.Revoked
+        TX-->>RTS: return ErrTokenReused
+        RTS->>RTS: Get(family) outside tx
+        RTS->>DS: RevokeTokenFamily(family) — bulk revoke
+        RTS-->>Caller: ErrTokenReused
+    else expired
+        TX-->>RTS: ErrTokenExpired
+        RTS-->>Caller: ErrTokenExpired
+    else fresh
+        TX->>DS: Put(old, Revoked=true)
+        RTS->>RTS: newToken := GenerateSecureToken()
+        TX->>DS: Put(newHash, Generation+1, same family, scopes, authzDetails)
+        TX-->>RTS: ok
+        RTS-->>Caller: new RefreshToken
     end
-    US-->>Caller: result
 ```
 
-### Kid grace-store cleanup
-
-`GAEKidStore.CleanExpired` scans the whole `KidKey` kind in the namespace and filters in Go, because `ExpiresAt` is `noindex` and Datastore can't combine an "is non-zero" predicate with a "less-than" range filter in one query. The iterator terminates on `iterator.Done` — that sentinel is end-of-query, not an error.
+### App registration round-trip
 
 ```mermaid
 sequenceDiagram
-    participant Caller
-    participant KS as GAEKidStore
+    participant Admin as DCR Handler
+    participant AS as GAEAppStore
     participant DS as Datastore
 
-    Caller->>KS: CleanExpired(ctx)
-    KS->>DS: GetAll(query KindKidKey, namespace)
-    DS-->>KS: entities[], keys[]
-    loop for each entity
-        KS->>KS: if !ExpiresAt.IsZero() && now > ExpiresAt
-        KS->>KS:   append key to toDelete
-    end
-    alt toDelete non-empty
-        KS->>DS: DeleteMulti(toDelete)
-    end
-    KS-->>Caller: {Removed: len(toDelete)}
-```
+    Admin->>AS: SaveApp(AppRegistration{ClientID,...})
+    AS->>AS: appKey(ClientID) with namespace
+    AS->>AS: appRegToEntity(key, app) — CreatedAt.UnixNano()
+    AS->>DS: Put(key, entity)
+    DS-->>AS: ok
+    AS-->>Admin: SaveAppResponse{}
 
-### Verification-token lookup with lazy expiry
-
-`TokenStore.GetToken` self-heals: if the token row exists but is past its `ExpiresAt`, it is deleted on the read path. This means a background cleanup job is not required for correctness, only for storage hygiene.
-
-```mermaid
-sequenceDiagram
-    participant Caller as localauth
-    participant TS as TokenStore
-    participant DS as Datastore
-
-    Caller->>TS: GetToken(ctx, token)
-    TS->>DS: Get(KindAuthToken, token)
+    Admin->>AS: GetApp(ClientID)
+    AS->>DS: Get(appKey)
     alt ErrNoSuchEntity
-        TS-->>Caller: "token not found"
-    else Found, !IsExpired
-        TS-->>Caller: *VerificationToken
-    else Found, IsExpired
-        TS->>DS: Delete(token)
-        TS-->>Caller: "token expired"
+        AS-->>Admin: core.ErrAppNotFound
+    else found
+        AS->>AS: entityToAppReg — unixNanosToTime(CreatedAt)
+        AS-->>Admin: AppRegistration
     end
 ```
 
 ## Gotchas
 
-- **`WithContext` is dead code post-#204c/d.** Every store still embeds a `ctx context.Context` field and exposes `WithContext`. None of the request methods read `s.ctx` — they all take `ctx` as a parameter. The shim survives only to keep older call sites compiling; do not add new code that depends on it. It will be removed once consumers are migrated.
-
-- **JSON-in-blob payloads cannot be queried.** `profile`, `credentials`, `device_info`, `scopes`, `authorization_details` are all `[]byte` with `noindex`. You can't filter "all refresh tokens with scope X" at the Datastore level — you have to scan and decode. This is deliberate (Datastore's flat-property indexes are expensive), but a real surprise if you try.
-
-- **Composite key names, not ancestors.** Identity keys are literally `"type:value"`, channel keys are `"provider:identityKey"`. There are no entity groups, so cross-entity transactions (`SetUserForIdentity`, `ChangeUsername`, refresh-token rotation) are cross-group writes and rely on Datastore's XG transaction limit (25 entity groups). Inside any single transaction in this package we only touch one or two rows, so this is fine — but if you add a flow that touches dozens of refresh tokens transactionally, you'll hit the cap.
-
-- **Namespace prefix on every key.** Every `namespacedKey` helper does `key.Namespace = s.namespace` after `datastore.NameKey(...)`. Datastore namespaces are how this package multi-tenants; forget the namespace assignment on a new key constructor or new query (`q.Namespace(s.namespace)`) and the store will silently read or write across tenants. There's no single helper that handles both — copy from an existing call site.
-
-- **`iterator.Done` is end-of-query, not an error.** Every `client.Run(ctx, query)` loop checks `if err == iterator.Done { break }` before treating `err` as fatal. This is the `google.golang.org/api/iterator` sentinel, not `datastore.ErrNoSuchEntity` (which is the per-key Get sentinel). Mixing them up will either eat real errors or short-circuit on success.
-
-- **`HasExpiry` flag for nullable timestamps.** Datastore stores `time.Time` zero-values as a real timestamp (the epoch), and `omitempty` on `time.Time` doesn't behave like it does for pointers. `APIKeyEntity.HasExpiry` is an explicit bool so the round-trip back to `*core.APIKey.ExpiresAt *time.Time` can decide whether to set the pointer at all. The same idiom is used for `RevokedAt` via `IsZero()` checks.
-
-- **`omitempty` on bool fields does nothing.** Several entity fields use `datastore:"...,omitempty"` (e.g. `RefreshTokenEntity.ClientID`, `RefreshTokenEntity.RevokedAt`, `APIKeyEntity.ExpiresAt`, `APIKeyEntity.RevokedAt`). For zero-value `time.Time` and empty string this saves index entries; for bool zero values (`Revoked`) it does not, which is why we always write `Revoked` explicitly.
-
-- **Kid cleanup scans the kind.** `GAEKidStore.CleanExpired` fetches every entity in the namespace, filters in Go, and `DeleteMulti`s the survivors. This works because kid grace stores stay small (a handful of entries per client during rotation), but it would not work as the design for a production refresh-token cleanup — which is why `RefreshTokenStore.CleanupExpiredTokens` uses indexed `expires_at` and `revoked`/`revoked_at` range filters instead.
-
-- **Refresh-token reuse revokes the family outside the transaction.** When `RotateRefreshToken` detects a previously-revoked token, the rotation transaction returns `ErrTokenReused`, then a separate `Get` + `RevokeTokenFamily` runs outside the tx. The window between detection and family revocation is unprotected — if an attacker burns all generations in parallel, the family revocation will catch up but the race exists. This is the same tradeoff GORM-store makes; the alternative (looping every family member into the rotation tx) blows past the entity-group limit.
-
-- **`RotateRefreshToken` builds the response inside the closure.** Watch the assignment to the outer `newRefreshToken *core.RefreshToken` inside `RunInTransaction` — if the transaction retries (Datastore can retry the closure on contention), the variable is overwritten on each attempt, which is fine, but if you ever add a side-effect that depends on `newRefreshToken` being final, it must run after the outer `err` check.
-
-- **`UserStore.SaveUser` re-reads the row to preserve `CreatedAt`.** It does a Get-then-Put without a transaction; two concurrent `SaveUser` calls can both observe the same `CreatedAt` and both write — last writer wins. There's no `Version` check on the user row (unlike `IdentityEntity`/`ChannelEntity`), so user updates are last-writer-wins by design.
-
-- **`SaveUser` only round-trips `IsActive` for `*GAEUser`.** If a caller passes some other `accounts.User` implementation, the entity is written with `IsActive: true` regardless of the actual state, because the value can only be read out via a type assertion.
-
-- **`stores.go` has a stray `log.Println` in `GetUserById`.** It logs every user lookup including the userId. Noise in production; harmless but worth knowing.
-
-- **`!wasm` build tag is on every `.go` file.** The package is excluded from WASM builds entirely. If you add a new file here, copy the `//go:build !wasm` header — without it the WASM build will try to compile Datastore.
-
-- **Sub-module, replace directives.** This folder is its own Go module (`go.mod`/`go.sum` live here). When developing against an unreleased main-module change, the consumer needs a `replace` directive — see `docs/MIGRATION.md` and the project `go.work` for the canonical layout. Do not edit `go.mod` / `go.sum` as part of a design pass.
-
-- **`GAEKidStore.GetKey` is intentionally broken.** It returns `ErrKeyNotFound` unconditionally because the kid store is a kid-indexed view, not a clientID-indexed primary store. The interface forces the method to exist; the implementation refuses to lie about it. Read `keys/SUMMARY.md` if this looks like a bug.
+- **AppRegistration timestamps stored as unix nanos.** Datastore truncates `time.Time` properties to microseconds, which breaks equality checks the `appstoretest` conformance suite makes against the in-memory result. `AppRegistrationEntity.CreatedAt` is therefore `int64` (nanos), and `unixNanosToTime` round-trips zero → `time.Time{}` so a never-set timestamp doesn't appear as `1970-01-01` (matching the GORM/FS/InMemory zero-default).
+- **Every AppRegistration field is `noindex`.** Datastore rejects indexed properties larger than 1500 bytes; a long `registration_client_uri` or a `redirect_uris` array with many entries would hit that limit. Because the only access pattern is "lookup by `client_id` (the key)", nothing in the value needs to be indexed, so all fields are marked `noindex`.
+- **`GAEKidStore.GetKey` is intentionally stubbed.** It satisfies the interface but always returns `ErrKeyNotFound` — `KidStorage` is a verification-only grace cache keyed by kid, not by clientID. Routing a clientID lookup here would silently miss; this is by design.
+- **`CleanExpired` (kid) and `CleanupExpiredTokens` (refresh) scan in Go, not in the query.** Datastore can't express "field is not the zero time AND field < now" in one inequality filter, so both methods fetch candidates and filter on the client. The refresh-token version does run two separate queries (one for `expires_at < now`, one for `revoked = true AND revoked_at < cutoff`), each as a keys-only + `DeleteMulti`.
+- **`RotateRefreshToken` family revocation happens outside the transaction.** When reuse is detected the tx returns `ErrTokenReused`, then `RevokeTokenFamily` runs as a separate write loop. If the process crashes between the two calls the attacker's reused token is already failed (tx returned the error), but the family is still live until the next reuse attempt or a manual revoke — acceptable because reuse detection is the trigger, not a separate guarantee.
+- **`UserStore.GetUserById` logs the key on every call.** `log.Println("UserStore Key: ", key, ...)` in `stores.go` is dev-leftover noise that ends up in production logs — worth cleaning up but not load-bearing.
+- **`RotateRefreshToken` updates `LastUsedAt` only on the new entity.** The old (now-revoked) entity keeps its prior `LastUsedAt`; only `RevokedAt` records when rotation happened. Audit consumers should read `RevokedAt`, not `LastUsedAt`, to see when rotation occurred.
+- **Sub-test cleanup runs before each conformance sub-test.** `keystore_test.go` / `kidstore_test.go` / `appstore_test.go` each call their cleanup closure inside the `RunAll` factory so every sub-test sees an empty namespace — necessary because the conformance suites reuse the same client across sub-tests.
 
 ## Depends on
 
-- [`../../accounts/DESIGN.md`](../../accounts/DESIGN.md) — the public account-side store interfaces this package implements: `accounts.UserStore` (with `accounts.User`), `accounts.IdentityStore` (with `accounts.Identity`), `accounts.ChannelStore` (with `accounts.Channel`), and `accounts.UsernameStore`. `GAEUser` is the concrete `accounts.User` returned by `UserStore.CreateUser` / `UserStore.GetUserById`.
-- [`../../core/DESIGN.md`](../../core/DESIGN.md) — token-side primitives: `core.TokenStore`, `core.RefreshTokenStore` (`core.RefreshToken`, `core.AuthorizationDetail`, `core.TokenExpiryRefreshToken`), `core.APIKeyStore` (`core.APIKey`), the secure-token helpers `core.GenerateSecureToken` / `core.GenerateAPIKeyID` / `core.GenerateAPIKeySecret`, and the sentinel errors `core.ErrTokenNotFound`, `core.ErrTokenReused`, `core.ErrTokenExpired`, `core.ErrTokenRevoked`, `core.ErrAPIKeyNotFound` returned from `RefreshTokenStore.RotateRefreshToken` / `APIKeyStore.ValidateAPIKey`.
-- [`../../keys/DESIGN.md`](../../keys/DESIGN.md) — the key-storage interfaces and DTO: `GAEKeyStore` implements `keys.KeyStorage`, `GAEKidStore` implements `keys.KidStorage`, both round-trip `keys.KeyRecord`, and they return `keys.ErrKeyNotFound` / `keys.ErrKidNotFound` / `keys.ErrAlgorithmMismatch` per the contract.
-- [`../../localauth/DESIGN.md`](../../localauth/DESIGN.md) — the verification-token shape: `VerificationTokenEntity` persists `localauth.VerificationType` plus a `localauth.VerificationToken` round-trip, and `TokenStore.CreateToken` / `TokenStore.GetToken` / `TokenStore.DeleteSubjectTokens` expose those types directly.
-- [`../../utils/DESIGN.md`](../../utils/DESIGN.md) — `utils.ComputeKid` derives the kid that `GAEKeyStore.PutKey` writes to `SigningKeyEntity.Kid` when the caller did not supply one.
+- [`core/`](../../core/DESIGN.md) — `AppRegistration`, `AppRegistrationStore`, `SaveAppRequest`/`Response`, `GetAppRequest`/`Response`, `ListAppsRequest`/`Response`, `DeleteAppRequest`/`Response`, `ErrAppNotFound`, `RefreshToken`, `RefreshTokenStore` + its Create/Get/Rotate/Revoke{,Subject,Family}/GetSubjectTokens/CleanupExpiredTokens request/response pairs, `APIKey`, `APIKeyStore` + its Create/GetByID/Validate/Revoke/ListSubject/UpdateLastUsed request/response pairs, `ErrAPIKeyNotFound`, `ErrTokenNotFound` / `ErrTokenExpired` / `ErrTokenRevoked` / `ErrTokenReused`, `GenerateSecureToken`, `GenerateAPIKeyID`, `GenerateAPIKeySecret`, `TokenExpiryRefreshToken`, `AuthorizationDetail`.
+- [`keys/`](../../keys/DESIGN.md) — `KeyStorage`, `KidStorage`, `KeyRecord`, `PutKey`/`GetKey`/`GetKeyByKid`/`DeleteKey`/`ListKeyIDs` request/response pairs, `AddKid`/`RemoveKid`/`CleanExpired` request/response pairs, `ErrKeyNotFound`, `ErrKidNotFound`, `ErrAlgorithmMismatch`.
+- [`utils/`](../../utils/DESIGN.md) — `ComputeKid`.
+- [`accounts/`](../../accounts/DESIGN.md) — `User`, `UserStore`, `IdentityStore`, `ChannelStore`, `UsernameStore`, `Identity`, `Channel`, plus all the Create/Get/Save/SetUserForIdentity/MarkIdentityVerified/GetUserIdentities/Reserve/Release/Change request and response types for those stores.
+- [`localauth/`](../../localauth/DESIGN.md) — `VerificationToken`, `VerificationType`, and the Create/Get/Delete/DeleteSubject verification-token request/response pairs implemented by `TokenStore`.

--- a/stores/gae/appstore.go
+++ b/stores/gae/appstore.go
@@ -64,6 +64,10 @@ func (s *GAEAppStore) appKey(clientID string) *datastore.Key {
 	return key
 }
 
+// SaveApp inserts or replaces the registration for req.App.ClientID. Empty
+// client_id is rejected with the same error message as InMemoryAppStore /
+// FSAppStore / GORMAppStore so the shared appstoretest contract passes
+// uniformly across backends.
 func (s *GAEAppStore) SaveApp(ctx context.Context, req *core.SaveAppRequest) (*core.SaveAppResponse, error) {
 	if req == nil || req.App == nil || req.App.ClientID == "" {
 		return nil, errors.New("AppRegistration.ClientID required")
@@ -75,6 +79,10 @@ func (s *GAEAppStore) SaveApp(ctx context.Context, req *core.SaveAppRequest) (*c
 	return &core.SaveAppResponse{}, nil
 }
 
+// GetApp returns the registration for req.ClientID, or core.ErrAppNotFound
+// when the entity is absent. Other Datastore errors (network, auth, quota)
+// surface unwrapped so callers can distinguish "not registered" from
+// "infrastructure problem."
 func (s *GAEAppStore) GetApp(ctx context.Context, req *core.GetAppRequest) (*core.GetAppResponse, error) {
 	if req == nil {
 		return nil, errors.New("GetApp: req is required")
@@ -89,6 +97,11 @@ func (s *GAEAppStore) GetApp(ctx context.Context, req *core.GetAppRequest) (*cor
 	return &core.GetAppResponse{App: entityToAppReg(&entity)}, nil
 }
 
+// ListApps returns every registration in this namespace. Order is unspecified
+// (Datastore queries without an explicit Order return results in key order,
+// which is implementation-defined). Returns an empty slice (not an error)
+// for an empty namespace, matching the other backends' "fresh store has no
+// apps" shape.
 func (s *GAEAppStore) ListApps(ctx context.Context, req *core.ListAppsRequest) (*core.ListAppsResponse, error) {
 	q := datastore.NewQuery(KindAppRegistration).Namespace(s.namespace)
 	it := s.client.Run(ctx, q)
@@ -107,6 +120,12 @@ func (s *GAEAppStore) ListApps(ctx context.Context, req *core.ListAppsRequest) (
 	return &core.ListAppsResponse{Apps: out}, nil
 }
 
+// DeleteApp removes the registration for req.ClientID. Returns
+// core.ErrAppNotFound if no such registration exists, matching the
+// other AppRegistrationStore backends — Datastore's bare Delete is
+// idempotent and silently succeeds on missing keys, so we Get-then-Delete
+// to honor the contract (the conformance suite's TestDeleteNonexistent
+// asserts on ErrAppNotFound).
 func (s *GAEAppStore) DeleteApp(ctx context.Context, req *core.DeleteAppRequest) (*core.DeleteAppResponse, error) {
 	if req == nil {
 		return nil, errors.New("DeleteApp: req is required")

--- a/stores/gae/appstore.go
+++ b/stores/gae/appstore.go
@@ -1,0 +1,175 @@
+//go:build !wasm
+// +build !wasm
+
+package gae
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/datastore"
+	"github.com/panyam/oneauth/core"
+	"google.golang.org/api/iterator"
+)
+
+const KindAppRegistration = "AppRegistration"
+
+// AppRegistrationEntity is the Datastore entity for app registrations.
+// All non-key fields are noindex — we only ever look up by the entity key
+// (client_id), and Datastore's 1500-byte per-property index limit would
+// reject long values like a registration_client_uri or many redirect_uris.
+type AppRegistrationEntity struct {
+	Key                       *datastore.Key `datastore:"__key__"`
+	ClientID                  string         `datastore:"client_id,noindex"`
+	ClientDomain              string         `datastore:"client_domain,noindex"`
+	SigningAlg                string         `datastore:"signing_alg,noindex"`
+	AuthorizationDetailsTypes []string       `datastore:"authorization_details_types,noindex"`
+	CreatedAt                 int64          `datastore:"created_at,noindex"` // unix nanos — keeps Datastore microsecond truncation out of the equality check
+	Revoked                   bool           `datastore:"revoked,noindex"`
+
+	ClientName              string   `datastore:"client_name,noindex"`
+	ClientURI               string   `datastore:"client_uri,noindex"`
+	RedirectURIs            []string `datastore:"redirect_uris,noindex"`
+	GrantTypes              []string `datastore:"grant_types,noindex"`
+	Scope                   string   `datastore:"scope,noindex"`
+	TokenEndpointAuthMethod string   `datastore:"token_endpoint_auth_method,noindex"`
+
+	RegistrationAccessToken string `datastore:"registration_access_token,noindex"`
+	RegistrationClientURI   string `datastore:"registration_client_uri,noindex"`
+}
+
+// GAEAppStore implements core.AppRegistrationStore using Google Cloud Datastore.
+// Multi-node compatible — Datastore is the shared source of truth — and slots
+// into stores/gae/ alongside GAEKeyStore and GAEKidStore.
+type GAEAppStore struct {
+	client    *datastore.Client
+	namespace string
+}
+
+var _ core.AppRegistrationStore = (*GAEAppStore)(nil)
+
+// NewAppStore creates a new Datastore-backed AppRegistrationStore.
+func NewAppStore(client *datastore.Client, namespace string) *GAEAppStore {
+	return &GAEAppStore{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+func (s *GAEAppStore) appKey(clientID string) *datastore.Key {
+	key := datastore.NameKey(KindAppRegistration, clientID, nil)
+	key.Namespace = s.namespace
+	return key
+}
+
+func (s *GAEAppStore) SaveApp(ctx context.Context, req *core.SaveAppRequest) (*core.SaveAppResponse, error) {
+	if req == nil || req.App == nil || req.App.ClientID == "" {
+		return nil, errors.New("AppRegistration.ClientID required")
+	}
+	entity := appRegToEntity(s.appKey(req.App.ClientID), req.App)
+	if _, err := s.client.Put(ctx, entity.Key, entity); err != nil {
+		return nil, err
+	}
+	return &core.SaveAppResponse{}, nil
+}
+
+func (s *GAEAppStore) GetApp(ctx context.Context, req *core.GetAppRequest) (*core.GetAppResponse, error) {
+	if req == nil {
+		return nil, errors.New("GetApp: req is required")
+	}
+	var entity AppRegistrationEntity
+	if err := s.client.Get(ctx, s.appKey(req.ClientID), &entity); err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, core.ErrAppNotFound
+		}
+		return nil, err
+	}
+	return &core.GetAppResponse{App: entityToAppReg(&entity)}, nil
+}
+
+func (s *GAEAppStore) ListApps(ctx context.Context, req *core.ListAppsRequest) (*core.ListAppsResponse, error) {
+	q := datastore.NewQuery(KindAppRegistration).Namespace(s.namespace)
+	it := s.client.Run(ctx, q)
+	out := []*core.AppRegistration{}
+	for {
+		var entity AppRegistrationEntity
+		_, err := it.Next(&entity)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("ListApps iterate: %w", err)
+		}
+		out = append(out, entityToAppReg(&entity))
+	}
+	return &core.ListAppsResponse{Apps: out}, nil
+}
+
+func (s *GAEAppStore) DeleteApp(ctx context.Context, req *core.DeleteAppRequest) (*core.DeleteAppResponse, error) {
+	if req == nil {
+		return nil, errors.New("DeleteApp: req is required")
+	}
+	key := s.appKey(req.ClientID)
+	var probe AppRegistrationEntity
+	if err := s.client.Get(ctx, key, &probe); err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, core.ErrAppNotFound
+		}
+		return nil, err
+	}
+	if err := s.client.Delete(ctx, key); err != nil {
+		return nil, err
+	}
+	return &core.DeleteAppResponse{}, nil
+}
+
+func appRegToEntity(key *datastore.Key, app *core.AppRegistration) *AppRegistrationEntity {
+	return &AppRegistrationEntity{
+		Key:                       key,
+		ClientID:                  app.ClientID,
+		ClientDomain:              app.ClientDomain,
+		SigningAlg:                app.SigningAlg,
+		AuthorizationDetailsTypes: app.AuthorizationDetailsTypes,
+		CreatedAt:                 app.CreatedAt.UnixNano(),
+		Revoked:                   app.Revoked,
+		ClientName:                app.ClientName,
+		ClientURI:                 app.ClientURI,
+		RedirectURIs:              app.RedirectURIs,
+		GrantTypes:                app.GrantTypes,
+		Scope:                     app.Scope,
+		TokenEndpointAuthMethod:   app.TokenEndpointAuthMethod,
+		RegistrationAccessToken:   app.RegistrationAccessToken,
+		RegistrationClientURI:     app.RegistrationClientURI,
+	}
+}
+
+func entityToAppReg(e *AppRegistrationEntity) *core.AppRegistration {
+	return &core.AppRegistration{
+		ClientID:                  e.ClientID,
+		ClientDomain:              e.ClientDomain,
+		SigningAlg:                e.SigningAlg,
+		AuthorizationDetailsTypes: e.AuthorizationDetailsTypes,
+		CreatedAt:                 unixNanosToTime(e.CreatedAt),
+		Revoked:                   e.Revoked,
+		ClientName:                e.ClientName,
+		ClientURI:                 e.ClientURI,
+		RedirectURIs:              e.RedirectURIs,
+		GrantTypes:                e.GrantTypes,
+		Scope:                     e.Scope,
+		TokenEndpointAuthMethod:   e.TokenEndpointAuthMethod,
+		RegistrationAccessToken:   e.RegistrationAccessToken,
+		RegistrationClientURI:     e.RegistrationClientURI,
+	}
+}
+
+// unixNanosToTime restores time.Time from a unix-nanosecond integer round-trip.
+// Returns the zero time when nanos == 0 so a never-set CreatedAt does not become
+// 1970-01-01 (matches GORM's NULL-time behavior and the InMemory/FS zero default).
+func unixNanosToTime(nanos int64) time.Time {
+	if nanos == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nanos).UTC()
+}

--- a/stores/gae/appstore_test.go
+++ b/stores/gae/appstore_test.go
@@ -1,0 +1,74 @@
+//go:build !wasm
+// +build !wasm
+
+// Tests for the Google App Engine Datastore-based AppRegistrationStore implementation.
+
+package gae
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+	"github.com/panyam/oneauth/appstoretest"
+	"github.com/panyam/oneauth/core"
+	"google.golang.org/api/option" //nolint:staticcheck // WithCredentialsFile is simpler for test use
+)
+
+// TestGAEAppStore runs the shared AppRegistrationStore conformance suite
+// against Google Cloud Datastore. Skips unless DATASTORE_PROJECT_ID is set —
+// same env contract as TestGAEKeyStore and TestGAEKidStore.
+//
+// To run against the Datastore emulator:
+//
+//	make upds && make testds
+//
+// Or manually:
+//
+//	export DATASTORE_EMULATOR_HOST=localhost:8081
+//	export DATASTORE_PROJECT_ID=test-project
+//	go test -v ./stores/gae/...
+func TestGAEAppStore(t *testing.T) {
+	projectID := os.Getenv("DATASTORE_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("DATASTORE_PROJECT_ID not set, skipping GAE AppStore tests")
+	}
+
+	namespace := os.Getenv("DATASTORE_TEST_NAMESPACE")
+	if namespace == "" {
+		namespace = "oneauth-appstore-test"
+	}
+
+	ctx := context.Background()
+	var opts []option.ClientOption
+	if credsFile := os.Getenv("DATASTORE_CREDENTIALS_FILE"); credsFile != "" {
+		opts = append(opts, option.WithCredentialsFile(credsFile))
+	}
+
+	client, err := datastore.NewClient(ctx, projectID, opts...)
+	if err != nil {
+		t.Fatalf("Failed to create Datastore client: %v", err)
+	}
+	defer client.Close()
+
+	cleanup := func() {
+		q := datastore.NewQuery(KindAppRegistration).KeysOnly().Namespace(namespace)
+		dsKeys, err := client.GetAll(ctx, q, nil)
+		if err != nil {
+			t.Logf("Cleanup warning: failed to query app entities: %v", err)
+			return
+		}
+		if len(dsKeys) > 0 {
+			if err := client.DeleteMulti(ctx, dsKeys); err != nil {
+				t.Logf("Cleanup warning: failed to delete app entities: %v", err)
+			}
+		}
+	}
+	t.Cleanup(cleanup)
+
+	appstoretest.RunAll(t, func(t *testing.T) core.AppRegistrationStore {
+		cleanup() // fresh state per sub-test
+		return NewAppStore(client, namespace)
+	})
+}


### PR DESCRIPTION
## What changes

Adds the third backend for `core.AppRegistrationStore` on Google Cloud Datastore so multi-node GAE deployments can persist DCR-registered apps. FS and GORM already implemented the interface in PRs 165/166/167; this fills the missing third slot and unblocks any deployment that uses `cmd/oneauth-server` with `app_store.type: gae`.

Closes issue 228.

## Reviewer's guide

Read in this order:
1. [stores/gae/appstore.go](https://github.com/panyam/oneauth/pull/234/files#diff-4ecf6aa544e8564218e784501bf4029c3e400fa16ebecb3f23175193e1ad1c85) — start here. Mirrors the shape of `GAEKeyStore` and `GAEKidStore`. Worth scrutinizing: the `noindex` tagging on every non-key field and the `int64` unix-nanos serialization of `CreatedAt`.
2. [stores/gae/appstore_test.go](https://github.com/panyam/oneauth/pull/234/files#diff-96517d6210bea6df59fb61dc6531a243c94831b78da69ecfc3365b45f1a5a296) — acceptance via `appstoretest.RunAll`. Same skip-unless-`DATASTORE_PROJECT_ID` pattern as the existing keystore/kidstore tests in this folder.
3. [cmd/oneauth-server/config.go](https://github.com/panyam/oneauth/pull/234/files#diff-356728f980c9546d1ae9802ac863c4ccc97a7df25253e12e3ed019d559653f30) — adds `GAE GAEConfig` to `AppStoreConfig`.
4. [cmd/oneauth-server/main.go](https://github.com/panyam/oneauth/pull/234/files#diff-e10cea20e37f1e5e5e61786642a3b5a2da9fa5b930d457555ca11400927e495a) — new `case \"gae\":` arm in `buildAppStore`, identical shape to the `gae` arm already in `buildKeyStore`.
5. [stores/gae/DESIGN.md](https://github.com/panyam/oneauth/pull/234/files#diff-01f0807913c3133ca63dbbf2bf5bdbd2ea8818992870800a4b530696ec5d25e0), [stores/gae/.design.yaml](https://github.com/panyam/oneauth/pull/234/files#diff-8bf66b861dab075f90e13ee2ac81d9ab8d3958f81dc43eaf01580638b04c9a5b) — regenerated by `/design-rebuild --force`. Skim or skip; mechanical.

## Decision log

- **Native Datastore `[]string` slices over JSON-serialized blobs.** GORM uses `gorm:\"serializer:json\"` because Postgres / MySQL slice handling diverges. Datastore handles repeated properties natively, so the entity stays plain `[]string`. Less code, same wire shape against the existing conformance suite.
- **`noindex` on every non-key field.** Datastore enforces a per-property 1500-byte limit on *indexed* properties. We only ever look up by entity key (client_id); querying by `scope` or `redirect_uris` is not in the contract. Tagging `noindex` keeps long values legal without needing a composite-index migration.
- **`CreatedAt` persisted as `int64` unix-nanos (not `time.Time`).** Datastore's `time.Time` storage truncates to microseconds, which would break `appstoretest.TestAllFieldsRoundTrip`'s `==` equality check against a Go `time.Now()`. Round-tripping as `UnixNano()` preserves the exact value. `unixNanosToTime(0)` returns `time.Time{}` rather than `1970-01-01T00:00:00Z` so a never-set CreatedAt matches the FS/GORM/InMemory zero-default behavior.
- **No new Makefile target.** `make testds` (emulator) and `make testrealDS` (real GCP) both run `go test -v ./stores/gae/...` and pick up `TestGAEAppStore` automatically. Adding a `testappgae` target would just shadow what's already there.
- **Kept the per-store Datastore client.** `buildKeyStore` opens its own `datastore.NewClient`, and so does `buildAppStore`. Reusing a single client when both are configured for the same project is reasonable but it's a separate refactor — not in scope for 228.

## Risk / blast radius

- **Affects:** `cmd/oneauth-server` deployments that opt into `app_store.type: gae`. No effect on existing memory / fs / gorm deployments.
- **Tests covering this:** `appstoretest.RunAll` — 9 sub-tests (`SaveAndGet`, `NotFound`, `DeleteApp`, `DeleteNonexistent`, `OverwriteApp`, `ListApps`, `ListAppsEmpty`, `Persistence`, `AllFieldsRoundTrip`).
- **Red-before-green confirmed.** With `SaveApp` deliberately stubbed as a no-op, 6 of 9 sub-tests fail; restoring the real impl turns them green. Assertion count is unchanged vs the inherited conformance suite (we don't add or weaken any assertions — we just add a new factory pointing at GAEAppStore).
- **Be paranoid about:** the `Datastore.ErrNoSuchEntity → core.ErrAppNotFound` mapping in both `GetApp` and `DeleteApp`. Same pattern as `GAEKeyStore.GetKey`, but worth a second look.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` (root + workspace) all green
- `cd stores/gae && GOWORK=off go test ./...` green (skip-mode without emulator)
- `make upds && make testds` — all 9 `TestGAEAppStore` sub-tests pass on the emulator
- `staticcheck ./...` clean
- `cd cmd/oneauth-server && go vet ./...` clean

## Out of scope (deliberately deferred)

- Encrypted AppStore wrapper analogous to `EncryptedKeyStorage` — no demand yet; file a follow-up if needed.
- Per-store Datastore client sharing — separate refactor.
