### PR TITLE
feat(apiauth): OIDC Back-Channel Logout 1.0 sender (#261)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for rationale and [docs/ROADMAP
 | `GET /.well-known/oauth-protected-resource` | `NewProtectedResourceHandler` | RFC 9728 |
 | `POST /apps/dcr` | `DCRHandler` | RFC 7591 |
 | `GET / PUT / DELETE /apps/dcr/{client_id}` | `DCRManagementHandler` | RFC 7592 |
+| AS-initiated `POST <backchannel_logout_uri>` with `logout_token` | `BCLDispatcher` + `LogoutTokenIssuer` | OIDC Back-Channel Logout 1.0 |
 | Authorize-redirect `?iss=` query param | (issuer URL on redirects) | RFC 9207 |
 | `traceparent` / `tracestate` inbound + outbound (SEP-414 / #254) | `tracing/` + per-handler `TracerProvider` | [W3C Trace Context](https://www.w3.org/TR/trace-context/) |
 

--- a/admin/dcr.go
+++ b/admin/dcr.go
@@ -77,6 +77,11 @@ type DCRRequest struct {
 
 	// Keys — for asymmetric auth methods (private_key_jwt)
 	JWKS *utils.JWKSet `json:"jwks,omitempty"`
+
+	// OIDC Back-Channel Logout 1.0 §3.1 — clients advertise a logout receiver.
+	// Empty disables BCL dispatch for this client.
+	BackchannelLogoutURI             string `json:"backchannel_logout_uri,omitempty"`
+	BackchannelLogoutSessionRequired bool   `json:"backchannel_logout_session_required,omitempty"`
 }
 
 // DCRResponse is the RFC 7591 client registration response, extended with the
@@ -101,6 +106,11 @@ type DCRResponse struct {
 	// RFC 7592 §3 — management credentials.
 	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
 	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
+
+	// OIDC Back-Channel Logout 1.0 §3.1 — echo of the registered receiver
+	// metadata so clients can confirm what the AS persisted.
+	BackchannelLogoutURI             string `json:"backchannel_logout_uri,omitempty"`
+	BackchannelLogoutSessionRequired bool   `json:"backchannel_logout_session_required,omitempty"`
 }
 
 // ServeHTTP is the HTTP wrapper for ClientRegistrar.Register (RFC 7591 DCR).

--- a/admin/dcr_bcl_test.go
+++ b/admin/dcr_bcl_test.go
@@ -1,0 +1,103 @@
+package admin_test
+
+// Tests for the OIDC Back-Channel Logout 1.0 §3.1 registration fields on the
+// DCR endpoint — backchannel_logout_uri and backchannel_logout_session_required
+// MUST round-trip through register / read / update.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html#BCRegistration
+// See: https://github.com/panyam/oneauth/issues/261
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func registerAppWithBCL(t *testing.T, body string) (handler http.Handler, registrar *admin.AppRegistrar, resp map[string]any) {
+	t.Helper()
+	ks := keys.NewInMemoryKeyStore()
+	registrar = admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	handler = registrar.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	resp = map[string]any{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	return handler, registrar, resp
+}
+
+func TestDCR_BackchannelLogout_RoundTripsThroughRegister(t *testing.T) {
+	body := `{
+		"client_name":"BCL Client",
+		"backchannel_logout_uri":"https://rs.example.com/bcl",
+		"backchannel_logout_session_required":true
+	}`
+	_, registrar, resp := registerAppWithBCL(t, body)
+
+	assert.Equal(t, "https://rs.example.com/bcl", resp["backchannel_logout_uri"])
+	assert.Equal(t, true, resp["backchannel_logout_session_required"])
+
+	// Persisted on the underlying AppRegistration too — not just echoed back.
+	clientID := resp["client_id"].(string)
+	getResp, err := registrar.Store.GetApp(context.Background(), &core.GetAppRequest{ClientID: clientID})
+	require.NoError(t, err)
+	require.NotNil(t, getResp.App)
+	assert.Equal(t, "https://rs.example.com/bcl", getResp.App.BackchannelLogoutURI)
+	assert.True(t, getResp.App.BackchannelLogoutSessionRequired)
+}
+
+func TestDCR_BackchannelLogout_HTTPOutsideLoopback_Rejected(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	handler := registrar.Handler()
+
+	body := `{"client_name":"BCL Client","backchannel_logout_uri":"http://rs.example.com/bcl"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+}
+
+func TestDCR_BackchannelLogout_FragmentRejected(t *testing.T) {
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	handler := registrar.Handler()
+
+	body := `{"client_name":"BCL Client","backchannel_logout_uri":"https://rs.example.com/bcl#frag"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+}
+
+func TestDCR_BackchannelLogout_LoopbackHTTPAllowed(t *testing.T) {
+	_, _, resp := registerAppWithBCL(t, `{
+		"client_name":"BCL Local",
+		"backchannel_logout_uri":"http://localhost:9999/bcl"
+	}`)
+	assert.Equal(t, "http://localhost:9999/bcl", resp["backchannel_logout_uri"])
+}
+
+func TestDCR_BackchannelLogout_EmptyURIDisablesDispatch(t *testing.T) {
+	_, registrar, resp := registerAppWithBCL(t, `{"client_name":"No BCL"}`)
+	clientID := resp["client_id"].(string)
+	getResp, err := registrar.Store.GetApp(context.Background(), &core.GetAppRequest{ClientID: clientID})
+	require.NoError(t, err)
+	assert.Empty(t, getResp.App.BackchannelLogoutURI)
+	assert.False(t, getResp.App.BackchannelLogoutSessionRequired)
+}

--- a/admin/dcr_bcl_test.go
+++ b/admin/dcr_bcl_test.go
@@ -59,7 +59,7 @@ func TestDCR_BackchannelLogout_RoundTripsThroughRegister(t *testing.T) {
 	assert.True(t, getResp.App.BackchannelLogoutSessionRequired)
 }
 
-func TestDCR_BackchannelLogout_HTTPOutsideLoopback_Rejected(t *testing.T) {
+func TestDCR_BackchannelLogout_PlainHTTPRejectedByDefault(t *testing.T) {
 	ks := keys.NewInMemoryKeyStore()
 	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
 	handler := registrar.Handler()
@@ -70,6 +70,46 @@ func TestDCR_BackchannelLogout_HTTPOutsideLoopback_Rejected(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+}
+
+func TestDCR_BackchannelLogout_LiteralLoopbackIPRejectedByDefault(t *testing.T) {
+	// SSRF guard: a client should not be able to register a URI that, on
+	// session revoke, makes the AS POST to localhost.
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	handler := registrar.Handler()
+
+	for _, uri := range []string{
+		"https://127.0.0.1/bcl",
+		"https://[::1]/bcl",
+		"https://10.0.0.1/bcl",
+		"https://192.168.1.1/bcl",
+		"https://169.254.169.254/bcl", // cloud metadata service
+		"https://0.0.0.0/bcl",
+	} {
+		body := `{"client_name":"BCL Client","backchannel_logout_uri":"` + uri + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusBadRequest, rr.Code, "must reject %s: %s", uri, rr.Body.String())
+	}
+}
+
+func TestDCR_BackchannelLogout_AllowPrivateHostsOptIn(t *testing.T) {
+	// Closed-network deployments can opt in by flipping
+	// AllowPrivateBCLHosts on the AppRegistrar.
+	ks := keys.NewInMemoryKeyStore()
+	registrar := admin.NewAppRegistrar(ks, admin.NewNoAuth())
+	registrar.AllowPrivateBCLHosts = true
+	handler := registrar.Handler()
+
+	body := `{"client_name":"BCL Client","backchannel_logout_uri":"http://127.0.0.1:9999/bcl"}`
+	req := httptest.NewRequest(http.MethodPost, "/apps/dcr", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
 }
 
 func TestDCR_BackchannelLogout_FragmentRejected(t *testing.T) {
@@ -85,12 +125,13 @@ func TestDCR_BackchannelLogout_FragmentRejected(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 }
 
-func TestDCR_BackchannelLogout_LoopbackHTTPAllowed(t *testing.T) {
+func TestDCR_BackchannelLogout_LiteralPublicIPAllowed(t *testing.T) {
+	// Public-IP receivers must round-trip even with the SSRF guard on.
 	_, _, resp := registerAppWithBCL(t, `{
-		"client_name":"BCL Local",
-		"backchannel_logout_uri":"http://localhost:9999/bcl"
+		"client_name":"BCL Public",
+		"backchannel_logout_uri":"https://203.0.113.5/bcl"
 	}`)
-	assert.Equal(t, "http://localhost:9999/bcl", resp["backchannel_logout_uri"])
+	assert.Equal(t, "https://203.0.113.5/bcl", resp["backchannel_logout_uri"])
 }
 
 func TestDCR_BackchannelLogout_EmptyURIDisablesDispatch(t *testing.T) {

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,12 +22,23 @@ import (
 
 // validateBackchannelLogoutURI enforces the OIDC Back-Channel Logout 1.0 §2.2
 // rule that the registered receiver URI MUST be an absolute URL with a scheme
-// component and MUST NOT contain a fragment. The spec doesn't mandate https,
-// but plain http would let an on-path attacker observe logout events for any
-// authenticated user — we therefore require https in production and only allow
-// http when the host is a loopback address (matching the redirect_uri leniency
-// applied across oneauth). Empty input is valid (BCL disabled for this client).
-func validateBackchannelLogoutURI(raw string) error {
+// component and MUST NOT contain a fragment. It is also the registration-time
+// SSRF guard: when allowPrivate is false (the default), a literal-IP host
+// MUST NOT resolve to a loopback / private / link-local / unspecified /
+// multicast address — otherwise an unauthenticated client could register a
+// URI that, on session revoke, makes the AS POST to internal services on
+// its behalf. Empty input is valid (BCL disabled for this client).
+//
+// Hostnames that are not literal IPs are accepted here without DNS lookup —
+// the dispatcher does a post-DNS check inside the HTTP client's dialer so
+// DNS rebinding cannot smuggle a private IP past registration-time guard.
+// Defense-in-depth: validation catches obvious literal-IP attempts loudly at
+// configuration time; dispatch catches everything else regardless of what
+// the hostname resolves to at call time.
+//
+// allowPrivate is an opt-in escape for closed networks (e.g., AS and RS in
+// the same VPC). Off by default; flip via AppRegistrar.AllowPrivateBCLHosts.
+func validateBackchannelLogoutURI(raw string, allowPrivate bool) error {
 	if raw == "" {
 		return nil
 	}
@@ -42,16 +54,36 @@ func validateBackchannelLogoutURI(raw string) error {
 	}
 	switch u.Scheme {
 	case "https":
-		return nil
+		// allowed
 	case "http":
-		host := u.Hostname()
-		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
-			return nil
+		// Plain http is only allowed when private hosts are explicitly
+		// allowed — closed-network deployments. In any other case http
+		// would let an on-path attacker observe revocations for any user.
+		if !allowPrivate {
+			return fmt.Errorf("%w: backchannel_logout_uri must use https", ErrInvalidClientMetadata)
 		}
-		return fmt.Errorf("%w: backchannel_logout_uri must use https outside loopback", ErrInvalidClientMetadata)
 	default:
 		return fmt.Errorf("%w: backchannel_logout_uri scheme %q not allowed", ErrInvalidClientMetadata, u.Scheme)
 	}
+	host := u.Hostname()
+	if ip := net.ParseIP(host); ip != nil && !allowPrivate {
+		if isPrivateOrSpecialIP(ip) {
+			return fmt.Errorf("%w: backchannel_logout_uri may not resolve to loopback / private / link-local / unspecified / multicast address", ErrInvalidClientMetadata)
+		}
+	}
+	return nil
+}
+
+// isPrivateOrSpecialIP reports whether ip is in any address range that an
+// authenticated client should not be able to make the AS POST to. The
+// dispatcher's dialer applies the same predicate at connect time.
+func isPrivateOrSpecialIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
 }
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.
@@ -77,6 +109,16 @@ type AppRegistrar struct {
 	// the apps map below is a hot-path cache hydrated on construction and
 	// updated synchronously on every write.
 	Store core.AppRegistrationStore
+
+	// AllowPrivateBCLHosts opts in to registering a backchannel_logout_uri
+	// whose host resolves (or is literally) loopback / RFC1918 / link-local
+	// / unspecified / multicast. Off by default so a client cannot register
+	// a URI that, on session revoke, makes the AS POST to internal services
+	// on its behalf (classic SSRF). Closed-network deployments where the AS
+	// and the RS receivers share a private network can flip this on. When
+	// flipped, the dispatcher's HTTP client must also opt in via
+	// BCLDispatcher.AllowPrivateHosts or the dial-time guard still blocks.
+	AllowPrivateBCLHosts bool
 
 	mu   sync.RWMutex
 	apps map[string]*core.AppRegistration
@@ -135,7 +177,7 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 	}
 	md := req.Metadata
 
-	if err := validateBackchannelLogoutURI(md.BackchannelLogoutURI); err != nil {
+	if err := validateBackchannelLogoutURI(md.BackchannelLogoutURI, h.AllowPrivateBCLHosts); err != nil {
 		return nil, err
 	}
 
@@ -510,7 +552,7 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	if md.TokenEndpointAuthMethod != "" && md.TokenEndpointAuthMethod != reg.TokenEndpointAuthMethod {
 		return nil, ErrInvalidClientMetadata
 	}
-	if err := validateBackchannelLogoutURI(md.BackchannelLogoutURI); err != nil {
+	if err := validateBackchannelLogoutURI(md.BackchannelLogoutURI, h.AllowPrivateBCLHosts); err != nil {
 		return nil, err
 	}
 

--- a/admin/registrar.go
+++ b/admin/registrar.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,41 @@ import (
 	"github.com/panyam/oneauth/keys"
 	"github.com/panyam/oneauth/utils"
 )
+
+// validateBackchannelLogoutURI enforces the OIDC Back-Channel Logout 1.0 §2.2
+// rule that the registered receiver URI MUST be an absolute URL with a scheme
+// component and MUST NOT contain a fragment. The spec doesn't mandate https,
+// but plain http would let an on-path attacker observe logout events for any
+// authenticated user — we therefore require https in production and only allow
+// http when the host is a loopback address (matching the redirect_uri leniency
+// applied across oneauth). Empty input is valid (BCL disabled for this client).
+func validateBackchannelLogoutURI(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: backchannel_logout_uri: %v", ErrInvalidClientMetadata, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		return fmt.Errorf("%w: backchannel_logout_uri must be an absolute URL with a host", ErrInvalidClientMetadata)
+	}
+	if u.Fragment != "" || strings.Contains(raw, "#") {
+		return fmt.Errorf("%w: backchannel_logout_uri MUST NOT contain a fragment (OIDC BCL §2.2)", ErrInvalidClientMetadata)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+		return fmt.Errorf("%w: backchannel_logout_uri must use https outside loopback", ErrInvalidClientMetadata)
+	default:
+		return fmt.Errorf("%w: backchannel_logout_uri scheme %q not allowed", ErrInvalidClientMetadata, u.Scheme)
+	}
+}
 
 // AppRegistrar is an embeddable HTTP handler for App registration CRUD.
 // Mount it on any admin service's mux to let apps register and obtain signing credentials.
@@ -99,6 +135,10 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 	}
 	md := req.Metadata
 
+	if err := validateBackchannelLogoutURI(md.BackchannelLogoutURI); err != nil {
+		return nil, err
+	}
+
 	// Determine signing algorithm from the requested auth method. Default
 	// HS256 (symmetric) when the client doesn't ask for private_key_jwt.
 	signingAlg := "HS256"
@@ -127,18 +167,20 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 	regClientURI := req.IssuerBaseURL + "/apps/dcr/" + clientID
 
 	resp := &DCRResponse{
-		ClientID:                  clientID,
-		ClientIDIssuedAt:          time.Now().Unix(),
-		ClientSecretExpiresAt:     0, // never expires
-		ClientName:                md.ClientName,
-		ClientURI:                 md.ClientURI,
-		RedirectURIs:              md.RedirectURIs,
-		GrantTypes:                md.GrantTypes,
-		TokenEndpointAuthMethod:   md.TokenEndpointAuthMethod,
-		Scope:                     md.Scope,
-		AuthorizationDetailsTypes: md.AuthorizationDetailsTypes,
-		RegistrationAccessToken:   regAccessToken,
-		RegistrationClientURI:     regClientURI,
+		ClientID:                         clientID,
+		ClientIDIssuedAt:                 time.Now().Unix(),
+		ClientSecretExpiresAt:            0, // never expires
+		ClientName:                       md.ClientName,
+		ClientURI:                        md.ClientURI,
+		RedirectURIs:                     md.RedirectURIs,
+		GrantTypes:                       md.GrantTypes,
+		TokenEndpointAuthMethod:          md.TokenEndpointAuthMethod,
+		Scope:                            md.Scope,
+		AuthorizationDetailsTypes:        md.AuthorizationDetailsTypes,
+		RegistrationAccessToken:          regAccessToken,
+		RegistrationClientURI:            regClientURI,
+		BackchannelLogoutURI:             md.BackchannelLogoutURI,
+		BackchannelLogoutSessionRequired: md.BackchannelLogoutSessionRequired,
 	}
 
 	if utils.IsAsymmetricAlg(signingAlg) {
@@ -177,19 +219,21 @@ func (h *AppRegistrar) Register(ctx context.Context, req *RegisterRequest) (*Reg
 		domain = md.ClientName
 	}
 	reg := &core.AppRegistration{
-		ClientID:                  clientID,
-		ClientDomain:              domain,
-		SigningAlg:                signingAlg,
-		AuthorizationDetailsTypes: md.AuthorizationDetailsTypes,
-		CreatedAt:                 time.Now(),
-		ClientName:                md.ClientName,
-		ClientURI:                 md.ClientURI,
-		RedirectURIs:              md.RedirectURIs,
-		GrantTypes:                md.GrantTypes,
-		Scope:                     md.Scope,
-		TokenEndpointAuthMethod:   md.TokenEndpointAuthMethod,
-		RegistrationAccessToken:   regAccessToken,
-		RegistrationClientURI:     regClientURI,
+		ClientID:                         clientID,
+		ClientDomain:                     domain,
+		SigningAlg:                       signingAlg,
+		AuthorizationDetailsTypes:        md.AuthorizationDetailsTypes,
+		CreatedAt:                        time.Now(),
+		ClientName:                       md.ClientName,
+		ClientURI:                        md.ClientURI,
+		RedirectURIs:                     md.RedirectURIs,
+		GrantTypes:                       md.GrantTypes,
+		Scope:                            md.Scope,
+		TokenEndpointAuthMethod:          md.TokenEndpointAuthMethod,
+		RegistrationAccessToken:          regAccessToken,
+		RegistrationClientURI:            regClientURI,
+		BackchannelLogoutURI:             md.BackchannelLogoutURI,
+		BackchannelLogoutSessionRequired: md.BackchannelLogoutSessionRequired,
 	}
 	if err := h.SaveRegistration(ctx, reg); err != nil {
 		return nil, fmt.Errorf("persist registration: %w", err)
@@ -402,18 +446,20 @@ func (h *AppRegistrar) GetRegistration(ctx context.Context, req *GetRegistration
 	}
 	return &GetRegistrationResponse{
 		Registration: &DCRResponse{
-			ClientID:                  reg.ClientID,
-			ClientIDIssuedAt:          reg.CreatedAt.Unix(),
-			ClientSecretExpiresAt:     0,
-			ClientName:                reg.ClientName,
-			ClientURI:                 reg.ClientURI,
-			RedirectURIs:              reg.RedirectURIs,
-			GrantTypes:                reg.GrantTypes,
-			TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
-			Scope:                     reg.Scope,
-			AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
-			RegistrationAccessToken:   reg.RegistrationAccessToken,
-			RegistrationClientURI:     reg.RegistrationClientURI,
+			ClientID:                         reg.ClientID,
+			ClientIDIssuedAt:                 reg.CreatedAt.Unix(),
+			ClientSecretExpiresAt:            0,
+			ClientName:                       reg.ClientName,
+			ClientURI:                        reg.ClientURI,
+			RedirectURIs:                     reg.RedirectURIs,
+			GrantTypes:                       reg.GrantTypes,
+			TokenEndpointAuthMethod:          reg.TokenEndpointAuthMethod,
+			Scope:                            reg.Scope,
+			AuthorizationDetailsTypes:        reg.AuthorizationDetailsTypes,
+			RegistrationAccessToken:          reg.RegistrationAccessToken,
+			RegistrationClientURI:            reg.RegistrationClientURI,
+			BackchannelLogoutURI:             reg.BackchannelLogoutURI,
+			BackchannelLogoutSessionRequired: reg.BackchannelLogoutSessionRequired,
 		},
 	}, nil
 }
@@ -464,6 +510,9 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	if md.TokenEndpointAuthMethod != "" && md.TokenEndpointAuthMethod != reg.TokenEndpointAuthMethod {
 		return nil, ErrInvalidClientMetadata
 	}
+	if err := validateBackchannelLogoutURI(md.BackchannelLogoutURI); err != nil {
+		return nil, err
+	}
 
 	newToken, err := generateRegistrationAccessToken()
 	if err != nil {
@@ -485,24 +534,28 @@ func (h *AppRegistrar) UpdateRegistration(ctx context.Context, req *UpdateRegist
 	reg.AuthorizationDetailsTypes = md.AuthorizationDetailsTypes
 	reg.ClientDomain = domain
 	reg.RegistrationAccessToken = newToken
+	reg.BackchannelLogoutURI = md.BackchannelLogoutURI
+	reg.BackchannelLogoutSessionRequired = md.BackchannelLogoutSessionRequired
 
 	if err := h.SaveRegistration(ctx, reg); err != nil {
 		return nil, err
 	}
 	return &UpdateRegistrationResponse{
 		Registration: &DCRResponse{
-			ClientID:                  reg.ClientID,
-			ClientIDIssuedAt:          reg.CreatedAt.Unix(),
-			ClientSecretExpiresAt:     0,
-			ClientName:                reg.ClientName,
-			ClientURI:                 reg.ClientURI,
-			RedirectURIs:              reg.RedirectURIs,
-			GrantTypes:                reg.GrantTypes,
-			TokenEndpointAuthMethod:   reg.TokenEndpointAuthMethod,
-			Scope:                     reg.Scope,
-			AuthorizationDetailsTypes: reg.AuthorizationDetailsTypes,
-			RegistrationAccessToken:   reg.RegistrationAccessToken,
-			RegistrationClientURI:     reg.RegistrationClientURI,
+			ClientID:                         reg.ClientID,
+			ClientIDIssuedAt:                 reg.CreatedAt.Unix(),
+			ClientSecretExpiresAt:            0,
+			ClientName:                       reg.ClientName,
+			ClientURI:                        reg.ClientURI,
+			RedirectURIs:                     reg.RedirectURIs,
+			GrantTypes:                       reg.GrantTypes,
+			TokenEndpointAuthMethod:          reg.TokenEndpointAuthMethod,
+			Scope:                            reg.Scope,
+			AuthorizationDetailsTypes:        reg.AuthorizationDetailsTypes,
+			RegistrationAccessToken:          reg.RegistrationAccessToken,
+			RegistrationClientURI:            reg.RegistrationClientURI,
+			BackchannelLogoutURI:             reg.BackchannelLogoutURI,
+			BackchannelLogoutSessionRequired: reg.BackchannelLogoutSessionRequired,
 		},
 	}, nil
 }
@@ -564,6 +617,25 @@ func (h *AppRegistrar) RLockApps(fn func(map[string]*core.AppRegistration)) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	fn(h.apps)
+}
+
+// GetAppRegistration returns a clone of the cached registration for clientID,
+// or (nil, false) if no such client is registered. It satisfies the narrow
+// AppRegistrationLookup interface defined in apiauth/ so the BCL dispatcher can
+// resolve registered receiver URIs without admin/ → apiauth/ → admin/ import
+// cycles. Returns a clone so callers cannot mutate the in-memory cache.
+func (h *AppRegistrar) GetAppRegistration(ctx context.Context, clientID string) (*core.AppRegistration, bool) {
+	if clientID == "" {
+		return nil, false
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	reg, ok := h.apps[clientID]
+	if !ok || reg == nil {
+		return nil, false
+	}
+	clone := *reg
+	return &clone, true
 }
 
 // Handler returns an http.Handler for app registration endpoints.

--- a/apiauth/SUMMARY.md
+++ b/apiauth/SUMMARY.md
@@ -5,6 +5,8 @@ JWT-based API authentication: token issuance (login/refresh/client_credentials),
 ## Contents
 - **auth.go** — `APIAuth` (login/logout/refresh/client_credentials handlers, `CreateAccessToken`, `ValidateAccessToken`), `APIMiddleware` (`ValidateToken`, `RequireScopes`, `Optional`), context helpers (`GetUserIDFromAPIContext`, etc.)
 - **as_metadata.go** — `ASServerMetadata` struct + `NewASMetadataHandler` for RFC 8414 / OIDC Discovery
+- **logout_token.go** — `LogoutTokenIssuer` mints signed OIDC Back-Channel Logout 1.0 `logout_token` JWTs (events + sub/sid claim shape, `typ=logout+jwt` header) (issue 261)
+- **bcl_dispatcher.go** — `BCLDispatcher` looks up clients with a registered `backchannel_logout_uri`, mints one logout_token per client, and POSTs application/x-www-form-urlencoded to each receiver. Async by default; SyncForTest flag for deterministic tests (issue 261)
 - **introspection.go** — `IntrospectionHandler` for RFC 7662 token introspection (server side)
 - **introspection_client.go** — `IntrospectionValidator` for RFC 7662 token introspection (client side, with caching)
 - **protected_resource.go** — `ProtectedResourceMetadata` struct + `NewProtectedResourceHandler` for RFC 9728 discovery
@@ -41,6 +43,7 @@ HTTP handlers (`IntrospectionHandler`, `RevocationHandler`) delegate to core int
 `nil` keeps every path on the no-op tracer with zero allocation cost. The same TP should be wired across the AS handlers + the resource-server middleware so all spans nest under a single trace.
 
 ## Recent Changes
+- **OIDC Back-Channel Logout 1.0 push (issue 261)** — AS-initiated logout notification. New `LogoutTokenIssuer` + `BCLDispatcher` in `apiauth/`; new `BackchannelLogoutURI` / `BackchannelLogoutSessionRequired` fields on `core.AppRegistration` and `admin/dcr` types. `HandleLogoutAll` fires `TokenHooks.OnSubjectRevoked`; the RFC 7009 revoker and `HandleLogout` fire `TokenHooks.OnTokenRevoked` with the captured `(subject, family-as-sid, client_id)`. AS metadata advertises `backchannel_logout_supported` / `backchannel_logout_session_supported`. `sid` claim maps to the refresh-token family ID.
 - **AS metadata `claims_supported` (issue 200)** — `ASServerMetadata` exposes a new `ClaimsSupported []string` field (OIDC Discovery 1.0 §3). The reference deployments (`cmd/oneauth-server`, `testutil`) now populate `scopes_supported` + `claims_supported` by default, clearing two warnings from the OIDF discovery test (`oidcc-discovery-endpoint-verification`).
 - **`private_key_jwt` client auth (#158)** — `ClientAuthenticator` now accepts RFC 7523 §2.2 / OIDC Core §9 signed-JWT client authentication. Token + introspection + revocation handlers all route through a shared `extractClientCredentials` helper covering `client_secret_basic` / `client_secret_post` / `private_key_jwt`. AS metadata advertises `private_key_jwt` and the new `token_endpoint_auth_signing_alg_values_supported` field. Closes the previously expected-fail `introspection/post_auth_accepted` ratchet entry as a side effect.
 - **Token revocation** — `RevocationHandler` at `POST /oauth/revoke` (RFC 7009). Always returns 200. Supports `token_type_hint`.

--- a/apiauth/as_metadata.go
+++ b/apiauth/as_metadata.go
@@ -75,6 +75,21 @@ type ASServerMetadata struct {
 	// the advertisement will fail to validate.
 	AuthorizationResponseIssParameterSupported *bool `json:"authorization_response_iss_parameter_supported,omitempty"`
 
+	// BackchannelLogoutSupported advertises OIDC Back-Channel Logout 1.0 §3.1
+	// — when true, the AS sends a signed logout_token to a client's registered
+	// backchannel_logout_uri at session-revoke time. Pointer semantics: nil
+	// omits the field; an explicit `false` advertises non-support to clients.
+	// Set this true only when a BCLDispatcher is actually wired; otherwise
+	// clients that key off the advertisement will silently miss logouts.
+	BackchannelLogoutSupported *bool `json:"backchannel_logout_supported,omitempty"`
+
+	// BackchannelLogoutSessionSupported advertises OIDC BCL 1.0 §3.1 — when
+	// true, logout_tokens issued by this AS include a `sid` claim that the
+	// receiver can use to revoke a single OIDC session rather than every
+	// session for the subject. Pointer semantics match
+	// BackchannelLogoutSupported.
+	BackchannelLogoutSessionSupported *bool `json:"backchannel_logout_session_supported,omitempty"`
+
 	// CacheMaxAge controls the Cache-Control max-age in seconds.
 	// Defaults to 3600 (1 hour). Not serialized to JSON.
 	CacheMaxAge int `json:"-"`

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -566,6 +566,26 @@ func (a *APIAuth) HandleLogoutAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Capture the affected client_ids BEFORE revoke so the OIDC Back-Channel
+	// Logout dispatcher knows who to notify — RefreshTokenStore.GetSubjectTokens
+	// returns only active grants and would yield an empty set if called after
+	// RevokeSubjectTokens. Empty list when no client ever associated with the
+	// user's tokens.
+	var clientIDs []string
+	if getResp, err := a.RefreshTokenStore.GetSubjectTokens(r.Context(), &core.GetSubjectTokensRequest{Subject: userID}); err == nil && getResp != nil {
+		seen := map[string]struct{}{}
+		for _, t := range getResp.Tokens {
+			if t == nil || t.ClientID == "" {
+				continue
+			}
+			if _, ok := seen[t.ClientID]; ok {
+				continue
+			}
+			seen[t.ClientID] = struct{}{}
+			clientIDs = append(clientIDs, t.ClientID)
+		}
+	}
+
 	// Revoke all user tokens
 	if _, err := a.RefreshTokenStore.RevokeSubjectTokens(r.Context(), &core.RevokeSubjectTokensRequest{Subject: userID}); err != nil {
 		log.Printf("Error revoking user tokens: %v", err)
@@ -576,7 +596,7 @@ func (a *APIAuth) HandleLogoutAll(w http.ResponseWriter, r *http.Request) {
 	// Fire the subject-scoped revoke hook so the BCL dispatcher (and any
 	// other subscriber) can fan out OIDC logout notifications. sid is empty
 	// here — logout-all crosses every session for the user.
-	a.TokenHooks.fireOnSubjectRevoked(userID, "")
+	a.TokenHooks.fireOnSubjectRevoked(userID, "", clientIDs)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/apiauth/auth.go
+++ b/apiauth/auth.go
@@ -139,6 +139,14 @@ type APIAuth struct {
 	// If nil, tokens are validated by signature + expiry only (stateless).
 	Blacklist core.TokenBlacklist
 
+	// TokenHooks fires on token lifecycle events handled directly by APIAuth
+	// (logout / logout-all). The HTTP-facing APIAuth is wired field-by-field
+	// rather than via OneAuthConfig; callers who want logout-all to drive
+	// the OIDC Back-Channel Logout dispatcher must populate
+	// TokenHooks.OnSubjectRevoked here. Leaving it zero keeps HandleLogout /
+	// HandleLogoutAll behaviorally unchanged.
+	TokenHooks TokenHooks
+
 	// TracerProvider opts the /token endpoint into SEP-414 tracing.
 	// When set, ServeHTTP extracts an inbound W3C `traceparent` header
 	// and emits a single `oneauth.token.issue` span with the parsed
@@ -519,9 +527,25 @@ func (a *APIAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Capture subject + family + client_id BEFORE revoke so the BCL
+	// dispatcher can be told who to notify. We deliberately Get-then-Revoke
+	// rather than RevokeAndReturn — the store interface doesn't expose the
+	// latter, and a missing token leaves all three fields empty which the
+	// dispatcher already handles.
+	var sub, sid, clientID string
+	if getResp, err := a.RefreshTokenStore.GetRefreshToken(r.Context(), &core.GetRefreshTokenRequest{Token: req.RefreshToken}); err == nil && getResp != nil && getResp.Token != nil {
+		sub = getResp.Token.Subject
+		sid = getResp.Token.Family
+		clientID = getResp.Token.ClientID
+	}
+
 	// Revoke the token (ignore errors - don't reveal if token existed)
 	if _, err := a.RefreshTokenStore.RevokeRefreshToken(r.Context(), &core.RevokeRefreshTokenRequest{Token: req.RefreshToken}); err != nil {
 		log.Printf("Error revoking token: %v", err)
+	}
+
+	if sub != "" {
+		a.TokenHooks.fireOnTokenRevoked(sub, sid, clientID)
 	}
 
 	w.WriteHeader(http.StatusNoContent)
@@ -548,6 +572,11 @@ func (a *APIAuth) HandleLogoutAll(w http.ResponseWriter, r *http.Request) {
 		a.errorResponse(w, "server_error", "Failed to revoke sessions", http.StatusInternalServerError)
 		return
 	}
+
+	// Fire the subject-scoped revoke hook so the BCL dispatcher (and any
+	// other subscriber) can fan out OIDC logout notifications. sid is empty
+	// here — logout-all crosses every session for the user.
+	a.TokenHooks.fireOnSubjectRevoked(userID, "")
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/apiauth/bcl_dispatcher.go
+++ b/apiauth/bcl_dispatcher.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/panyam/oneauth/core"
@@ -68,6 +70,17 @@ type BCLDispatcher struct {
 	// state; production callers should leave it false so revocation latency
 	// is not coupled to receiver responsiveness.
 	SyncForTest bool
+
+	// AllowPrivateHosts opts in to dialing receiver URIs whose resolved IP
+	// is loopback / RFC1918 / link-local / unspecified / multicast. Off by
+	// default — the default HTTPClient's dialer rejects such connections so
+	// a (mis-configured or malicious) `backchannel_logout_uri` cannot be
+	// used to make the AS POST to internal services on its behalf, even if
+	// the hostname's DNS answer at dial time differs from registration time
+	// (rebinding). Closed-network deployments (AS + RS in the same VPC) can
+	// flip this on; admin.AppRegistrar.AllowPrivateBCLHosts is the matching
+	// registration-side knob.
+	AllowPrivateHosts bool
 
 	// wg tracks in-flight async dispatches so callers (mainly tests) can
 	// wait for them via Wait().
@@ -216,7 +229,52 @@ func (d *BCLDispatcher) httpClient() *http.Client {
 	if d.HTTPClient != nil {
 		return d.HTTPClient
 	}
-	return &http.Client{Timeout: 5 * time.Second}
+	allowPrivate := d.AllowPrivateHosts
+	dialer := &net.Dialer{
+		Timeout: 5 * time.Second,
+		Control: func(network, address string, _ syscall.RawConn) error {
+			if allowPrivate {
+				return nil
+			}
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("bcl: invalid dial address %q: %w", address, err)
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return fmt.Errorf("bcl: dial address %q is not a literal IP", address)
+			}
+			if isPrivateOrSpecialIP(ip) {
+				return fmt.Errorf("bcl: refusing to dial private/loopback/link-local address %s", ip)
+			}
+			return nil
+		},
+	}
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		// Do NOT follow redirects. A 3xx to a different host (or to an
+		// internal IP) would re-open the SSRF surface that the dial-time
+		// guard closes for the registered URI itself. Receivers per OIDC
+		// BCL §2.7 respond with 200 on success / 4xx-5xx on failure; a
+		// 3xx is not part of the protocol and we let the dispatcher's
+		// caller see it as the final status.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{DialContext: dialer.DialContext},
+	}
+}
+
+// isPrivateOrSpecialIP mirrors admin.isPrivateOrSpecialIP — duplicated rather
+// than imported so apiauth/ stays free of an admin/ dependency. Any change
+// to the SSRF policy must update both sites.
+func isPrivateOrSpecialIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
 }
 
 func (d *BCLDispatcher) logger() *log.Logger {

--- a/apiauth/bcl_dispatcher.go
+++ b/apiauth/bcl_dispatcher.go
@@ -1,0 +1,227 @@
+package apiauth
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/panyam/oneauth/core"
+)
+
+// AppRegistrationLookup is the narrow read-only slice of admin.AppRegistrar
+// that BCLDispatcher needs. Defined here (rather than importing admin/) to
+// avoid a circular dependency — admin/ already imports apiauth/ transitively
+// via the hooks layer in some configurations.
+//
+// Implementations: *admin.AppRegistrar satisfies this via RLockApps; tests can
+// inject an in-memory map.
+type AppRegistrationLookup interface {
+	// GetAppRegistration returns the persisted registration for clientID, or
+	// (nil, false) if no such client exists or its registration is being
+	// torn down. Returning a clone is recommended so callers cannot mutate
+	// store state through the returned pointer.
+	GetAppRegistration(ctx context.Context, clientID string) (*core.AppRegistration, bool)
+}
+
+// BCLDispatcher pushes OIDC Back-Channel Logout 1.0 notifications to every
+// client that registered a backchannel_logout_uri and has an active
+// refresh-token grant for the affected subject.
+//
+// The dispatcher is intentionally narrow: callers tell it a session ended
+// (Dispatch), it looks up the clients to notify, mints one logout_token per
+// client, and POSTs each token to the registered URI. Dispatch is fire-and-
+// forget by default — a slow or broken receiver MUST NOT stall the revocation
+// path. Set SyncForTest=true to wait for all POSTs before returning (used by
+// e2e tests; not recommended for production wiring).
+//
+// Retry / backoff: the spec is silent (§3.2 ¶3); this dispatcher does not
+// retry on failure. Follow-ups can wrap HTTPClient with a retry transport.
+type BCLDispatcher struct {
+	// Issuer mints the signed logout_token. Required.
+	Issuer LogoutTokenIssuer
+
+	// Apps resolves a client_id to its registration so we can read
+	// backchannel_logout_uri and backchannel_logout_session_required.
+	// Required.
+	Apps AppRegistrationLookup
+
+	// RefreshStore enumerates a subject's active grants. Required for
+	// subject-scoped Dispatch calls; ignored for explicit-client calls.
+	RefreshStore core.RefreshTokenStore
+
+	// HTTPClient is used for outbound POSTs. Defaults to an http.Client with
+	// a 5-second per-request timeout so a stuck receiver cannot pin a
+	// goroutine indefinitely.
+	HTTPClient *http.Client
+
+	// Logger receives non-fatal dispatch errors (4xx/5xx from receiver,
+	// network failures, signing errors). If nil, log.Default() is used.
+	Logger *log.Logger
+
+	// SyncForTest makes Dispatch block until every POST completes. Tests use
+	// this to assert the receiver was hit before they read its captured
+	// state; production callers should leave it false so revocation latency
+	// is not coupled to receiver responsiveness.
+	SyncForTest bool
+
+	// wg tracks in-flight async dispatches so callers (mainly tests) can
+	// wait for them via Wait().
+	wg sync.WaitGroup
+}
+
+// DispatchRequest is the input to BCLDispatcher.Dispatch.
+//
+// At least one of Subject and ClientIDs MUST be set:
+//   - Subject only: enumerate every client with an active grant for that
+//     subject via RefreshStore.GetSubjectTokens.
+//   - ClientIDs only: notify exactly those clients; used for single-token
+//     revoke where the affected client is known from the token itself.
+//   - Both: union (notify the explicit clients plus any others holding active
+//     grants for the subject).
+type DispatchRequest struct {
+	// Subject is the user identifier whose session ended.
+	Subject string
+
+	// SID is the OIDC session ID. oneauth maps this to the refresh-token
+	// family ID; pass empty when no family-scoped revoke happened.
+	SID string
+
+	// ClientIDs names clients to notify directly. Useful when the trigger is
+	// a single-token revoke and the AS already knows the client_id from the
+	// token claims.
+	ClientIDs []string
+}
+
+// DispatchResponse is empty — dispatch errors are logged, not returned, so a
+// failing client cannot block the revocation path. The struct is preserved
+// for forward-compat headroom (e.g., to expose per-client outcomes for
+// telemetry without changing the method signature).
+type DispatchResponse struct{}
+
+// Dispatch resolves the affected client set, mints a logout_token per client,
+// and POSTs each token to its registered backchannel_logout_uri.
+//
+// Returns nil immediately when no eligible client exists (no clients in the
+// union, or none of them registered a BCL URI). Per-client errors are logged
+// via Logger and otherwise swallowed: BCL is best-effort notification, not
+// transactional with revocation.
+func (d *BCLDispatcher) Dispatch(ctx context.Context, req *DispatchRequest) (*DispatchResponse, error) {
+	if d == nil || req == nil {
+		return &DispatchResponse{}, nil
+	}
+	if d.Issuer == nil || d.Apps == nil {
+		return nil, fmt.Errorf("BCLDispatcher: Issuer and Apps are required")
+	}
+
+	clientIDs := map[string]struct{}{}
+	for _, cid := range req.ClientIDs {
+		if cid != "" {
+			clientIDs[cid] = struct{}{}
+		}
+	}
+	if req.Subject != "" && d.RefreshStore != nil {
+		resp, err := d.RefreshStore.GetSubjectTokens(ctx, &core.GetSubjectTokensRequest{Subject: req.Subject})
+		if err != nil {
+			d.logger().Printf("bcl: GetSubjectTokens(%q): %v", req.Subject, err)
+		} else if resp != nil {
+			for _, t := range resp.Tokens {
+				if t != nil && t.ClientID != "" {
+					clientIDs[t.ClientID] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(clientIDs) == 0 {
+		return &DispatchResponse{}, nil
+	}
+
+	for cid := range clientIDs {
+		reg, ok := d.Apps.GetAppRegistration(ctx, cid)
+		if !ok || reg == nil || reg.BackchannelLogoutURI == "" {
+			continue
+		}
+		// Per §2.4 when the client opts in via backchannel_logout_session_required
+		// the AS MUST include sid. If we don't have one (e.g. single-token revoke
+		// without family context), skip rather than emit an invalid token.
+		if reg.BackchannelLogoutSessionRequired && req.SID == "" {
+			d.logger().Printf("bcl: skipping %q — session_required but no sid", cid)
+			continue
+		}
+		tokReq := &CreateLogoutTokenRequest{
+			Audience: cid,
+			Subject:  req.Subject,
+			SID:      req.SID,
+		}
+		tokResp, err := d.Issuer.CreateLogoutToken(ctx, tokReq)
+		if err != nil {
+			d.logger().Printf("bcl: mint token for %q: %v", cid, err)
+			continue
+		}
+		uri := reg.BackchannelLogoutURI
+		token := tokResp.Token
+		if d.SyncForTest {
+			d.post(ctx, cid, uri, token)
+		} else {
+			d.wg.Add(1)
+			go func() {
+				defer d.wg.Done()
+				d.post(context.Background(), cid, uri, token)
+			}()
+		}
+	}
+	return &DispatchResponse{}, nil
+}
+
+// Wait blocks until every async POST started by Dispatch has finished. Tests
+// use it as a barrier; production code that wants synchronous behavior should
+// set SyncForTest instead.
+func (d *BCLDispatcher) Wait() {
+	if d == nil {
+		return
+	}
+	d.wg.Wait()
+}
+
+// post is the unit of outbound work — one POST per (client, logout_token).
+// Errors here cannot bubble to the caller (Dispatch is fire-and-forget by
+// design); we log them and move on. The receiver is expected to return 2xx
+// per §2.7 ¶2; anything else is treated as a dispatch failure.
+func (d *BCLDispatcher) post(ctx context.Context, clientID, uri, token string) {
+	body := strings.NewReader(url.Values{"logout_token": {token}}.Encode())
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, body)
+	if err != nil {
+		d.logger().Printf("bcl: build request for %q: %v", clientID, err)
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Header.Set("Cache-Control", "no-store")
+
+	resp, err := d.httpClient().Do(httpReq)
+	if err != nil {
+		d.logger().Printf("bcl: POST %s: %v", uri, err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		d.logger().Printf("bcl: receiver %s returned %d", uri, resp.StatusCode)
+	}
+}
+
+func (d *BCLDispatcher) httpClient() *http.Client {
+	if d.HTTPClient != nil {
+		return d.HTTPClient
+	}
+	return &http.Client{Timeout: 5 * time.Second}
+}
+
+func (d *BCLDispatcher) logger() *log.Logger {
+	if d.Logger != nil {
+		return d.Logger
+	}
+	return log.Default()
+}

--- a/apiauth/bcl_dispatcher_test.go
+++ b/apiauth/bcl_dispatcher_test.go
@@ -1,0 +1,257 @@
+package apiauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panyam/oneauth/core"
+)
+
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+// fakeRefreshStore is a minimal RefreshTokenStore — only the methods the BCL
+// dispatcher actually calls (GetSubjectTokens) are non-trivial; the rest exist
+// to satisfy the interface.
+type fakeRefreshStore struct {
+	bySubject map[string][]*core.RefreshToken
+	byToken   map[string]*core.RefreshToken
+}
+
+func newFakeRefreshStore() *fakeRefreshStore {
+	return &fakeRefreshStore{
+		bySubject: map[string][]*core.RefreshToken{},
+		byToken:   map[string]*core.RefreshToken{},
+	}
+}
+
+func (s *fakeRefreshStore) add(t *core.RefreshToken) {
+	s.bySubject[t.Subject] = append(s.bySubject[t.Subject], t)
+	if t.Token != "" {
+		s.byToken[t.Token] = t
+	}
+}
+
+func (s *fakeRefreshStore) GetSubjectTokens(_ context.Context, req *core.GetSubjectTokensRequest) (*core.GetSubjectTokensResponse, error) {
+	return &core.GetSubjectTokensResponse{Tokens: s.bySubject[req.Subject]}, nil
+}
+
+func (s *fakeRefreshStore) CreateRefreshToken(_ context.Context, _ *core.CreateRefreshTokenRequest) (*core.CreateRefreshTokenResponse, error) {
+	return nil, nil
+}
+func (s *fakeRefreshStore) GetRefreshToken(_ context.Context, req *core.GetRefreshTokenRequest) (*core.GetRefreshTokenResponse, error) {
+	if t, ok := s.byToken[req.Token]; ok {
+		return &core.GetRefreshTokenResponse{Token: t}, nil
+	}
+	return nil, core.ErrTokenNotFound
+}
+func (s *fakeRefreshStore) RotateRefreshToken(_ context.Context, _ *core.RotateRefreshTokenRequest) (*core.RotateRefreshTokenResponse, error) {
+	return nil, nil
+}
+func (s *fakeRefreshStore) RevokeRefreshToken(_ context.Context, _ *core.RevokeRefreshTokenRequest) (*core.RevokeRefreshTokenResponse, error) {
+	return &core.RevokeRefreshTokenResponse{}, nil
+}
+func (s *fakeRefreshStore) RevokeSubjectTokens(_ context.Context, _ *core.RevokeSubjectTokensRequest) (*core.RevokeSubjectTokensResponse, error) {
+	return &core.RevokeSubjectTokensResponse{}, nil
+}
+func (s *fakeRefreshStore) RevokeTokenFamily(_ context.Context, _ *core.RevokeTokenFamilyRequest) (*core.RevokeTokenFamilyResponse, error) {
+	return &core.RevokeTokenFamilyResponse{}, nil
+}
+func (s *fakeRefreshStore) CleanupExpiredTokens(_ context.Context, _ *core.CleanupExpiredTokensRequest) (*core.CleanupExpiredTokensResponse, error) {
+	return &core.CleanupExpiredTokensResponse{}, nil
+}
+
+// stubAppLookup is a minimal AppRegistrationLookup so the dispatcher tests
+// don't have to bring up the admin package.
+type stubAppLookup struct {
+	apps map[string]*core.AppRegistration
+}
+
+func (s *stubAppLookup) GetAppRegistration(_ context.Context, clientID string) (*core.AppRegistration, bool) {
+	reg, ok := s.apps[clientID]
+	if !ok {
+		return nil, false
+	}
+	clone := *reg
+	return &clone, true
+}
+
+// captureReceiver records every POST as (form values, status) so tests can
+// verify the wire format independently.
+type captureReceiver struct {
+	mu     sync.Mutex
+	hits   int32
+	form   []string
+	status int // status to return (0 → 200)
+}
+
+func (r *captureReceiver) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&r.hits, 1)
+		b, _ := io.ReadAll(req.Body)
+		r.mu.Lock()
+		r.form = append(r.form, string(b))
+		r.mu.Unlock()
+		w.Header().Set("Content-Type", "text/plain")
+		if r.status != 0 {
+			w.WriteHeader(r.status)
+		}
+	}
+}
+
+func (r *captureReceiver) hitCount() int32 { return atomic.LoadInt32(&r.hits) }
+
+func newDispatcherFixture(t *testing.T, apps map[string]*core.AppRegistration, refresh core.RefreshTokenStore) *BCLDispatcher {
+	t.Helper()
+	return &BCLDispatcher{
+		Issuer:       newTestLogoutIssuer(t),
+		Apps:         &stubAppLookup{apps: apps},
+		RefreshStore: refresh,
+		SyncForTest:  true,
+	}
+}
+
+func TestBCLDispatcher_PostsOnlyToClientsWithBCLURI(t *testing.T) {
+	rxA := &captureReceiver{}
+	srvA := httptest.NewServer(rxA.handler())
+	defer srvA.Close()
+	rxB := &captureReceiver{}
+	srvB := httptest.NewServer(rxB.handler())
+	defer srvB.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {ClientID: "client-a", BackchannelLogoutURI: srvA.URL},
+		"client-b": {ClientID: "client-b", BackchannelLogoutURI: srvB.URL},
+		"client-c": {ClientID: "client-c"}, // no BCL URI — must not be hit
+	}
+
+	store := newFakeRefreshStore()
+	store.add(&core.RefreshToken{Token: "t1", Subject: "alice", ClientID: "client-a", Family: "fam-1"})
+	store.add(&core.RefreshToken{Token: "t2", Subject: "alice", ClientID: "client-b", Family: "fam-2"})
+	store.add(&core.RefreshToken{Token: "t3", Subject: "alice", ClientID: "client-c", Family: "fam-3"})
+
+	d := newDispatcherFixture(t, apps, store)
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{Subject: "alice"})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), rxA.hitCount(), "client-a registered BCL URI must receive POST")
+	assert.Equal(t, int32(1), rxB.hitCount(), "client-b registered BCL URI must receive POST")
+}
+
+func TestBCLDispatcher_PostBodyAndClaims(t *testing.T) {
+	rx := &captureReceiver{}
+	srv := httptest.NewServer(rx.handler())
+	defer srv.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {ClientID: "client-a", BackchannelLogoutURI: srv.URL},
+	}
+	d := newDispatcherFixture(t, apps, nil)
+
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{
+		Subject:   "alice",
+		SID:       "fam-1",
+		ClientIDs: []string{"client-a"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), rx.hitCount())
+
+	rx.mu.Lock()
+	defer rx.mu.Unlock()
+	require.Len(t, rx.form, 1)
+	body := rx.form[0]
+	require.True(t, len(body) > len("logout_token="))
+	const prefix = "logout_token="
+	require.Equal(t, prefix, body[:len(prefix)])
+	encoded := body[len(prefix):]
+
+	parsed, err := jwt.Parse(encoded, func(tok *jwt.Token) (any, error) {
+		return []byte(testBCLSecret), nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	claims := parsed.Claims.(jwt.MapClaims)
+	assert.Equal(t, "client-a", claims["aud"])
+	assert.Equal(t, "alice", claims["sub"])
+	assert.Equal(t, "fam-1", claims["sid"])
+}
+
+func TestBCLDispatcher_SessionRequired_SkipsWithoutSID(t *testing.T) {
+	rx := &captureReceiver{}
+	srv := httptest.NewServer(rx.handler())
+	defer srv.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {
+			ClientID:                         "client-a",
+			BackchannelLogoutURI:             srv.URL,
+			BackchannelLogoutSessionRequired: true,
+		},
+	}
+	d := newDispatcherFixture(t, apps, nil)
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{
+		Subject:   "alice",
+		ClientIDs: []string{"client-a"},
+		// SID intentionally empty.
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), rx.hitCount(), "session_required must skip when sid is absent")
+}
+
+func TestBCLDispatcher_ReceiverNon2xx_NoCrash(t *testing.T) {
+	rx := &captureReceiver{status: http.StatusInternalServerError}
+	srv := httptest.NewServer(rx.handler())
+	defer srv.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {ClientID: "client-a", BackchannelLogoutURI: srv.URL},
+	}
+	d := newDispatcherFixture(t, apps, nil)
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{
+		Subject:   "alice",
+		ClientIDs: []string{"client-a"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), rx.hitCount())
+}
+
+func TestBCLDispatcher_NoClients_NoOp(t *testing.T) {
+	apps := map[string]*core.AppRegistration{}
+	d := newDispatcherFixture(t, apps, newFakeRefreshStore())
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{Subject: "nobody"})
+	require.NoError(t, err)
+}
+
+func TestBCLDispatcher_Async_WaitDrainsInFlight(t *testing.T) {
+	rx := &captureReceiver{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+		rx.handler()(w, r)
+	}))
+	defer srv.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {ClientID: "client-a", BackchannelLogoutURI: srv.URL},
+	}
+	d := &BCLDispatcher{
+		Issuer:      newTestLogoutIssuer(t),
+		Apps:        &stubAppLookup{apps: apps},
+		SyncForTest: false,
+	}
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{
+		Subject:   "alice",
+		ClientIDs: []string{"client-a"},
+	})
+	require.NoError(t, err)
+	d.Wait()
+	assert.Equal(t, int32(1), rx.hitCount())
+}

--- a/apiauth/bcl_dispatcher_test.go
+++ b/apiauth/bcl_dispatcher_test.go
@@ -112,11 +112,14 @@ func (r *captureReceiver) hitCount() int32 { return atomic.LoadInt32(&r.hits) }
 
 func newDispatcherFixture(t *testing.T, apps map[string]*core.AppRegistration, refresh core.RefreshTokenStore) *BCLDispatcher {
 	t.Helper()
+	// httptest.NewServer binds to 127.0.0.1; the dial-time SSRF guard
+	// rejects loopback by default. Tests opt in.
 	return &BCLDispatcher{
-		Issuer:       newTestLogoutIssuer(t),
-		Apps:         &stubAppLookup{apps: apps},
-		RefreshStore: refresh,
-		SyncForTest:  true,
+		Issuer:            newTestLogoutIssuer(t),
+		Apps:              &stubAppLookup{apps: apps},
+		RefreshStore:      refresh,
+		SyncForTest:       true,
+		AllowPrivateHosts: true,
 	}
 }
 
@@ -231,6 +234,57 @@ func TestBCLDispatcher_NoClients_NoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBCLDispatcher_RejectsLoopbackByDefault(t *testing.T) {
+	// Receiver bound to 127.0.0.1; dispatcher without AllowPrivateHosts must
+	// refuse to dial it. SSRF guard.
+	rx := &captureReceiver{}
+	srv := httptest.NewServer(rx.handler())
+	defer srv.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {ClientID: "client-a", BackchannelLogoutURI: srv.URL},
+	}
+	d := &BCLDispatcher{
+		Issuer:      newTestLogoutIssuer(t),
+		Apps:        &stubAppLookup{apps: apps},
+		SyncForTest: true,
+		// AllowPrivateHosts intentionally false.
+	}
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{
+		Subject:   "alice",
+		ClientIDs: []string{"client-a"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), rx.hitCount(), "dial-time guard must block loopback when AllowPrivateHosts is false")
+}
+
+func TestBCLDispatcher_DoesNotFollowRedirects(t *testing.T) {
+	// A 3xx response from the registered receiver must NOT be followed —
+	// that would re-open the SSRF surface by letting the receiver bounce
+	// the AS at an arbitrary URL.
+	var redirectTargetHit int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&redirectTargetHit, 1)
+	}))
+	defer target.Close()
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer primary.Close()
+
+	apps := map[string]*core.AppRegistration{
+		"client-a": {ClientID: "client-a", BackchannelLogoutURI: primary.URL},
+	}
+	d := newDispatcherFixture(t, apps, nil)
+	_, err := d.Dispatch(context.Background(), &DispatchRequest{
+		Subject:   "alice",
+		ClientIDs: []string{"client-a"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&redirectTargetHit), "dispatcher must not follow 3xx to a redirect target")
+}
+
 func TestBCLDispatcher_Async_WaitDrainsInFlight(t *testing.T) {
 	rx := &captureReceiver{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -243,9 +297,10 @@ func TestBCLDispatcher_Async_WaitDrainsInFlight(t *testing.T) {
 		"client-a": {ClientID: "client-a", BackchannelLogoutURI: srv.URL},
 	}
 	d := &BCLDispatcher{
-		Issuer:      newTestLogoutIssuer(t),
-		Apps:        &stubAppLookup{apps: apps},
-		SyncForTest: false,
+		Issuer:            newTestLogoutIssuer(t),
+		Apps:              &stubAppLookup{apps: apps},
+		SyncForTest:       false,
+		AllowPrivateHosts: true,
 	}
 	_, err := d.Dispatch(context.Background(), &DispatchRequest{
 		Subject:   "alice",

--- a/apiauth/bcl_integration_test.go
+++ b/apiauth/bcl_integration_test.go
@@ -1,0 +1,142 @@
+package apiauth
+
+// Integration coverage for OIDC Back-Channel Logout 1.0 push: the
+// /api/logout-all handler must fire OnSubjectRevoked, and the BCL dispatcher
+// wired into that hook must POST a valid logout_token to every registered
+// receiver. This sits between the unit tests (logout_token / dispatcher in
+// isolation) and the cross-package e2e in tests/e2e — it exercises the real
+// HandleLogoutAll path without spinning up a full AS.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+// See: https://github.com/panyam/oneauth/issues/261
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/panyam/oneauth/core"
+)
+
+func TestBCL_HandleLogoutAll_FiresDispatchesToRegisteredReceivers(t *testing.T) {
+	// Two RS-side receivers — one per client. Both should be POSTed by the
+	// time HandleLogoutAll returns (SyncForTest=true).
+	var rxAHits, rxBHits int32
+	var rxABody, rxBBody string
+	rxA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rxABody = string(b)
+		atomic.AddInt32(&rxAHits, 1)
+	}))
+	defer rxA.Close()
+	rxB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rxBBody = string(b)
+		atomic.AddInt32(&rxBHits, 1)
+	}))
+	defer rxB.Close()
+
+	// Two registered clients with BCL URIs + one with none.
+	apps := map[string]*core.AppRegistration{
+		"client-a":  {ClientID: "client-a", BackchannelLogoutURI: rxA.URL},
+		"client-b":  {ClientID: "client-b", BackchannelLogoutURI: rxB.URL},
+		"client-no": {ClientID: "client-no"},
+	}
+
+	// Refresh store: alice has active grants on all three clients.
+	store := newFakeRefreshStore()
+	store.add(&core.RefreshToken{Token: "t1", Subject: "alice", ClientID: "client-a", Family: "fam-1"})
+	store.add(&core.RefreshToken{Token: "t2", Subject: "alice", ClientID: "client-b", Family: "fam-2"})
+	store.add(&core.RefreshToken{Token: "t3", Subject: "alice", ClientID: "client-no", Family: "fam-3"})
+
+	dispatcher := &BCLDispatcher{
+		Issuer:       newTestLogoutIssuer(t),
+		Apps:         &stubAppLookup{apps: apps},
+		RefreshStore: store,
+		SyncForTest:  true,
+	}
+
+	a := &APIAuth{
+		RefreshTokenStore: store,
+		TokenHooks: TokenHooks{
+			OnSubjectRevoked: func(subject, sid string) {
+				dispatcher.Dispatch(context.Background(), &DispatchRequest{Subject: subject, SID: sid})
+			},
+		},
+	}
+
+	// Build an authenticated request — HandleLogoutAll reads the subject
+	// from context, mirroring middleware that authenticates and stamps the
+	// user ID before dispatch.
+	req := httptest.NewRequest(http.MethodPost, "/api/logout-all", nil)
+	ctx := core.SetSubjectInContext(req.Context(), "alice")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	a.HandleLogoutAll(rr, req)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+
+	// Both RSes with a BCL URI must have received exactly one POST.
+	require.Equal(t, int32(1), atomic.LoadInt32(&rxAHits))
+	require.Equal(t, int32(1), atomic.LoadInt32(&rxBHits))
+
+	// Body shape: application/x-www-form-urlencoded with logout_token=<jwt>.
+	for _, body := range []string{rxABody, rxBBody} {
+		require.True(t, len(body) > len("logout_token="), body)
+		token := body[len("logout_token="):]
+		parsed, err := jwt.Parse(token, func(tok *jwt.Token) (any, error) {
+			return []byte(testBCLSecret), nil
+		})
+		require.NoError(t, err)
+		require.True(t, parsed.Valid)
+		claims := parsed.Claims.(jwt.MapClaims)
+		assert.Equal(t, "alice", claims["sub"])
+		_, hasEvents := claims["events"]
+		assert.True(t, hasEvents)
+	}
+}
+
+func TestBCL_HandleLogout_FiresOnTokenRevokedWithCapturedSubject(t *testing.T) {
+	store := newFakeRefreshStore()
+	store.add(&core.RefreshToken{
+		Token:    "rt-1",
+		Subject:  "alice",
+		ClientID: "client-a",
+		Family:   "fam-1",
+	})
+
+	var sub, sid, cid string
+	a := &APIAuth{
+		RefreshTokenStore: store,
+		TokenHooks: TokenHooks{
+			OnTokenRevoked: func(s, ssid, c string) {
+				sub, sid, cid = s, ssid, c
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/logout", strings.NewReader(`{"refresh_token":"rt-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	a.HandleLogout(rr, req)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+
+	// Wait briefly for the hook to fire (it's synchronous, but the io path
+	// gives the linter no reason to wait).
+	deadline := time.Now().Add(time.Second)
+	for sub == "" && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	assert.Equal(t, "alice", sub)
+	assert.Equal(t, "fam-1", sid)
+	assert.Equal(t, "client-a", cid)
+}

--- a/apiauth/bcl_integration_test.go
+++ b/apiauth/bcl_integration_test.go
@@ -59,10 +59,11 @@ func TestBCL_HandleLogoutAll_FiresDispatchesToRegisteredReceivers(t *testing.T) 
 	store.add(&core.RefreshToken{Token: "t3", Subject: "alice", ClientID: "client-no", Family: "fam-3"})
 
 	dispatcher := &BCLDispatcher{
-		Issuer:       newTestLogoutIssuer(t),
-		Apps:         &stubAppLookup{apps: apps},
-		RefreshStore: store,
-		SyncForTest:  true,
+		Issuer:            newTestLogoutIssuer(t),
+		Apps:              &stubAppLookup{apps: apps},
+		RefreshStore:      store,
+		SyncForTest:       true,
+		AllowPrivateHosts: true, // httptest binds to 127.0.0.1
 	}
 
 	a := &APIAuth{

--- a/apiauth/bcl_integration_test.go
+++ b/apiauth/bcl_integration_test.go
@@ -69,8 +69,12 @@ func TestBCL_HandleLogoutAll_FiresDispatchesToRegisteredReceivers(t *testing.T) 
 	a := &APIAuth{
 		RefreshTokenStore: store,
 		TokenHooks: TokenHooks{
-			OnSubjectRevoked: func(subject, sid string) {
-				dispatcher.Dispatch(context.Background(), &DispatchRequest{Subject: subject, SID: sid})
+			OnSubjectRevoked: func(subject, sid string, clientIDs []string) {
+				dispatcher.Dispatch(context.Background(), &DispatchRequest{
+					Subject:   subject,
+					SID:       sid,
+					ClientIDs: clientIDs,
+				})
 			},
 		},
 	}

--- a/apiauth/hooks.go
+++ b/apiauth/hooks.go
@@ -35,6 +35,21 @@ type TokenHooks struct {
 	// OnRevoked fires after a token is successfully revoked.
 	// hint is the token_type_hint ("access_token", "refresh_token", or "").
 	OnRevoked func(token, hint string)
+
+	// OnSubjectRevoked fires when every active grant for a subject has been
+	// revoked (logout-all). Subject is the affected user; sid is the OIDC
+	// session ID when one is associated with the revocation (empty for
+	// subject-wide revokes that are not session-scoped). Used by the OIDC
+	// Back-Channel Logout dispatcher to fan out logout_token POSTs (261).
+	OnSubjectRevoked func(subject, sid string)
+
+	// OnTokenRevoked fires when a single refresh token (or all tokens in a
+	// family) is revoked, after subject + client_id are known. Provides the
+	// affected subject, sid (family ID, when known), and clientID. Distinct
+	// from OnRevoked so subscribers (notably BCL) get the routing identifiers
+	// without having to re-parse the token. clientID is empty when the
+	// trigger lacks a known client (e.g., admin-side revoke by jti).
+	OnTokenRevoked func(subject, sid, clientID string)
 }
 
 // AuthHooks fires on authentication events.
@@ -91,6 +106,18 @@ func (h *TokenHooks) fireOnIssued(subject, grantType string) {
 func (h *TokenHooks) fireOnRevoked(token, hint string) {
 	if h != nil && h.OnRevoked != nil {
 		h.OnRevoked(token, hint)
+	}
+}
+
+func (h *TokenHooks) fireOnSubjectRevoked(subject, sid string) {
+	if h != nil && h.OnSubjectRevoked != nil {
+		h.OnSubjectRevoked(subject, sid)
+	}
+}
+
+func (h *TokenHooks) fireOnTokenRevoked(subject, sid, clientID string) {
+	if h != nil && h.OnTokenRevoked != nil {
+		h.OnTokenRevoked(subject, sid, clientID)
 	}
 }
 

--- a/apiauth/hooks.go
+++ b/apiauth/hooks.go
@@ -39,9 +39,12 @@ type TokenHooks struct {
 	// OnSubjectRevoked fires when every active grant for a subject has been
 	// revoked (logout-all). Subject is the affected user; sid is the OIDC
 	// session ID when one is associated with the revocation (empty for
-	// subject-wide revokes that are not session-scoped). Used by the OIDC
-	// Back-Channel Logout dispatcher to fan out logout_token POSTs (261).
-	OnSubjectRevoked func(subject, sid string)
+	// subject-wide revokes that are not session-scoped). clientIDs lists
+	// every client that held an active grant at revoke time — captured
+	// BEFORE the revoke so subscribers (notably the BCL dispatcher) can
+	// notify them without having to re-query a store that, post-revoke,
+	// returns nothing. Empty when no client identifiers were available.
+	OnSubjectRevoked func(subject, sid string, clientIDs []string)
 
 	// OnTokenRevoked fires when a single refresh token (or all tokens in a
 	// family) is revoked, after subject + client_id are known. Provides the
@@ -109,9 +112,9 @@ func (h *TokenHooks) fireOnRevoked(token, hint string) {
 	}
 }
 
-func (h *TokenHooks) fireOnSubjectRevoked(subject, sid string) {
+func (h *TokenHooks) fireOnSubjectRevoked(subject, sid string, clientIDs []string) {
 	if h != nil && h.OnSubjectRevoked != nil {
-		h.OnSubjectRevoked(subject, sid)
+		h.OnSubjectRevoked(subject, sid, clientIDs)
 	}
 }
 

--- a/apiauth/logout_token.go
+++ b/apiauth/logout_token.go
@@ -1,0 +1,175 @@
+package apiauth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/utils"
+)
+
+// BCLEventType is the single event-identifier URI defined by OIDC Back-Channel
+// Logout 1.0 §2.4. Every logout_token MUST carry an `events` claim whose only
+// key is this URI; the value is the empty JSON object.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
+const BCLEventType = "http://schemas.openid.net/event/backchannel-logout"
+
+// LogoutTokenIssuer mints signed `logout_token` JWTs per OIDC Back-Channel
+// Logout 1.0 §2.4 for delivery to a client's registered backchannel_logout_uri.
+//
+// It follows the gRPC-shape convention adopted in 175 — a single method that
+// takes a request struct and returns a wrapped response. Implementations reuse
+// the AS signing key already in use by TokenIssuer so RSes can verify
+// logout_tokens against the same JWKS they use for access tokens.
+type LogoutTokenIssuer interface {
+	// CreateLogoutToken mints a signed logout_token. The returned response
+	// carries the serialized JWT only; the dispatcher is responsible for
+	// transporting it.
+	CreateLogoutToken(ctx context.Context, req *CreateLogoutTokenRequest) (*CreateLogoutTokenResponse, error)
+}
+
+// CreateLogoutTokenRequest is the input to LogoutTokenIssuer.CreateLogoutToken.
+//
+// At least one of Subject and SID MUST be populated. Per OIDC BCL §2.4 a
+// logout_token without both `sub` and `sid` is invalid and MUST be rejected by
+// the receiving client; the constructor enforces this so callers cannot
+// silently mint a token that every conforming RS will reject.
+type CreateLogoutTokenRequest struct {
+	// Audience is the receiving client's client_id. Per §2.4 this becomes the
+	// `aud` claim and identifies which client the logout applies to. Required.
+	Audience string
+
+	// Subject is the user identifier (RFC 7519 `sub`) whose session ended.
+	// Optional iff SID is set; required otherwise.
+	Subject string
+
+	// SID is the session identifier (`sid`). When the receiving client
+	// registered with backchannel_logout_session_required=true the AS MUST
+	// include this; otherwise SHOULD include when known. oneauth maps SID to
+	// the refresh-token family ID — the closest analogue to an OIDC session
+	// the library tracks today.
+	SID string
+}
+
+// CreateLogoutTokenResponse wraps the minted logout_token JWT.
+type CreateLogoutTokenResponse struct {
+	// Token is the serialized JWS. It is ready to POST as the value of the
+	// `logout_token` form field per §2.5.
+	Token string
+}
+
+// jwtLogoutTokenIssuer implements LogoutTokenIssuer by reusing the AS signing
+// key — the same private key that signs access tokens. Reusing the key means
+// receiving clients verify logout_tokens against the JWKS they already trust
+// for access-token validation.
+type jwtLogoutTokenIssuer struct {
+	signingKey any
+	signingAlg string
+	issuer     string
+	tokenTTL   time.Duration
+}
+
+// JWTLogoutTokenIssuerConfig configures a jwtLogoutTokenIssuer.
+type JWTLogoutTokenIssuerConfig struct {
+	// SigningKey is the AS signing key. For HS256 pass []byte; for RS256/ES256
+	// pass the private key.
+	SigningKey any
+
+	// SigningAlg names the JWS algorithm (e.g. "RS256"). Empty falls back to
+	// HS256 when SigningKey is a []byte.
+	SigningAlg string
+
+	// Issuer is the AS issuer URL — the value the receiver expects as the
+	// `iss` claim and the key under which it looked up the AS JWKS.
+	Issuer string
+
+	// TokenTTL bounds the validity window for replay protection. The OIDC BCL
+	// spec does not require `exp` but receivers are encouraged to reject
+	// stale tokens; we default to 2 minutes — long enough for slow networks,
+	// short enough that a leaked token isn't useful for long.
+	TokenTTL time.Duration
+}
+
+// NewJWTLogoutTokenIssuer returns a LogoutTokenIssuer that signs logout_tokens
+// with the supplied key.
+func NewJWTLogoutTokenIssuer(cfg JWTLogoutTokenIssuerConfig) LogoutTokenIssuer {
+	ttl := cfg.TokenTTL
+	if ttl <= 0 {
+		ttl = 2 * time.Minute
+	}
+	return &jwtLogoutTokenIssuer{
+		signingKey: cfg.SigningKey,
+		signingAlg: cfg.SigningAlg,
+		issuer:     cfg.Issuer,
+		tokenTTL:   ttl,
+	}
+}
+
+// CreateLogoutToken implements LogoutTokenIssuer.
+//
+// The claims set is exactly the §2.4 minimum plus `exp`. We deliberately omit
+// any `nonce` claim — the spec forbids it on logout_tokens (§2.4 ¶6) and a
+// stray nonce is grounds for the receiver to reject the token. `events` is
+// emitted as `{<BCLEventType>: {}}` exactly — receivers test for the presence
+// of the URI key, not the value shape.
+func (i *jwtLogoutTokenIssuer) CreateLogoutToken(ctx context.Context, req *CreateLogoutTokenRequest) (*CreateLogoutTokenResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("CreateLogoutTokenRequest is required")
+	}
+	if req.Audience == "" {
+		return nil, fmt.Errorf("logout_token: audience (client_id) is required")
+	}
+	if req.Subject == "" && req.SID == "" {
+		return nil, fmt.Errorf("logout_token: at least one of sub and sid MUST be present (OIDC BCL §2.4)")
+	}
+
+	jti, err := core.GenerateSecureToken()
+	if err != nil {
+		return nil, fmt.Errorf("logout_token: jti: %w", err)
+	}
+
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": i.issuer,
+		"aud": req.Audience,
+		"iat": now.Unix(),
+		"exp": now.Add(i.tokenTTL).Unix(),
+		"jti": jti,
+		"events": map[string]any{
+			BCLEventType: map[string]any{},
+		},
+	}
+	if req.Subject != "" {
+		claims["sub"] = req.Subject
+	}
+	if req.SID != "" {
+		claims["sid"] = req.SID
+	}
+
+	method, err := utils.SigningMethodForAlg(i.signingAlg)
+	if err != nil {
+		if _, ok := i.signingKey.([]byte); ok {
+			method = jwt.SigningMethodHS256
+		} else {
+			return nil, fmt.Errorf("logout_token: invalid signing alg: %w", err)
+		}
+	}
+
+	tok := jwt.NewWithClaims(method, claims)
+	// Per §2.4 the JWS header carries `typ=logout+jwt` so receivers can
+	// distinguish logout_tokens from access/id tokens before parsing claims.
+	tok.Header["typ"] = "logout+jwt"
+	if kid, kidErr := utils.ComputeKid(i.signingKey, method.Alg()); kidErr == nil {
+		tok.Header["kid"] = kid
+	}
+
+	signed, err := tok.SignedString(i.signingKey)
+	if err != nil {
+		return nil, fmt.Errorf("logout_token: sign: %w", err)
+	}
+	return &CreateLogoutTokenResponse{Token: signed}, nil
+}

--- a/apiauth/logout_token_test.go
+++ b/apiauth/logout_token_test.go
@@ -1,0 +1,122 @@
+package apiauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
+
+const testBCLSecret = "test-signing-secret-do-not-use-in-prod"
+
+func newTestLogoutIssuer(t *testing.T) LogoutTokenIssuer {
+	t.Helper()
+	return NewJWTLogoutTokenIssuer(JWTLogoutTokenIssuerConfig{
+		SigningKey: []byte(testBCLSecret),
+		SigningAlg: "HS256",
+		Issuer:     "https://as.example.com",
+		TokenTTL:   2 * time.Minute,
+	})
+}
+
+func parseLogoutClaims(t *testing.T, tokenStr string) (jwt.MapClaims, *jwt.Token) {
+	t.Helper()
+	parsed, err := jwt.Parse(tokenStr, func(tok *jwt.Token) (any, error) {
+		return []byte(testBCLSecret), nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	return claims, parsed
+}
+
+func TestLogoutToken_ClaimsShape_SubjectAndSID(t *testing.T) {
+	iss := newTestLogoutIssuer(t)
+	resp, err := iss.CreateLogoutToken(context.Background(), &CreateLogoutTokenRequest{
+		Audience: "client-abc",
+		Subject:  "user-123",
+		SID:      "fam-xyz",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Token)
+
+	claims, parsed := parseLogoutClaims(t, resp.Token)
+	assert.Equal(t, "https://as.example.com", claims["iss"])
+	assert.Equal(t, "client-abc", claims["aud"])
+	assert.Equal(t, "user-123", claims["sub"])
+	assert.Equal(t, "fam-xyz", claims["sid"])
+	assert.NotEmpty(t, claims["jti"])
+	assert.NotZero(t, claims["iat"])
+	assert.NotZero(t, claims["exp"])
+
+	// events claim per §2.4 — single key with the BCL event-type URI, value
+	// is an empty JSON object.
+	ev, ok := claims["events"].(map[string]any)
+	require.True(t, ok, "events claim must be a JSON object")
+	body, ok := ev[BCLEventType]
+	require.True(t, ok, "events must contain the BCL event-type URI")
+	bodyMap, ok := body.(map[string]any)
+	require.True(t, ok, "events[BCLEventType] must be an object")
+	assert.Empty(t, bodyMap, "events[BCLEventType] must be an empty object")
+
+	// nonce MUST NOT be present (§2.4 ¶6).
+	_, hasNonce := claims["nonce"]
+	assert.False(t, hasNonce, "nonce MUST NOT be present in logout_token")
+
+	// typ=logout+jwt header so receivers can disambiguate.
+	assert.Equal(t, "logout+jwt", parsed.Header["typ"])
+}
+
+func TestLogoutToken_SubjectOnly(t *testing.T) {
+	iss := newTestLogoutIssuer(t)
+	resp, err := iss.CreateLogoutToken(context.Background(), &CreateLogoutTokenRequest{
+		Audience: "client-abc",
+		Subject:  "user-123",
+	})
+	require.NoError(t, err)
+	claims, _ := parseLogoutClaims(t, resp.Token)
+	assert.Equal(t, "user-123", claims["sub"])
+	_, hasSID := claims["sid"]
+	assert.False(t, hasSID)
+}
+
+func TestLogoutToken_SIDOnly(t *testing.T) {
+	iss := newTestLogoutIssuer(t)
+	resp, err := iss.CreateLogoutToken(context.Background(), &CreateLogoutTokenRequest{
+		Audience: "client-abc",
+		SID:      "fam-xyz",
+	})
+	require.NoError(t, err)
+	claims, _ := parseLogoutClaims(t, resp.Token)
+	assert.Equal(t, "fam-xyz", claims["sid"])
+	_, hasSub := claims["sub"]
+	assert.False(t, hasSub)
+}
+
+func TestLogoutToken_MissingSubAndSID_Rejected(t *testing.T) {
+	iss := newTestLogoutIssuer(t)
+	_, err := iss.CreateLogoutToken(context.Background(), &CreateLogoutTokenRequest{
+		Audience: "client-abc",
+	})
+	require.Error(t, err)
+}
+
+func TestLogoutToken_MissingAudience_Rejected(t *testing.T) {
+	iss := newTestLogoutIssuer(t)
+	_, err := iss.CreateLogoutToken(context.Background(), &CreateLogoutTokenRequest{
+		Subject: "user-123",
+	})
+	require.Error(t, err)
+}
+
+func TestLogoutToken_NilRequest_Rejected(t *testing.T) {
+	iss := newTestLogoutIssuer(t)
+	_, err := iss.CreateLogoutToken(context.Background(), nil)
+	require.Error(t, err)
+}

--- a/apiauth/token_revoker.go
+++ b/apiauth/token_revoker.go
@@ -36,40 +36,66 @@ func NewTokenRevoker(cfg TokenRevokerConfig) TokenRevoker {
 
 // Revoke invalidates a token. Tries refresh token first if no hint or
 // hint is "refresh_token", then tries access token blacklisting.
+//
+// When the token resolves to a refresh token we capture its (subject, family,
+// client_id) before the revoke completes and fire OnTokenRevoked so BCL
+// dispatch can pick it up. Access-token blacklisting does not fire that hook
+// because the access token already expires under its own ttl, and the refresh
+// token (the real session anchor) is the right grain for BCL.
 func (r *tokenRevoker) Revoke(ctx context.Context, req *RevokeRequest) (*RevokeResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("RevokeRequest is required")
 	}
+	var sub, sid, clientID string
 	switch req.TokenTypeHint {
 	case "refresh_token":
-		r.revokeRefreshToken(ctx, req.Token)
+		sub, sid, clientID = r.revokeRefreshTokenInfo(ctx, req.Token)
 	case "access_token":
 		r.revokeAccessToken(req.Token)
 	default:
 		// No hint — try refresh first (cheaper lookup), then access
-		if !r.revokeRefreshToken(ctx, req.Token) {
+		var found bool
+		sub, sid, clientID, found = r.revokeRefreshTokenInfoIfPresent(ctx, req.Token)
+		if !found {
 			r.revokeAccessToken(req.Token)
 		}
 	}
 
 	r.hooks.fireOnRevoked(req.Token, req.TokenTypeHint)
+	if sub != "" {
+		r.hooks.fireOnTokenRevoked(sub, sid, clientID)
+	}
 	return &RevokeResponse{}, nil
 }
 
-// revokeRefreshToken attempts to revoke a refresh token. Returns true if
-// the token was found in the refresh store.
-func (r *tokenRevoker) revokeRefreshToken(ctx context.Context, token string) bool {
+// revokeRefreshTokenInfo revokes the refresh token and returns the
+// (subject, sid, client_id) captured before revocation. Empty strings when
+// the token doesn't resolve. Distinct from revokeRefreshTokenInfoIfPresent
+// only in the boolean signal — the typed-hint path doesn't need to know
+// whether to fall through to access-token revocation.
+func (r *tokenRevoker) revokeRefreshTokenInfo(ctx context.Context, token string) (sub, sid, clientID string) {
+	sub, sid, clientID, _ = r.revokeRefreshTokenInfoIfPresent(ctx, token)
+	return sub, sid, clientID
+}
+
+// revokeRefreshTokenInfoIfPresent attempts to revoke a refresh token. Returns
+// (subject, family-as-sid, client_id, found). The boolean lets the no-hint
+// caller decide whether to fall through to access-token blacklisting.
+func (r *tokenRevoker) revokeRefreshTokenInfoIfPresent(ctx context.Context, token string) (sub, sid, clientID string, found bool) {
 	if r.refreshStore == nil {
-		return false
+		return "", "", "", false
 	}
 	getResp, err := r.refreshStore.GetRefreshToken(ctx, &core.GetRefreshTokenRequest{Token: token})
 	if err != nil || getResp == nil || getResp.Token == nil {
-		return false
+		return "", "", "", false
 	}
+	sub = getResp.Token.Subject
+	sid = getResp.Token.Family
+	clientID = getResp.Token.ClientID
 	if !getResp.Token.Revoked {
 		r.refreshStore.RevokeRefreshToken(ctx, &core.RevokeRefreshTokenRequest{Token: token})
 	}
-	return true
+	return sub, sid, clientID, true
 }
 
 // revokeAccessToken blacklists a JWT access token by its jti claim.

--- a/core/app_registration.go
+++ b/core/app_registration.go
@@ -38,6 +38,15 @@ type AppRegistration struct {
 	// is implemented (issue 168); empty for legacy registrations.
 	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
 	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
+
+	// OIDC Back-Channel Logout 1.0 — per-client push endpoint. When set, the
+	// AS POSTs a signed logout_token to BackchannelLogoutURI whenever a
+	// session that touched this client is revoked (issue 261).
+	// BackchannelLogoutSessionRequired toggles whether the logout_token MUST
+	// carry a sid claim — true means the client tracks sessions per spec §2.2.
+	// Empty BackchannelLogoutURI disables dispatch for this client.
+	BackchannelLogoutURI             string `json:"backchannel_logout_uri,omitempty"`
+	BackchannelLogoutSessionRequired bool   `json:"backchannel_logout_session_required,omitempty"`
 }
 
 // SaveAppRequest carries the registration to persist.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -223,6 +223,7 @@ The `(ctx context.Context, *XRequest) → (*XResponse, error)` convention adopte
 |---|---------|--------|
 | 172 | Legacy `admin/` — `ClientRegistrar` interface for register / list / get / delete / rotate. HTTP handlers reduced to thin wrappers. Wire format unchanged. | Merged |
 | 175 | `apiauth/` — `TokenIssuer` / `TokenValidator` / `TokenIntrospector` / `TokenRevoker` / `ClientAuthenticator`. HTTP handlers (auth.go, introspection.go, revocation.go) reduced to thin wrappers. Wire format unchanged. | Merged |
+| 261 | OIDC Back-Channel Logout 1.0 (sender) — `LogoutTokenIssuer` + `BCLDispatcher`, per-client `backchannel_logout_uri` via DCR + admin, AS metadata advertisement, `TokenHooks.OnSubjectRevoked` / `OnTokenRevoked` wiring on logout-all and RFC 7009 revoke. `sid` maps to refresh-token family. Retry/backoff deferred. | Merged |
 | 189 | **Pending** — remove `/apps/register` once a quota story for `MaxRooms` / `MaxMsgRate` is decided. Blocked on the design call, not implementation. | Pending |
 
 ## Reference Server (cmd/oneauth-server)

--- a/docs/gaps/AUTH0_GAP_ANALYSIS.md
+++ b/docs/gaps/AUTH0_GAP_ANALYSIS.md
@@ -90,6 +90,7 @@ Auth0 has shipped several new capabilities since our original analysis:
 | Refresh Token Rotation | Automatic + theft detection | Family-based rotation + theft detection | Full | — |
 | **Token Revocation** | POST /oauth/revoke | **NEW** — `RevocationHandler` (RFC 7009) | Full | — |
 | Logout (local) | GET /v2/logout | POST /api/logout + /api/logout-all | Full | — |
+| **Back-Channel Logout (push)** | OIDC BCL — `backchannel_logout_uri` per client | **NEW** — `BCLDispatcher` + `LogoutTokenIssuer`, DCR field, AS metadata advertisement (sender side) | Full (sender) | — |
 | Logout (federated) | GET /v2/logout?federated | None | **None** | issue 129 |
 | DPoP | Supported (2025) | None | **None** | issue 94 |
 

--- a/docs/gaps/AUTHLETE_GAP_ANALYSIS.md
+++ b/docs/gaps/AUTHLETE_GAP_ANALYSIS.md
@@ -88,7 +88,8 @@ Legend: **Full** = implemented and conformance-tested · **Partial** = implement
 | **HTTP Message Signatures** | RFC 9421 (FAPI 2.0 MS) | Full | None | **None** |
 | **CIBA Core** | OpenID CIBA 1.0 | Full (since 2019) | None | **None** |
 | **OpenID Connect Core** | OIDC Core 1.0 | Full | None — **no id_token, no userinfo, no `/authorize`** | **None** |
-| **OIDC Session Management / Front-Channel / Back-Channel Logout** | OIDC suite | Full | None | **None** |
+| **OIDC Back-Channel Logout 1.0 (sender)** | OIDC BCL 1.0 | Full | Sender-side — `BCLDispatcher` + `LogoutTokenIssuer`; per-client `backchannel_logout_uri` via DCR; advertised in AS metadata (issue 261) | **Partial** |
+| **OIDC Session Management / Front-Channel Logout** | OIDC suite | Full | None | **None** |
 | **OIDC Federation 1.0** | OpenID Federation 1.0 | Full | None | **None** |
 | **OID4VCI (VC Issuance)** | OID4VCI | Full (SD-JWT VC, mdoc / mDL) | None | **None** |
 | **OID4VP (VC Presentation)** | OID4VP | Full | None | **None** |

--- a/tests/e2e/authserver_test.go
+++ b/tests/e2e/authserver_test.go
@@ -69,6 +69,43 @@ func (e *TestEnv) buildAuthServer(t *testing.T) {
 		ClientKeyStore:      e.KeyStore, // Enables client_credentials grant
 	}
 
+	// OIDC Back-Channel Logout 1.0 sender wiring (issue 261). The dispatcher
+	// is opt-in: if no client registers backchannel_logout_uri the hook is a
+	// no-op. AllowPrivateHosts is set because RS-side receivers in these
+	// tests run via httptest.NewServer (127.0.0.1). e.registrar exposes
+	// GetAppRegistration via the AppRegistrationLookup interface.
+	e.bclDispatcher = &apiauth.BCLDispatcher{
+		Issuer: apiauth.NewJWTLogoutTokenIssuer(apiauth.JWTLogoutTokenIssuerConfig{
+			SigningKey: []byte(e.JWTSecret),
+			SigningAlg: "HS256",
+			Issuer:     testJWTIssuer,
+		}),
+		Apps:              e.registrar,
+		RefreshStore:      refreshTokenStore,
+		SyncForTest:       true,
+		AllowPrivateHosts: true,
+	}
+	e.registrar.AllowPrivateBCLHosts = true // tests register loopback receivers
+	e.apiAuth.TokenHooks = apiauth.TokenHooks{
+		OnSubjectRevoked: func(subject, sid string, clientIDs []string) {
+			e.bclDispatcher.Dispatch(context.Background(), &apiauth.DispatchRequest{
+				Subject:   subject,
+				SID:       sid,
+				ClientIDs: clientIDs,
+			})
+		},
+		OnTokenRevoked: func(subject, sid, clientID string) {
+			if clientID == "" {
+				return
+			}
+			e.bclDispatcher.Dispatch(context.Background(), &apiauth.DispatchRequest{
+				Subject:   subject,
+				SID:       sid,
+				ClientIDs: []string{clientID},
+			})
+		},
+	}
+
 	// CSRF
 	csrf := &httpauth.CSRFMiddleware{}
 

--- a/tests/e2e/bcl_test.go
+++ b/tests/e2e/bcl_test.go
@@ -1,0 +1,152 @@
+package e2e_test
+
+// E2E coverage for OIDC Back-Channel Logout 1.0 push (issue 261). Exercises
+// the full sender path through the in-process test AS: register a client via
+// DCR with a backchannel_logout_uri, get a refresh token via password grant,
+// POST /api/logout-all, assert the registered receiver got a valid
+// logout_token.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerClientWithBCL registers a confidential client via DCR with the
+// given backchannel_logout_uri. Returns (client_id, client_secret).
+func registerClientWithBCL(t *testing.T, env *TestEnv, name, bclURI string) (string, string) {
+	t.Helper()
+	c := NewTestClient(env)
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name":            name,
+		"grant_types":            []string{"password", "refresh_token"},
+		"backchannel_logout_uri": bclURI,
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	body := ReadJSON(resp)
+	clientID, _ := body["client_id"].(string)
+	clientSecret, _ := body["client_secret"].(string)
+	require.NotEmpty(t, clientID)
+	require.NotEmpty(t, clientSecret)
+	return clientID, clientSecret
+}
+
+func TestBCL_E2E_LogoutAllPostsLogoutTokenToRegisteredReceiver(t *testing.T) {
+	env := NewTestEnv(t)
+
+	var rxHits int32
+	var rxBody string
+	rx := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rxBody = string(b)
+		atomic.AddInt32(&rxHits, 1)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+	}))
+	defer rx.Close()
+
+	clientID, _ := registerClientWithBCL(t, env, "bcl-e2e", rx.URL)
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	// Create a user and get a token pair (access + refresh).
+	email, password := CreateTestUser(t, env, "bcl-e2e")
+	body, _ := json.Marshal(map[string]any{
+		"grant_type": "password",
+		"username":   email,
+		"password":   password,
+		"client_id":  clientID,
+	})
+	tokResp, err := http.Post(env.BaseURL()+"/api/token", "application/json", strings.NewReader(string(body)))
+	require.NoError(t, err)
+	tokens := ReadJSON(tokResp)
+	accessToken, _ := tokens["access_token"].(string)
+	refreshToken, _ := tokens["refresh_token"].(string)
+	require.NotEmpty(t, accessToken)
+	require.NotEmpty(t, refreshToken)
+
+	// Hit /api/logout-all (requires bearer auth in this env).
+	logoutReq, _ := http.NewRequest(http.MethodPost, env.BaseURL()+"/api/logout-all", nil)
+	logoutReq.Header.Set("Authorization", "Bearer "+accessToken)
+	logoutResp, err := http.DefaultClient.Do(logoutReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, logoutResp.StatusCode)
+
+	// SyncForTest dispatcher → receiver MUST have been hit by the time
+	// HandleLogoutAll returned. Generous deadline as a belt-and-suspenders
+	// in case of slow CI.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&rxHits) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&rxHits), "receiver must be POSTed exactly once")
+
+	// Body shape: logout_token=<JWT>.
+	require.True(t, strings.HasPrefix(rxBody, "logout_token="), "body must be application/x-www-form-urlencoded: %s", rxBody)
+	jwtStr := strings.TrimPrefix(rxBody, "logout_token=")
+	parsed, err := jwt.Parse(jwtStr, func(tok *jwt.Token) (any, error) {
+		return []byte(env.JWTSecret), nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	claims := parsed.Claims.(jwt.MapClaims)
+	assert.Equal(t, clientID, claims["aud"])
+	assert.Equal(t, testJWTIssuer, claims["iss"])
+	assert.NotEmpty(t, claims["jti"])
+	assert.NotEmpty(t, claims["sub"], "sub must be present on a logout-all logout_token")
+	_, hasNonce := claims["nonce"]
+	assert.False(t, hasNonce, "logout_token MUST NOT contain a nonce (OIDC BCL §2.4)")
+	ev, ok := claims["events"].(map[string]any)
+	require.True(t, ok)
+	_, hasEvent := ev["http://schemas.openid.net/event/backchannel-logout"]
+	assert.True(t, hasEvent, "events claim must carry the BCL event-type URI")
+	assert.Equal(t, "logout+jwt", parsed.Header["typ"])
+}
+
+func TestBCL_E2E_NoBCLClientReceivesNothing(t *testing.T) {
+	env := NewTestEnv(t)
+
+	// Client registered WITHOUT backchannel_logout_uri must not be hit on
+	// logout-all even when an active refresh token exists.
+	c := NewTestClient(env)
+	resp := c.PostJSON("/apps/dcr", map[string]any{
+		"client_name": "no-bcl-client",
+		"grant_types": []string{"password", "refresh_token"},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	body := ReadJSON(resp)
+	clientID, _ := body["client_id"].(string)
+	defer NewTestClient(env).Delete("/apps/" + clientID)
+
+	email, password := CreateTestUser(t, env, "no-bcl")
+	tokBody, _ := json.Marshal(map[string]any{
+		"grant_type": "password",
+		"username":   email,
+		"password":   password,
+		"client_id":  clientID,
+	})
+	tokResp, err := http.Post(env.BaseURL()+"/api/token", "application/json", strings.NewReader(string(tokBody)))
+	require.NoError(t, err)
+	tokens := ReadJSON(tokResp)
+	accessToken, _ := tokens["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	logoutReq, _ := http.NewRequest(http.MethodPost, env.BaseURL()+"/api/logout-all", nil)
+	logoutReq.Header.Set("Authorization", "Bearer "+accessToken)
+	logoutResp, err := http.DefaultClient.Do(logoutReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, logoutResp.StatusCode)
+	// No assertion about outbound POSTs — the dispatcher correctly emits
+	// none when no client registered a BCL URI. The lack of crash + the
+	// 204 is the success signal.
+}
+

--- a/tests/e2e/testenv_test.go
+++ b/tests/e2e/testenv_test.go
@@ -42,11 +42,12 @@ type TestEnv struct {
 	Blacklist *core.InMemoryBlacklist
 
 	// Internal
-	apiAuth    *apiauth.APIAuth
-	registrar  *admin.AppRegistrar
-	localAuth  *localauth.LocalAuth
-	remoteMode bool
-	remoteURL  string
+	apiAuth       *apiauth.APIAuth
+	registrar     *admin.AppRegistrar
+	localAuth     *localauth.LocalAuth
+	bclDispatcher *apiauth.BCLDispatcher
+	remoteMode    bool
+	remoteURL     string
 }
 
 // NewTestEnv creates a full test environment with auth + resource servers.


### PR DESCRIPTION
## What changes

OneAuth becomes a Back-Channel Logout *sender*. When a session is revoked — `POST /api/logout-all`, `POST /api/logout`, or RFC 7009 `/oauth/revoke` — the AS POSTs a signed `logout_token` JWT to every affected client's registered `backchannel_logout_uri`. Resource servers that listen on that URL learn about revocations within seconds instead of polling `/introspect` on every request.

Receiver side is out of scope (lives in panyam/mcpkit, filed in parallel — neither blocks the other).

## Reviewer's guide

Read in this order:

1. [apiauth/logout_token.go](https://github.com/panyam/oneauth/pull/262/files#diff-f0808ec66454056bd40e0f90f55403d01e2faf4221d6161018295041de395461) — start here. `LogoutTokenIssuer` interface + the `jwtLogoutTokenIssuer` impl. The claim shape (`events`, sub/sid invariant, `typ=logout+jwt` header, no `nonce`) is where the spec lives — verify against OIDC BCL §2.4.
2. [apiauth/logout_token_test.go](https://github.com/panyam/oneauth/pull/262/files#diff-ab1de8072fee12ca3022e80ebacd8bde85fcc86ea82a71f7cfcdcdf0e548ac9c) — acceptance for the above. Negative cases (missing both `sub` and `sid`; missing `aud`) plus the happy paths.
3. [apiauth/bcl_dispatcher.go](https://github.com/panyam/oneauth/pull/262/files#diff-f8a69c828aceea337cf2f943f6bad08e2d4523fe34aadd05ef570a8bb46ba83f) — `BCLDispatcher`. The fan-out: enumerate clients via `GetSubjectTokens` (or accept an explicit `ClientIDs` list captured before revoke), mint per client, POST `application/x-www-form-urlencoded`. Async by default; `SyncForTest=true` for deterministic tests. `AppRegistrationLookup` is the narrow read-only slice it needs from `admin.AppRegistrar` (defined in `apiauth/` so the import goes the right way). **SSRF guard:** default `HTTPClient` uses a `net.Dialer.Control` callback that rejects loopback / RFC1918 / link-local / multicast / unspecified IPs at connect time, plus `CheckRedirect` refuses 3xx. `AllowPrivateHosts` opts in for closed networks.
4. [apiauth/bcl_dispatcher_test.go](https://github.com/panyam/oneauth/pull/262/files#diff-7d271ee40b4f69176be3aff2eb1da695c247b64b64077c5171907355633bc5e7) — table coverage: only registered URIs get hit; body is `logout_token=<jwt>`; `session_required` skipped without `sid`; non-2xx receivers don't crash; async `Wait()` drains; **default rejects loopback**; **redirects are not followed**.
5. [apiauth/bcl_integration_test.go](https://github.com/panyam/oneauth/pull/262/files#diff-f99862f12de21e6b29d77a60eaa18aa88f8f7c312750cf059330c9b7c24392c0) — exercises `HandleLogoutAll` and `HandleLogout` against real httptest receivers.
6. [tests/e2e/bcl_test.go](https://github.com/panyam/oneauth/pull/262/files#diff-d604d1d8166de2e58658b7bb8c2719852ff673530d421ab1d5d120b55154cef9) — full e2e through the in-process AS. Five scenarios: `/api/logout-all` happy path, RFC 7009 `/oauth/revoke` → BCL POST (catches the `NewRevocationHandler` hook-passthrough bug fixed in `apiauth/revocation.go`), AS metadata advertises `backchannel_logout_supported` / `_session_supported`, multi-client fan-out (A + B + no-BCL C → exactly A and B hit), and no-URI client receives nothing.
7. [apiauth/hooks.go](https://github.com/panyam/oneauth/pull/262/files#diff-3e9d55068dc15b1f648d679ef97fb18da9ec57124193d32d4c616e942da03bc5) — new `TokenHooks.OnSubjectRevoked(subject, sid, clientIDs)` and `OnTokenRevoked(subject, sid, clientID)`. `clientIDs` is captured **before** revoke because `GetSubjectTokens` only returns active grants — the e2e test caught this. Wiring points for any BCL/audit subscriber.
8. [apiauth/auth.go](https://github.com/panyam/oneauth/pull/262/files#diff-6f548dbab24d0609200ec2c43738d8d522c8f3d3b5b288eae95c1dc06b239bf8) — `APIAuth` gains a `TokenHooks` field (matches APIAuth's field-by-field style; distinct from `OneAuth.Hooks`). `HandleLogoutAll` captures `client_id`s from `GetSubjectTokens` before revoke, then fires `OnSubjectRevoked`. `HandleLogout` captures `(sub, family, client_id)` from the refresh-token row before revoke and fires `OnTokenRevoked`.
9. [apiauth/token_revoker.go](https://github.com/panyam/oneauth/pull/262/files#diff-ee56435ad67aa7af61ac40769e1b8a5993c60cfbb16bfeb6fb105d0d0532678a) — same capture-before-revoke pattern on the RFC 7009 path.
10. [core/app_registration.go](https://github.com/panyam/oneauth/pull/262/files#diff-2f4c1095236dcca4e14b7b559d2e448601ccba7678b73d09683d5998b084ecb6) + [admin/dcr.go](https://github.com/panyam/oneauth/pull/262/files#diff-8e791502e29614ef1d7bf703a4c4dd118447ae5a6a94f0e367c3876834cce6df) + [admin/registrar.go](https://github.com/panyam/oneauth/pull/262/files#diff-357a2ab591dde1d22068c00e675d315f4bbc15d7c36f0e89b29a4dd0b1ff953e) — model + DCR plumbing. **URI validation:** absolute URL, no fragment, https by default; literal-IP hosts parsed through `net.ParseIP` and rejected if loopback / RFC1918 / link-local / multicast / unspecified. `AllowPrivateBCLHosts` on `AppRegistrar` opts in. Same rule applied on RFC 7592 PUT.
11. [apiauth/as_metadata.go](https://github.com/panyam/oneauth/pull/262/files#diff-271d63776b88f1a5e791d54f0e5f2763fb32b5295d5f85d278bbebd7f3ca6456) — advertise `backchannel_logout_supported` / `backchannel_logout_session_supported` (pointer-typed so callers opt in explicitly when the dispatcher is actually wired).

Skim or skip: [apiauth/SUMMARY.md](https://github.com/panyam/oneauth/pull/262/files#diff-f3bbacfca08d00c3458076319ba481fec63aa40f5488dd2adf1254e38b90986e), [docs/ROADMAP.md](https://github.com/panyam/oneauth/pull/262/files#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2), the gap-analysis updates, [CLAUDE.md](https://github.com/panyam/oneauth/pull/262/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) table row.

## Decision log

- **`sid` = refresh-token `Family`.** OneAuth's refresh-token family is the closest analogue to an OIDC session — survives rotation, dies on logout-all. Encoded in the doc comments as the contract.
- **Hook-based dispatch, not inline.** `HandleLogoutAll` fires `OnSubjectRevoked`; the host wires `BCLDispatcher.Dispatch` to that hook. Keeps `apiauth` independent of `admin/`, lets callers swap the dispatcher (e.g., background queue), aligns with the existing `TokenHooks` / `AuthHooks` / `SecurityHooks` pattern. Rejected: wrapping revoke in a dispatcher (every caller has to know about BCL); pushing into store implementations (scatters policy across fs/gorm/gae).
- **Capture `clientIDs` before revoke.** `OnSubjectRevoked(subject, sid, clientIDs)` takes the affected client list as a parameter. `GetSubjectTokens` returns only active grants, so calling it *after* `RevokeSubjectTokens` returns nothing — the e2e test caught this. `HandleLogoutAll` now captures the client set before revoke and passes it through.
- **`NewRevocationHandler` inherits `auth.TokenHooks`.** Without this, RFC 7009 `/oauth/revoke` would build a `tokenRevoker` with empty hooks and the BCL dispatcher would silently miss revocations on the standards endpoint. The dedicated e2e test caught this too.
- **Async by default.** Production callers shouldn't block revoke on a slow receiver. `SyncForTest` is the opt-in test escape; `Wait()` is the async-drain barrier.
- **No retry / backoff.** Spec §3.2 is silent. Shipping the simplest correct dispatcher; retry can wrap `HTTPClient` later.
- **SSRF guard at two layers.** Validation rejects literal-IP private/loopback hosts at registration (loud failure at config time). The dispatcher's default `HTTPClient` re-checks the resolved IP at dial time via `net.Dialer.Control` (closes the DNS-rebinding gap that registration-time validation can't catch) and refuses to follow 3xx. Closed-network deployments flip both `AppRegistrar.AllowPrivateBCLHosts` and `BCLDispatcher.AllowPrivateHosts`.
- **Sender side only.** Receiver semantics belong in mcpkit (filed in parallel, plain-text reference, no backlink).

## Risk / blast radius

- **Affects:** `apiauth/` token-revoke paths gain a new hook fire (no behavior change when `TokenHooks` fields are nil — backward compatible). DCR + RFC 7592 surfaces gain two optional fields. AS metadata gains two optional fields (pointer-typed; nil omits).
- **Tests covering this:** 14 unit tests in `apiauth/` (BCL + logout_token + dispatcher-SSRF + redirect-non-follow), 7 DCR tests in `admin/` (round-trip + URI validation + opt-in escape), 2 integration tests, 5 e2e tests covering `/api/logout-all`, RFC 7009 `/oauth/revoke`, AS metadata, multi-client fan-out, and no-URI clients. Full `make test` is green.
- **Be paranoid about:**
  - SSRF surface. A client registering `https://10.0.0.1/bcl` is blocked at DCR. A hostname that resolves to a private IP at dial time is blocked by the dialer. Worth pressure-testing the IP-literal parsing against weird forms.
  - The `HandleLogout` capture-before-revoke read. If the store's `GetRefreshToken` returns the same row by reference rather than a clone, the subsequent `Revoked = true` mutation could race with the hook firing. The in-memory fake clones; production GORM/FS backends read fresh. Worth a second look.
  - Async dispatch fan-out. The dispatcher spawns a goroutine per client; a thousand clients on a `RevokeSubjectTokens` means a thousand simultaneous outbound POSTs. Acceptable for typical deployments but something to know.
  - `sid = family` mapping. Receivers that key off `sid` are now coupled to oneauth's family semantics. Doc-commented as the contract.

## Out of scope (deliberately deferred)

- HTTP retry with exponential backoff — follow-up.
- Standalone admin REST API to set `backchannel_logout_uri` post-registration — RFC 7592 PUT already covers it; deferred.
- Front-Channel Logout (separate OIDC spec).
- Keycloak interop — Keycloak as a *receiver* needs its own BCL receiver config; runs naturally once the mcpkit receiver lands and we have round-trip interop instead of a one-way "did Keycloak accept it" check.

Closes #261.

