### PR TITLE
feat(cmd/oneauth): introspect / dcr / jwks subcommands + CLI docs (#258, #260)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,7 +1,7 @@
 # OneAuth
 
 ## Version
-v0.1.13
+v0.1.20
 
 ## Provides
 - local-authentication: Email/password authentication with signup policy, rate limiting, account lockout
@@ -39,6 +39,7 @@ v0.1.13
 - lifecycle-hooks: Grouped callbacks (TokenHooks, AuthHooks, ClientHooks, SecurityHooks) for audit, alerting, integration
 - interactive-examples: 10 progressive examples on demokit v0.0.16 — split into `main.go` (server with `--serve` real-port mode) + `walkthrough.go` (client demo). Slim `README.md` + generated `WALKTHROUGH.md` (mermaid + steps + copy-paste curl reproductions). Default `make demo` uses the TUI renderer.
 - client-sdk: AuthClient with credential store, auto-refresh, browser login
+- oneauth-cli: `cmd/oneauth` Cobra binary covering OAuth 2.0 token acquisition (browser / client-credentials / password / refresh), RFC 7662 introspection, RFC 7591/7592 dynamic client registration + management, and RFC 7517 JWKS inspection. `--format json|bash|access-token-only` for shell integration. Dogfoods `client/` SDK + `apiauth.IntrospectionValidator`. Issues 255 (token) + 258 (introspect / dcr / jwks).
 - test-infrastructure: Reusable testutil package with TestAuthServer (RSA, JWKS, AS metadata) and shared OAuth helpers
 
 ## Module

--- a/cmd/oneauth/SUMMARY.md
+++ b/cmd/oneauth/SUMMARY.md
@@ -1,8 +1,8 @@
 # cmd/oneauth — OAuth client CLI
 
-Cobra-based CLI that wraps the `client/` SDK. First-shipped surface is
-the `token` subcommand for acquiring OAuth 2.0 access tokens against
-any RFC 8414 / OIDC-compliant authorization server.
+Cobra-based CLI that wraps the `client/` SDK and dogfoods
+`apiauth.IntrospectionValidator`. Ships `token`, `introspect`, `dcr`,
+and `jwks` against any RFC 8414 / OIDC-compliant authorization server.
 
 ## Contents
 
@@ -19,6 +19,16 @@ any RFC 8414 / OIDC-compliant authorization server.
   6749 §4.3 ROPC grant; prints a deprecation banner to stderr.
 - **cmd/token_refresh.go** — `oneauth token refresh <issuer>` — RFC 6749
   §6 refresh_token grant. Calls `client.AuthClient.RefreshToken`.
+- **cmd/introspect.go** — `oneauth introspect <issuer>` — RFC 7662 token
+  introspection via `apiauth.IntrospectionValidator`. `--format active`
+  prints just `true|false` for shell predicates (issue 258).
+- **cmd/dcr.go** — `oneauth dcr register|get|put|delete <issuer>` —
+  RFC 7591 registration + RFC 7592 management. Wraps
+  `client.RegisterClient`, `client.GetRegistration`,
+  `client.UpdateRegistration`, `client.DeleteRegistration` (issue 258).
+- **cmd/jwks.go** — `oneauth jwks <issuer>` — fetch + pretty-print
+  RFC 7517 JSON Web Key Set. `--kid` and `--sig-only` filters; `--format
+  table` for a human-scan-friendly summary (issue 258).
 - **cmd/format.go** — JSON / bash / access-token-only emitters.
 
 ## Module structure
@@ -36,7 +46,9 @@ dependency graph — downstream library consumers don't pull CLI deps.
 
 ## See
 
-- Issue: panyam/oneauth issue 255
+- Issues: panyam/oneauth issue 255 (token), 258 (introspect / dcr / jwks).
 - Library entry points: `client.AuthClient.LoginWithBrowser`,
   `client.AuthClient.ClientCredentials`, `client.AuthClient.Login`,
-  `client.AuthClient.RefreshToken`.
+  `client.AuthClient.RefreshToken`, `client.RegisterClient` /
+  `GetRegistration` / `UpdateRegistration` / `DeleteRegistration`,
+  `apiauth.IntrospectionValidator`.

--- a/cmd/oneauth/cmd/dcr.go
+++ b/cmd/oneauth/cmd/dcr.go
@@ -1,0 +1,347 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/panyam/oneauth/client"
+	"github.com/spf13/cobra"
+)
+
+// dcrFlags holds the persistent --format flag for `oneauth dcr`. Each
+// subcommand defines its own request flags directly.
+type dcrFlags struct {
+	format string
+}
+
+// newDCRCommand builds `oneauth dcr`, the RFC 7591 Dynamic Client
+// Registration parent. Subcommands are register / get / put / delete —
+// the verb set RFC 7592 lays out for the full lifecycle.
+func newDCRCommand() *cobra.Command {
+	df := &dcrFlags{}
+	cmd := &cobra.Command{
+		Use:   "dcr",
+		Short: "Manage OAuth client registrations (RFC 7591 / RFC 7592)",
+		Long: `Register, read, update, and delete OAuth clients via the auth server's
+Dynamic Client Registration endpoint (RFC 7591) and management endpoint
+(RFC 7592). The registration_access_token returned at registration time
+is required for every subsequent management call.`,
+	}
+	cmd.PersistentFlags().StringVar(&df.format, "format", "json", `output format: "json" | "bash"`)
+	cmd.AddCommand(
+		newDCRRegisterCommand(df),
+		newDCRGetCommand(df),
+		newDCRPutCommand(df),
+		newDCRDeleteCommand(df),
+	)
+	return cmd
+}
+
+// --- register --------------------------------------------------------
+
+type dcrRegisterFlags struct {
+	clientName              string
+	clientURI               string
+	grantTypes              []string
+	responseTypes           []string
+	redirectURIs            []string
+	scope                   string
+	tokenEndpointAuthMethod string
+	applicationType         string
+}
+
+func newDCRRegisterCommand(df *dcrFlags) *cobra.Command {
+	rf := &dcrRegisterFlags{}
+	cmd := &cobra.Command{
+		Use:   "register <issuer>",
+		Short: "Register a new OAuth client (RFC 7591)",
+		Long: `POST to the auth server's registration_endpoint (RFC 7591). The AS
+assigns a fresh client_id, optional client_secret, and the RFC 7592
+management credentials (registration_access_token, registration_client_uri).
+
+Persist the registration_access_token and registration_client_uri — they
+are the only way to subsequently read / update / delete this
+registration.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDCRRegister(cmd.Context(), cmd.OutOrStdout(), args[0], df, rf)
+		},
+	}
+	cmd.Flags().StringVar(&rf.clientName, "client-name", "", "human-readable client name")
+	cmd.Flags().StringVar(&rf.clientURI, "client-uri", "", "client home page URL")
+	cmd.Flags().StringSliceVar(&rf.grantTypes, "grant-types", nil, `OAuth grant types (e.g., "authorization_code","refresh_token")`)
+	cmd.Flags().StringSliceVar(&rf.responseTypes, "response-types", nil, `OAuth response types (e.g., "code")`)
+	cmd.Flags().StringSliceVar(&rf.redirectURIs, "redirect-uri", nil, "redirect URI (repeatable)")
+	cmd.Flags().StringVar(&rf.scope, "scope", "", `space-delimited OAuth scopes (e.g., "read write")`)
+	cmd.Flags().StringVar(&rf.tokenEndpointAuthMethod, "token-endpoint-auth-method", "", `auth method: "client_secret_basic" | "client_secret_post" | "private_key_jwt" | "none"`)
+	cmd.Flags().StringVar(&rf.applicationType, "application-type", "", `OIDC application type: "web" | "native"`)
+	return cmd
+}
+
+func runDCRRegister(_ context.Context, stdout io.Writer, issuer string, df *dcrFlags, rf *dcrRegisterFlags) error {
+	_, meta, err := newAuthClient(issuer)
+	if err != nil {
+		return err
+	}
+	if meta.RegistrationEndpoint == "" {
+		return fmt.Errorf("registration_endpoint not advertised by %s", issuer)
+	}
+	req := client.ClientRegistrationRequest{
+		ClientName:              rf.clientName,
+		ClientURI:               rf.clientURI,
+		RedirectURIs:            rf.redirectURIs,
+		GrantTypes:              rf.grantTypes,
+		ResponseTypes:           rf.responseTypes,
+		TokenEndpointAuthMethod: rf.tokenEndpointAuthMethod,
+		Scope:                   rf.scope,
+		ApplicationType:         rf.applicationType,
+	}
+	resp, err := client.RegisterClient(meta.RegistrationEndpoint, req, http.DefaultClient)
+	if err != nil {
+		return fmt.Errorf("dcr register: %w", err)
+	}
+	return emitDCR(stdout, df.format, resp)
+}
+
+// --- get -------------------------------------------------------------
+
+type dcrGetFlags struct {
+	clientID                string
+	registrationAccessToken string
+	registrationClientURI   string
+}
+
+func newDCRGetCommand(df *dcrFlags) *cobra.Command {
+	gf := &dcrGetFlags{}
+	cmd := &cobra.Command{
+		Use:   "get <issuer>",
+		Short: "Read a registered client (RFC 7592 §2.1)",
+		Long: `GET the management endpoint for an existing registration. Either
+--registration-client-uri (the absolute URI returned at registration
+time) or --client-id (resolved against the issuer's registration_endpoint
++ client_id path) is required.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDCRGet(cmd.Context(), cmd.OutOrStdout(), args[0], df, gf)
+		},
+	}
+	dcrManagementFlags(cmd, &gf.clientID, &gf.registrationAccessToken, &gf.registrationClientURI)
+	_ = cmd.MarkFlagRequired("registration-access-token")
+	return cmd
+}
+
+func runDCRGet(ctx context.Context, stdout io.Writer, issuer string, df *dcrFlags, gf *dcrGetFlags) error {
+	uri, err := resolveManagementURI(issuer, gf.clientID, gf.registrationClientURI)
+	if err != nil {
+		return err
+	}
+	resp, err := client.GetRegistration(ctx, &client.GetRegistrationRequest{
+		RegistrationClientURI:   uri,
+		RegistrationAccessToken: gf.registrationAccessToken,
+	})
+	if err != nil {
+		return mapRegistrationErr(err, "dcr get")
+	}
+	return emitDCR(stdout, df.format, resp.Registration)
+}
+
+// --- put (update) ----------------------------------------------------
+
+type dcrPutFlags struct {
+	clientID                string
+	registrationAccessToken string
+	registrationClientURI   string
+	clientName              string
+	clientURI               string
+	grantTypes              []string
+	responseTypes           []string
+	redirectURIs            []string
+	scope                   string
+	tokenEndpointAuthMethod string
+	applicationType         string
+}
+
+func newDCRPutCommand(df *dcrFlags) *cobra.Command {
+	pf := &dcrPutFlags{}
+	cmd := &cobra.Command{
+		Use:   "put <issuer>",
+		Short: "Replace a registered client's metadata (RFC 7592 §2.2)",
+		Long: `PUT to the management endpoint. RFC 7592 treats this as a
+full-replace — fields you omit are blanked. Fetch first with
+` + "`oneauth dcr get`" + ` and edit the response if you only want to
+change a subset of fields. The AS rotates the registration_access_token
+on success; the new token is in the response.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDCRPut(cmd.Context(), cmd.OutOrStdout(), args[0], df, pf)
+		},
+	}
+	dcrManagementFlags(cmd, &pf.clientID, &pf.registrationAccessToken, &pf.registrationClientURI)
+	cmd.Flags().StringVar(&pf.clientName, "client-name", "", "human-readable client name")
+	cmd.Flags().StringVar(&pf.clientURI, "client-uri", "", "client home page URL")
+	cmd.Flags().StringSliceVar(&pf.grantTypes, "grant-types", nil, "OAuth grant types")
+	cmd.Flags().StringSliceVar(&pf.responseTypes, "response-types", nil, "OAuth response types")
+	cmd.Flags().StringSliceVar(&pf.redirectURIs, "redirect-uri", nil, "redirect URI (repeatable)")
+	cmd.Flags().StringVar(&pf.scope, "scope", "", `space-delimited OAuth scopes`)
+	cmd.Flags().StringVar(&pf.tokenEndpointAuthMethod, "token-endpoint-auth-method", "", "auth method")
+	cmd.Flags().StringVar(&pf.applicationType, "application-type", "", `OIDC application type: "web" | "native"`)
+	_ = cmd.MarkFlagRequired("client-id")
+	_ = cmd.MarkFlagRequired("registration-access-token")
+	return cmd
+}
+
+func runDCRPut(ctx context.Context, stdout io.Writer, issuer string, df *dcrFlags, pf *dcrPutFlags) error {
+	uri, err := resolveManagementURI(issuer, pf.clientID, pf.registrationClientURI)
+	if err != nil {
+		return err
+	}
+	resp, err := client.UpdateRegistration(ctx, &client.UpdateRegistrationRequest{
+		RegistrationClientURI:   uri,
+		RegistrationAccessToken: pf.registrationAccessToken,
+		ClientID:                pf.clientID,
+		Metadata: client.ClientRegistrationRequest{
+			ClientName:              pf.clientName,
+			ClientURI:               pf.clientURI,
+			RedirectURIs:            pf.redirectURIs,
+			GrantTypes:              pf.grantTypes,
+			ResponseTypes:           pf.responseTypes,
+			Scope:                   pf.scope,
+			TokenEndpointAuthMethod: pf.tokenEndpointAuthMethod,
+			ApplicationType:         pf.applicationType,
+		},
+	})
+	if err != nil {
+		return mapRegistrationErr(err, "dcr put")
+	}
+	return emitDCR(stdout, df.format, resp.Registration)
+}
+
+// --- delete ----------------------------------------------------------
+
+type dcrDeleteFlags struct {
+	clientID                string
+	registrationAccessToken string
+	registrationClientURI   string
+}
+
+func newDCRDeleteCommand(df *dcrFlags) *cobra.Command {
+	xf := &dcrDeleteFlags{}
+	cmd := &cobra.Command{
+		Use:   "delete <issuer>",
+		Short: "Delete a registered client (RFC 7592 §2.3)",
+		Long: `DELETE the management endpoint. The AS invalidates the
+registration's signing credentials so any tokens already issued under
+this client_id fail subsequent validation.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDCRDelete(cmd.Context(), cmd.OutOrStdout(), args[0], df, xf)
+		},
+	}
+	dcrManagementFlags(cmd, &xf.clientID, &xf.registrationAccessToken, &xf.registrationClientURI)
+	_ = cmd.MarkFlagRequired("registration-access-token")
+	return cmd
+}
+
+func runDCRDelete(ctx context.Context, stdout io.Writer, issuer string, df *dcrFlags, xf *dcrDeleteFlags) error {
+	uri, err := resolveManagementURI(issuer, xf.clientID, xf.registrationClientURI)
+	if err != nil {
+		return err
+	}
+	if _, err := client.DeleteRegistration(ctx, &client.DeleteRegistrationRequest{
+		RegistrationClientURI:   uri,
+		RegistrationAccessToken: xf.registrationAccessToken,
+	}); err != nil {
+		return mapRegistrationErr(err, "dcr delete")
+	}
+	if df.format == "bash" {
+		fmt.Fprintf(stdout, "# deleted %s\n", uri)
+		return nil
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]any{"deleted": true, "registration_client_uri": uri})
+}
+
+// --- shared helpers --------------------------------------------------
+
+func dcrManagementFlags(cmd *cobra.Command, clientID, accessToken, regURI *string) {
+	cmd.Flags().StringVar(clientID, "client-id", "", "client_id (resolved against issuer's registration_endpoint when --registration-client-uri is absent)")
+	cmd.Flags().StringVar(accessToken, "registration-access-token", "", "RFC 7592 management token returned at registration (required)")
+	cmd.Flags().StringVar(regURI, "registration-client-uri", "", "absolute management URI (overrides --client-id derivation)")
+}
+
+// resolveManagementURI computes the registration_client_uri to call. When
+// the caller supplies it directly that's the answer; otherwise we
+// discover the issuer's registration_endpoint and append /client_id —
+// the convention used by oneauth's own admin server. ASes that deviate
+// (Keycloak, Auth0) require the caller to pass --registration-client-uri
+// explicitly.
+func resolveManagementURI(issuer, clientID, registrationClientURI string) (string, error) {
+	if registrationClientURI != "" {
+		return registrationClientURI, nil
+	}
+	if clientID == "" {
+		return "", fmt.Errorf("--registration-client-uri or --client-id is required")
+	}
+	_, meta, err := newAuthClient(issuer)
+	if err != nil {
+		return "", err
+	}
+	if meta.RegistrationEndpoint == "" {
+		return "", fmt.Errorf("registration_endpoint not advertised by %s; pass --registration-client-uri explicitly", issuer)
+	}
+	return joinPath(meta.RegistrationEndpoint, clientID), nil
+}
+
+// joinPath safely appends a path segment. Avoids the double-slash and
+// missing-slash failure modes that bite naive string concatenation.
+func joinPath(base, segment string) string {
+	if base == "" {
+		return segment
+	}
+	if base[len(base)-1] == '/' {
+		return base + segment
+	}
+	return base + "/" + segment
+}
+
+// emitDCR writes a registration response in the requested format. The
+// "bash" form exports the fields a downstream shell script most often
+// needs (client_id, client_secret, registration_access_token).
+func emitDCR(w io.Writer, format string, r *client.ClientRegistrationResponse) error {
+	switch format {
+	case "", "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	case "bash":
+		fmt.Fprintf(w, "export OAUTH_CLIENT_ID=%s\n", shellSingleQuote(r.ClientID))
+		if r.ClientSecret != "" {
+			fmt.Fprintf(w, "export OAUTH_CLIENT_SECRET=%s\n", shellSingleQuote(r.ClientSecret))
+		}
+		if r.RegistrationAccessToken != "" {
+			fmt.Fprintf(w, "export OAUTH_REGISTRATION_ACCESS_TOKEN=%s\n", shellSingleQuote(r.RegistrationAccessToken))
+		}
+		if r.RegistrationClientURI != "" {
+			fmt.Fprintf(w, "export OAUTH_REGISTRATION_CLIENT_URI=%s\n", shellSingleQuote(r.RegistrationClientURI))
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q (want json | bash)", format)
+	}
+}
+
+// mapRegistrationErr maps client.ErrRegistrationUnauthorized to a CLI
+// message that distinguishes auth failure from generic errors. RFC 7592
+// returns 401 for every auth failure mode (wrong token, missing token,
+// unknown client_id) so the CLI can't be more specific.
+func mapRegistrationErr(err error, prefix string) error {
+	if errors.Is(err, client.ErrRegistrationUnauthorized) {
+		return fmt.Errorf("%s: unauthorized — check --registration-access-token", prefix)
+	}
+	return fmt.Errorf("%s: %w", prefix, err)
+}

--- a/cmd/oneauth/cmd/dcr_test.go
+++ b/cmd/oneauth/cmd/dcr_test.go
@@ -1,0 +1,273 @@
+package cmd
+
+// Tests for `oneauth dcr <register|get|put|delete>` against an in-memory
+// AS that serves RFC 8414 metadata + the RFC 7591 registration endpoint
+// + the RFC 7592 management endpoint.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type syntheticDCRAS struct {
+	srv *httptest.Server
+	mu  sync.Mutex
+	// clients keyed by client_id. Holds registration metadata + a
+	// rotating registration_access_token (RFC 7592 §2.2 rotates on PUT).
+	clients map[string]*dcrClientState
+}
+
+type dcrClientState struct {
+	clientName   string
+	clientURI    string
+	redirectURIs []string
+	grantTypes   []string
+	accessToken  string
+}
+
+func newSyntheticDCRAS(t *testing.T) *syntheticDCRAS {
+	t.Helper()
+	as := &syntheticDCRAS{clients: map[string]*dcrClientState{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                as.srv.URL,
+			"token_endpoint":        as.srv.URL + "/token",
+			"registration_endpoint": as.srv.URL + "/apps/dcr",
+		})
+	})
+	mux.HandleFunc("/apps/dcr", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		clientID := fmt.Sprintf("client-%d", len(as.clients)+1)
+		token := fmt.Sprintf("regtok-%s", clientID)
+		state := &dcrClientState{
+			clientName:  asString(body["client_name"]),
+			clientURI:   asString(body["client_uri"]),
+			accessToken: token,
+		}
+		if v, ok := body["redirect_uris"].([]any); ok {
+			for _, u := range v {
+				state.redirectURIs = append(state.redirectURIs, asString(u))
+			}
+		}
+		if v, ok := body["grant_types"].([]any); ok {
+			for _, g := range v {
+				state.grantTypes = append(state.grantTypes, asString(g))
+			}
+		}
+		as.mu.Lock()
+		as.clients[clientID] = state
+		as.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id":                 clientID,
+			"client_secret":             "secret-" + clientID,
+			"client_name":               state.clientName,
+			"redirect_uris":             state.redirectURIs,
+			"grant_types":               state.grantTypes,
+			"registration_access_token": token,
+			"registration_client_uri":   as.srv.URL + "/apps/dcr/" + clientID,
+		})
+	})
+	mux.HandleFunc("/apps/dcr/", func(w http.ResponseWriter, r *http.Request) {
+		clientID := strings.TrimPrefix(r.URL.Path, "/apps/dcr/")
+		as.mu.Lock()
+		state, ok := as.clients[clientID]
+		as.mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+state.accessToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "invalid_token"})
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"client_id":                 clientID,
+				"client_name":               state.clientName,
+				"redirect_uris":             state.redirectURIs,
+				"grant_types":               state.grantTypes,
+				"registration_access_token": state.accessToken,
+				"registration_client_uri":   as.srv.URL + "/apps/dcr/" + clientID,
+			})
+		case http.MethodPut:
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			as.mu.Lock()
+			state.clientName = asString(body["client_name"])
+			state.redirectURIs = nil
+			if v, ok := body["redirect_uris"].([]any); ok {
+				for _, u := range v {
+					state.redirectURIs = append(state.redirectURIs, asString(u))
+				}
+			}
+			// RFC 7592 §2.2 rotates the token on every successful PUT.
+			state.accessToken = state.accessToken + "-rotated"
+			as.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"client_id":                 clientID,
+				"client_name":               state.clientName,
+				"redirect_uris":             state.redirectURIs,
+				"registration_access_token": state.accessToken,
+				"registration_client_uri":   as.srv.URL + "/apps/dcr/" + clientID,
+			})
+		case http.MethodDelete:
+			as.mu.Lock()
+			delete(as.clients, clientID)
+			as.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	as.srv = httptest.NewServer(mux)
+	t.Cleanup(as.srv.Close)
+	return as
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func TestRunDCRRegister_HappyPath(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	df := &dcrFlags{format: "json"}
+	rf := &dcrRegisterFlags{
+		clientName:   "demo",
+		redirectURIs: []string{"https://app.example/cb"},
+		grantTypes:   []string{"authorization_code", "refresh_token"},
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runDCRRegister(context.Background(), &stdout, as.srv.URL, df, rf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, "client-1", out["client_id"])
+	assert.Equal(t, "regtok-client-1", out["registration_access_token"])
+}
+
+func TestRunDCRRegister_BashFormatExportsCredentials(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	df := &dcrFlags{format: "bash"}
+	rf := &dcrRegisterFlags{clientName: "demo"}
+	var stdout bytes.Buffer
+	require.NoError(t, runDCRRegister(context.Background(), &stdout, as.srv.URL, df, rf))
+	out := stdout.String()
+	assert.Contains(t, out, "export OAUTH_CLIENT_ID='client-1'")
+	assert.Contains(t, out, "export OAUTH_REGISTRATION_ACCESS_TOKEN='regtok-client-1'")
+}
+
+func TestRunDCRGet_HappyPath(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	// Register first.
+	df := &dcrFlags{format: "json"}
+	require.NoError(t, runDCRRegister(context.Background(), new(bytes.Buffer), as.srv.URL,
+		df, &dcrRegisterFlags{clientName: "demo"}))
+
+	gf := &dcrGetFlags{
+		clientID:                "client-1",
+		registrationAccessToken: "regtok-client-1",
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runDCRGet(context.Background(), &stdout, as.srv.URL, df, gf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, "client-1", out["client_id"])
+	assert.Equal(t, "demo", out["client_name"])
+}
+
+func TestRunDCRGet_WrongTokenRejected(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	require.NoError(t, runDCRRegister(context.Background(), new(bytes.Buffer), as.srv.URL,
+		&dcrFlags{format: "json"}, &dcrRegisterFlags{clientName: "demo"}))
+
+	gf := &dcrGetFlags{
+		clientID:                "client-1",
+		registrationAccessToken: "WRONG",
+	}
+	err := runDCRGet(context.Background(), new(bytes.Buffer), as.srv.URL, &dcrFlags{format: "json"}, gf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthorized")
+}
+
+func TestRunDCRPut_UpdatesAndRotatesToken(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	df := &dcrFlags{format: "json"}
+	require.NoError(t, runDCRRegister(context.Background(), new(bytes.Buffer), as.srv.URL,
+		df, &dcrRegisterFlags{clientName: "demo"}))
+
+	pf := &dcrPutFlags{
+		clientID:                "client-1",
+		registrationAccessToken: "regtok-client-1",
+		clientName:              "demo-renamed",
+		redirectURIs:            []string{"https://app.example/v2/cb"},
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runDCRPut(context.Background(), &stdout, as.srv.URL, df, pf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, "demo-renamed", out["client_name"])
+	assert.Equal(t, "regtok-client-1-rotated", out["registration_access_token"],
+		"PUT MUST surface the rotated registration_access_token (RFC 7592 §2.2)")
+}
+
+func TestRunDCRDelete_HappyPath(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	df := &dcrFlags{format: "json"}
+	require.NoError(t, runDCRRegister(context.Background(), new(bytes.Buffer), as.srv.URL,
+		df, &dcrRegisterFlags{clientName: "demo"}))
+
+	xf := &dcrDeleteFlags{
+		clientID:                "client-1",
+		registrationAccessToken: "regtok-client-1",
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runDCRDelete(context.Background(), &stdout, as.srv.URL, df, xf))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, true, out["deleted"])
+
+	// And the client is gone — subsequent get yields unauthorized (RFC 7592
+	// returns 401 for unknown client_id to avoid existence probing).
+	gf := &dcrGetFlags{
+		clientID:                "client-1",
+		registrationAccessToken: "regtok-client-1",
+	}
+	require.Error(t, runDCRGet(context.Background(), new(bytes.Buffer), as.srv.URL, df, gf))
+}
+
+func TestRunDCRGet_NeitherIDNorURI(t *testing.T) {
+	as := newSyntheticDCRAS(t)
+	df := &dcrFlags{format: "json"}
+	err := runDCRGet(context.Background(), new(bytes.Buffer), as.srv.URL, df, &dcrGetFlags{
+		registrationAccessToken: "regtok",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client-id")
+}

--- a/cmd/oneauth/cmd/introspect.go
+++ b/cmd/oneauth/cmd/introspect.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/spf13/cobra"
+)
+
+// introspectFlags carries the inputs for `oneauth introspect`.
+type introspectFlags struct {
+	token             string
+	tokenStdin        bool
+	clientID          string
+	clientSecret      string
+	clientSecretStdin bool
+	format            string
+}
+
+// newIntrospectCommand builds `oneauth introspect <issuer>`. The verb is
+// a sibling of `token` rather than a child because it answers a
+// completely different question — "is this token still active?" — and
+// the RFC 7662 wire format has no overlap with token issuance.
+//
+// The CLI dogfoods apiauth.IntrospectionValidator so any future
+// behavior change (tracing, header handling) lands here automatically.
+func newIntrospectCommand() *cobra.Command {
+	ff := &introspectFlags{}
+	cmd := &cobra.Command{
+		Use:   "introspect <issuer>",
+		Short: "Check a token's validity via RFC 7662 introspection",
+		Long: `Call the auth server's introspection endpoint (RFC 7662) to check
+whether a token is active and read its claims (sub, scope, exp, iss, jti, aud).
+
+The issuer is the AS base URL — the introspection endpoint is resolved
+via OIDC / RFC 8414 discovery (` + "`/.well-known/openid-configuration`" + `).
+
+Use --token-stdin and --client-secret-stdin to keep secrets out of
+shell history and process listings.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runIntrospect(cmd.Context(), cmd.OutOrStdout(), args[0], ff)
+		},
+	}
+	cmd.Flags().StringVar(&ff.token, "token", "", "token to introspect (required unless --token-stdin)")
+	cmd.Flags().BoolVar(&ff.tokenStdin, "token-stdin", false, "read token from stdin")
+	cmd.Flags().StringVar(&ff.clientID, "client-id", "", "client_id authenticating to the introspection endpoint (required)")
+	cmd.Flags().StringVar(&ff.clientSecret, "client-secret", "", "client_secret (required unless --client-secret-stdin)")
+	cmd.Flags().BoolVar(&ff.clientSecretStdin, "client-secret-stdin", false, "read client secret from stdin")
+	cmd.Flags().StringVar(&ff.format, "format", "json", `output format: "json" | "active"`)
+	_ = cmd.MarkFlagRequired("client-id")
+	return cmd
+}
+
+func runIntrospect(ctx context.Context, stdout io.Writer, issuer string, ff *introspectFlags) error {
+	token, err := resolveSecret(ff.token, ff.tokenStdin, "--token")
+	if err != nil {
+		return err
+	}
+	if token == "" {
+		return fmt.Errorf("--token (or --token-stdin) is required")
+	}
+	secret, err := resolveSecret(ff.clientSecret, ff.clientSecretStdin, "--client-secret")
+	if err != nil {
+		return err
+	}
+
+	_, meta, err := newAuthClient(issuer)
+	if err != nil {
+		return err
+	}
+	if meta.IntrospectionEndpoint == "" {
+		return fmt.Errorf("introspection_endpoint not advertised by %s", issuer)
+	}
+
+	iv := &apiauth.IntrospectionValidator{
+		IntrospectionURL: meta.IntrospectionEndpoint,
+		ClientID:         ff.clientID,
+		ClientSecret:     secret,
+		HTTPClient:       http.DefaultClient,
+	}
+	result, err := iv.ValidateWithContext(ctx, token)
+	if err != nil {
+		return fmt.Errorf("introspect: %w", err)
+	}
+	return emitIntrospection(stdout, ff.format, result)
+}
+
+// emitIntrospection writes the introspection result in the requested
+// format. The "active" format prints just `true` / `false` — useful as
+// the predicate of a shell `if`.
+func emitIntrospection(w io.Writer, format string, r *apiauth.IntrospectionResult) error {
+	switch format {
+	case "", "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	case "active":
+		_, err := fmt.Fprintln(w, r.Active)
+		return err
+	default:
+		return fmt.Errorf("unknown format %q (want json | active)", format)
+	}
+}

--- a/cmd/oneauth/cmd/introspect_test.go
+++ b/cmd/oneauth/cmd/introspect_test.go
@@ -1,0 +1,163 @@
+package cmd
+
+// Tests for `oneauth introspect <issuer>` against an in-memory AS that
+// serves RFC 8414 metadata and RFC 7662 introspection responses.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syntheticIntrospectAS extends syntheticAS-style infrastructure with an
+// /introspect endpoint. Defined here (rather than threading flags into
+// the shared fixture in token_test.go) so a future token-only assertion
+// doesn't accidentally depend on introspection behavior.
+type syntheticIntrospectAS struct {
+	srv         *httptest.Server
+	introspect  func(form map[string][]string, basicUser, basicPass string) (status int, body map[string]any)
+	hitCount    atomic.Int32
+	lastAuthHdr atomic.Value // string
+}
+
+func newSyntheticIntrospectAS(t *testing.T) *syntheticIntrospectAS {
+	t.Helper()
+	as := &syntheticIntrospectAS{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 as.srv.URL,
+			"token_endpoint":         as.srv.URL + "/token",
+			"introspection_endpoint": as.srv.URL + "/oauth/introspect",
+		})
+	})
+	mux.HandleFunc("/oauth/introspect", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		as.hitCount.Add(1)
+		user, pass, _ := r.BasicAuth()
+		as.lastAuthHdr.Store(user + ":" + pass)
+		status, body := http.StatusOK, map[string]any{"active": false}
+		if as.introspect != nil {
+			status, body = as.introspect(r.Form, user, pass)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+	})
+	as.srv = httptest.NewServer(mux)
+	t.Cleanup(as.srv.Close)
+	return as
+}
+
+func TestRunIntrospect_ActiveTokenJSON(t *testing.T) {
+	as := newSyntheticIntrospectAS(t)
+	as.introspect = func(form map[string][]string, user, pass string) (int, map[string]any) {
+		assert.Equal(t, []string{"TOK"}, form["token"])
+		return http.StatusOK, map[string]any{
+			"active":    true,
+			"sub":       "alice",
+			"scope":     "read write",
+			"client_id": "rs",
+		}
+	}
+	ff := &introspectFlags{
+		token:        "TOK",
+		clientID:     "rs",
+		clientSecret: "shh",
+		format:       "json",
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runIntrospect(context.Background(), &stdout, as.srv.URL, ff))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, true, out["active"])
+	assert.Equal(t, "alice", out["sub"])
+	assert.Equal(t, "read write", out["scope"])
+	assert.Equal(t, "rs:shh", as.lastAuthHdr.Load())
+}
+
+func TestRunIntrospect_InactiveActiveFormat(t *testing.T) {
+	// --format active prints the bare bool — the predicate form for
+	// `if [ "$(oneauth introspect ... --format active)" = "true" ]`.
+	as := newSyntheticIntrospectAS(t)
+	as.introspect = func(_ map[string][]string, _, _ string) (int, map[string]any) {
+		return http.StatusOK, map[string]any{"active": false}
+	}
+	ff := &introspectFlags{
+		token:        "TOK",
+		clientID:     "rs",
+		clientSecret: "shh",
+		format:       "active",
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runIntrospect(context.Background(), &stdout, as.srv.URL, ff))
+	assert.Equal(t, "false\n", stdout.String())
+}
+
+func TestRunIntrospect_StdinToken(t *testing.T) {
+	as := newSyntheticIntrospectAS(t)
+	as.introspect = func(form map[string][]string, _, _ string) (int, map[string]any) {
+		assert.Equal(t, []string{"stdin-token"}, form["token"])
+		return http.StatusOK, map[string]any{"active": true}
+	}
+	stdin, restore := redirectStdin(t, "stdin-token\n")
+	defer restore(stdin)
+
+	ff := &introspectFlags{
+		tokenStdin:   true,
+		clientID:     "rs",
+		clientSecret: "shh",
+		format:       "json",
+	}
+	var stdout bytes.Buffer
+	require.NoError(t, runIntrospect(context.Background(), &stdout, as.srv.URL, ff))
+}
+
+func TestRunIntrospect_MissingToken(t *testing.T) {
+	as := newSyntheticIntrospectAS(t)
+	ff := &introspectFlags{
+		clientID:     "rs",
+		clientSecret: "shh",
+		format:       "json",
+	}
+	err := runIntrospect(context.Background(), new(bytes.Buffer), as.srv.URL, ff)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--token")
+}
+
+func TestRunIntrospect_NoIntrospectionEndpointAdvertised(t *testing.T) {
+	// When AS metadata lacks introspection_endpoint, the CLI must fail
+	// loudly rather than silently POSTing to an empty URL.
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":         srv.URL,
+			"token_endpoint": srv.URL + "/token",
+			// no introspection_endpoint
+		})
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	ff := &introspectFlags{
+		token:        "TOK",
+		clientID:     "rs",
+		clientSecret: "shh",
+		format:       "json",
+	}
+	err := runIntrospect(context.Background(), new(bytes.Buffer), srv.URL, ff)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "introspection_endpoint")
+}

--- a/cmd/oneauth/cmd/jwks.go
+++ b/cmd/oneauth/cmd/jwks.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/panyam/oneauth/utils"
+	"github.com/spf13/cobra"
+)
+
+// jwksFlags carries the options for `oneauth jwks`.
+type jwksFlags struct {
+	format string
+	sigOnly bool
+	kid     string
+}
+
+// newJWKSCommand builds `oneauth jwks <issuer>` — fetch the AS's JWKS
+// and pretty-print it. Routine debugging tool: confirm kid matches a
+// token header, check the advertised alg, compare across rotations.
+//
+// jwks_uri is resolved via OIDC / RFC 8414 discovery; if the issuer's
+// metadata omits it the command fails loudly rather than guessing
+// /.well-known/jwks.json.
+func newJWKSCommand() *cobra.Command {
+	jf := &jwksFlags{}
+	cmd := &cobra.Command{
+		Use:   "jwks <issuer>",
+		Short: "Fetch and pretty-print the auth server's JWKS",
+		Long: `Fetch the auth server's JWKS (RFC 7517) from its advertised
+` + "`jwks_uri`" + ` and print it. Pair with --kid to surface just the
+key matching a token header, or --sig-only to drop verification-only
+keys filtered by use=sig.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runJWKS(cmd.Context(), cmd.OutOrStdout(), args[0], jf)
+		},
+	}
+	cmd.Flags().StringVar(&jf.format, "format", "json", `output format: "json" | "table"`)
+	cmd.Flags().BoolVar(&jf.sigOnly, "sig-only", false, `print only keys with use="sig"`)
+	cmd.Flags().StringVar(&jf.kid, "kid", "", "print only the key matching this kid")
+	return cmd
+}
+
+func runJWKS(ctx context.Context, stdout io.Writer, issuer string, jf *jwksFlags) error {
+	_, meta, err := newAuthClient(issuer)
+	if err != nil {
+		return err
+	}
+	if meta.JWKSURI == "" {
+		return fmt.Errorf("jwks_uri not advertised by %s", issuer)
+	}
+	set, err := fetchJWKS(ctx, meta.JWKSURI)
+	if err != nil {
+		return err
+	}
+	set = filterJWKS(set, jf)
+	return emitJWKS(stdout, jf.format, set)
+}
+
+// fetchJWKS GETs the JWKS URL and unmarshals it. Surfaces non-2xx
+// statuses as errors rather than parsing whatever HTML the AS returned.
+func fetchJWKS(ctx context.Context, url string) (*utils.JWKSet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build jwks request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch jwks (%s): %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("jwks %s returned %d", url, resp.StatusCode)
+	}
+	var set utils.JWKSet
+	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
+		return nil, fmt.Errorf("decode jwks: %w", err)
+	}
+	return &set, nil
+}
+
+// filterJWKS narrows the set by --kid / --sig-only. Returns the input
+// unchanged when no filters apply so the caller observes the original
+// JWKS shape.
+func filterJWKS(set *utils.JWKSet, jf *jwksFlags) *utils.JWKSet {
+	if jf.kid == "" && !jf.sigOnly {
+		return set
+	}
+	out := &utils.JWKSet{}
+	for _, k := range set.Keys {
+		if jf.kid != "" && k.Kid != jf.kid {
+			continue
+		}
+		if jf.sigOnly && k.Use != "" && k.Use != "sig" {
+			continue
+		}
+		out.Keys = append(out.Keys, k)
+	}
+	return out
+}
+
+// emitJWKS prints the (possibly filtered) JWKS. The "table" format is a
+// human-scan-friendly two-column summary; the underlying parameters
+// (n, e, x, y) are usually not what you want at the terminal.
+func emitJWKS(w io.Writer, format string, set *utils.JWKSet) error {
+	switch format {
+	case "", "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(set)
+	case "table":
+		fmt.Fprintf(w, "%-10s %-8s %-6s %-6s %s\n", "ALG", "USE", "KTY", "CRV", "KID")
+		for _, k := range set.Keys {
+			fmt.Fprintf(w, "%-10s %-8s %-6s %-6s %s\n", k.Alg, k.Use, k.Kty, k.Crv, k.Kid)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q (want json | table)", format)
+	}
+}

--- a/cmd/oneauth/cmd/jwks_test.go
+++ b/cmd/oneauth/cmd/jwks_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+// Tests for `oneauth jwks <issuer>` against an in-memory AS that
+// advertises a jwks_uri and serves an RFC 7517 JSON Web Key Set.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/panyam/oneauth/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type syntheticJWKSAS struct {
+	srv *httptest.Server
+	set utils.JWKSet
+}
+
+func newSyntheticJWKSAS(t *testing.T, set utils.JWKSet) *syntheticJWKSAS {
+	t.Helper()
+	as := &syntheticJWKSAS{set: set}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":         as.srv.URL,
+			"token_endpoint": as.srv.URL + "/token",
+			"jwks_uri":       as.srv.URL + "/.well-known/jwks.json",
+		})
+	})
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(as.set)
+	})
+	as.srv = httptest.NewServer(mux)
+	t.Cleanup(as.srv.Close)
+	return as
+}
+
+func TestRunJWKS_HappyPath(t *testing.T) {
+	as := newSyntheticJWKSAS(t, utils.JWKSet{Keys: []utils.JWK{
+		{Kty: "RSA", Kid: "abc", Alg: "RS256", Use: "sig", N: "n", E: "AQAB"},
+		{Kty: "EC", Kid: "def", Alg: "ES256", Use: "sig", Crv: "P-256", X: "x", Y: "y"},
+	}})
+	jf := &jwksFlags{format: "json"}
+	var stdout bytes.Buffer
+	require.NoError(t, runJWKS(context.Background(), &stdout, as.srv.URL, jf))
+
+	var got utils.JWKSet
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	require.Len(t, got.Keys, 2)
+	assert.Equal(t, "abc", got.Keys[0].Kid)
+	assert.Equal(t, "def", got.Keys[1].Kid)
+}
+
+func TestRunJWKS_KidFilter(t *testing.T) {
+	as := newSyntheticJWKSAS(t, utils.JWKSet{Keys: []utils.JWK{
+		{Kty: "RSA", Kid: "abc", Alg: "RS256", Use: "sig"},
+		{Kty: "RSA", Kid: "xyz", Alg: "RS256", Use: "sig"},
+	}})
+	jf := &jwksFlags{format: "json", kid: "xyz"}
+	var stdout bytes.Buffer
+	require.NoError(t, runJWKS(context.Background(), &stdout, as.srv.URL, jf))
+
+	var got utils.JWKSet
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	require.Len(t, got.Keys, 1)
+	assert.Equal(t, "xyz", got.Keys[0].Kid)
+}
+
+func TestRunJWKS_SigOnlyFilter(t *testing.T) {
+	as := newSyntheticJWKSAS(t, utils.JWKSet{Keys: []utils.JWK{
+		{Kty: "RSA", Kid: "abc", Alg: "RS256", Use: "sig"},
+		{Kty: "RSA", Kid: "enc", Alg: "RS256", Use: "enc"},
+	}})
+	jf := &jwksFlags{format: "json", sigOnly: true}
+	var stdout bytes.Buffer
+	require.NoError(t, runJWKS(context.Background(), &stdout, as.srv.URL, jf))
+
+	var got utils.JWKSet
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	require.Len(t, got.Keys, 1)
+	assert.Equal(t, "abc", got.Keys[0].Kid)
+}
+
+func TestRunJWKS_TableFormat(t *testing.T) {
+	as := newSyntheticJWKSAS(t, utils.JWKSet{Keys: []utils.JWK{
+		{Kty: "RSA", Kid: "abc", Alg: "RS256", Use: "sig"},
+	}})
+	jf := &jwksFlags{format: "table"}
+	var stdout bytes.Buffer
+	require.NoError(t, runJWKS(context.Background(), &stdout, as.srv.URL, jf))
+	out := stdout.String()
+	assert.True(t, strings.HasPrefix(out, "ALG"), "table header expected: %s", out)
+	assert.Contains(t, out, "RS256")
+	assert.Contains(t, out, "abc")
+}
+
+func TestRunJWKS_NoJWKSURI(t *testing.T) {
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":         srv.URL,
+			"token_endpoint": srv.URL + "/token",
+			// no jwks_uri
+		})
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	jf := &jwksFlags{format: "json"}
+	err := runJWKS(context.Background(), new(bytes.Buffer), srv.URL, jf)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "jwks_uri")
+}
+
+func TestRunJWKS_Non2xxFromJWKSURI(t *testing.T) {
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":         srv.URL,
+			"token_endpoint": srv.URL + "/token",
+			"jwks_uri":       srv.URL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	jf := &jwksFlags{format: "json"}
+	err := runJWKS(context.Background(), new(bytes.Buffer), srv.URL, jf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}

--- a/cmd/oneauth/cmd/root.go
+++ b/cmd/oneauth/cmd/root.go
@@ -12,10 +12,13 @@ func NewRoot() *cobra.Command {
 	root := &cobra.Command{
 		Use:           "oneauth",
 		Short:         "OneAuth client CLI",
-		Long:          "OneAuth client CLI — currently ships `token`; sibling subcommands (introspect, dcr, jwks) are planned.",
+		Long:          "OneAuth client CLI for OAuth 2.0 token acquisition, introspection, dynamic client registration, and JWKS inspection.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	root.AddCommand(newTokenCommand())
+	root.AddCommand(newIntrospectCommand())
+	root.AddCommand(newDCRCommand())
+	root.AddCommand(newJWKSCommand())
 	return root
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,6 +2,35 @@
 
 Get a Go application running with local authentication in 5 minutes.
 
+## Get a token in 30 seconds (no Go code)
+
+If you just need to test against an OAuth server, the `oneauth` CLI ships
+the four standard grants and a few sibling subcommands. No application
+boilerplate required.
+
+```bash
+go install github.com/panyam/oneauth/cmd/oneauth@latest
+
+# Service-to-service token via RFC 6749 §4.4 client_credentials.
+oneauth token client-credentials https://auth.example.com \
+  --client-id my-app --client-secret-stdin <<<"$CLIENT_SECRET"
+
+# Check whether a token is still active (RFC 7662).
+oneauth introspect https://auth.example.com \
+  --token "$ACCESS_TOKEN" --client-id my-rs --client-secret-stdin <<<"$RS_SECRET"
+
+# Register a fresh client (RFC 7591) and stash credentials in env vars.
+eval "$(oneauth dcr register https://auth.example.com \
+  --client-name 'ci-runner' --grant-types client_credentials --format bash)"
+
+# Inspect the AS's verification keys.
+oneauth jwks https://auth.example.com --format table
+```
+
+`oneauth --help` enumerates every subcommand. The walkthrough below is
+for embedding the SDK into your Go app — skip it if the CLI covers your
+case.
+
 ## Installation
 
 ```bash

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -335,6 +335,45 @@ Some applications use OneAuth in a federated model where you authenticate with o
 - Your client uses this token to connect to the relay
 - If the token expires, your client reconnects automatically with a fresh token from the host
 
+### Use the CLI
+
+The `oneauth` binary covers token acquisition, introspection, dynamic client registration, and JWKS inspection without writing any Go. Install once:
+
+```bash
+go install github.com/panyam/oneauth/cmd/oneauth@latest
+```
+
+**Three output formats** are available via `--format`:
+
+- `json` (default) — RFC 6749 §5.1 shape; pipe to `jq`.
+- `bash` — `export OAUTH_…=` lines suitable for `eval` / `source`.
+- `access-token-only` — the bare token; suitable for `Authorization: Bearer $(oneauth token cc … --format access-token-only)`.
+
+**Sourceable example**:
+
+```bash
+# Acquire a token and load it into the calling shell.
+eval "$(oneauth token client-credentials https://auth.example.com \
+  --client-id my-app --client-secret-stdin --format bash <<<"$CLIENT_SECRET")"
+
+# Now $OAUTH_ACCESS_TOKEN is set; use it directly.
+curl -H "Authorization: Bearer $OAUTH_ACCESS_TOKEN" https://api.example.com/me
+```
+
+**Subcommand cheat sheet**:
+
+| Command | What it does |
+|---------|--------------|
+| `oneauth token browser <issuer>` | Authorization code + PKCE for desktop / CLI clients (RFC 8252). |
+| `oneauth token client-credentials <issuer>` | Machine-to-machine grant (RFC 6749 §4.4); aliased as `cc`. |
+| `oneauth token password <issuer>` | Username/password grant (RFC 6749 §4.3); deprecated for new use. |
+| `oneauth token refresh <issuer>` | Exchange a refresh token for a fresh access token (RFC 6749 §6). |
+| `oneauth introspect <issuer>` | Check whether a token is active (RFC 7662). `--format active` returns just `true`/`false` for shell predicates. |
+| `oneauth dcr register \| get \| put \| delete <issuer>` | Dynamic Client Registration + management (RFC 7591 / 7592). |
+| `oneauth jwks <issuer>` | Fetch + pretty-print the AS's JSON Web Key Set (RFC 7517). `--kid` / `--sig-only` filters. |
+
+`oneauth <subcommand> --help` enumerates every flag for each command.
+
 ### Browser Requirements
 
 OneAuth works with modern browsers that support:

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,23 @@ Before an App can get tokens, it must register with the Auth Server and receive 
 | Resource Token (Example 02-03) | Bot posts to #general *as Alice* (on her behalf) | Yes — token carries Alice's user ID | The app mints a token for Alice |
 | Auth Code + PKCE (future) | Alice clicks "Sign in with Slack" on a third-party site | Yes — Alice logs in via browser | The user authenticates directly |
 
+## CLI first
+
+If you only need a token — not embedded SDK behavior — reach for the
+`oneauth` binary first:
+
+```bash
+go install github.com/panyam/oneauth/cmd/oneauth@latest
+oneauth token client-credentials https://auth.example.com --client-id … --client-secret-stdin <<<"$SECRET"
+oneauth introspect https://auth.example.com --token "$ACCESS" --client-id rs --client-secret-stdin <<<"$RS_SECRET"
+oneauth dcr register https://auth.example.com --client-name ci --grant-types client_credentials
+oneauth jwks https://auth.example.com --format table
+```
+
+The examples below show the SDK embedded inside a Go program — useful
+when you need caching, auto-refresh, custom hooks, or other behavior
+the CLI doesn't expose. See [docs/USER_GUIDE.md → Use the CLI](../docs/USER_GUIDE.md#use-the-cli) for the full subcommand reference.
+
 ## Examples
 
 | #                                     | Example                       | Type   | Infra               | Keycloak | What you'll learn                                                      |


### PR DESCRIPTION
## What changes

Grows the `oneauth` CLI from a token-only tool into a full client-side OAuth swiss-army knife: introspect a token (RFC 7662), manage client registrations (RFC 7591 / 7592), and inspect an AS's JWKS (RFC 7517). All subcommands dogfood the existing SDK — no ad-hoc HTTP, so future SDK behavior (tracing, header conventions, error mapping) lands in the CLI automatically. Closes #258 and #260.

Also closes the docs gap: the narrative onboarding (`docs/GETTING_STARTED.md`, `docs/USER_GUIDE.md`, `examples/README.md`) now leads with \"if you just want a token, run this binary\" before the SDK walkthrough — so the first thing a new reader does is paste a command, not write Go.

#259 verified already fixed on `main` and closed separately (see issue thread).

## Reviewer's guide

Read in this order:

1. [cmd/oneauth/cmd/introspect.go](https://github.com/panyam/oneauth/pull/263/files#diff-0b2eac8c6818def90a48da02e5732690064a6f1893374c1007e7854f2866e62a) — start here. Smallest of the three. Builds an `apiauth.IntrospectionValidator` from the discovered `introspection_endpoint` and prints the result. `--format active` is the shell-predicate form.
2. [cmd/oneauth/cmd/introspect_test.go](https://github.com/panyam/oneauth/pull/263/files#diff-736ca8262166f568e58b6b326b4560cdc63c8aec0d14cae50ae4b225635674c9) — acceptance: active-token JSON, inactive `--format active`, stdin token, missing token, no advertised endpoint.
3. [cmd/oneauth/cmd/dcr.go](https://github.com/panyam/oneauth/pull/263/files#diff-7cfab88481ff7921b3103221def4fa9e25c1dd33fc719ec3f4ef61fa7053a4cc) — `register`/`get`/`put`/`delete` subcommands. `resolveManagementURI` is the only piece worth a second look — when `--registration-client-uri` is supplied, we use it as-is; otherwise we derive `<registration_endpoint>/<client_id>` (the oneauth admin convention). ASes that deviate (Keycloak, Auth0) require the caller to pass the explicit URI.
4. [cmd/oneauth/cmd/dcr_test.go](https://github.com/panyam/oneauth/pull/263/files#diff-b2ee2202e17c76c1d5959f6e2d6d0016ffe1383564c1dc6760edd16fa3a2ae4e) — register + bash-format credentials export; get round-trip; PUT rotates the registration_access_token per RFC 7592 §2.2; delete + subsequent get returns unauthorized; missing flags rejected.
5. [cmd/oneauth/cmd/jwks.go](https://github.com/panyam/oneauth/pull/263/files#diff-ba4886f5a75811ca6ebf76e8605b86575af0947a8d6a7975199c385f91ae462e) — fetch + filter (`--kid`, `--sig-only`) + emit (`json`/`table`). Surfaces non-2xx from `jwks_uri` as errors instead of garbage parsing.
6. [cmd/oneauth/cmd/jwks_test.go](https://github.com/panyam/oneauth/pull/263/files#diff-8f4ccbacd2e97a18b8b0bdeb67964fe6ece61eec3910ce8fbd3a79e563faf71b) — happy path; kid filter; sig-only filter; table format; missing `jwks_uri`; 500 from the endpoint.
7. [cmd/oneauth/cmd/root.go](https://github.com/panyam/oneauth/pull/263/files#diff-901f41a04852a2f12e41965415c57a4765a33644dad1baecd7507438f78e5906) — wires the three new commands into the root.
8. [cmd/oneauth/SUMMARY.md](https://github.com/panyam/oneauth/pull/263/files#diff-a59bda21efc29276cc051bcd415b83779d5ac47b9ab6fc541b27c2f6bb6691fd) — content listing + library entry points updated.
9. [docs/GETTING_STARTED.md](https://github.com/panyam/oneauth/pull/263/files#diff-96f9ebb9f60e0a8354a5def3958ce814d311147ca1a5d5c6ba9c36d922d9429c) — \"Get a token in 30 seconds\" block leading the document.
10. [docs/USER_GUIDE.md](https://github.com/panyam/oneauth/pull/263/files#diff-c9e79bd9c348b38575101f5125cf14872969c3fd6985deba7a32d97e2b5cd87b) — \"Use the CLI\" subsection under Technical Users → API Access with subcommand cheat sheet + sourceable-bash example.
11. [examples/README.md](https://github.com/panyam/oneauth/pull/263/files#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9) — \"CLI first\" pointer above the example table.
12. [CAPABILITIES.md](https://github.com/panyam/oneauth/pull/263/files#diff-de1b0082e39b8f99294b95eed0bc723cbdc06d1e26de5ff8f18b80b0e69c313c) — version bumped to v0.1.20, `oneauth-cli` capability added.

Skim or skip: the SUMMARY/CAPABILITIES diffs.

## Decision log

- **`apiauth.IntrospectionValidator` over ad-hoc POST.** CLI dogfoods the SDK — any future change to tracing, header conventions, or error mapping in the validator lands here for free. The caching it provides is unused in a one-shot CLI invocation, but that's a no-op since `CacheTTL` defaults to 0.
- **`oneauth dcr put` instead of `update`.** Matches RFC 7592's PUT semantics (full-replace, not patch); the help text calls that out so callers don't accidentally blank fields they meant to leave alone.
- **`--registration-client-uri` opt-in.** Default behavior derives the management URI from `registration_endpoint` + `client_id` (the oneauth admin convention). Non-conforming ASes pass the explicit URI. Documented in the long help text and surfaced via a loud error when discovery doesn't advertise the registration endpoint.
- **`oneauth jwks rotate` deferred.** Admin-side operation; needs a different auth model. Filed naturally under #148 (server-side admin CLI).
- **Sub-module isolation preserved.** All new code lives in `cmd/oneauth/`; the root `github.com/panyam/oneauth` module still doesn't pull Cobra/pflag for downstream library consumers.

## Risk / blast radius

- **Affects:** the `oneauth` CLI binary only. Library API is unchanged. Existing `oneauth token` subcommands untouched.
- **Tests covering this:** 17 new unit tests across the three subcommands (5 introspect + 7 dcr + 5 jwks), each driving the run-functions against a synthetic in-memory AS. `go test ./... ./cmd/oneauth/...` is green.
- **Be paranoid about:** 
  - The DCR PUT path treats request as full-replace — a CLI user who only wants to change one field will blank the others. The long help text says so, but worth a second pass to ensure that's the contract you want.
  - `--registration-client-uri` derivation against non-oneauth ASes. Documented as a known sharp edge.

## Before / after

\`\`\`text
$ oneauth jwks https://auth.example.com --format table
ALG        USE      KTY    CRV    KID
RS256      sig      RSA           abc123
ES256      sig      EC     P-256  def456
\`\`\`

\`\`\`text
$ oneauth introspect https://auth.example.com --token TOK --client-id rs --client-secret-stdin --format active <<< 'shh'
true
\`\`\`

## Out of scope (deliberately deferred)

- `oneauth jwks rotate` — admin-side, separate auth model. Fold into #148.
- Keycloak interop e2e for the new subcommands → file follow-up.
- Shell completions, version subcommand → not blocking; not in #258.

Closes #258, #260.
