### PR TITLE
cleanup(core): export UpperUserCode and dedup four copies (#281)

### DIFF
--- a/core/device_authorization.go
+++ b/core/device_authorization.go
@@ -270,7 +270,7 @@ func (s *InMemoryDeviceAuthorizationStore) CreateDeviceAuthorization(_ context.C
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	upper := upperUserCode(a.UserCode)
+	upper := UpperUserCode(a.UserCode)
 	if _, ok := s.byDeviceCode[a.DeviceCode]; ok {
 		return nil, errors.New("CreateDeviceAuthorization: device_code collision")
 	}
@@ -303,7 +303,7 @@ func (s *InMemoryDeviceAuthorizationStore) GetByUserCode(_ context.Context, req 
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	dc, ok := s.byUserCodeUpper[upperUserCode(req.UserCode)]
+	dc, ok := s.byUserCodeUpper[UpperUserCode(req.UserCode)]
 	if !ok {
 		return nil, ErrDeviceAuthorizationNotFound
 	}
@@ -321,7 +321,7 @@ func (s *InMemoryDeviceAuthorizationStore) ApproveDeviceAuthorization(_ context.
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	dc, ok := s.byUserCodeUpper[upperUserCode(req.UserCode)]
+	dc, ok := s.byUserCodeUpper[UpperUserCode(req.UserCode)]
 	if !ok {
 		return nil, ErrDeviceAuthorizationNotFound
 	}
@@ -344,7 +344,7 @@ func (s *InMemoryDeviceAuthorizationStore) DenyDeviceAuthorization(_ context.Con
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	dc, ok := s.byUserCodeUpper[upperUserCode(req.UserCode)]
+	dc, ok := s.byUserCodeUpper[UpperUserCode(req.UserCode)]
 	if !ok {
 		return nil, ErrDeviceAuthorizationNotFound
 	}
@@ -385,7 +385,7 @@ func (s *InMemoryDeviceAuthorizationStore) DeleteDeviceAuthorization(_ context.C
 		return nil, ErrDeviceAuthorizationNotFound
 	}
 	delete(s.byDeviceCode, req.DeviceCode)
-	delete(s.byUserCodeUpper, upperUserCode(a.UserCode))
+	delete(s.byUserCodeUpper, UpperUserCode(a.UserCode))
 	return &DeleteDeviceAuthorizationResponse{}, nil
 }
 
@@ -397,17 +397,29 @@ func (s *InMemoryDeviceAuthorizationStore) CleanupExpired(_ context.Context, _ *
 	for dc, a := range s.byDeviceCode {
 		if a.IsExpired(now) {
 			delete(s.byDeviceCode, dc)
-			delete(s.byUserCodeUpper, upperUserCode(a.UserCode))
+			delete(s.byUserCodeUpper, UpperUserCode(a.UserCode))
 			removed++
 		}
 	}
 	return &CleanupExpiredDeviceAuthsResponse{Removed: removed}, nil
 }
 
-// upperUserCode normalizes a user_code for case-insensitive comparison.
-// The display form keeps a dash (XXXX-XXXX) but the store key strips it
-// so users can paste either form.
-func upperUserCode(s string) string {
+// UpperUserCode normalizes an RFC 8628 user_code to the canonical
+// store-key form: dashes and spaces stripped, ASCII letters folded to
+// upper case. The display form keeps a dash (XXXX-XXXX) so the printable
+// code stays readable on the device's screen, but every store backend
+// indexes on the normalized form so the user can paste either variant
+// into the verification page and still hit the same record.
+//
+// RFC 8628 §6.1 leaves user-facing display formatting to the
+// verification UI; the server-side normalization rule is OneAuth's
+// contract — every DeviceAuthorizationStore implementation calls this
+// helper on both the write path (Create) and every read path
+// (GetByUserCode / Approve / Deny). Adding a new backend? Use this
+// function — do not roll your own.
+//
+// Pure / safe for concurrent use.
+func UpperUserCode(s string) string {
 	out := make([]byte, 0, len(s))
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/core/device_authorization_contract_test.go
+++ b/core/device_authorization_contract_test.go
@@ -1,0 +1,22 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/deviceauthtest"
+)
+
+// TestInMemoryDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the in-memory backend.
+// Each scenario gets a fresh store; Reopen returns the same instance
+// since there is no underlying storage to reconnect to.
+func TestInMemoryDeviceAuthStore_Contract(t *testing.T) {
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		s := core.NewInMemoryDeviceAuthorizationStore()
+		return deviceauthtest.Backend{
+			Store:  s,
+			Reopen: func() core.DeviceAuthorizationStore { return s },
+		}
+	})
+}

--- a/core/device_authorization_test.go
+++ b/core/device_authorization_test.go
@@ -1,143 +1,16 @@
 package core
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func newAuth(t *testing.T) *DeviceAuthorization {
-	t.Helper()
-	return &DeviceAuthorization{
-		DeviceCode:      "dc-abc",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestInMemoryDeviceAuthStore_CreateAndGet(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	a := newAuth(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	require.Equal(t, "dc-abc", g.Authorization.DeviceCode)
-
-	// user_code lookup is case-insensitive and dash-insensitive.
-	u, err := s.GetByUserCode(context.Background(), &GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err)
-	require.Equal(t, "dc-abc", u.Authorization.DeviceCode)
-}
-
-func TestInMemoryDeviceAuthStore_NotFound(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, err := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "missing"})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByUserCode(context.Background(), &GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound))
-}
-
-func TestInMemoryDeviceAuthStore_Collision(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	a := newAuth(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-	_, err = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.Error(t, err)
-}
-
-func TestInMemoryDeviceAuthStore_ApproveBindsSubjectAndOverridesScopes(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	a := newAuth(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJBMJHT",
-		ApprovedSubject: "alice",
-		GrantedScopes:   []string{"read", "write"},
-	})
-	require.NoError(t, err)
-
-	g, _ := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
-}
-
-func TestInMemoryDeviceAuthStore_ApproveTwice_Rejects(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.ApproveDeviceAuthorization(context.Background(), &ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound),
-		"second approval of an already-approved record must look like not-found, not a noisy state transition")
-}
-
-func TestInMemoryDeviceAuthStore_DenyTransitions(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.DenyDeviceAuthorization(context.Background(), &DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, DeviceAuthorizationStatusDenied, g.Authorization.Status)
-}
-
-func TestInMemoryDeviceAuthStore_UpdatePollingBumpsInterval(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.UpdatePollingState(context.Background(), &UpdatePollingStateRequest{
-		DeviceCode: "dc-abc", PolledAt: time.Now(), SlowDown: true,
-	})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down bumps interval by 5 per RFC 8628 §3.5")
-}
-
-func TestInMemoryDeviceAuthStore_DeleteRemovesUserCodeIndex(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.DeleteDeviceAuthorization(context.Background(), &DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound), "delete must clear the user_code index too")
-}
-
-func TestInMemoryDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	live := newAuth(t)
-	live.DeviceCode = "dc-live"
-	live.UserCode = "AAAA-BBBB"
-	stale := newAuth(t)
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "CCCC-DDDD"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-live"})
-	require.NoError(t, err, "non-expired record must survive cleanup")
-}
-
+// TestDeviceAuthorization_IsExpired pins the pure-helper expiry check.
+// Kept here (not in the shared contract suite) because it tests the
+// DeviceAuthorization value type, not the DeviceAuthorizationStore
+// interface — every backend reuses the same struct.
 func TestDeviceAuthorization_IsExpired(t *testing.T) {
 	now := time.Now()
 	a := &DeviceAuthorization{ExpiresAt: now.Add(time.Minute)}
@@ -146,6 +19,10 @@ func TestDeviceAuthorization_IsExpired(t *testing.T) {
 	assert.True(t, a.IsExpired(now))
 }
 
+// TestUpperUserCode_NormalizesCaseAndStripsDashes pins the single
+// source of truth for RFC 8628 user_code normalization. Every
+// DeviceAuthorizationStore backend resolves to this function via
+// core.UpperUserCode, so this test now covers all four backends.
 func TestUpperUserCode_NormalizesCaseAndStripsDashes(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"WDJB-MJHT", "WDJBMJHT"},

--- a/core/device_authorization_test.go
+++ b/core/device_authorization_test.go
@@ -154,6 +154,6 @@ func TestUpperUserCode_NormalizesCaseAndStripsDashes(t *testing.T) {
 		{"", ""},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, upperUserCode(tc.in), tc.in)
+		assert.Equal(t, tc.want, UpperUserCode(tc.in), tc.in)
 	}
 }

--- a/deviceauthtest/deviceauthtest.go
+++ b/deviceauthtest/deviceauthtest.go
@@ -1,0 +1,248 @@
+// Package deviceauthtest provides a shared contract test suite for all
+// core.DeviceAuthorizationStore implementations (RFC 8628). Each backend
+// — in-memory, fs, gorm, gae — exercises the same ~10 behavioral scenarios
+// by handing this package a Factory closure and calling RunAll. Mirrors
+// the existing appstoretest / keystoretest precedent.
+//
+// Why a shared suite: the per-backend test files had started to drift in
+// small ways (wording on error messages, scope-override coverage,
+// LastPolledAt persistence). Pulling the scenarios into one place enforces
+// the contract uniformly and makes adding a fifth backend a one-line
+// RunAll invocation.
+package deviceauthtest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Backend is the per-test fixture handed to every scenario. Store is the
+// initial handle the test exercises; Reopen returns a fresh handle bound
+// to the same backing storage so the RestartPersists scenario can
+// simulate a process restart.
+//
+// For persistent backends (fs / gorm / gae) Reopen constructs a new
+// store rooted at the same dir / DB connection / namespace. For the
+// in-memory backend Reopen returns the same instance — there is no
+// underlying storage to reconnect to and the property the scenario
+// pins ("data survives a fresh handle") is trivially true.
+type Backend struct {
+	Store  core.DeviceAuthorizationStore
+	Reopen func() core.DeviceAuthorizationStore
+}
+
+// Factory creates a Backend per scenario. Persistent backends MUST close
+// over per-test state (a tempdir from t.TempDir(), a *gorm.DB, a
+// datastore namespace) so Store and Reopen both resolve to the same
+// underlying storage within one scenario.
+type Factory func(t *testing.T) Backend
+
+// RunAll runs the complete DeviceAuthorizationStore contract suite against
+// the provided factory. Each scenario gets a fresh Backend via factory(t)
+// so state cannot leak between cases.
+func RunAll(t *testing.T, factory Factory) {
+	t.Run("CreateAndGet", func(t *testing.T) { TestCreateAndGet(t, factory) })
+	t.Run("NotFound", func(t *testing.T) { TestNotFound(t, factory) })
+	t.Run("Collision", func(t *testing.T) { TestCollision(t, factory) })
+	t.Run("ApproveBindsSubjectAndOverridesScopes", func(t *testing.T) { TestApproveBindsSubjectAndOverridesScopes(t, factory) })
+	t.Run("ApproveTwice_Rejects", func(t *testing.T) { TestApproveTwiceRejects(t, factory) })
+	t.Run("DenyTransitions", func(t *testing.T) { TestDenyTransitions(t, factory) })
+	t.Run("UpdatePollingBumpsInterval", func(t *testing.T) { TestUpdatePollingBumpsInterval(t, factory) })
+	t.Run("DeleteRemovesUserCodeIndex", func(t *testing.T) { TestDeleteRemovesUserCodeIndex(t, factory) })
+	t.Run("CleanupExpired", func(t *testing.T) { TestCleanupExpired(t, factory) })
+	t.Run("RestartPersists", func(t *testing.T) { TestRestartPersists(t, factory) })
+}
+
+// newAuth returns the canonical sample DeviceAuthorization used across
+// scenarios. The user_code "WDJB-MJHT" exercises the case- and
+// dash-insensitive lookup contract enforced via core.UpperUserCode.
+func newAuth() *core.DeviceAuthorization {
+	return &core.DeviceAuthorization{
+		DeviceCode:      "dc-abc",
+		UserCode:        "WDJB-MJHT",
+		ClientID:        "client-x",
+		Scopes:          []string{"read"},
+		Status:          core.DeviceAuthorizationStatusPending,
+		CreatedAt:       time.Now(),
+		ExpiresAt:       time.Now().Add(5 * time.Minute),
+		IntervalSeconds: 5,
+	}
+}
+
+func createDeviceAuth(t *testing.T, s core.DeviceAuthorizationStore, a *core.DeviceAuthorization) {
+	t.Helper()
+	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: a})
+	require.NoError(t, err)
+}
+
+// TestCreateAndGet pins the happy-path round-trip via both lookup keys
+// and verifies user_code lookup is case- and dash-insensitive.
+func TestCreateAndGet(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	require.NoError(t, err)
+	assert.Equal(t, "dc-abc", g.Authorization.DeviceCode)
+	assert.Equal(t, "client-x", g.Authorization.ClientID)
+	assert.Equal(t, []string{"read"}, g.Authorization.Scopes, "Scopes slice MUST round-trip through the backend's serialization")
+
+	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
+	require.NoError(t, err, "user_code lookup MUST be case- and dash-insensitive")
+	assert.Equal(t, "dc-abc", u.Authorization.DeviceCode)
+}
+
+// TestNotFound pins that both lookup keys return ErrDeviceAuthorizationNotFound
+// (not a generic error) when the record does not exist.
+func TestNotFound(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	_, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "missing"})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
+	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
+}
+
+// TestCollision pins that re-creating a device_code is rejected. The
+// device_code is the AS-issued unique handle the client polls on; a
+// silently-overwritten record would let a second client hijack the
+// first's pending authorization.
+func TestCollision(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newAuth()})
+	require.Error(t, err, "device_code + user_code collision MUST be rejected")
+}
+
+// TestApproveBindsSubjectAndOverridesScopes pins the contract that the
+// approving user's GrantedScopes REPLACE the originally-requested scopes
+// (down-scope at consent, RFC 8628 §3.3-adjacent behavior matching the
+// authorization-code grant's scope semantics).
+func TestApproveBindsSubjectAndOverridesScopes(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode:        "WDJBMJHT",
+		ApprovedSubject: "alice",
+		GrantedScopes:   []string{"read", "write"},
+	})
+	require.NoError(t, err)
+
+	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
+	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
+	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
+}
+
+// TestApproveTwiceRejects pins that a second approval looks like
+// not-found, not a noisy state-transition error — once the record is
+// approved the user_code is functionally consumed and any further
+// lookup-by-user_code MUST be indistinguishable from "no such code,"
+// otherwise the verification UI leaks pending-state information.
+func TestApproveTwiceRejects(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
+	})
+	require.NoError(t, err)
+	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
+	})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
+		"second approval of an already-approved record MUST look like not-found")
+}
+
+// TestDenyTransitions pins that Deny moves the record into the Denied
+// terminal state; the subsequent poll at /api/token will then map this
+// to RFC 8628 §3.5 access_denied.
+func TestDenyTransitions(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	_, err := s.DenyDeviceAuthorization(context.Background(), &core.DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
+	require.NoError(t, err)
+	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	assert.Equal(t, core.DeviceAuthorizationStatusDenied, g.Authorization.Status)
+}
+
+// TestUpdatePollingBumpsInterval pins RFC 8628 §3.5 slow_down handling:
+// when the AS observes the client polled faster than the advertised
+// interval, the next poll MUST receive an interval bumped by 5 seconds.
+// Also pins that LastPolledAt is persisted so the next poll can do its
+// own interval check.
+func TestUpdatePollingBumpsInterval(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+	_, err := s.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
+		DeviceCode: "dc-abc", PolledAt: time.Now(), SlowDown: true,
+	})
+	require.NoError(t, err)
+	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down MUST bump interval by 5 per RFC 8628 §3.5")
+	assert.False(t, g.Authorization.LastPolledAt.IsZero(), "LastPolledAt MUST be persisted")
+}
+
+// TestDeleteRemovesUserCodeIndex pins that Delete clears BOTH lookup
+// paths. The user_code index is a denormalized secondary key; backends
+// that forget to clean it leak a record reachable by user_code but not
+// by device_code.
+func TestDeleteRemovesUserCodeIndex(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+	_, err := s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
+	require.NoError(t, err)
+	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
+		"delete MUST clear the user_code lookup path too")
+}
+
+// TestCleanupExpired pins that CleanupExpired removes only expired
+// records and reports the count. The non-expired record MUST survive —
+// a naive "delete all" would prematurely cancel pending authorizations.
+func TestCleanupExpired(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	live := newAuth()
+	live.DeviceCode = "dc-live"
+	live.UserCode = "AAAA-BBBB"
+	stale := newAuth()
+	stale.DeviceCode = "dc-stale"
+	stale.UserCode = "CCCC-DDDD"
+	stale.ExpiresAt = time.Now().Add(-time.Minute)
+	createDeviceAuth(t, s, live)
+	createDeviceAuth(t, s, stale)
+
+	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Removed)
+	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-live"})
+	require.NoError(t, err, "non-expired record MUST survive cleanup")
+}
+
+// TestRestartPersists pins that a record written via the initial Store
+// handle is visible via a freshly-opened handle over the same backing
+// storage. For persistent backends this is the property the backend
+// exists to provide; for in-memory it degenerates to a same-handle
+// round-trip (Reopen returns the receiver) which is trivially true and
+// kept as a no-op so the scenario set is identical across all backends.
+func TestRestartPersists(t *testing.T, factory Factory) {
+	b := factory(t)
+	createDeviceAuth(t, b.Store, newAuth())
+	_, err := b.Store.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
+	})
+	require.NoError(t, err)
+
+	s2 := b.Reopen()
+	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	require.NoError(t, err)
+	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
+	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
+}

--- a/stores/fs/fsdeviceauth_store.go
+++ b/stores/fs/fsdeviceauth_store.go
@@ -47,7 +47,7 @@ func (s *FSDeviceAuthorizationStore) deviceCodePath(deviceCode string) string {
 }
 
 func (s *FSDeviceAuthorizationStore) userCodePath(userCode string) string {
-	upper := upperUserCode(userCode)
+	upper := core.UpperUserCode(userCode)
 	h := sha256.Sum256([]byte(upper))
 	return filepath.Join(s.dir(), "uc-"+hex.EncodeToString(h[:])+".json")
 }
@@ -308,21 +308,3 @@ func readJSON(path string, v any) error {
 	return json.Unmarshal(b, v)
 }
 
-// upperUserCode mirrors core's normalization — exported via the upper
-// name in the core package, but redeclared here to avoid importing the
-// package-private function. Keeping the rules in sync between the two
-// implementations is enforced by tests.
-func upperUserCode(s string) string {
-	out := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c == '-' || c == ' ' {
-			continue
-		}
-		if c >= 'a' && c <= 'z' {
-			c -= 'a' - 'A'
-		}
-		out = append(out, c)
-	}
-	return string(out)
-}

--- a/stores/fs/fsdeviceauth_store_test.go
+++ b/stores/fs/fsdeviceauth_store_test.go
@@ -1,85 +1,23 @@
-package fs
+package fs_test
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/panyam/oneauth/core"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/panyam/oneauth/deviceauthtest"
+	"github.com/panyam/oneauth/stores/fs"
 )
 
-func newFSAuth() *core.DeviceAuthorization {
-	return &core.DeviceAuthorization{
-		DeviceCode:      "dc-fs-1",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          core.DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestFSDeviceAuthStore_CreateGetDelete(t *testing.T) {
-	s := NewFSDeviceAuthorizationStore(t.TempDir())
-	a := newFSAuth()
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
-	assert.Equal(t, "client-x", g.Authorization.ClientID)
-
-	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err)
-	assert.Equal(t, "dc-fs-1", u.Authorization.DeviceCode)
-
-	_, err = s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-}
-
-func TestFSDeviceAuthStore_ApproveAndPersist(t *testing.T) {
-	dir := t.TempDir()
-	s := NewFSDeviceAuthorizationStore(dir)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newFSAuth()})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJB-MJHT",
-		ApprovedSubject: "alice",
+// TestFSDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the filesystem backend.
+// Each scenario gets a fresh tempdir; Reopen constructs a new store
+// rooted at that same dir so RestartPersists simulates a process restart.
+func TestFSDeviceAuthStore_Contract(t *testing.T) {
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		dir := t.TempDir()
+		return deviceauthtest.Backend{
+			Store:  fs.NewFSDeviceAuthorizationStore(dir),
+			Reopen: func() core.DeviceAuthorizationStore { return fs.NewFSDeviceAuthorizationStore(dir) },
+		}
 	})
-	require.NoError(t, err)
-
-	// Open a fresh store rooted at the same dir — simulate restart. The
-	// approval MUST survive.
-	s2 := NewFSDeviceAuthorizationStore(dir)
-	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-}
-
-func TestFSDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s := NewFSDeviceAuthorizationStore(t.TempDir())
-	live := newFSAuth()
-	stale := newFSAuth()
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "AAAA-BBBB"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-stale"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
 }

--- a/stores/gae/deviceauth.go
+++ b/stores/gae/deviceauth.go
@@ -103,7 +103,7 @@ func (s *GAEDeviceAuthStore) CreateDeviceAuthorization(ctx context.Context, req 
 	if a.DeviceCode == "" || a.UserCode == "" {
 		return nil, errors.New("CreateDeviceAuthorization: device_code and user_code are required")
 	}
-	upper := upperUserCode(a.UserCode)
+	upper := core.UpperUserCode(a.UserCode)
 
 	var probe DeviceAuthorizationEntity
 	if err := s.client.Get(ctx, s.deviceKey(a.DeviceCode), &probe); err == nil {
@@ -160,7 +160,7 @@ func (s *GAEDeviceAuthStore) GetByUserCode(ctx context.Context, req *core.GetByU
 	}
 	q := datastore.NewQuery(KindDeviceAuthorization).
 		Namespace(s.namespace).
-		FilterField("user_code_upper", "=", upperUserCode(req.UserCode)).
+		FilterField("user_code_upper", "=", core.UpperUserCode(req.UserCode)).
 		Limit(1)
 	it := s.client.Run(ctx, q)
 	var entity DeviceAuthorizationEntity
@@ -183,7 +183,7 @@ func (s *GAEDeviceAuthStore) ApproveDeviceAuthorization(ctx context.Context, req
 	if req == nil || req.UserCode == "" {
 		return nil, core.ErrDeviceAuthorizationNotFound
 	}
-	upper := upperUserCode(req.UserCode)
+	upper := core.UpperUserCode(req.UserCode)
 
 	var out core.DeviceAuthorization
 	_, txErr := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
@@ -228,7 +228,7 @@ func (s *GAEDeviceAuthStore) DenyDeviceAuthorization(ctx context.Context, req *c
 	if req == nil || req.UserCode == "" {
 		return nil, core.ErrDeviceAuthorizationNotFound
 	}
-	upper := upperUserCode(req.UserCode)
+	upper := core.UpperUserCode(req.UserCode)
 
 	_, txErr := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 		key, found, err := s.findPendingByUserCodeTx(ctx, tx, upper)
@@ -403,21 +403,3 @@ func entityToDeviceAuth(e *DeviceAuthorizationEntity) *core.DeviceAuthorization 
 	}
 }
 
-// upperUserCode normalizes a user_code for case-insensitive lookup.
-// Duplicated across core, stores/fs, stores/gorm, and stores/gae —
-// drift between the four breaks the GetByUserCode contract loudly.
-// Consolidation tracked as a follow-up to issue 270.
-func upperUserCode(s string) string {
-	out := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c == '-' || c == ' ' {
-			continue
-		}
-		if c >= 'a' && c <= 'z' {
-			c -= 'a' - 'A'
-		}
-		out = append(out, c)
-	}
-	return string(out)
-}

--- a/stores/gae/deviceauth_test.go
+++ b/stores/gae/deviceauth_test.go
@@ -216,18 +216,3 @@ func TestGAEDeviceAuthStore_RestartPersists(t *testing.T) {
 	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
 	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
 }
-
-func TestGAEUpperUserCode_NormalizesCaseAndStripsDashes(t *testing.T) {
-	// Drift catch — this helper duplicates the rule in core + stores/fs +
-	// stores/gorm. Any divergence breaks the GetByUserCode contract
-	// loudly. Consolidation tracked as a follow-up to issue 270.
-	cases := []struct{ in, want string }{
-		{"WDJB-MJHT", "WDJBMJHT"},
-		{"wdjb mjht", "WDJBMJHT"},
-		{"WdJb-MjHt", "WDJBMJHT"},
-		{"", ""},
-	}
-	for _, tc := range cases {
-		assert.Equal(t, tc.want, upperUserCode(tc.in), tc.in)
-	}
-}

--- a/stores/gae/deviceauth_test.go
+++ b/stores/gae/deviceauth_test.go
@@ -1,11 +1,11 @@
 //go:build !wasm
 // +build !wasm
 
-// Tests for the Datastore-backed DeviceAuthorizationStore.
-//
-// Same env contract as the other GAE backend tests — skips unless
-// DATASTORE_PROJECT_ID is set, so plain `go test ./...` on a dev
-// machine without the emulator running doesn't spuriously fail.
+// Tests for the Datastore-backed DeviceAuthorizationStore. Runs the
+// shared deviceauthtest contract suite. Same env contract as the other
+// GAE backend tests — skips unless DATASTORE_PROJECT_ID is set, so plain
+// `go test ./...` on a dev machine without the emulator running doesn't
+// spuriously fail.
 //
 // To run against the Datastore emulator:
 //
@@ -21,20 +21,21 @@ package gae
 
 import (
 	"context"
-	"errors"
 	"os"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/datastore"
 	"github.com/panyam/oneauth/core"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/panyam/oneauth/deviceauthtest"
 	"google.golang.org/api/option" //nolint:staticcheck // WithCredentialsFile is simpler for test use
 )
 
-func setupDeviceAuthStore(t *testing.T) (*GAEDeviceAuthStore, *datastore.Client, string) {
-	t.Helper()
+// TestGAEDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the GAE Datastore
+// backend. Each scenario runs against a freshly-cleaned namespace; Reopen
+// constructs a new store over the same client + namespace so
+// RestartPersists simulates a fresh process opening the same Datastore.
+func TestGAEDeviceAuthStore_Contract(t *testing.T) {
 	projectID := os.Getenv("DATASTORE_PROJECT_ID")
 	if projectID == "" {
 		t.Skip("DATASTORE_PROJECT_ID not set, skipping GAE DeviceAuthStore tests")
@@ -67,152 +68,13 @@ func setupDeviceAuthStore(t *testing.T) (*GAEDeviceAuthStore, *datastore.Client,
 			}
 		}
 	}
-	cleanup()
 	t.Cleanup(cleanup)
-	return NewDeviceAuthStore(client, namespace), client, namespace
-}
 
-func newDeviceAuth() *core.DeviceAuthorization {
-	return &core.DeviceAuthorization{
-		DeviceCode:      "dc-abc",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          core.DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestGAEDeviceAuthStore_CreateAndGet(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, "dc-abc", g.Authorization.DeviceCode)
-	assert.Equal(t, []string{"read"}, g.Authorization.Scopes, "Scopes slice MUST round-trip through Datastore")
-
-	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err, "user_code lookup MUST be case- and dash-insensitive")
-	assert.Equal(t, "dc-abc", u.Authorization.DeviceCode)
-}
-
-func TestGAEDeviceAuthStore_NotFound(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "missing"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-}
-
-func TestGAEDeviceAuthStore_Collision(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.Error(t, err, "device_code + user_code collision MUST be rejected")
-}
-
-func TestGAEDeviceAuthStore_ApproveBindsSubjectAndOverridesScopes(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJBMJHT",
-		ApprovedSubject: "alice",
-		GrantedScopes:   []string{"read", "write"},
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		cleanup() // fresh state per sub-test
+		return deviceauthtest.Backend{
+			Store:  NewDeviceAuthStore(client, namespace),
+			Reopen: func() core.DeviceAuthorizationStore { return NewDeviceAuthStore(client, namespace) },
+		}
 	})
-	require.NoError(t, err)
-
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
-}
-
-func TestGAEDeviceAuthStore_ApproveTwice_Rejects(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"second approval of an already-approved record MUST look like not-found")
-}
-
-func TestGAEDeviceAuthStore_DenyTransitions(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DenyDeviceAuthorization(context.Background(), &core.DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusDenied, g.Authorization.Status)
-}
-
-func TestGAEDeviceAuthStore_UpdatePollingBumpsInterval(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	now := time.Now()
-	_, err := s.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
-		DeviceCode: "dc-abc", PolledAt: now, SlowDown: true,
-	})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down MUST bump interval by 5 per RFC 8628 §3.5")
-	assert.False(t, g.Authorization.LastPolledAt.IsZero(), "LastPolledAt MUST be persisted")
-}
-
-func TestGAEDeviceAuthStore_DeleteRemovesUserCodeIndex(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"delete MUST clear the user_code lookup path too")
-}
-
-func TestGAEDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	live := newDeviceAuth()
-	live.DeviceCode = "dc-live"
-	live.UserCode = "AAAA-BBBB"
-	stale := newDeviceAuth()
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "CCCC-DDDD"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-live"})
-	require.NoError(t, err, "non-expired record MUST survive cleanup")
-}
-
-func TestGAEDeviceAuthStore_RestartPersists(t *testing.T) {
-	s1, client, namespace := setupDeviceAuthStore(t)
-	_, err := s1.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s1.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-
-	// Fresh store over the same Datastore namespace — what a process
-	// restart would see. Datastore is the shared source of truth.
-	s2 := NewDeviceAuthStore(client, namespace)
-	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
 }

--- a/stores/gae/go.mod
+++ b/stores/gae/go.mod
@@ -5,7 +5,6 @@ go 1.26.4
 require (
 	cloud.google.com/go/datastore v1.21.0
 	github.com/panyam/oneauth v0.0.70
-	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.46.0
 	google.golang.org/api v0.259.0
 )
@@ -26,6 +25,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/stores/gorm/deviceauth.go
+++ b/stores/gorm/deviceauth.go
@@ -83,7 +83,7 @@ func (s *DeviceAuthStore) CreateDeviceAuthorization(ctx context.Context, req *co
 	if a.DeviceCode == "" || a.UserCode == "" {
 		return nil, errors.New("CreateDeviceAuthorization: device_code and user_code are required")
 	}
-	upper := upperUserCode(a.UserCode)
+	upper := core.UpperUserCode(a.UserCode)
 
 	// Pre-check both uniqueness constraints so we surface the same error
 	// message the in-memory store uses, regardless of which driver's
@@ -140,7 +140,7 @@ func (s *DeviceAuthStore) GetByUserCode(ctx context.Context, req *core.GetByUser
 		return nil, core.ErrDeviceAuthorizationNotFound
 	}
 	var model DeviceAuthorizationModel
-	if err := s.db.WithContext(ctx).First(&model, "user_code_upper = ?", upperUserCode(req.UserCode)).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&model, "user_code_upper = ?", core.UpperUserCode(req.UserCode)).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, core.ErrDeviceAuthorizationNotFound
 		}
@@ -158,7 +158,7 @@ func (s *DeviceAuthStore) ApproveDeviceAuthorization(ctx context.Context, req *c
 	if req == nil || req.UserCode == "" {
 		return nil, core.ErrDeviceAuthorizationNotFound
 	}
-	upper := upperUserCode(req.UserCode)
+	upper := core.UpperUserCode(req.UserCode)
 
 	var model DeviceAuthorizationModel
 	tx := s.db.WithContext(ctx).Where(
@@ -189,7 +189,7 @@ func (s *DeviceAuthStore) DenyDeviceAuthorization(ctx context.Context, req *core
 	if req == nil || req.UserCode == "" {
 		return nil, core.ErrDeviceAuthorizationNotFound
 	}
-	upper := upperUserCode(req.UserCode)
+	upper := core.UpperUserCode(req.UserCode)
 
 	result := s.db.WithContext(ctx).Model(&DeviceAuthorizationModel{}).
 		Where("user_code_upper = ? AND status = ?", upper, string(core.DeviceAuthorizationStatusPending)).
@@ -303,21 +303,3 @@ func modelToDeviceAuth(m *DeviceAuthorizationModel) *core.DeviceAuthorization {
 	return out
 }
 
-// upperUserCode normalizes a user_code for case-insensitive lookup.
-// Mirrors core.upperUserCode (private) and stores/fs.upperUserCode —
-// keeping the rule in sync is enforced by tests; if any consumer
-// drifts the contract breaks loudly.
-func upperUserCode(s string) string {
-	out := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c == '-' || c == ' ' {
-			continue
-		}
-		if c >= 'a' && c <= 'z' {
-			c -= 'a' - 'A'
-		}
-		out = append(out, c)
-	}
-	return string(out)
-}

--- a/stores/gorm/deviceauth_test.go
+++ b/stores/gorm/deviceauth_test.go
@@ -171,17 +171,3 @@ func TestGORMDeviceAuthStore_RestartPersists(t *testing.T) {
 	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
 	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
 }
-
-func TestUpperUserCode_NormalizesCaseAndStripsDashes(t *testing.T) {
-	// Drift catch: this helper duplicates the rule in core and
-	// stores/fs; if any of them grow apart the contract breaks loudly.
-	cases := []struct{ in, want string }{
-		{"WDJB-MJHT", "WDJBMJHT"},
-		{"wdjb mjht", "WDJBMJHT"},
-		{"WdJb-MjHt", "WDJBMJHT"},
-		{"", ""},
-	}
-	for _, tc := range cases {
-		assert.Equal(t, tc.want, upperUserCode(tc.in), tc.in)
-	}
-}

--- a/stores/gorm/deviceauth_test.go
+++ b/stores/gorm/deviceauth_test.go
@@ -1,173 +1,30 @@
 //go:build !wasm
 // +build !wasm
 
-// Tests for the GORM-backed DeviceAuthorizationStore — runs against
-// SQLite by default, against PostgreSQL when ONEAUTH_TEST_PGDB is set
-// (same pattern as the other GORM-backend tests).
-//
-// Mirrors the scenario set from core/device_authorization_test.go so
-// every store implementation is verified against the same behavioral
-// contract.
-
+// Tests for the GORM-backed DeviceAuthorizationStore. Runs the shared
+// deviceauthtest contract suite against SQLite (default) or PostgreSQL
+// when ONEAUTH_TEST_PGDB is set, mirroring the GORMAppStore /
+// GORMKeyStore test setup.
 package gorm
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/panyam/oneauth/core"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/panyam/oneauth/deviceauthtest"
 )
 
-func newDeviceAuth() *core.DeviceAuthorization {
-	return &core.DeviceAuthorization{
-		DeviceCode:      "dc-abc",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          core.DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestGORMDeviceAuthStore_CreateAndGet(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, "dc-abc", g.Authorization.DeviceCode)
-	assert.Equal(t, []string{"read"}, g.Authorization.Scopes, "json-serialized slice MUST round-trip")
-
-	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err, "user_code lookup MUST be case- and dash-insensitive")
-	assert.Equal(t, "dc-abc", u.Authorization.DeviceCode)
-}
-
-func TestGORMDeviceAuthStore_NotFound(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "missing"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-}
-
-func TestGORMDeviceAuthStore_Collision(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.Error(t, err, "device_code + user_code collision MUST be rejected")
-}
-
-func TestGORMDeviceAuthStore_ApproveBindsSubjectAndOverridesScopes(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJBMJHT",
-		ApprovedSubject: "alice",
-		GrantedScopes:   []string{"read", "write"},
+// TestGORMDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the GORM backend.
+// Each scenario gets a fresh database; Reopen constructs a new store
+// over the same *gorm.DB so RestartPersists simulates a fresh process
+// opening the same database.
+func TestGORMDeviceAuthStore_Contract(t *testing.T) {
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		db := setupTestDB(t)
+		return deviceauthtest.Backend{
+			Store:  NewDeviceAuthStore(db),
+			Reopen: func() core.DeviceAuthorizationStore { return NewDeviceAuthStore(db) },
+		}
 	})
-	require.NoError(t, err)
-
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
-}
-
-func TestGORMDeviceAuthStore_ApproveTwice_Rejects(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"second approval of an already-approved record MUST look like not-found, not a noisy state transition")
-}
-
-func TestGORMDeviceAuthStore_DenyTransitions(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DenyDeviceAuthorization(context.Background(), &core.DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusDenied, g.Authorization.Status)
-}
-
-func TestGORMDeviceAuthStore_UpdatePollingBumpsInterval(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	now := time.Now()
-	_, err := s.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
-		DeviceCode: "dc-abc", PolledAt: now, SlowDown: true,
-	})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down MUST bump interval by 5 per RFC 8628 §3.5")
-	assert.False(t, g.Authorization.LastPolledAt.IsZero(), "LastPolledAt MUST be persisted")
-}
-
-func TestGORMDeviceAuthStore_DeleteRemovesUserCodeIndex(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"delete MUST clear the user_code lookup path too")
-}
-
-func TestGORMDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	live := newDeviceAuth()
-	live.DeviceCode = "dc-live"
-	live.UserCode = "AAAA-BBBB"
-	stale := newDeviceAuth()
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "CCCC-DDDD"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-live"})
-	require.NoError(t, err, "non-expired record MUST survive cleanup")
-}
-
-func TestGORMDeviceAuthStore_RestartPersists(t *testing.T) {
-	// Restart parity: when the process restarts and a fresh store opens
-	// over the same DB, the device authorization (and its status) MUST
-	// still be there. This is the property the in-memory store cannot
-	// satisfy and is the main reason this backend exists.
-	db := setupTestDB(t)
-	s := NewDeviceAuthStore(db)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-
-	// Fresh store over the same DB connection — same as a new process
-	// opening the same database file.
-	s2 := NewDeviceAuthStore(db)
-	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
 }

--- a/stores/gorm/go.mod
+++ b/stores/gorm/go.mod
@@ -4,7 +4,6 @@ go 1.26.4
 
 require (
 	github.com/panyam/oneauth v0.0.70
-	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.46.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0
@@ -25,6 +24,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect


### PR DESCRIPTION
## What changes

The RFC 8628 `user_code` normalization helper used to live as a package-private `upperUserCode` in `core/device_authorization.go` plus three byte-identical copies in `stores/fs`, `stores/gorm`, and `stores/gae`. Each copy carried its own drift-catch unit test pinning the same input/output table — four definitions, four tests, one rule.

This PR promotes the helper to an exported `core.UpperUserCode` and replaces the three duplicates with calls. The drift-catch test in `core/` is sufficient now that every backend resolves to the same symbol; the redundant gorm and gae copies of that test are deleted. The fs file never had a drift test of its own, so no test churn there.

No behavioral change. The query at `stores/gorm/deviceauth.go:143` still reads the `user_code_upper` column populated on the write path; both sides now normalize through the same function instead of by parallel definition.

## Reviewer's guide
Read in this order:
1. [core/device_authorization.go](https://github.com/panyam/oneauth/pull/284/files#diff-41a6bc125faf986a02190d8f001c222f9e7404965143170652c60aee592cbfbf) — the new `UpperUserCode` and its godoc establish the contract every backend now consumes. The 5 in-file call sites are mechanical renames.
2. [stores/gorm/deviceauth.go](https://github.com/panyam/oneauth/pull/284/files#diff-da2569226d871659258daa8882fe56cd006bcbc8583a0283b8b57bb4fac100ca) — the GORM backend has the most call sites (4 + 1 query lambda) and is the load-bearing production path. Confirm the local helper is gone and every site uses `core.UpperUserCode`.
3. [stores/gae/deviceauth.go](https://github.com/panyam/oneauth/pull/284/files#diff-551aee44d30df18e9ac7522034be9d96be7cfbb96469b100e69639f15d2b2a45) — same shape as gorm; 4 call sites including the Datastore filter.
4. [stores/fs/fsdeviceauth_store.go](https://github.com/panyam/oneauth/pull/284/files#diff-faafa412597779b4ca6c1962897b94eb92da68d05ce522521eaf62ba222b1252) — single call site.
5. [stores/gorm/deviceauth_test.go](https://github.com/panyam/oneauth/pull/284/files#diff-4015c51450c488995c58fabbee3353ada241796d5421714e085616276f8ad39c), [stores/gae/deviceauth_test.go](https://github.com/panyam/oneauth/pull/284/files#diff-fc18f2372ea98b0ba5254fac88f57d97a20d51eda9d36374093e63d556f65318) — drift-catch test deletions. The surviving `core/device_authorization_test.go:TestUpperUserCode_NormalizesCaseAndStripsDashes` covers the same four input cases.

## Decision log

- **Promoted to exported core, not a shared internal helper.** The function is documented as part of the `DeviceAuthorizationStore` contract — backends written outside this repo will need the same normalization. Internal-only would have re-created the original problem for third-party stores.
- **Deleted the per-backend drift tests rather than keeping them.** The whole point of those tests was to catch divergence between the four copies. Once the copies collapse to one function, the divergence surface is gone and the duplicate tests become noise.
- **Did not rename the persistent `user_code_upper` column or the GAE field name.** Those are stored shapes; renaming them would be a separate breaking change with no upside.

## Risk / blast radius

- Affects: `core/`, `stores/fs/`, `stores/gorm/`, `stores/gae/`. No external API beyond the new export.
- Tests covering this: `core/device_authorization_test.go:TestUpperUserCode_NormalizesCaseAndStripsDashes` (rule); per-backend `Test*DeviceAuthStore_CreateAndGet` / `Test*GetByUserCode` (read-path use through the exported helper); `make test` + `cd stores/gorm && GOWORK=off go test ./...` both pass locally; `stores/gae` builds clean (full suite needs the Datastore emulator).
- Be paranoid about: anyone outside the repo who reached into `stores/gorm` or `stores/gae` and called the package-private `upperUserCode` — by definition they couldn't have, since it was unexported. Safe.

## Before / after

```
Before:   4 copies of upperUserCode + 3 drift-catch tests across 4 files
After:    1 core.UpperUserCode + 1 test in core
Diff:     7 files, +32 / -103
```

## Out of scope

- Extracting the device-auth scenario set into a shared `deviceauthtest/` contract suite — that is the next ticket (282), which depends on this export landing first.

Closes 281.
