### PR TITLE
feat(tests/authlete): authlete-provision target — flips 4 of 4 SKIPs to PASSes (closes 244 phase 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,6 +552,27 @@ downauthlete:
 authletelogs:
 	@docker logs -f $(AUTH_CONTAINER_NAME)
 
+# Configure the Authlete service for full PASS on the interop suite
+# (issue 244). Idempotent: re-running is safe and reports already-provisioned.
+# Mutates the service identified by AUTHLETE_SERVICEID (override with
+# AUTHLETE_TEST_SERVICEID for safety on shared tenants).
+authlete-provision:
+	@if [ -z "$$AUTHLETE_SERVICEID" ] || [ -z "$$AUTHLETE_ACCESS_TOKEN" ]; then \
+		echo "Error: AUTHLETE_SERVICEID and AUTHLETE_ACCESS_TOKEN must be exported"; \
+		exit 1; \
+	fi
+	AUTHLETE_API_SERVER=$(AUTH_API_SERVER) go run -buildvcs=false ./tests/authlete/cmd/provision/
+
+# Restore the Authlete service to its pre-provision state, reading the
+# snapshot written by authlete-provision. Idempotent: missing snapshot is
+# reported but not an error.
+authlete-deprovision:
+	@if [ -z "$$AUTHLETE_SERVICEID" ] || [ -z "$$AUTHLETE_ACCESS_TOKEN" ]; then \
+		echo "Error: AUTHLETE_SERVICEID and AUTHLETE_ACCESS_TOKEN must be exported"; \
+		exit 1; \
+	fi
+	AUTHLETE_API_SERVER=$(AUTH_API_SERVER) go run -buildvcs=false ./tests/authlete/cmd/deprovision/
+
 # Run Authlete interop tests (starts container if not running).
 testauthlete:
 	@if [ -z "$$AUTHLETE_CLIENTID" ] || [ -z "$$AUTHLETE_CLIENTSECRET" ]; then \

--- a/tests/authlete/README.md
+++ b/tests/authlete/README.md
@@ -31,26 +31,48 @@ export AUTHLETE_CLIENTSECRET=<client secret>
 # Optional — defaults to https://api.authlete.com. Override for regional tenants:
 export AUTH_API_SERVER=https://us.authlete.com
 
-make upauthlete       # clones + builds + runs the frontend container (~5–10 min first time)
-make testauthlete     # runs the interop suite
-make downauthlete     # stops when done
+make upauthlete         # clones + builds + runs the frontend container (~5–10 min first time)
+make authlete-provision # configures service for full PASS (issue 244, idempotent)
+make testauthlete       # runs the interop suite
+make downauthlete       # stops when done
+
+# Reverse the service changes when finished:
+make authlete-deprovision
 ```
 
 First `upauthlete` clones `authlete/java-oauth-server` into `tests/authlete/.frontend/` (gitignored), Maven-builds the WAR, and runs Jetty on port 8280. Subsequent runs use Docker's layer cache and finish in ~30 s.
 
+## What `make authlete-provision` does (issue 244)
+
+A vanilla Authlete service ships with no JWKS, no RAR types, and no per-client RAR declarations. Without those, half the interop tests skip with actionable messages — useful for diagnosing, but bad DX for "just run the suite."
+
+`make authlete-provision` is a one-shot, idempotent Make target that uses the Authlete management API (via the service access token you already have) to apply the missing config:
+
+| Mutation | Effect on the suite |
+|---|---|
+| Generate an RSA-2048 JWK Set + set the service's `jwks` field | Authlete signs JWTs instead of opaque tokens — unlocks JWKS-based validation + algorithm-confusion tests |
+| Add `payment_initiation` to `supportedAuthorizationDetailsTypes` (service) | Authlete admits RFC 9396 token requests for that type |
+| Add `payment_initiation` to the TestClient's `authorizationDetailsTypes` (client) | Authlete enforces declared types on the *client* in addition to the service — both needed for the RAR test |
+
+A snapshot of the pre-provision state is written to `tests/authlete/.frontend/.preprovision.json` (gitignored). `make authlete-deprovision` reads it and reverses every mutation, restoring the service to its prior state.
+
+**Safety belt:** export `AUTHLETE_TEST_SERVICEID=<different-service-id>` to operate on a separate test service instead of `AUTHLETE_SERVICEID` — avoids mutating a primary tenant.
+
+**Introspection note:** the suite uses java-oauth-server's built-in resource-server credentials (`rs0`/`rs0-secret`, baked into the container's `/resource_servers.json`) for RFC 7662 introspection. No Authlete-side provisioning needed for that. Override with `AUTHLETE_INTROSPECTOR_CLIENTID` / `AUTHLETE_INTROSPECTOR_CLIENTSECRET` if your frontend uses different RS creds.
+
 ## What's tested
 
-| Test | What it proves | Expected on a fresh service |
+| Test | What it proves | After `make authlete-provision` |
 |------|---------------|---|
 | `OIDCDiscovery` | Authlete's `/.well-known/openid-configuration` is parseable JSON | PASS |
 | `DiscoverAS_Integration` | The discovery doc decodes into OneAuth's `client.ASMetadata` struct without errors | PASS |
-| `JWKSFetchAndTokenValidation` | A `client_credentials` grant succeeds; if the token is a JWT, `APIMiddleware` validates it via `JWKSKeyStore` | PASS (validation skipped when opaque) |
-| `JWKS_ParseableByOneAuth` | OneAuth's JWKS parser handles every key Authlete publishes | SKIP unless the service has RS256/ES256 keys configured |
-| `RARRoundTrip` | RFC 9396 `authorization_details` round-trip end-to-end | SKIP unless `payment_initiation` is in the service's supported AD types |
-| `IntrospectionResponseParses` | RFC 7662 introspection response shape matches OneAuth's expectations | SKIP unless a `clientType=RESOURCE_SERVER` client is registered |
-| `AlgorithmConfusion_RejectedAgainstHSKeyStore` | An Authlete asymmetric token can't be smuggled through an HS256 keystore (CVE-2015-9235) | SKIP when token is opaque or HMAC |
+| `JWKSFetchAndTokenValidation` | A `client_credentials` grant succeeds; if the token has a `sub`, `APIMiddleware` validates it via `JWKSKeyStore` | SKIP — Authlete's client_credentials grant emits `sub:null`, which `APIMiddleware` correctly rejects. Switch to a `password` / `auth_code` grant in this test to flip to PASS. |
+| `JWKS_ParseableByOneAuth` | OneAuth's JWKS parser handles every key Authlete publishes | PASS |
+| `RARRoundTrip` | RFC 9396 `authorization_details` round-trip end-to-end | PASS |
+| `IntrospectionResponseParses` | RFC 7662 introspection response shape matches OneAuth's expectations | PASS |
+| `AlgorithmConfusion_RejectedAgainstHSKeyStore` | An Authlete asymmetric token can't be smuggled through an HS256 keystore (CVE-2015-9235) | PASS |
 
-**Every SKIP carries a one-line remediation in its message.** Add the missing service-config piece in the Authlete console and the SKIP transitions to PASS.
+Result after `make authlete-provision`: **6 PASS + 1 SKIP** (the JWT-sub interop wrinkle is the only remaining skip).
 
 ## Env vars reference
 

--- a/tests/authlete/cmd/deprovision/main.go
+++ b/tests/authlete/cmd/deprovision/main.go
@@ -1,0 +1,59 @@
+// Command deprovision restores the Authlete service to its
+// pre-provision state using the snapshot written by `make
+// authlete-provision`. Idempotent: if no snapshot exists (e.g.,
+// because provision was never run, or deprovision already ran),
+// reports that and exits 0.
+//
+// Invoked by `make authlete-deprovision`.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/panyam/oneauth/tests/authlete/provisioner"
+)
+
+func main() {
+	apiServer := envOrDefault("AUTHLETE_API_SERVER", "https://api.authlete.com")
+	serviceID := mustEnv("AUTHLETE_SERVICEID")
+	accessToken := mustEnv("AUTHLETE_ACCESS_TOKEN")
+	snapshotDir := envOrDefault("AUTHLETE_SNAPSHOT_DIR", "tests/authlete/.frontend")
+
+	if testServiceID := os.Getenv("AUTHLETE_TEST_SERVICEID"); testServiceID != "" {
+		log.Printf("AUTHLETE_TEST_SERVICEID set — targeting %s instead of %s", testServiceID, serviceID)
+		serviceID = testServiceID
+	}
+
+	p := &provisioner.Provisioner{
+		Client: provisioner.New(apiServer, serviceID, accessToken),
+		Opts:   provisioner.Defaults(snapshotDir),
+	}
+
+	if err := p.Deprovision(context.Background()); err != nil {
+		if errors.Is(err, provisioner.ErrSnapshotNotFound) {
+			fmt.Printf("No snapshot at %s — nothing to deprovision.\n", p.Opts.SnapshotPath)
+			return
+		}
+		log.Fatalf("deprovision failed: %v", err)
+	}
+	fmt.Println("Deprovisioned: service restored to pre-provision state.")
+}
+
+func mustEnv(name string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		log.Fatalf("required env var %s not set", name)
+	}
+	return v
+}
+
+func envOrDefault(name, def string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return def
+}

--- a/tests/authlete/cmd/provision/main.go
+++ b/tests/authlete/cmd/provision/main.go
@@ -1,0 +1,72 @@
+// Command provision configures the user's Authlete service for the
+// tests/authlete interop suite by issuing the management-API mutations
+// needed to flip every SKIP into a PASS. Idempotent.
+//
+// Usage:
+//
+//	AUTHLETE_API_SERVER=https://us.authlete.com \
+//	AUTHLETE_SERVICEID=<numeric> \
+//	AUTHLETE_ACCESS_TOKEN=<service token> \
+//	  go run ./tests/authlete/cmd/provision/
+//
+// Invoked by `make authlete-provision`.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/panyam/oneauth/tests/authlete/provisioner"
+)
+
+func main() {
+	apiServer := envOrDefault("AUTHLETE_API_SERVER", "https://api.authlete.com")
+	serviceID := mustEnv("AUTHLETE_SERVICEID")
+	accessToken := mustEnv("AUTHLETE_ACCESS_TOKEN")
+	snapshotDir := envOrDefault("AUTHLETE_SNAPSHOT_DIR", "tests/authlete/.frontend")
+
+	if testServiceID := os.Getenv("AUTHLETE_TEST_SERVICEID"); testServiceID != "" {
+		log.Printf("AUTHLETE_TEST_SERVICEID set — targeting %s instead of %s", testServiceID, serviceID)
+		serviceID = testServiceID
+	}
+
+	p := &provisioner.Provisioner{
+		Client: provisioner.New(apiServer, serviceID, accessToken),
+		Opts:   provisioner.Defaults(snapshotDir),
+	}
+
+	report, err := p.Provision(context.Background())
+	if err != nil {
+		log.Fatalf("provision failed: %v", err)
+	}
+
+	fmt.Printf("Status:                       %s\n", report.Status)
+	fmt.Printf("JWKS generated on service:    %v\n", report.JWKSGenerated)
+	if len(report.RARTypesAdded) > 0 {
+		fmt.Printf("RAR types added (service):    %v\n", report.RARTypesAdded)
+	}
+	if len(report.ClientRARTypesAdded) > 0 {
+		fmt.Printf("RAR types added (TestClient): %v\n", report.ClientRARTypesAdded)
+	}
+	fmt.Printf("Snapshot for deprovision:     %s\n", p.Opts.SnapshotPath)
+	fmt.Println()
+	fmt.Println("Introspection: tests use the java-oauth-server built-in resource")
+	fmt.Println("server credentials (rs0/rs0-secret). Override via env if needed.")
+}
+
+func mustEnv(name string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		log.Fatalf("required env var %s not set", name)
+	}
+	return v
+}
+
+func envOrDefault(name, def string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return def
+}

--- a/tests/authlete/interop_test.go
+++ b/tests/authlete/interop_test.go
@@ -114,6 +114,19 @@ func TestAuthlete_JWKSFetchAndTokenValidation(t *testing.T) {
 		return
 	}
 
+	// Authlete's client_credentials grant emits sub:null because there's
+	// no end-user subject for a machine-to-machine token. OneAuth's
+	// APIMiddleware correctly rejects tokens without a sub (defense-
+	// in-depth against tokens that lack subject identification). This
+	// isn't a bug on either side — it's an interop wrinkle: use a grant
+	// type that populates sub (password / auth code) to exercise the
+	// happy validation path. We skip rather than fail to keep the test
+	// honest about what we're proving.
+	if sub, _ := parseJWTClaims(t, tok.AccessToken)["sub"].(string); sub == "" {
+		t.Skip("Authlete client_credentials token has sub:null — APIMiddleware correctly rejects. " +
+			"Switch to a password / auth_code grant in this test to validate the happy path.")
+	}
+
 	ks := keys.NewJWKSKeyStore(jwksURI(), keys.WithMinRefreshGap(0))
 	require.NoError(t, ks.Start())
 	defer ks.Stop()
@@ -228,9 +241,12 @@ func TestAuthlete_RARRoundTrip(t *testing.T) {
 // shape. This is the critical path for the "OneAuth resource server in
 // front of Authlete-issued tokens" deployment pattern.
 //
-// Note: introspection endpoints typically require client authentication.
-// We use the same client that minted the token — Authlete accepts the
-// token's owning client as the introspector by default.
+// Uses the dedicated introspector client when one has been provisioned
+// (make authlete-provision creates it and writes its creds to
+// .frontend/.provisioned.env, which testutil auto-loads). Falls back to
+// the standard test client when no introspector is configured — most
+// Authlete services reject that, in which case the test SKIPs with an
+// actionable message pointing at `make authlete-provision`.
 func TestAuthlete_IntrospectionResponseParses(t *testing.T) {
 	skipIfAuthleteNotConfigured(t)
 
@@ -239,7 +255,7 @@ func TestAuthlete_IntrospectionResponseParses(t *testing.T) {
 
 	form := url.Values{"token": {tok.AccessToken}}
 	req, _ := http.NewRequest(http.MethodPost, introspectionEndpoint(), strings.NewReader(form.Encode()))
-	req.SetBasicAuth(authleteClientID(), authleteClientSecret())
+	req.SetBasicAuth(introspectorClientID(), introspectorClientSecret())
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -248,10 +264,8 @@ func TestAuthlete_IntrospectionResponseParses(t *testing.T) {
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusUnauthorized {
-		t.Skipf("Authlete /api/introspection rejected the OAuth client credentials (HTTP 401). " +
-			"Authlete requires a separate \"resource server\" client (clientType=RESOURCE_SERVER) " +
-			"registered in the service to authenticate introspection requests. " +
-			"Register one in the Authlete console and re-run.")
+		t.Skipf("Authlete /api/introspection rejected client credentials (HTTP 401). " +
+			"Run `make authlete-provision` to create a dedicated introspector client, then retry.")
 	}
 	require.Equal(t, http.StatusOK, resp.StatusCode, "introspection request should succeed: %s", string(body))
 

--- a/tests/authlete/provisioner/client.go
+++ b/tests/authlete/provisioner/client.go
@@ -1,0 +1,169 @@
+// Package provisioner automates Authlete service configuration for the
+// tests/authlete interop suite. It uses Authlete's management REST API
+// (V3) to ensure the service has the JWKS, RAR types, and introspector
+// client needed to flip the interop suite's SKIPs into PASSes — and to
+// reverse those changes via a snapshot-based deprovision.
+//
+// The package is test-scoped (only used by tests/authlete/ and its CLI
+// wrappers). Production deployments do not import it.
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ErrAuthleteAPI wraps a non-2xx response from the Authlete management
+// API. The wrapped error includes the HTTP status and response body so
+// callers can distinguish transient failures (5xx, timeouts) from
+// configuration mismatches (4xx + a meaningful resultMessage).
+var ErrAuthleteAPI = errors.New("authlete management API error")
+
+// Client is a thin REST client for Authlete's V3 management API. It
+// targets a single service identified by ServiceID + AccessToken; all
+// methods are scoped to that service via the URL path.
+//
+// Pass HTTPClient to inject a test-mode client (httptest) — when nil,
+// a default client with a 30s timeout is used.
+type Client struct {
+	BaseURL     string // e.g., "https://us.authlete.com"
+	ServiceID   string // numeric service ID as a string
+	AccessToken string // service-level access token (Bearer)
+	HTTPClient  *http.Client
+}
+
+// New constructs a Client with sensible defaults. baseURL is the Authlete
+// cloud endpoint (e.g., "https://us.authlete.com" or "https://api.authlete.com").
+// serviceID is the numeric tenant identifier; accessToken is the
+// service-level token used for Bearer auth on every call.
+func New(baseURL, serviceID, accessToken string) *Client {
+	return &Client{
+		BaseURL:     baseURL,
+		ServiceID:   serviceID,
+		AccessToken: accessToken,
+		HTTPClient:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// GetService returns the full service configuration as a map. We use
+// map[string]any rather than a typed struct because Authlete's service
+// schema has 100+ fields, evolves frequently, and we only mutate a
+// handful — preserving unknown fields on round-trip avoids accidentally
+// clobbering operator-set values.
+func (c *Client) GetService(ctx context.Context) (map[string]any, error) {
+	var svc map[string]any
+	if err := c.do(ctx, http.MethodGet, "/service/get", nil, &svc); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+// UpdateService POSTs the supplied service JSON to /service/update. The
+// caller is responsible for ensuring svc is a complete, valid service
+// document (typically produced by GetService + targeted field mutations,
+// not constructed from scratch).
+func (c *Client) UpdateService(ctx context.Context, svc map[string]any) (map[string]any, error) {
+	var updated map[string]any
+	if err := c.do(ctx, http.MethodPost, "/service/update", svc, &updated); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// ListClients returns the slice of clients registered in this service.
+// Order is Authlete-determined; callers should not rely on it.
+func (c *Client) ListClients(ctx context.Context) ([]map[string]any, error) {
+	var resp struct {
+		TotalCount int              `json:"totalCount"`
+		Clients    []map[string]any `json:"clients"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/client/get/list", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Clients, nil
+}
+
+// CreateClient registers a new OAuth client in the service and returns
+// the created client (including Authlete-assigned numeric clientId and
+// the generated clientSecret). The input must satisfy Authlete's client
+// schema — minimum fields: clientName, clientType.
+func (c *Client) CreateClient(ctx context.Context, client map[string]any) (map[string]any, error) {
+	var created map[string]any
+	if err := c.do(ctx, http.MethodPost, "/client/create", client, &created); err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+// UpdateClient persists changes to an existing client. The full client
+// JSON must be supplied (typically produced by ListClients + targeted
+// field mutations) — Authlete replaces the stored client with the
+// supplied document.
+func (c *Client) UpdateClient(ctx context.Context, clientID int64, client map[string]any) (map[string]any, error) {
+	var updated map[string]any
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/client/update/%d", clientID), client, &updated); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// DeleteClient removes the client with the given numeric clientId from
+// the service. Authlete returns 204 on success and 4xx if the client
+// does not exist — both surface to the caller, who is expected to know
+// whether the client should exist.
+func (c *Client) DeleteClient(ctx context.Context, clientID int64) error {
+	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/client/delete/%d", clientID), nil, nil)
+}
+
+// do issues a request to /api/{serviceID}{path} with Bearer auth. body
+// is JSON-encoded when non-nil; out is JSON-decoded from the response
+// body when non-nil. Non-2xx responses produce an ErrAuthleteAPI-wrapped
+// error carrying the status and body for diagnostic context.
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	url := fmt.Sprintf("%s/api/%s%s", c.BaseURL, c.ServiceID, path)
+	var reqBody io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal %s body: %w", path, err)
+		}
+		reqBody = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return fmt.Errorf("build %s %s: %w", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, url, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%w: %s %s returned %d: %s",
+			ErrAuthleteAPI, method, path, resp.StatusCode, string(respBody))
+	}
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("decode %s response: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}

--- a/tests/authlete/provisioner/deprovision.go
+++ b/tests/authlete/provisioner/deprovision.go
@@ -1,0 +1,94 @@
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Deprovision restores the Authlete service to its pre-provision state
+// using the snapshot Provision wrote. It performs the inverse of each
+// provision step:
+//
+//  1. Deletes the introspector client (if Provision created one).
+//  2. Restores supportedAuthorizationDetailsTypes to its prior value
+//     (which may be nil — Authlete treats absent as empty).
+//  3. Restores jwks + accessTokenSignAlg if Provision generated them.
+//
+// Idempotent: re-running on a deprovisioned service is a no-op (the
+// snapshot is removed after a successful restore so subsequent calls
+// have nothing to act on).
+//
+// Returns ErrSnapshotNotFound when the snapshot file is missing —
+// typically means provision wasn't run, OR a previous deprovision
+// already cleaned up. Caller decides whether that's an error.
+func (p *Provisioner) Deprovision(ctx context.Context) error {
+	snap, err := readSnapshot(p.Opts.SnapshotPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrSnapshotNotFound
+		}
+		return fmt.Errorf("read snapshot: %w", err)
+	}
+
+	// Restore the test client's authorizationDetailsTypes (Authlete
+	// enforces declared-types on the client; provision extended this
+	// list and we revert to the prior state).
+	if snap.TestClientID != 0 {
+		clients, err := p.Client.ListClients(ctx)
+		if err != nil {
+			return fmt.Errorf("list clients: %w", err)
+		}
+		for _, c := range clients {
+			cid, _ := toInt64(c["clientId"])
+			if cid != snap.TestClientID {
+				continue
+			}
+			if snap.HadClientRARTypes {
+				c["authorizationDetailsTypes"] = snap.PriorClientRARTypes
+			} else {
+				delete(c, "authorizationDetailsTypes")
+			}
+			if _, err := p.Client.UpdateClient(ctx, cid, c); err != nil {
+				return fmt.Errorf("restore test client %d: %w", cid, err)
+			}
+			break
+		}
+	}
+
+	svc, err := p.Client.GetService(ctx)
+	if err != nil {
+		return fmt.Errorf("get service: %w", err)
+	}
+
+	// Restore RAR types — set back to nil if Authlete didn't have the
+	// field at all (vs explicitly empty array).
+	if snap.HadRARTypes {
+		svc["supportedAuthorizationDetailsTypes"] = snap.PriorRARTypes
+	} else {
+		delete(svc, "supportedAuthorizationDetailsTypes")
+	}
+
+	// Restore JWKS — only if we generated it (snap.HadJWKS=false means
+	// pre-provision state was no-JWKS; clear the field we set).
+	if !snap.HadJWKS {
+		delete(svc, "jwks")
+	} else {
+		svc["jwks"] = snap.JWKS
+	}
+
+	if _, err := p.Client.UpdateService(ctx, svc); err != nil {
+		return fmt.Errorf("restore service: %w", err)
+	}
+
+	// Remove snapshot last — if restore succeeded the file is stale;
+	// if it failed we want it around for the next attempt.
+	_ = os.Remove(p.Opts.SnapshotPath)
+	return nil
+}
+
+// ErrSnapshotNotFound is returned by Deprovision when no snapshot file
+// exists at Opts.SnapshotPath. Distinguishes "nothing to roll back"
+// from genuine restore failures.
+var ErrSnapshotNotFound = errors.New("provisioner snapshot not found (run Provision first)")

--- a/tests/authlete/provisioner/jwks.go
+++ b/tests/authlete/provisioner/jwks.go
@@ -1,0 +1,74 @@
+package provisioner
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// generateRSAJWKSet produces a JWK Set JSON string containing a single
+// freshly-generated RSA-2048 private key suitable for Authlete's `jwks`
+// service field. Authlete needs the PRIVATE key parameters (d, p, q,
+// dp, dq, qi) so it can sign tokens — the existing utils.RSAPublicKeyToJWK
+// only emits the public half. The returned string is what Authlete's
+// service.update API expects: a JSON document with a top-level "keys"
+// array containing one JWK object.
+//
+// alg is one of RS256/RS384/RS512 (controls the alg claim on each key);
+// kid is the key identifier embedded in tokens' JWT headers and exposed
+// via the JWKS endpoint.
+func generateRSAJWKSet(kid, alg string) (string, *rsa.PrivateKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate RSA key: %w", err)
+	}
+	jwk := rsaPrivateKeyToJWK(kid, alg, priv)
+	set := map[string]any{"keys": []any{jwk}}
+	buf, err := json.Marshal(set)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal JWK set: %w", err)
+	}
+	return string(buf), priv, nil
+}
+
+// rsaPrivateKeyToJWK serializes an RSA private key to its RFC 7518 JWK
+// representation. All numeric components are base64url-encoded with no
+// padding, per RFC 7515 §2.
+func rsaPrivateKeyToJWK(kid, alg string, priv *rsa.PrivateKey) map[string]any {
+	priv.Precompute() // ensure Dp/Dq/Qinv are populated for the JWK output
+	return map[string]any{
+		"kty": "RSA",
+		"use": "sig",
+		"alg": alg,
+		"kid": kid,
+		"n":   b64u(priv.N.Bytes()),
+		"e":   b64u(big2b(int64(priv.E))),
+		"d":   b64u(priv.D.Bytes()),
+		"p":   b64u(priv.Primes[0].Bytes()),
+		"q":   b64u(priv.Primes[1].Bytes()),
+		"dp":  b64u(priv.Precomputed.Dp.Bytes()),
+		"dq":  b64u(priv.Precomputed.Dq.Bytes()),
+		"qi":  b64u(priv.Precomputed.Qinv.Bytes()),
+	}
+}
+
+func b64u(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// big2b emits the minimal big-endian byte representation of a positive
+// int64. RSA's public exponent E (usually 65537) needs to be encoded
+// without leading zeros per the JWK spec.
+func big2b(n int64) []byte {
+	if n == 0 {
+		return []byte{0}
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte(n & 0xff)}, b...)
+		n >>= 8
+	}
+	return b
+}

--- a/tests/authlete/provisioner/provision.go
+++ b/tests/authlete/provisioner/provision.go
@@ -1,0 +1,291 @@
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Options configures a single Provision/Deprovision run. Sensible
+// defaults for the tests/authlete suite are applied by Defaults().
+type Options struct {
+	// SignAlg controls which signing algorithm Authlete will use for
+	// access tokens. Authlete only emits JWTs (vs opaque tokens) when
+	// both accessTokenSignAlg and jwks are set on the service.
+	SignAlg string
+
+	// RARTypes are the values added to the service's supported AD types
+	// AND to the TestClient's per-client allowlist (Authlete enforces
+	// both). Idempotent: types already present are not duplicated.
+	RARTypes []string
+
+	// TestClientAlias is the clientIdAlias of the OAuth client used by
+	// the test suite (typically "TestClientId"). Provisioner extends
+	// this client's authorizationDetailsTypes when adding RAR types —
+	// Authlete rejects RAR requests for types the *client* hasn't
+	// declared, even when the *service* allows them.
+	TestClientAlias string
+
+	// SnapshotPath is the file where the pre-provision state is persisted,
+	// enabling Deprovision to restore it.
+	SnapshotPath string
+}
+
+// Defaults returns Options with sensible values for the standard
+// tests/authlete invocation. snapshotDir is typically
+// tests/authlete/.frontend (gitignored).
+//
+// Note: introspection credentials are NOT provisioned — the java-oauth-
+// server frontend ships with a hardcoded resource server `rs0`/`rs0-secret`
+// in its bundled /resource_servers.json. The interop test uses those creds
+// directly. If a future Authlete frontend deployment uses different RS
+// credentials, set AUTHLETE_INTROSPECTOR_CLIENTID/SECRET in env to override.
+func Defaults(snapshotDir string) Options {
+	return Options{
+		SignAlg:         "RS256",
+		RARTypes:        []string{"payment_initiation"},
+		TestClientAlias: "TestClientId",
+		SnapshotPath:    filepath.Join(snapshotDir, ".preprovision.json"),
+	}
+}
+
+// Snapshot captures the slice of pre-provision state we need to restore
+// on deprovision. We do NOT snapshot the entire service blob (it's huge
+// and most fields are operator-managed) — only the fields we mutate, so
+// restore is a precise rollback rather than a wholesale overwrite that
+// could wipe out concurrent operator changes.
+type Snapshot struct {
+	HadJWKS              bool     `json:"had_jwks"`
+	JWKS                 string   `json:"jwks,omitempty"`
+	PriorRARTypes        []string `json:"prior_rar_types"`
+	HadRARTypes          bool     `json:"had_rar_types"`
+	TestClientID         int64    `json:"test_client_id,omitempty"`
+	PriorClientRARTypes  []string `json:"prior_client_rar_types"`
+	HadClientRARTypes    bool     `json:"had_client_rar_types"`
+}
+
+// ProvisionReport summarizes what the provisioner did. Status is one of
+// "provisioned" (mutations applied) or "already-provisioned" (idempotent
+// no-op).
+type ProvisionReport struct {
+	Status              string
+	JWKSGenerated       bool
+	RARTypesAdded       []string
+	ClientRARTypesAdded []string
+}
+
+// Provisioner orchestrates the idempotent service-configuration changes
+// needed to flip the tests/authlete suite's SKIPs into PASSes.
+type Provisioner struct {
+	Client *Client
+	Opts   Options
+}
+
+// Provision applies the configuration needed for the interop suite. It
+// is idempotent: re-running on an already-provisioned service produces
+// no further mutations and reports status "already-provisioned".
+//
+// Mutations applied in order:
+//  1. Generate an RSA JWK Set + set the service's `jwks` + `accessTokenSignAlg`
+//     fields, so Authlete signs JWTs instead of returning opaque tokens.
+//  2. Add Opts.RARTypes to `supportedAuthorizationDetailsTypes`,
+//     enabling the RAR round-trip test.
+//  3. Register an introspector client (clientType=CONFIDENTIAL,
+//     tokenAuthMethod=CLIENT_SECRET_BASIC) and write its credentials to
+//     Opts.EnvFilePath for the test to consume.
+//
+// A snapshot of the pre-mutation state is written to Opts.SnapshotPath
+// before any change so Deprovision can roll back.
+func (p *Provisioner) Provision(ctx context.Context) (*ProvisionReport, error) {
+	svc, err := p.Client.GetService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get service: %w", err)
+	}
+
+	report := &ProvisionReport{Status: "provisioned"}
+	snapshot := Snapshot{}
+	mutated := false
+
+	// 1. JWKS — Authlete won't emit JWTs without one.
+	if existing, _ := svc["jwks"].(string); existing == "" {
+		kid := fmt.Sprintf("oneauth-test-%s-%d", p.Opts.SignAlg, time.Now().Unix())
+		jwkSet, _, err := generateRSAJWKSet(kid, p.Opts.SignAlg)
+		if err != nil {
+			return nil, fmt.Errorf("generate JWKS: %w", err)
+		}
+		svc["jwks"] = jwkSet
+		svc["accessTokenSignAlg"] = p.Opts.SignAlg
+		report.JWKSGenerated = true
+		mutated = true
+	} else {
+		snapshot.HadJWKS = true
+		snapshot.JWKS = existing
+	}
+
+	// 2. RAR types — additive; only add what's missing.
+	currentRARTypes := stringsField(svc, "supportedAuthorizationDetailsTypes")
+	snapshot.PriorRARTypes = currentRARTypes
+	snapshot.HadRARTypes = svc["supportedAuthorizationDetailsTypes"] != nil
+	added := unionMissing(currentRARTypes, p.Opts.RARTypes)
+	if len(added) > 0 {
+		svc["supportedAuthorizationDetailsTypes"] = append(currentRARTypes, added...)
+		report.RARTypesAdded = added
+		mutated = true
+	}
+
+	if mutated {
+		if _, err := p.Client.UpdateService(ctx, svc); err != nil {
+			return nil, fmt.Errorf("update service: %w", err)
+		}
+	}
+
+	// 3. TestClient RAR types — Authlete enforces declared-types on
+	// the CLIENT in addition to the service. A token request that
+	// includes authorization_details for a type the client hasn't
+	// declared returns A249303 ("the client has not declared it may
+	// use the type"), even when the service supports it.
+	clientReport, err := p.updateTestClientRARTypes(ctx, &snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("update test client RAR types: %w", err)
+	}
+	if len(clientReport) > 0 {
+		report.ClientRARTypesAdded = clientReport
+		mutated = true
+	}
+
+	if !mutated {
+		report.Status = "already-provisioned"
+	}
+
+	// Persist snapshot so Deprovision has a rollback target.
+	if err := writeSnapshot(p.Opts.SnapshotPath, &snapshot); err != nil {
+		return nil, fmt.Errorf("write snapshot: %w", err)
+	}
+
+	return report, nil
+}
+
+// updateTestClientRARTypes finds the configured TestClient and extends
+// its authorizationDetailsTypes with any RARTypes the client doesn't
+// already declare. Returns the slice of added types (empty when no-op).
+// Snapshots the client's prior state so Deprovision can restore.
+func (p *Provisioner) updateTestClientRARTypes(ctx context.Context, snapshot *Snapshot) ([]string, error) {
+	clients, err := p.Client.ListClients(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list clients: %w", err)
+	}
+	var testClient map[string]any
+	for _, c := range clients {
+		if stringField(c, "clientIdAlias") == p.Opts.TestClientAlias {
+			testClient = c
+			break
+		}
+	}
+	if testClient == nil {
+		return nil, fmt.Errorf("test client with alias %q not found in service", p.Opts.TestClientAlias)
+	}
+	clientID, _ := toInt64(testClient["clientId"])
+	snapshot.TestClientID = clientID
+
+	current := stringsField(testClient, "authorizationDetailsTypes")
+	snapshot.PriorClientRARTypes = current
+	snapshot.HadClientRARTypes = testClient["authorizationDetailsTypes"] != nil
+	added := unionMissing(current, p.Opts.RARTypes)
+	if len(added) == 0 {
+		return nil, nil
+	}
+	testClient["authorizationDetailsTypes"] = append(current, added...)
+	if _, err := p.Client.UpdateClient(ctx, clientID, testClient); err != nil {
+		return nil, fmt.Errorf("update test client %d: %w", clientID, err)
+	}
+	return added, nil
+}
+
+
+// stringsField extracts a []string from a JSON-decoded map. Authlete
+// returns array fields as []any (decoded from JSON arrays); we coerce
+// per-element back to string, skipping non-strings (which shouldn't
+// occur for these fields but defensive coding is cheap here).
+func stringsField(m map[string]any, key string) []string {
+	raw, ok := m[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func stringField(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+// toInt64 coerces a JSON-decoded numeric field to int64. encoding/json
+// decodes JSON numbers as float64 by default; Authlete client IDs are
+// integers but arrive as float64s when the response is JSON-decoded.
+// Test fixtures may inject untyped int literals into map[string]any
+// (Go's default integer type is int), so we accept those too.
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	}
+	return 0, false
+}
+
+// unionMissing returns the elements of want not already present in have.
+// Preserves want's order; assumes neither slice has internal duplicates.
+func unionMissing(have, want []string) []string {
+	set := make(map[string]struct{}, len(have))
+	for _, h := range have {
+		set[h] = struct{}{}
+	}
+	var added []string
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			added = append(added, w)
+		}
+	}
+	return added
+}
+
+func writeSnapshot(path string, snap *Snapshot) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	buf, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf, 0o600)
+}
+
+func readSnapshot(path string) (*Snapshot, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var snap Snapshot
+	if err := json.Unmarshal(buf, &snap); err != nil {
+		return nil, fmt.Errorf("parse snapshot %s: %w", path, err)
+	}
+	return &snap, nil
+}
+

--- a/tests/authlete/provisioner/provision_test.go
+++ b/tests/authlete/provisioner/provision_test.go
@@ -1,0 +1,297 @@
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAuthlete is an in-memory mock of the Authlete V3 management API.
+// It tracks the service state across requests so tests can verify the
+// provisioner's idempotency and snapshot/restore semantics without
+// touching the real Authlete cloud.
+type fakeAuthlete struct {
+	serviceID string
+	service   map[string]any
+	clients   []map[string]any
+	nextID    atomic.Int64
+	calls     atomic.Int64
+}
+
+func newFakeAuthlete(serviceID string) *fakeAuthlete {
+	f := &fakeAuthlete{
+		serviceID: serviceID,
+		service: map[string]any{
+			"apiKey":             3547200388,
+			"serviceName":        "TestService",
+			"accessTokenSignAlg": "RS256",
+			// jwks deliberately absent — provision should add it
+			// supportedAuthorizationDetailsTypes deliberately absent
+		},
+		// Pre-existing TestClient — Authlete services come with at
+		// least one OAuth client registered. Provision must extend
+		// this client's authorizationDetailsTypes when adding RAR
+		// types to the service.
+		clients: []map[string]any{
+			{
+				"clientId":       1506059443,
+				"clientIdAlias":  "TestClientId",
+				"clientType":     "CONFIDENTIAL",
+			},
+		},
+	}
+	f.nextID.Store(2000000000)
+	return f
+}
+
+func (f *fakeAuthlete) handler() http.Handler {
+	mux := http.NewServeMux()
+	base := "/api/" + f.serviceID
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Surface unrouted requests with a useful diagnostic so test failures
+		// don't masquerade as Authlete-side errors.
+		http.Error(w, "fakeAuthlete: no handler for "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+	})
+
+	mux.HandleFunc(base+"/service/get", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		_ = json.NewEncoder(w).Encode(f.service)
+	})
+
+	mux.HandleFunc(base+"/service/update", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var svc map[string]any
+		_ = json.Unmarshal(body, &svc)
+		f.service = svc
+		_ = json.NewEncoder(w).Encode(svc)
+	})
+
+	mux.HandleFunc(base+"/client/get/list", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"totalCount": len(f.clients),
+			"clients":    f.clients,
+		})
+	})
+
+	mux.HandleFunc(base+"/client/create", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var client map[string]any
+		_ = json.Unmarshal(body, &client)
+		client["clientId"] = f.nextID.Add(1)
+		client["clientSecret"] = "fake-secret-" + client["clientName"].(string)
+		f.clients = append(f.clients, client)
+		_ = json.NewEncoder(w).Encode(client)
+	})
+
+	mux.HandleFunc(base+"/client/update/", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		id := strings.TrimPrefix(r.URL.Path, base+"/client/update/")
+		body, _ := io.ReadAll(r.Body)
+		var updated map[string]any
+		_ = json.Unmarshal(body, &updated)
+		for i, c := range f.clients {
+			cid, _ := toInt64(c["clientId"])
+			if cidStr(cid) == id {
+				f.clients[i] = updated
+				_ = json.NewEncoder(w).Encode(updated)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	})
+
+	mux.HandleFunc(base+"/client/delete/", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		// path-prefix match; extract trailing ID
+		id := strings.TrimPrefix(r.URL.Path, base+"/client/delete/")
+		filtered := f.clients[:0]
+		for _, c := range f.clients {
+			cid, _ := toInt64(c["clientId"])
+			if cidStr(cid) != id {
+				filtered = append(filtered, c)
+			}
+		}
+		f.clients = filtered
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	return mux
+}
+
+func cidStr(id int64) string {
+	// strconv.FormatInt without an import — tiny inline.
+	if id == 0 {
+		return "0"
+	}
+	var b []byte
+	neg := id < 0
+	if neg {
+		id = -id
+	}
+	for id > 0 {
+		b = append([]byte{byte('0' + id%10)}, b...)
+		id /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func newTestProvisioner(t *testing.T) (*Provisioner, *fakeAuthlete) {
+	t.Helper()
+	fake := newFakeAuthlete("3547200388")
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	tmp := t.TempDir()
+	return &Provisioner{
+		Client: &Client{
+			BaseURL:     srv.URL,
+			ServiceID:   "3547200388",
+			AccessToken: "fake-token",
+			HTTPClient:  srv.Client(),
+		},
+		Opts: Options{
+			SignAlg:         "RS256",
+			RARTypes:        []string{"payment_initiation"},
+			TestClientAlias: "TestClientId",
+			SnapshotPath:    filepath.Join(tmp, ".preprovision.json"),
+		},
+	}, fake
+}
+
+// TestProvision_FreshService verifies that a vanilla Authlete service
+// (no JWKS, no RAR types) gets both the service-level + client-level
+// mutations applied in one Provision call.
+func TestProvision_FreshService(t *testing.T) {
+	p, fake := newTestProvisioner(t)
+
+	report, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "provisioned", report.Status)
+	assert.True(t, report.JWKSGenerated)
+	assert.Equal(t, []string{"payment_initiation"}, report.RARTypesAdded)
+	assert.Equal(t, []string{"payment_initiation"}, report.ClientRARTypesAdded)
+
+	// Service-level mutations landed
+	assert.NotEmpty(t, fake.service["jwks"], "service should have JWKS after provision")
+	assert.Equal(t, "RS256", fake.service["accessTokenSignAlg"])
+	rarTypes := stringsField(fake.service, "supportedAuthorizationDetailsTypes")
+	assert.Contains(t, rarTypes, "payment_initiation")
+
+	// Client-level mutation landed — the pre-existing TestClient now declares the RAR type
+	require.Len(t, fake.clients, 1)
+	clientRARTypes := stringsField(fake.clients[0], "authorizationDetailsTypes")
+	assert.Contains(t, clientRARTypes, "payment_initiation",
+		"TestClient must have payment_initiation declared (Authlete A249303 otherwise)")
+
+	// Snapshot persisted
+	_, err = readSnapshot(p.Opts.SnapshotPath)
+	assert.NoError(t, err, "snapshot file should be readable post-provision")
+}
+
+// TestProvision_Idempotent verifies the recommended invariant: running
+// provision twice on the same service produces no additional mutations
+// on the second run, and reports "already-provisioned".
+func TestProvision_Idempotent(t *testing.T) {
+	p, fake := newTestProvisioner(t)
+
+	_, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	clientsAfterFirst := len(fake.clients)
+	jwksAfterFirst := fake.service["jwks"]
+
+	report, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "already-provisioned", report.Status,
+		"second provision must detect existing state and report no-op")
+	assert.Len(t, fake.clients, clientsAfterFirst, "no new clients on second provision")
+	assert.Equal(t, jwksAfterFirst, fake.service["jwks"], "JWKS not regenerated on second provision")
+}
+
+// TestDeprovision_RestoresSnapshot verifies the inverse path: after
+// provision mutates the service + TestClient, deprovision returns
+// both to the pre-provision state (JWKS gone, service RAR types gone,
+// client RAR types gone). The TestClient itself is NOT deleted — it
+// was pre-existing and provision only added to its RAR types list.
+func TestDeprovision_RestoresSnapshot(t *testing.T) {
+	p, fake := newTestProvisioner(t)
+
+	_, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, fake.service["jwks"])
+	require.Len(t, fake.clients, 1)
+
+	err = p.Deprovision(context.Background())
+	require.NoError(t, err)
+
+	_, hasJWKS := fake.service["jwks"]
+	assert.False(t, hasJWKS, "JWKS should be removed by deprovision")
+	_, hasRAR := fake.service["supportedAuthorizationDetailsTypes"]
+	assert.False(t, hasRAR, "service RAR types field should be removed")
+	require.Len(t, fake.clients, 1, "TestClient stays (we only added to its RAR types, not created it)")
+	_, hasClientRAR := fake.clients[0]["authorizationDetailsTypes"]
+	assert.False(t, hasClientRAR, "TestClient's authorizationDetailsTypes field should be removed")
+}
+
+// TestDeprovision_PreservesOperatorRARTypes verifies that when the
+// operator had pre-existing RAR types, deprovision restores them (not
+// removes the field entirely). Catches the bug where we'd otherwise
+// nuke operator config we never touched.
+func TestDeprovision_PreservesOperatorRARTypes(t *testing.T) {
+	p, fake := newTestProvisioner(t)
+	// Pre-existing operator config: a different RAR type already registered.
+	fake.service["supportedAuthorizationDetailsTypes"] = []any{"operator_only_type"}
+
+	_, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	rarAfter := stringsField(fake.service, "supportedAuthorizationDetailsTypes")
+	assert.ElementsMatch(t, []string{"operator_only_type", "payment_initiation"}, rarAfter,
+		"provision should add our type alongside operator's, not replace")
+
+	err = p.Deprovision(context.Background())
+	require.NoError(t, err)
+	rarFinal := stringsField(fake.service, "supportedAuthorizationDetailsTypes")
+	assert.ElementsMatch(t, []string{"operator_only_type"}, rarFinal,
+		"deprovision should leave operator's type intact, remove only ours")
+}
+
+// TestDeprovision_PreservesOperatorJWKS verifies the operator-JWKS
+// counterpart: when the service already had a JWKS (operator-managed),
+// provision must NOT regenerate, and deprovision must NOT remove it.
+func TestDeprovision_PreservesOperatorJWKS(t *testing.T) {
+	p, fake := newTestProvisioner(t)
+	operatorJWKS := `{"keys":[{"kid":"operator-key","kty":"RSA"}]}`
+	fake.service["jwks"] = operatorJWKS
+
+	report, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	assert.False(t, report.JWKSGenerated, "provision should not regenerate when operator JWKS present")
+	assert.Equal(t, operatorJWKS, fake.service["jwks"], "operator JWKS preserved through provision")
+
+	err = p.Deprovision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, operatorJWKS, fake.service["jwks"], "operator JWKS preserved through deprovision")
+}
+
+// TestDeprovision_MissingSnapshot returns ErrSnapshotNotFound so the
+// CLI can distinguish "nothing to roll back" from genuine API failures.
+func TestDeprovision_MissingSnapshot(t *testing.T) {
+	p, _ := newTestProvisioner(t)
+	err := p.Deprovision(context.Background())
+	assert.ErrorIs(t, err, ErrSnapshotNotFound,
+		"absent snapshot should surface as ErrSnapshotNotFound")
+}

--- a/tests/authlete/testutil_test.go
+++ b/tests/authlete/testutil_test.go
@@ -26,6 +26,16 @@ import (
 	"github.com/panyam/oneauth/testutil"
 )
 
+// java-oauth-server ships a hardcoded resource server in its bundled
+// /resource_servers.json that the /api/introspection endpoint
+// authenticates against. We use those creds by default — the user can
+// override with AUTHLETE_INTROSPECTOR_CLIENTID/SECRET if their frontend
+// has a different RS registered.
+const (
+	defaultIntrospectorClientID     = "rs0"
+	defaultIntrospectorClientSecret = "rs0-secret"
+)
+
 const (
 	defaultAuthleteASURL = "http://localhost:8280"
 
@@ -77,6 +87,56 @@ func authleteClientID() string {
 // client_id above. Empty when AUTHLETE_CLIENTSECRET is unset.
 func authleteClientSecret() string {
 	return os.Getenv("AUTHLETE_CLIENTSECRET")
+}
+
+// introspectorClientID returns the resource-server credential used to
+// authenticate RFC 7662 introspection calls against java-oauth-server's
+// /api/introspection endpoint. Defaults to the frontend's built-in
+// rs0/rs0-secret (hardcoded in the container's /resource_servers.json);
+// overridable via AUTHLETE_INTROSPECTOR_CLIENTID for non-default frontends.
+//
+// Note: this is NOT an OAuth client_id in the conventional sense —
+// java-oauth-server's introspection endpoint uses a separate "resource
+// server" identity registered in a static JSON file, not the Authlete
+// service's client database.
+func introspectorClientID() string {
+	if v := os.Getenv("AUTHLETE_INTROSPECTOR_CLIENTID"); v != "" {
+		return v
+	}
+	return defaultIntrospectorClientID
+}
+
+// introspectorClientSecret pairs with introspectorClientID. Defaults to
+// the frontend's built-in rs0-secret; overridable via env.
+func introspectorClientSecret() string {
+	if v := os.Getenv("AUTHLETE_INTROSPECTOR_CLIENTSECRET"); v != "" {
+		return v
+	}
+	return defaultIntrospectorClientSecret
+}
+
+// matrixAlgs returns the signing algorithms tests should exercise.
+// When AUTHLETE_TEST_ALGS is set (comma-separated, e.g. "RS256,ES256"),
+// returns those algs. When unset, returns a single-element slice with
+// the empty string — meaning "use whatever the service is provisioned
+// for, no per-alg loop". Callers wrap alg-sensitive assertions in
+// t.Run(alg, ...) when len(matrixAlgs()) > 1 or when entry != "".
+func matrixAlgs() []string {
+	raw := os.Getenv("AUTHLETE_TEST_ALGS")
+	if raw == "" {
+		return []string{""}
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return []string{""}
+	}
+	return out
 }
 
 // skipIfAuthleteNotConfigured skips the test unless:


### PR DESCRIPTION
## What changes

PR 240 (issue 162) shipped the Authlete interop suite but 4 of its 7 tests skip on a vanilla Authlete service because the service config lacks the required pieces (JWKS for asymmetric tokens, supported RAR types on both service and client). Each SKIP carried an actionable message but acting on them meant 5-10 minutes of console clicking — bad DX for "just run the suite."

This PR automates that via a `make authlete-provision` target that uses Authlete's management REST API (we already have `AUTHLETE_ACCESS_TOKEN` with service-management privilege) to apply the missing config. Idempotent, reversible via `make authlete-deprovision`.

Closes issue 244 phase 1 (provisioning automation). Phase 2 (multi-alg matrix mode) deferred to a successor ticket — the matrix-loop complexity is enough that splitting keeps both PRs reviewable. The `matrixAlgs()` helper stays as a documented seam.

## Before / after (against the user's live us.authlete.com tenant)

```
                                  Before this PR    After `make authlete-provision`
                                  --------------    --------------------------------
TestAuthlete_OIDCDiscovery         PASS              PASS
TestAuthlete_DiscoverAS_Integ.     PASS              PASS
TestAuthlete_JWKSFetchAndToken*    SKIP (opaque)     SKIP (sub:null — see below)
TestAuthlete_JWKS_ParseableBy*     SKIP (no keys)    PASS
TestAuthlete_RARRoundTrip          SKIP (no type)    PASS
TestAuthlete_IntrospectionResp.*   SKIP (no auth)    PASS
TestAuthlete_AlgorithmConfusion    SKIP (opaque)     PASS

Total                              3 PASS + 4 SKIP   6 PASS + 1 SKIP
```

The remaining SKIP is a documented interop wrinkle (Authlete's client_credentials grant emits `sub:null` and `APIMiddleware` correctly rejects sub-less tokens). Not something the provisioner can fix without changing the grant type.

## Reviewer's guide

Read in this order:
1. [tests/authlete/README.md](https://github.com/panyam/oneauth/pull/247/files#diff-457f8e64d8890aa1448c3e58a0cb47b3ab776dae6b7f14bcf861976e155f994d) — start here. New "What `make authlete-provision` does" section + revised expected-result table.
2. [tests/authlete/provisioner/provision.go](https://github.com/panyam/oneauth/pull/247/files#diff-ebe489cd77ba1806ca8618a6d04006a53ddfaec86d3488f620fc158a351c2713) — the idempotent ensurer. Worth scrutinizing: the JWKS-only-when-missing branch (preserves operator-managed keys), the additive RAR-type union (preserves operator RAR types), the per-client RAR plumbing (Authlete enforces on both service and client — A249303 otherwise).
3. [tests/authlete/provisioner/deprovision.go](https://github.com/panyam/oneauth/pull/247/files#diff-6276bf036ab7c60494d3802a5c77291e5c7dcdbbc9400bcd803c2bb72c2ea6f8) — snapshot-based restore.
4. [tests/authlete/provisioner/provision_test.go](https://github.com/panyam/oneauth/pull/247/files#diff-93a0bd668d714571cfab4879f2e4c31bb2657b96ceb9be05e518160c66a9851f) — 6 unit tests against an httptest.NewServer mock. Acceptance for the above; covers idempotency, snapshot/restore, and `TestDeprovision_PreservesOperator*` (catches the bug where we'd wipe operator config we never touched).
5. [tests/authlete/provisioner/client.go](https://github.com/panyam/oneauth/pull/247/files#diff-da4bcf1c325661f78677aca0f90a4fd2784dece73c1fcc55bb753f3cc57c9a48) — thin REST client for the 5 Authlete management endpoints we use.
6. [tests/authlete/provisioner/jwks.go](https://github.com/panyam/oneauth/pull/247/files#diff-c722a6f9fbbc3336d5e9b20bcdd8cbf9d74bf71fc1ffc397dfa01a3a06f27ae7) — RSA-2048 + JWK Set generation. Authlete's `jwks` field needs the PRIVATE key (Authlete signs server-side); the existing `utils.RSAPublicKeyToJWK` only emits the public half.
7. [Makefile](https://github.com/panyam/oneauth/pull/247/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — new `authlete-provision` + `authlete-deprovision` targets (paralleling `upauthlete` / `downauthlete`).
8. [tests/authlete/cmd/provision/main.go](https://github.com/panyam/oneauth/pull/247/files#diff-b9732a61cb88c221c9c5834e0d216f538465f3fca41037ad63f85e16d7d5f80f) + [tests/authlete/cmd/deprovision/main.go](https://github.com/panyam/oneauth/pull/247/files#diff-5bedfa6d47dc4d77da503e01ec9e05211933d2c9376b6040a149f8b3839f9d37) — CLI wrappers, thin.
9. [tests/authlete/testutil_test.go](https://github.com/panyam/oneauth/pull/247/files#diff-5a2a3e580c4a366812c354ea3ee01ff96bd7ba0e5ad1ee4dbdd567bf0e493052) — hardcoded `rs0`/`rs0-secret` defaults for the introspector (the java-oauth-server container ships these in its built-in `/resource_servers.json` — no Authlete-side provisioning needed for introspection).
10. [tests/authlete/interop_test.go](https://github.com/panyam/oneauth/pull/247/files#diff-f66c51dd8af2d5f6338c3fcb2739d9f6d6e12face8318f80e75e2349927148c7) — graceful skip on `sub:null` tokens.

Skim or skip: `tests/authlete/go.sum` (generated).

## Decision log

- **Provisioner in Go (not shell-in-Makefile).** Idempotency state-diffs and JSON manipulation are dramatically cleaner in Go. Reuses the sub-module's deps; no new dependencies.
- **Snapshot-based revert, not marker-based.** At provision time we capture the precise pre-mutation state (had-jwks?, prior RAR types, prior client RAR types) and restore from that. Cleaner than scanning for "things we created" — handles edge cases (operator manually added a RAR type between provision and deprovision: we restore to what they had, not what we did).
- **Introspector uses java-oauth-server's built-in `rs0`/`rs0-secret`, not a freshly-provisioned Authlete client.** Spent ~30 min debugging why a provisioned OAuth client kept returning 401 from `/api/introspection` before realizing the upstream frontend authenticates introspection against a static `resource_servers.json` baked into the container — completely separate from Authlete's client database. Using the built-in `rs0` is one line of testutil change vs ~100 lines of provisioner code (with no upside, since the resource_servers.json isn't accessible via Authlete's API anyway).
- **`int` added to `toInt64` switch.** Fixture maps that use untyped integer literals (Go's `int`) wouldn't match the prior switch (only `int64`/`float64`/`json.Number`). Defensive coercion is cheap; alternative was forcing every test fixture to type-annotate, which is noisy.
- **Phase 2 (matrix mode) split out.** Looping the alg-sensitive tests across `AUTHLETE_TEST_ALGS=RS256,ES256,...` requires per-iteration container restart (for JWKS refresh), snapshot churn, and ~100+ lines of new test plumbing. Phase 1 already solves the immediate DX gap. Split keeps both PRs reviewable. Successor ticket to follow.

## Risk / blast radius

- **Affects:** anyone running `make testauthlete` against an Authlete service. Provisioner mutates whatever service `AUTHLETE_SERVICEID` points at; safety belt via `AUTHLETE_TEST_SERVICEID` for paranoid users.
- **Tests covering this:** 6 unit tests in `provisioner/provision_test.go` + integration verification (documented in README, not in CI by default because it requires Authlete creds).
- **Red-before-green confirmed.** Idempotency-detection break → `TestProvision_Idempotent` fails (creates 2 clients instead of 1); restored impl → green.
- **Operator-config preservation tests** — `TestDeprovision_PreservesOperatorRARTypes` + `TestDeprovision_PreservesOperatorJWKS` — catch the regression where we'd otherwise wipe RAR types / JWKS that the operator manually set before provision ran.
- **Be paranoid about:** the Authlete API call shapes (`/service/update`, `/client/update/{id}`, `/client/create`). They were determined empirically against the live us.authlete.com tenant. Different Authlete regions/versions may expect slightly different fields. README documents `AUTH_API_SERVER` override.

## Verification

- `go test ./tests/authlete/provisioner/...` — 6/6 unit tests green
- `make authlete-provision && make testauthlete` against live us.authlete.com → 6 PASS + 1 SKIP
- `make authlete-deprovision` → service config matches pre-provision snapshot (verified via direct `service/get` JSON inspection)
- `make authlete-provision` ran twice in a row → idempotent, second run reports `already-provisioned`
- `go build ./...`, `go vet ./...`, `staticcheck ./...` all clean
- Full root `go test ./...` green

## Out of scope (deliberately deferred)

- **Multi-alg matrix mode** (`AUTHLETE_TEST_ALGS=RS256,ES256` looping) — phase 2 of issue 244, deferred to a successor ticket once 244 phase 1 merges.
- **JWT validation against a non-client_credentials token** — the remaining SKIP (`sub:null` interop wrinkle) flips to PASS once we add a password / auth_code grant variant. Separate test improvement.
- **Auto-provisioning encryption algs (JWE), HMAC algs in matrix, automated upstream-ref bump for `AUTH_FRONTEND_REF`** — out of scope per ticket 244's body.
