### PR TITLE
feat(client): surface iss on browser-login callback + validate metadata issuer in DiscoverAS (closes 235)

### DIFF
--- a/client/as_cache_test.go
+++ b/client/as_cache_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -96,13 +97,14 @@ func TestDiscoverASUsesCache(t *testing.T) {
 	var fetchCount atomic.Int32
 
 	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		fetchCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"issuer":"http://test","token_endpoint":"http://test/token"}`))
+		// Issuer must match the fetched URL per RFC 8414 §3.3 (DiscoverAS rejects mismatches).
+		fmt.Fprintf(w, `{"issuer":%q,"token_endpoint":%q}`, ts.URL, ts.URL+"/token")
 	})
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
 
 	store := NewMemoryASMetadataStore(0)
 
@@ -111,7 +113,7 @@ func TestDiscoverASUsesCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first DiscoverAS failed: %v", err)
 	}
-	if md1.Issuer != "http://test" {
+	if md1.Issuer != ts.URL {
 		t.Errorf("unexpected issuer: %q", md1.Issuer)
 	}
 	if got := fetchCount.Load(); got != 1 {
@@ -123,7 +125,7 @@ func TestDiscoverASUsesCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second DiscoverAS failed: %v", err)
 	}
-	if md2.Issuer != "http://test" {
+	if md2.Issuer != ts.URL {
 		t.Errorf("unexpected issuer on second call: %q", md2.Issuer)
 	}
 	if got := fetchCount.Load(); got != 1 {
@@ -138,13 +140,14 @@ func TestDiscoverASCacheMissOnExpiry(t *testing.T) {
 	var fetchCount atomic.Int32
 
 	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		fetchCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"issuer":"http://test","token_endpoint":"http://test/token"}`))
+		// Issuer must match the fetched URL per RFC 8414 §3.3 (DiscoverAS rejects mismatches).
+		fmt.Fprintf(w, `{"issuer":%q,"token_endpoint":%q}`, ts.URL, ts.URL+"/token")
 	})
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
 
 	store := NewMemoryASMetadataStore(10 * time.Millisecond)
 
@@ -177,13 +180,14 @@ func TestDiscoverASNoCache(t *testing.T) {
 	var fetchCount atomic.Int32
 
 	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		fetchCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"issuer":"http://test","token_endpoint":"http://test/token"}`))
+		// Issuer must match the fetched URL per RFC 8414 §3.3 (DiscoverAS rejects mismatches).
+		fmt.Fprintf(w, `{"issuer":%q,"token_endpoint":%q}`, ts.URL, ts.URL+"/token")
 	})
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
 
 	_, _ = DiscoverAS(ts.URL)
 	_, _ = DiscoverAS(ts.URL)

--- a/client/browser_login.go
+++ b/client/browser_login.go
@@ -93,12 +93,45 @@ type BrowserLoginRequest struct {
 	// instead of using ClientSecret. Mutually exclusive with
 	// ClientSecret — when both are set, ClientAssertion wins.
 	ClientAssertion *ClientAssertionConfig
+
+	// OnCallback, when non-nil, fires after the loopback receives the
+	// authorization-code redirect and after state validation, but BEFORE
+	// the token exchange. Consumers use it to apply per-policy validation
+	// of the RFC 9207 `iss` query parameter (which oneauth surfaces but
+	// deliberately does not enforce — the spec leaves enforcement to the
+	// client per §2.4). Returning a non-nil error aborts the flow and the
+	// error is returned (wrapped) from LoginWithBrowser; no token exchange
+	// is performed.
+	OnCallback func(ctx context.Context, params CallbackParams) error
+}
+
+// CallbackParams carries the loopback-redirect query parameters that the
+// authorization server sent on the success path. Passed to
+// BrowserLoginRequest.OnCallback so the caller can apply policy (e.g.,
+// RFC 9207 iss-issuer matching) before the code is exchanged.
+type CallbackParams struct {
+	// Iss is the RFC 9207 `iss` query parameter — the issuer identifier of
+	// the authorization response. Empty when the AS does not send it (legacy
+	// ASes pre-dating RFC 9207). Consumers MAY treat absence as a hard
+	// failure for high-assurance flows; oneauth itself does not enforce.
+	Iss string
+
+	// Code is the OAuth 2.0 `code` query parameter (the authorization code
+	// to be exchanged at the token endpoint). Non-empty by the time the
+	// hook fires.
+	Code string
+
+	// State is the OAuth 2.0 `state` query parameter as echoed back by the
+	// AS. Already validated against the client-issued state before the hook
+	// fires — exposed for logging / audit only.
+	State string
 }
 
 // callbackResult holds the result received on the loopback redirect.
 type callbackResult struct {
 	Code  string
 	State string
+	Iss   string // RFC 9207 — see CallbackParams.Iss
 	Err   error
 }
 
@@ -170,7 +203,8 @@ func (c *AuthClient) LoginWithBrowser(ctx context.Context, req *BrowserLoginRequ
 		}
 		code := q.Get("code")
 		callbackState := q.Get("state")
-		resultCh <- callbackResult{Code: code, State: callbackState}
+		iss := q.Get("iss")
+		resultCh <- callbackResult{Code: code, State: callbackState, Iss: iss}
 		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprint(w, "<html><body><h1>Login Successful</h1><p>You can close this tab and return to the terminal.</p></body></html>")
 	})
@@ -270,6 +304,20 @@ func (c *AuthClient) LoginWithBrowser(ctx context.Context, req *BrowserLoginRequ
 
 	if result.Code == "" {
 		return nil, fmt.Errorf("no authorization code received")
+	}
+
+	// RFC 9207 hook (#235): hand the iss / code / state to the caller so
+	// they can apply policy (typically: assert Iss matches the discovered
+	// issuer) BEFORE the code is exchanged. We deliberately don't enforce
+	// here — RFC 9207 §2.4 leaves the policy to the client.
+	if cfg.OnCallback != nil {
+		if err := cfg.OnCallback(ctx, CallbackParams{
+			Iss:   result.Iss,
+			Code:  result.Code,
+			State: result.State,
+		}); err != nil {
+			return nil, fmt.Errorf("callback hook rejected authorization response: %w", err)
+		}
 	}
 
 	// Exchange code for tokens

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -2,11 +2,22 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 )
+
+// ErrMetadataIssuerMismatch is returned by DiscoverAS when the AS metadata
+// document's `issuer` field does not match the URL the document was fetched
+// from (RFC 8414 §3.3 — the issuer identifier MUST be identical to the URL
+// used to construct the well-known URL). A mismatch means a server is
+// claiming an identity it doesn't control at the discovery URL; the
+// document MUST be rejected per the spec.
+//
+// See: https://www.rfc-editor.org/rfc/rfc8414#section-3.3
+var ErrMetadataIssuerMismatch = errors.New("AS metadata issuer does not match discovery URL")
 
 // ASMetadata holds OAuth 2.0 Authorization Server metadata discovered from
 // a well-known endpoint. Fields follow RFC 8414 and OpenID Connect Discovery 1.0.
@@ -94,6 +105,12 @@ func WithASCacheTTL(ttl time.Duration) DiscoveryOption {
 //
 // Returns the first successful response. Returns an error if all attempts fail.
 //
+// The returned metadata's `issuer` field is validated against the fetch URL
+// per RFC 8414 §3.3 — a document claiming an issuer different from the URL
+// it was served at is rejected with ErrMetadataIssuerMismatch (no fallback
+// to the next discovery URL on this failure, since a malicious well-known
+// response shouldn't get a retry).
+//
 // See: https://www.rfc-editor.org/rfc/rfc8414#section-3
 func DiscoverAS(issuerURL string, opts ...DiscoveryOption) (*ASMetadata, error) {
 	cfg := &discoveryConfig{
@@ -120,6 +137,16 @@ func DiscoverAS(issuerURL string, opts ...DiscoveryOption) (*ASMetadata, error) 
 	for _, u := range urls {
 		meta, err := fetchMetadata(cfg.httpClient, u)
 		if err == nil {
+			// RFC 8414 §3.3: the issuer identifier in the metadata MUST
+			// equal the URL used to construct the well-known URL.
+			// A mismatch is a security failure (server claiming an
+			// identity it doesn't control at the discovery URL) — reject
+			// rather than fall through to the next URL, since a malicious
+			// well-known response shouldn't get a retry.
+			if strings.TrimRight(meta.Issuer, "/") != issuerURL {
+				return nil, fmt.Errorf("%w: fetched from %q, document claims issuer %q",
+					ErrMetadataIssuerMismatch, issuerURL, meta.Issuer)
+			}
 			// Store in cache if configured
 			if cfg.store != nil {
 				cfg.store.Put(issuerURL, meta, cfg.cacheTTL)

--- a/client/discovery_test.go
+++ b/client/discovery_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,16 +32,35 @@ import (
 )
 
 // newDiscoveryServer creates a test HTTP server that serves AS metadata
-// at the given path with the given metadata fields.
+// at the given path. The "issuer" field is auto-filled with the live
+// httptest URL so DiscoverAS's RFC 8414 §3.3 issuer-match check passes.
+// Tests that want to exercise a mismatch supply their own server inline.
 func newDiscoveryServer(t *testing.T, path string, meta map[string]any) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(meta)
-	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Mutate a copy so concurrent test runs don't race on the shared map.
+		// Legacy fixtures hardcode "https://auth.example.com" — rewrite every
+		// string value to point at the live srv.URL so DiscoverAS's RFC 8414
+		// §3.3 issuer-equality check passes. Tests that want to exercise a
+		// mismatch should build their server inline rather than going through
+		// this helper.
+		emit := make(map[string]any, len(meta)+1)
+		for k, v := range meta {
+			if s, ok := v.(string); ok {
+				emit[k] = strings.ReplaceAll(s, "https://auth.example.com", srv.URL)
+			} else {
+				emit[k] = v
+			}
+		}
+		if _, present := emit["issuer"]; !present {
+			emit["issuer"] = srv.URL
+		}
+		json.NewEncoder(w).Encode(emit)
+	})
 	return srv
 }
 
@@ -67,11 +87,11 @@ func TestDiscoverAS_OIDCEndpoint(t *testing.T) {
 	result, err := DiscoverAS(srv.URL, WithHTTPClientForDiscovery(srv.Client()))
 	require.NoError(t, err)
 
-	assert.Equal(t, "https://auth.example.com", result.Issuer)
-	assert.Equal(t, "https://auth.example.com/token", result.TokenEndpoint)
-	assert.Equal(t, "https://auth.example.com/authorize", result.AuthorizationEndpoint)
-	assert.Equal(t, "https://auth.example.com/.well-known/jwks.json", result.JWKSURI)
-	assert.Equal(t, "https://auth.example.com/introspect", result.IntrospectionEndpoint)
+	assert.Equal(t, srv.URL, result.Issuer)
+	assert.Equal(t, srv.URL+"/token", result.TokenEndpoint)
+	assert.Equal(t, srv.URL+"/authorize", result.AuthorizationEndpoint)
+	assert.Equal(t, srv.URL+"/.well-known/jwks.json", result.JWKSURI)
+	assert.Equal(t, srv.URL+"/introspect", result.IntrospectionEndpoint)
 	assert.Contains(t, result.ScopesSupported, "read")
 	assert.Contains(t, result.GrantTypesSupported, "client_credentials")
 	assert.Contains(t, result.ResponseTypesSupported, "code")
@@ -93,7 +113,7 @@ func TestDiscoverAS_RFC8414Endpoint(t *testing.T) {
 
 	result, err := DiscoverAS(srv.URL, WithHTTPClientForDiscovery(srv.Client()))
 	require.NoError(t, err)
-	assert.Equal(t, "https://auth.example.com/token", result.TokenEndpoint)
+	assert.Equal(t, srv.URL+"/token", result.TokenEndpoint)
 }
 
 // TestDiscoverAS_FallbackToOIDC verifies that when the RFC 8414 endpoint
@@ -110,7 +130,7 @@ func TestDiscoverAS_FallbackToOIDC(t *testing.T) {
 
 	result, err := DiscoverAS(srv.URL, WithHTTPClientForDiscovery(srv.Client()))
 	require.NoError(t, err)
-	assert.Equal(t, "https://auth.example.com/token", result.TokenEndpoint)
+	assert.Equal(t, srv.URL+"/token", result.TokenEndpoint)
 }
 
 // TestDiscoverAS_PathBasedIssuer verifies that discovery works for
@@ -128,7 +148,7 @@ func TestDiscoverAS_PathBasedIssuer(t *testing.T) {
 
 	result, err := DiscoverAS(srv.URL+"/tenant1", WithHTTPClientForDiscovery(srv.Client()))
 	require.NoError(t, err)
-	assert.Equal(t, "https://auth.example.com/tenant1/token", result.TokenEndpoint)
+	assert.Equal(t, srv.URL+"/tenant1/token", result.TokenEndpoint)
 }
 
 // TestDiscoverAS_Unreachable verifies that DiscoverAS returns an error
@@ -172,9 +192,33 @@ func TestDiscoverAS_MinimalMetadata(t *testing.T) {
 
 	result, err := DiscoverAS(srv.URL, WithHTTPClientForDiscovery(srv.Client()))
 	require.NoError(t, err)
-	assert.Equal(t, "https://auth.example.com", result.Issuer)
-	assert.Equal(t, "https://auth.example.com/token", result.TokenEndpoint)
+	assert.Equal(t, srv.URL, result.Issuer)
+	assert.Equal(t, srv.URL+"/token", result.TokenEndpoint)
 	assert.Empty(t, result.JWKSURI)
 	assert.Empty(t, result.IntrospectionEndpoint)
 	assert.Empty(t, result.ScopesSupported)
+}
+
+// TestDiscoverAS_MetadataIssuerMismatch_Rejected verifies that DiscoverAS
+// rejects a metadata document whose `issuer` field does not match the URL
+// it was fetched from (RFC 8414 §3.3). Mirrors the `metadata-issuer-mismatch`
+// failure scenario in the mcpkit SEP-2468 audit (#235).
+func TestDiscoverAS_MetadataIssuerMismatch_Rejected(t *testing.T) {
+	// Inline server — bypass newDiscoveryServer's auto-substitution so we
+	// can serve a deliberately mismatched issuer.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":         "https://attacker.example.com",
+			"token_endpoint": "https://attacker.example.com/token",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	_, err := DiscoverAS(srv.URL, WithHTTPClientForDiscovery(srv.Client()))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMetadataIssuerMismatch,
+		"metadata claiming a different issuer than the fetch URL must be rejected per RFC 8414 §3.3")
 }

--- a/client/iss_callback_test.go
+++ b/client/iss_callback_test.go
@@ -1,0 +1,190 @@
+package client
+
+// Tests for the RFC 9207 iss surfacing on the loopback redirect callback (#235).
+// The hook on BrowserLoginRequest fires between state validation and the
+// token exchange so consumers can apply their own iss policy.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9207
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAuthServerWithIss is a variant of mockAuthServer that includes (or
+// omits, when includeIss=false) the RFC 9207 iss query parameter on the
+// success redirect. issValue is the issuer URL the AS claims for itself.
+func mockAuthServerWithIss(t *testing.T, includeIss bool, issValue string) *httptest.Server {
+	t.Helper()
+	var storedChallenge, storedState, storedRedirectURI string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		storedChallenge = q.Get("code_challenge")
+		storedState = q.Get("state")
+		storedRedirectURI = q.Get("redirect_uri")
+
+		redirectURL := fmt.Sprintf("%s?code=test-auth-code&state=%s", storedRedirectURI, storedState)
+		if includeIss {
+			redirectURL += "&iss=" + issValue
+		}
+		http.Redirect(w, r, redirectURL, http.StatusFound)
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		verifier := r.FormValue("code_verifier")
+		hash := sha256.Sum256([]byte(verifier))
+		computed := base64.RawURLEncoding.EncodeToString(hash[:])
+		if computed != storedChallenge {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "mock-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   900,
+		})
+	})
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		srv := r.Host
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                           "http://" + srv,
+			"authorization_endpoint":           "http://" + srv + "/authorize",
+			"token_endpoint":                   "http://" + srv + "/token",
+			"code_challenge_methods_supported": []string{"S256"},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestLoginWithBrowser_IssPassedToCallback asserts that the iss query
+// parameter sent on the authorization-response redirect lands in the
+// OnCallback hook with the exact value the AS sent.
+func TestLoginWithBrowser_IssPassedToCallback(t *testing.T) {
+	const wantIss = "http://issuer.example.test"
+	authSrv := mockAuthServerWithIss(t, true, wantIss)
+	store := newMockCredentialStore()
+	authClient := NewAuthClient(authSrv.URL, store)
+
+	var gotParams CallbackParams
+	var hookFired bool
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
+		ClientID: "test-cli",
+		Scopes:   []string{"openid"},
+		Timeout:  5 * time.Second,
+		OpenBrowser: func(authURL string) error {
+			go simulateBrowser(authURL)
+			return nil
+		},
+		OnCallback: func(_ context.Context, params CallbackParams) error {
+			hookFired = true
+			gotParams = params
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, hookFired, "OnCallback should have fired")
+	assert.Equal(t, wantIss, gotParams.Iss, "iss query parameter must be passed through verbatim")
+	assert.Equal(t, "test-auth-code", gotParams.Code)
+	assert.NotEmpty(t, gotParams.State)
+}
+
+// TestLoginWithBrowser_NoIssQueryParam asserts that when the AS omits the
+// iss parameter (legacy ASes pre-dating RFC 9207), the hook still fires
+// with Iss=="" so consumer policy can decide whether absence is acceptable.
+func TestLoginWithBrowser_NoIssQueryParam(t *testing.T) {
+	authSrv := mockAuthServerWithIss(t, false, "")
+	store := newMockCredentialStore()
+	authClient := NewAuthClient(authSrv.URL, store)
+
+	var gotParams CallbackParams
+	var hookFired bool
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
+		ClientID: "test-cli",
+		Scopes:   []string{"openid"},
+		Timeout:  5 * time.Second,
+		OpenBrowser: func(authURL string) error {
+			go simulateBrowser(authURL)
+			return nil
+		},
+		OnCallback: func(_ context.Context, params CallbackParams) error {
+			hookFired = true
+			gotParams = params
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, hookFired)
+	assert.Empty(t, gotParams.Iss, "absent iss should surface as empty, not synthesized")
+	assert.NotEmpty(t, gotParams.Code)
+}
+
+// TestLoginWithBrowser_CallbackHookErrorAbortsFlow asserts that returning
+// a non-nil error from the hook aborts the flow with that error wrapped,
+// and crucially that the token exchange never fires (verified by a server
+// that would fail the request if /token were hit).
+func TestLoginWithBrowser_CallbackHookErrorAbortsFlow(t *testing.T) {
+	var tokenCalled bool
+	mux := http.NewServeMux()
+	var storedState, storedRedirectURI string
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		storedState = q.Get("state")
+		storedRedirectURI = q.Get("redirect_uri")
+		http.Redirect(w, r,
+			fmt.Sprintf("%s?code=x&state=%s&iss=http://evil.example", storedRedirectURI, storedState),
+			http.StatusFound)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                           "http://" + r.Host,
+			"authorization_endpoint":           "http://" + r.Host + "/authorize",
+			"token_endpoint":                   "http://" + r.Host + "/token",
+			"code_challenge_methods_supported": []string{"S256"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rejectErr := errors.New("iss mismatch")
+	authClient := NewAuthClient(srv.URL, newMockCredentialStore())
+	_, err := authClient.LoginWithBrowser(context.Background(), &BrowserLoginRequest{
+		ClientID: "test-cli",
+		Scopes:   []string{"openid"},
+		Timeout:  5 * time.Second,
+		OpenBrowser: func(authURL string) error {
+			go simulateBrowser(authURL)
+			return nil
+		},
+		OnCallback: func(_ context.Context, params CallbackParams) error {
+			return rejectErr
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rejectErr, "hook error must be wrapped, not swallowed")
+	assert.False(t, tokenCalled, "token exchange must NOT happen when hook rejects")
+}


### PR DESCRIPTION
## What changes

Two narrow client-side validation gaps that show up as downstream MCP conformance failures (mcpkit `make testconf-upstream-audit` — 4 of 7 failing SEP-2468 scenarios + 1 metadata-issuer-mismatch):

- **Cluster A — surface `iss` on the loopback callback (RFC 9207):** new `OnCallback` hook on `BrowserLoginRequest` fires after state validation, before token exchange, with a `CallbackParams{Iss, Code, State}` payload. Consumers decide whether absence/mismatch is fatal — oneauth doesn't enforce.
- **Cluster B — `DiscoverAS` validates metadata issuer (RFC 8414 §3.3):** the returned `*ASMetadata.Issuer` is now required to equal the URL it was fetched from. Mismatch returns the new `ErrMetadataIssuerMismatch` sentinel and aborts (no fallback to the next discovery URL, since a malicious well-known response shouldn't get a retry).

Closes issue 235. Unblocks mcpkit#380 once a oneauth release contains this commit.

## Reviewer's guide

Read in this order:
1. [client/browser_login.go](https://github.com/panyam/oneauth/pull/237/files#diff-d5734d6e88ef6fa1ad180d1a3759f873c04caa9fea8d60123ec6c06db9d0db3e) — `CallbackParams` struct + `OnCallback` field on `BrowserLoginRequest` + the hook firing block (after state check, before token exchange). Worth scrutinizing: the error-wrap shape (`fmt.Errorf(\"...: %w\", err)`) so `errors.Is` works for callers, and the placement guaranteeing the token endpoint is not hit if the hook rejects.
2. [client/iss_callback_test.go](https://github.com/panyam/oneauth/pull/237/files#diff-f8d033d3323b2a21906d6e4da6f5dcce7bfc4b9da3de4b2afb5883a6cdf6ff3c) — acceptance for Cluster A. 3 tests: `IssPassedToCallback`, `NoIssQueryParam`, `CallbackHookErrorAbortsFlow` (red-before-green confirmed — disabled hook → all 3 fail).
3. [client/discovery.go](https://github.com/panyam/oneauth/pull/237/files#diff-0d6c1e4b6e6cf986699d916f9be1a95c3e25fa093ebf5237e7e166be0c786e20) — `ErrMetadataIssuerMismatch` sentinel + the validation block inside `DiscoverAS` + the godoc extension.
4. [client/discovery_test.go](https://github.com/panyam/oneauth/pull/237/files#diff-7ef99ec0b4760549be429aa5e6b874113bbd22e7ee51ffafae59a9e57c9e23de) — acceptance for Cluster B (`TestDiscoverAS_MetadataIssuerMismatch_Rejected`). Also fixture refresh: the `newDiscoveryServer` helper now rewrites hardcoded `https://auth.example.com` to the live httptest URL so existing tests exercise the happy path. Per-test assertions upgraded from string literals to `srv.URL` — same equality contract, just against the right value.
5. [client/as_cache_test.go](https://github.com/panyam/oneauth/pull/237/files#diff-d93ce9af21c172893074979a07797963b99c383d498a768c2106e6c6f7138ce5) — same fixture refresh for the cache tests; assertions upgraded to `ts.URL`.

Skim or skip: nothing — all changes are intentional.

## Decision log

- **Hook on the request, not a field on `ServerCredential`.** Returning a wrapped `*ServerCredential, *CallbackMetadata` from `LoginWithBrowser` would be a breaking API change for every existing caller. A field on the persisted credential conflates the RFC 9207 authorization-response issuer (consumed once, validated, discarded) with the token issuer (persisted, refreshed against). A hook is per-call, non-breaking, and gives the consumer everything they need at the right point in the flow.
- **No enforcement in oneauth.** RFC 9207 §2.4 explicitly leaves the iss policy to the client (some flows have a discovered expected issuer, others don't). Surfacing the value gives consumers what they need without forcing a one-size-fits-all check. The issue body documents this split explicitly.
- **`FollowRedirects` needs no change.** The iss query parameter arrives at the loopback handler regardless of how the browser was opened. One read, both code paths.
- **Mismatch is fatal in `DiscoverAS` — no fallback.** RFC 8414 §3.3 doesn't permit retry on a lying issuer. A second well-known URL on the same host would just be a second chance for the same lying server to convince us.

## Risk / blast radius

- **Affects:** any caller of `client.DiscoverAS` whose AS metadata lies about its issuer (would now fail loud instead of silently using a wrong identifier). Any caller of `client.LoginWithBrowser` that didn't set `OnCallback` is unaffected — the hook is opt-in.
- **Tests covering this:** new tests in `client/iss_callback_test.go` (3) and `client/discovery_test.go` (1 mismatch test + 5 happy-path fixtures refreshed). Full client suite green.
- **Be paranoid about:** the fixture refresh in `discovery_test.go` and `as_cache_test.go`. The hardcoded `https://auth.example.com` issuer in those mocks would now correctly fail under the new check — I updated the helper to rewrite the substring to the live `srv.URL` and updated the per-test assertions accordingly. These are NOT relaxed assertions; they're the same equality check against the right value. Net assertion count: +14.

## Out of scope (deliberately deferred)

- Enforcing iss policy inside oneauth — per the RFC and #180's split, this is consumer territory.
- Token-endpoint `iss` claim validation — server-side companion already shipped in #180.
- Tag bump — happens after merge.
