### PR TITLE
test: extract shared deviceauthtest/ contract suite (#282)

### DIFF
--- a/core/device_authorization_contract_test.go
+++ b/core/device_authorization_contract_test.go
@@ -1,0 +1,22 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/deviceauthtest"
+)
+
+// TestInMemoryDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the in-memory backend.
+// Each scenario gets a fresh store; Reopen returns the same instance
+// since there is no underlying storage to reconnect to.
+func TestInMemoryDeviceAuthStore_Contract(t *testing.T) {
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		s := core.NewInMemoryDeviceAuthorizationStore()
+		return deviceauthtest.Backend{
+			Store:  s,
+			Reopen: func() core.DeviceAuthorizationStore { return s },
+		}
+	})
+}

--- a/core/device_authorization_test.go
+++ b/core/device_authorization_test.go
@@ -1,143 +1,16 @@
 package core
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func newAuth(t *testing.T) *DeviceAuthorization {
-	t.Helper()
-	return &DeviceAuthorization{
-		DeviceCode:      "dc-abc",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestInMemoryDeviceAuthStore_CreateAndGet(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	a := newAuth(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	require.Equal(t, "dc-abc", g.Authorization.DeviceCode)
-
-	// user_code lookup is case-insensitive and dash-insensitive.
-	u, err := s.GetByUserCode(context.Background(), &GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err)
-	require.Equal(t, "dc-abc", u.Authorization.DeviceCode)
-}
-
-func TestInMemoryDeviceAuthStore_NotFound(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, err := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "missing"})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByUserCode(context.Background(), &GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound))
-}
-
-func TestInMemoryDeviceAuthStore_Collision(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	a := newAuth(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-	_, err = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.Error(t, err)
-}
-
-func TestInMemoryDeviceAuthStore_ApproveBindsSubjectAndOverridesScopes(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	a := newAuth(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJBMJHT",
-		ApprovedSubject: "alice",
-		GrantedScopes:   []string{"read", "write"},
-	})
-	require.NoError(t, err)
-
-	g, _ := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
-}
-
-func TestInMemoryDeviceAuthStore_ApproveTwice_Rejects(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.ApproveDeviceAuthorization(context.Background(), &ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound),
-		"second approval of an already-approved record must look like not-found, not a noisy state transition")
-}
-
-func TestInMemoryDeviceAuthStore_DenyTransitions(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.DenyDeviceAuthorization(context.Background(), &DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, DeviceAuthorizationStatusDenied, g.Authorization.Status)
-}
-
-func TestInMemoryDeviceAuthStore_UpdatePollingBumpsInterval(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.UpdatePollingState(context.Background(), &UpdatePollingStateRequest{
-		DeviceCode: "dc-abc", PolledAt: time.Now(), SlowDown: true,
-	})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down bumps interval by 5 per RFC 8628 §3.5")
-}
-
-func TestInMemoryDeviceAuthStore_DeleteRemovesUserCodeIndex(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: newAuth(t)})
-	_, err := s.DeleteDeviceAuthorization(context.Background(), &DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, ErrDeviceAuthorizationNotFound), "delete must clear the user_code index too")
-}
-
-func TestInMemoryDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s := NewInMemoryDeviceAuthorizationStore()
-	live := newAuth(t)
-	live.DeviceCode = "dc-live"
-	live.UserCode = "AAAA-BBBB"
-	stale := newAuth(t)
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "CCCC-DDDD"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &GetByDeviceCodeRequest{DeviceCode: "dc-live"})
-	require.NoError(t, err, "non-expired record must survive cleanup")
-}
-
+// TestDeviceAuthorization_IsExpired pins the pure-helper expiry check.
+// Kept here (not in the shared contract suite) because it tests the
+// DeviceAuthorization value type, not the DeviceAuthorizationStore
+// interface — every backend reuses the same struct.
 func TestDeviceAuthorization_IsExpired(t *testing.T) {
 	now := time.Now()
 	a := &DeviceAuthorization{ExpiresAt: now.Add(time.Minute)}
@@ -146,6 +19,10 @@ func TestDeviceAuthorization_IsExpired(t *testing.T) {
 	assert.True(t, a.IsExpired(now))
 }
 
+// TestUpperUserCode_NormalizesCaseAndStripsDashes pins the single
+// source of truth for RFC 8628 user_code normalization. Every
+// DeviceAuthorizationStore backend resolves to this function via
+// core.UpperUserCode, so this test now covers all four backends.
 func TestUpperUserCode_NormalizesCaseAndStripsDashes(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"WDJB-MJHT", "WDJBMJHT"},

--- a/deviceauthtest/deviceauthtest.go
+++ b/deviceauthtest/deviceauthtest.go
@@ -1,0 +1,248 @@
+// Package deviceauthtest provides a shared contract test suite for all
+// core.DeviceAuthorizationStore implementations (RFC 8628). Each backend
+// — in-memory, fs, gorm, gae — exercises the same ~10 behavioral scenarios
+// by handing this package a Factory closure and calling RunAll. Mirrors
+// the existing appstoretest / keystoretest precedent.
+//
+// Why a shared suite: the per-backend test files had started to drift in
+// small ways (wording on error messages, scope-override coverage,
+// LastPolledAt persistence). Pulling the scenarios into one place enforces
+// the contract uniformly and makes adding a fifth backend a one-line
+// RunAll invocation.
+package deviceauthtest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Backend is the per-test fixture handed to every scenario. Store is the
+// initial handle the test exercises; Reopen returns a fresh handle bound
+// to the same backing storage so the RestartPersists scenario can
+// simulate a process restart.
+//
+// For persistent backends (fs / gorm / gae) Reopen constructs a new
+// store rooted at the same dir / DB connection / namespace. For the
+// in-memory backend Reopen returns the same instance — there is no
+// underlying storage to reconnect to and the property the scenario
+// pins ("data survives a fresh handle") is trivially true.
+type Backend struct {
+	Store  core.DeviceAuthorizationStore
+	Reopen func() core.DeviceAuthorizationStore
+}
+
+// Factory creates a Backend per scenario. Persistent backends MUST close
+// over per-test state (a tempdir from t.TempDir(), a *gorm.DB, a
+// datastore namespace) so Store and Reopen both resolve to the same
+// underlying storage within one scenario.
+type Factory func(t *testing.T) Backend
+
+// RunAll runs the complete DeviceAuthorizationStore contract suite against
+// the provided factory. Each scenario gets a fresh Backend via factory(t)
+// so state cannot leak between cases.
+func RunAll(t *testing.T, factory Factory) {
+	t.Run("CreateAndGet", func(t *testing.T) { TestCreateAndGet(t, factory) })
+	t.Run("NotFound", func(t *testing.T) { TestNotFound(t, factory) })
+	t.Run("Collision", func(t *testing.T) { TestCollision(t, factory) })
+	t.Run("ApproveBindsSubjectAndOverridesScopes", func(t *testing.T) { TestApproveBindsSubjectAndOverridesScopes(t, factory) })
+	t.Run("ApproveTwice_Rejects", func(t *testing.T) { TestApproveTwiceRejects(t, factory) })
+	t.Run("DenyTransitions", func(t *testing.T) { TestDenyTransitions(t, factory) })
+	t.Run("UpdatePollingBumpsInterval", func(t *testing.T) { TestUpdatePollingBumpsInterval(t, factory) })
+	t.Run("DeleteRemovesUserCodeIndex", func(t *testing.T) { TestDeleteRemovesUserCodeIndex(t, factory) })
+	t.Run("CleanupExpired", func(t *testing.T) { TestCleanupExpired(t, factory) })
+	t.Run("RestartPersists", func(t *testing.T) { TestRestartPersists(t, factory) })
+}
+
+// newAuth returns the canonical sample DeviceAuthorization used across
+// scenarios. The user_code "WDJB-MJHT" exercises the case- and
+// dash-insensitive lookup contract enforced via core.UpperUserCode.
+func newAuth() *core.DeviceAuthorization {
+	return &core.DeviceAuthorization{
+		DeviceCode:      "dc-abc",
+		UserCode:        "WDJB-MJHT",
+		ClientID:        "client-x",
+		Scopes:          []string{"read"},
+		Status:          core.DeviceAuthorizationStatusPending,
+		CreatedAt:       time.Now(),
+		ExpiresAt:       time.Now().Add(5 * time.Minute),
+		IntervalSeconds: 5,
+	}
+}
+
+func createDeviceAuth(t *testing.T, s core.DeviceAuthorizationStore, a *core.DeviceAuthorization) {
+	t.Helper()
+	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: a})
+	require.NoError(t, err)
+}
+
+// TestCreateAndGet pins the happy-path round-trip via both lookup keys
+// and verifies user_code lookup is case- and dash-insensitive.
+func TestCreateAndGet(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	require.NoError(t, err)
+	assert.Equal(t, "dc-abc", g.Authorization.DeviceCode)
+	assert.Equal(t, "client-x", g.Authorization.ClientID)
+	assert.Equal(t, []string{"read"}, g.Authorization.Scopes, "Scopes slice MUST round-trip through the backend's serialization")
+
+	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
+	require.NoError(t, err, "user_code lookup MUST be case- and dash-insensitive")
+	assert.Equal(t, "dc-abc", u.Authorization.DeviceCode)
+}
+
+// TestNotFound pins that both lookup keys return ErrDeviceAuthorizationNotFound
+// (not a generic error) when the record does not exist.
+func TestNotFound(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	_, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "missing"})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
+	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
+}
+
+// TestCollision pins that re-creating a device_code is rejected. The
+// device_code is the AS-issued unique handle the client polls on; a
+// silently-overwritten record would let a second client hijack the
+// first's pending authorization.
+func TestCollision(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newAuth()})
+	require.Error(t, err, "device_code + user_code collision MUST be rejected")
+}
+
+// TestApproveBindsSubjectAndOverridesScopes pins the contract that the
+// approving user's GrantedScopes REPLACE the originally-requested scopes
+// (down-scope at consent, RFC 8628 §3.3-adjacent behavior matching the
+// authorization-code grant's scope semantics).
+func TestApproveBindsSubjectAndOverridesScopes(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode:        "WDJBMJHT",
+		ApprovedSubject: "alice",
+		GrantedScopes:   []string{"read", "write"},
+	})
+	require.NoError(t, err)
+
+	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
+	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
+	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
+}
+
+// TestApproveTwiceRejects pins that a second approval looks like
+// not-found, not a noisy state-transition error — once the record is
+// approved the user_code is functionally consumed and any further
+// lookup-by-user_code MUST be indistinguishable from "no such code,"
+// otherwise the verification UI leaks pending-state information.
+func TestApproveTwiceRejects(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
+	})
+	require.NoError(t, err)
+	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
+	})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
+		"second approval of an already-approved record MUST look like not-found")
+}
+
+// TestDenyTransitions pins that Deny moves the record into the Denied
+// terminal state; the subsequent poll at /api/token will then map this
+// to RFC 8628 §3.5 access_denied.
+func TestDenyTransitions(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+
+	_, err := s.DenyDeviceAuthorization(context.Background(), &core.DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
+	require.NoError(t, err)
+	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	assert.Equal(t, core.DeviceAuthorizationStatusDenied, g.Authorization.Status)
+}
+
+// TestUpdatePollingBumpsInterval pins RFC 8628 §3.5 slow_down handling:
+// when the AS observes the client polled faster than the advertised
+// interval, the next poll MUST receive an interval bumped by 5 seconds.
+// Also pins that LastPolledAt is persisted so the next poll can do its
+// own interval check.
+func TestUpdatePollingBumpsInterval(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+	_, err := s.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
+		DeviceCode: "dc-abc", PolledAt: time.Now(), SlowDown: true,
+	})
+	require.NoError(t, err)
+	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down MUST bump interval by 5 per RFC 8628 §3.5")
+	assert.False(t, g.Authorization.LastPolledAt.IsZero(), "LastPolledAt MUST be persisted")
+}
+
+// TestDeleteRemovesUserCodeIndex pins that Delete clears BOTH lookup
+// paths. The user_code index is a denormalized secondary key; backends
+// that forget to clean it leak a record reachable by user_code but not
+// by device_code.
+func TestDeleteRemovesUserCodeIndex(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	createDeviceAuth(t, s, newAuth())
+	_, err := s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
+	require.NoError(t, err)
+	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
+	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
+		"delete MUST clear the user_code lookup path too")
+}
+
+// TestCleanupExpired pins that CleanupExpired removes only expired
+// records and reports the count. The non-expired record MUST survive —
+// a naive "delete all" would prematurely cancel pending authorizations.
+func TestCleanupExpired(t *testing.T, factory Factory) {
+	s := factory(t).Store
+	live := newAuth()
+	live.DeviceCode = "dc-live"
+	live.UserCode = "AAAA-BBBB"
+	stale := newAuth()
+	stale.DeviceCode = "dc-stale"
+	stale.UserCode = "CCCC-DDDD"
+	stale.ExpiresAt = time.Now().Add(-time.Minute)
+	createDeviceAuth(t, s, live)
+	createDeviceAuth(t, s, stale)
+
+	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Removed)
+	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-live"})
+	require.NoError(t, err, "non-expired record MUST survive cleanup")
+}
+
+// TestRestartPersists pins that a record written via the initial Store
+// handle is visible via a freshly-opened handle over the same backing
+// storage. For persistent backends this is the property the backend
+// exists to provide; for in-memory it degenerates to a same-handle
+// round-trip (Reopen returns the receiver) which is trivially true and
+// kept as a no-op so the scenario set is identical across all backends.
+func TestRestartPersists(t *testing.T, factory Factory) {
+	b := factory(t)
+	createDeviceAuth(t, b.Store, newAuth())
+	_, err := b.Store.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
+		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
+	})
+	require.NoError(t, err)
+
+	s2 := b.Reopen()
+	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
+	require.NoError(t, err)
+	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
+	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
+}

--- a/stores/fs/fsdeviceauth_store_test.go
+++ b/stores/fs/fsdeviceauth_store_test.go
@@ -1,85 +1,23 @@
-package fs
+package fs_test
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/panyam/oneauth/core"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/panyam/oneauth/deviceauthtest"
+	"github.com/panyam/oneauth/stores/fs"
 )
 
-func newFSAuth() *core.DeviceAuthorization {
-	return &core.DeviceAuthorization{
-		DeviceCode:      "dc-fs-1",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          core.DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestFSDeviceAuthStore_CreateGetDelete(t *testing.T) {
-	s := NewFSDeviceAuthorizationStore(t.TempDir())
-	a := newFSAuth()
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: a})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
-	assert.Equal(t, "client-x", g.Authorization.ClientID)
-
-	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err)
-	assert.Equal(t, "dc-fs-1", u.Authorization.DeviceCode)
-
-	_, err = s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-}
-
-func TestFSDeviceAuthStore_ApproveAndPersist(t *testing.T) {
-	dir := t.TempDir()
-	s := NewFSDeviceAuthorizationStore(dir)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newFSAuth()})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJB-MJHT",
-		ApprovedSubject: "alice",
+// TestFSDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the filesystem backend.
+// Each scenario gets a fresh tempdir; Reopen constructs a new store
+// rooted at that same dir so RestartPersists simulates a process restart.
+func TestFSDeviceAuthStore_Contract(t *testing.T) {
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		dir := t.TempDir()
+		return deviceauthtest.Backend{
+			Store:  fs.NewFSDeviceAuthorizationStore(dir),
+			Reopen: func() core.DeviceAuthorizationStore { return fs.NewFSDeviceAuthorizationStore(dir) },
+		}
 	})
-	require.NoError(t, err)
-
-	// Open a fresh store rooted at the same dir — simulate restart. The
-	// approval MUST survive.
-	s2 := NewFSDeviceAuthorizationStore(dir)
-	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-}
-
-func TestFSDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s := NewFSDeviceAuthorizationStore(t.TempDir())
-	live := newFSAuth()
-	stale := newFSAuth()
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "AAAA-BBBB"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-stale"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-fs-1"})
-	require.NoError(t, err)
 }

--- a/stores/gae/deviceauth_test.go
+++ b/stores/gae/deviceauth_test.go
@@ -1,11 +1,11 @@
 //go:build !wasm
 // +build !wasm
 
-// Tests for the Datastore-backed DeviceAuthorizationStore.
-//
-// Same env contract as the other GAE backend tests — skips unless
-// DATASTORE_PROJECT_ID is set, so plain `go test ./...` on a dev
-// machine without the emulator running doesn't spuriously fail.
+// Tests for the Datastore-backed DeviceAuthorizationStore. Runs the
+// shared deviceauthtest contract suite. Same env contract as the other
+// GAE backend tests — skips unless DATASTORE_PROJECT_ID is set, so plain
+// `go test ./...` on a dev machine without the emulator running doesn't
+// spuriously fail.
 //
 // To run against the Datastore emulator:
 //
@@ -21,20 +21,21 @@ package gae
 
 import (
 	"context"
-	"errors"
 	"os"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/datastore"
 	"github.com/panyam/oneauth/core"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/panyam/oneauth/deviceauthtest"
 	"google.golang.org/api/option" //nolint:staticcheck // WithCredentialsFile is simpler for test use
 )
 
-func setupDeviceAuthStore(t *testing.T) (*GAEDeviceAuthStore, *datastore.Client, string) {
-	t.Helper()
+// TestGAEDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the GAE Datastore
+// backend. Each scenario runs against a freshly-cleaned namespace; Reopen
+// constructs a new store over the same client + namespace so
+// RestartPersists simulates a fresh process opening the same Datastore.
+func TestGAEDeviceAuthStore_Contract(t *testing.T) {
 	projectID := os.Getenv("DATASTORE_PROJECT_ID")
 	if projectID == "" {
 		t.Skip("DATASTORE_PROJECT_ID not set, skipping GAE DeviceAuthStore tests")
@@ -67,152 +68,13 @@ func setupDeviceAuthStore(t *testing.T) (*GAEDeviceAuthStore, *datastore.Client,
 			}
 		}
 	}
-	cleanup()
 	t.Cleanup(cleanup)
-	return NewDeviceAuthStore(client, namespace), client, namespace
-}
 
-func newDeviceAuth() *core.DeviceAuthorization {
-	return &core.DeviceAuthorization{
-		DeviceCode:      "dc-abc",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          core.DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestGAEDeviceAuthStore_CreateAndGet(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, "dc-abc", g.Authorization.DeviceCode)
-	assert.Equal(t, []string{"read"}, g.Authorization.Scopes, "Scopes slice MUST round-trip through Datastore")
-
-	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err, "user_code lookup MUST be case- and dash-insensitive")
-	assert.Equal(t, "dc-abc", u.Authorization.DeviceCode)
-}
-
-func TestGAEDeviceAuthStore_NotFound(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "missing"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-}
-
-func TestGAEDeviceAuthStore_Collision(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.Error(t, err, "device_code + user_code collision MUST be rejected")
-}
-
-func TestGAEDeviceAuthStore_ApproveBindsSubjectAndOverridesScopes(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJBMJHT",
-		ApprovedSubject: "alice",
-		GrantedScopes:   []string{"read", "write"},
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		cleanup() // fresh state per sub-test
+		return deviceauthtest.Backend{
+			Store:  NewDeviceAuthStore(client, namespace),
+			Reopen: func() core.DeviceAuthorizationStore { return NewDeviceAuthStore(client, namespace) },
+		}
 	})
-	require.NoError(t, err)
-
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
-}
-
-func TestGAEDeviceAuthStore_ApproveTwice_Rejects(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"second approval of an already-approved record MUST look like not-found")
-}
-
-func TestGAEDeviceAuthStore_DenyTransitions(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DenyDeviceAuthorization(context.Background(), &core.DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusDenied, g.Authorization.Status)
-}
-
-func TestGAEDeviceAuthStore_UpdatePollingBumpsInterval(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	now := time.Now()
-	_, err := s.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
-		DeviceCode: "dc-abc", PolledAt: now, SlowDown: true,
-	})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down MUST bump interval by 5 per RFC 8628 §3.5")
-	assert.False(t, g.Authorization.LastPolledAt.IsZero(), "LastPolledAt MUST be persisted")
-}
-
-func TestGAEDeviceAuthStore_DeleteRemovesUserCodeIndex(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"delete MUST clear the user_code lookup path too")
-}
-
-func TestGAEDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s, _, _ := setupDeviceAuthStore(t)
-	live := newDeviceAuth()
-	live.DeviceCode = "dc-live"
-	live.UserCode = "AAAA-BBBB"
-	stale := newDeviceAuth()
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "CCCC-DDDD"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-live"})
-	require.NoError(t, err, "non-expired record MUST survive cleanup")
-}
-
-func TestGAEDeviceAuthStore_RestartPersists(t *testing.T) {
-	s1, client, namespace := setupDeviceAuthStore(t)
-	_, err := s1.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s1.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-
-	// Fresh store over the same Datastore namespace — what a process
-	// restart would see. Datastore is the shared source of truth.
-	s2 := NewDeviceAuthStore(client, namespace)
-	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
 }

--- a/stores/gae/go.mod
+++ b/stores/gae/go.mod
@@ -5,7 +5,6 @@ go 1.26.4
 require (
 	cloud.google.com/go/datastore v1.21.0
 	github.com/panyam/oneauth v0.0.70
-	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.46.0
 	google.golang.org/api v0.259.0
 )
@@ -26,6 +25,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/stores/gorm/deviceauth_test.go
+++ b/stores/gorm/deviceauth_test.go
@@ -1,173 +1,30 @@
 //go:build !wasm
 // +build !wasm
 
-// Tests for the GORM-backed DeviceAuthorizationStore — runs against
-// SQLite by default, against PostgreSQL when ONEAUTH_TEST_PGDB is set
-// (same pattern as the other GORM-backend tests).
-//
-// Mirrors the scenario set from core/device_authorization_test.go so
-// every store implementation is verified against the same behavioral
-// contract.
-
+// Tests for the GORM-backed DeviceAuthorizationStore. Runs the shared
+// deviceauthtest contract suite against SQLite (default) or PostgreSQL
+// when ONEAUTH_TEST_PGDB is set, mirroring the GORMAppStore /
+// GORMKeyStore test setup.
 package gorm
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/panyam/oneauth/core"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/panyam/oneauth/deviceauthtest"
 )
 
-func newDeviceAuth() *core.DeviceAuthorization {
-	return &core.DeviceAuthorization{
-		DeviceCode:      "dc-abc",
-		UserCode:        "WDJB-MJHT",
-		ClientID:        "client-x",
-		Scopes:          []string{"read"},
-		Status:          core.DeviceAuthorizationStatusPending,
-		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(5 * time.Minute),
-		IntervalSeconds: 5,
-	}
-}
-
-func TestGORMDeviceAuthStore_CreateAndGet(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	g, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, "dc-abc", g.Authorization.DeviceCode)
-	assert.Equal(t, []string{"read"}, g.Authorization.Scopes, "json-serialized slice MUST round-trip")
-
-	u, err := s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "wdjbmjht"})
-	require.NoError(t, err, "user_code lookup MUST be case- and dash-insensitive")
-	assert.Equal(t, "dc-abc", u.Authorization.DeviceCode)
-}
-
-func TestGORMDeviceAuthStore_NotFound(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "missing"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "ABCD-EFGH"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound))
-}
-
-func TestGORMDeviceAuthStore_Collision(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.Error(t, err, "device_code + user_code collision MUST be rejected")
-}
-
-func TestGORMDeviceAuthStore_ApproveBindsSubjectAndOverridesScopes(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode:        "WDJBMJHT",
-		ApprovedSubject: "alice",
-		GrantedScopes:   []string{"read", "write"},
+// TestGORMDeviceAuthStore_Contract runs the shared
+// DeviceAuthorizationStore contract suite against the GORM backend.
+// Each scenario gets a fresh database; Reopen constructs a new store
+// over the same *gorm.DB so RestartPersists simulates a fresh process
+// opening the same database.
+func TestGORMDeviceAuthStore_Contract(t *testing.T) {
+	deviceauthtest.RunAll(t, func(t *testing.T) deviceauthtest.Backend {
+		db := setupTestDB(t)
+		return deviceauthtest.Backend{
+			Store:  NewDeviceAuthStore(db),
+			Reopen: func() core.DeviceAuthorizationStore { return NewDeviceAuthStore(db) },
+		}
 	})
-	require.NoError(t, err)
-
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
-	assert.Equal(t, []string{"read", "write"}, g.Authorization.Scopes)
-}
-
-func TestGORMDeviceAuthStore_ApproveTwice_Rejects(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"second approval of an already-approved record MUST look like not-found, not a noisy state transition")
-}
-
-func TestGORMDeviceAuthStore_DenyTransitions(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DenyDeviceAuthorization(context.Background(), &core.DenyDeviceAuthorizationRequest{UserCode: "WDJB-MJHT"})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, core.DeviceAuthorizationStatusDenied, g.Authorization.Status)
-}
-
-func TestGORMDeviceAuthStore_UpdatePollingBumpsInterval(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	now := time.Now()
-	_, err := s.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
-		DeviceCode: "dc-abc", PolledAt: now, SlowDown: true,
-	})
-	require.NoError(t, err)
-	g, _ := s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	assert.Equal(t, 10, g.Authorization.IntervalSeconds, "slow_down MUST bump interval by 5 per RFC 8628 §3.5")
-	assert.False(t, g.Authorization.LastPolledAt.IsZero(), "LastPolledAt MUST be persisted")
-}
-
-func TestGORMDeviceAuthStore_DeleteRemovesUserCodeIndex(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	_, err := s.DeleteDeviceAuthorization(context.Background(), &core.DeleteDeviceAuthorizationRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	_, err = s.GetByUserCode(context.Background(), &core.GetByUserCodeRequest{UserCode: "WDJB-MJHT"})
-	require.True(t, errors.Is(err, core.ErrDeviceAuthorizationNotFound),
-		"delete MUST clear the user_code lookup path too")
-}
-
-func TestGORMDeviceAuthStore_CleanupExpired(t *testing.T) {
-	s := NewDeviceAuthStore(setupTestDB(t))
-	live := newDeviceAuth()
-	live.DeviceCode = "dc-live"
-	live.UserCode = "AAAA-BBBB"
-	stale := newDeviceAuth()
-	stale.DeviceCode = "dc-stale"
-	stale.UserCode = "CCCC-DDDD"
-	stale.ExpiresAt = time.Now().Add(-time.Minute)
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: live})
-	_, _ = s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: stale})
-
-	resp, err := s.CleanupExpired(context.Background(), &core.CleanupExpiredDeviceAuthsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Removed)
-	_, err = s.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-live"})
-	require.NoError(t, err, "non-expired record MUST survive cleanup")
-}
-
-func TestGORMDeviceAuthStore_RestartPersists(t *testing.T) {
-	// Restart parity: when the process restarts and a fresh store opens
-	// over the same DB, the device authorization (and its status) MUST
-	// still be there. This is the property the in-memory store cannot
-	// satisfy and is the main reason this backend exists.
-	db := setupTestDB(t)
-	s := NewDeviceAuthStore(db)
-	_, err := s.CreateDeviceAuthorization(context.Background(), &core.CreateDeviceAuthorizationRequest{Authorization: newDeviceAuth()})
-	require.NoError(t, err)
-	_, err = s.ApproveDeviceAuthorization(context.Background(), &core.ApproveDeviceAuthorizationRequest{
-		UserCode: "WDJB-MJHT", ApprovedSubject: "alice",
-	})
-	require.NoError(t, err)
-
-	// Fresh store over the same DB connection — same as a new process
-	// opening the same database file.
-	s2 := NewDeviceAuthStore(db)
-	g, err := s2.GetByDeviceCode(context.Background(), &core.GetByDeviceCodeRequest{DeviceCode: "dc-abc"})
-	require.NoError(t, err)
-	assert.Equal(t, core.DeviceAuthorizationStatusApproved, g.Authorization.Status)
-	assert.Equal(t, "alice", g.Authorization.ApprovedSubject)
 }

--- a/stores/gorm/go.mod
+++ b/stores/gorm/go.mod
@@ -4,7 +4,6 @@ go 1.26.4
 
 require (
 	github.com/panyam/oneauth v0.0.70
-	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.46.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0
@@ -25,6 +24,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect


### PR DESCRIPTION
## What changes

The four `DeviceAuthorizationStore` backends — in-memory (core), fs, gorm, gae — each carried their own per-test scenario set covering the same ~10 behaviors. The files had started to drift in tiny ways (test names, scope-override coverage, `LastPolledAt` persistence assertions, GAE re-using the client connection vs gorm a single SQLite DB). This PR collapses them into one shared `deviceauthtest/` package mirroring the existing `appstoretest/` precedent.

Every backend's test file now reduces to a single `Test*DeviceAuthStore_Contract` that calls `deviceauthtest.RunAll(t, factory)`. The 10 scenarios live in one place; adding a fifth backend becomes a 5-line factory + 1-line RunAll invocation.

**Stacked on PR 284** (the `core.UpperUserCode` export). Review 284 first.

## Reviewer's guide
Read in this order:

1. [deviceauthtest/deviceauthtest.go](https://github.com/panyam/oneauth/pull/285/files#diff-540858e933d4e0eddd5294ac3d06c7149d4fd8a9097bd7196328d24e7f4ad87a) — the new contract suite. Start with the `Backend` / `Factory` types and `RunAll` to see the scenario list, then the 10 `Test*` functions for the assertions each one pins.
2. [core/device_authorization_contract_test.go](https://github.com/panyam/oneauth/pull/285/files#diff-7cc7ea19b1c6d1d444b770baf81c0e8c54dd45a5905583dda6e5a25f6c1d9f7e) — the in-memory `Backend` factory. Note the `Reopen` closure returns the same instance since the in-mem backend has no underlying storage to reconnect to.
3. [stores/fs/fsdeviceauth_store_test.go](https://github.com/panyam/oneauth/pull/285/files#diff-e52b3a3e4bb715a027fae4dfb88d82580f6da4ad3f8d4d9b55336a6d8515c1df) — fs `Backend` factory: same tempdir across `Store` and `Reopen`. Diff against the prior version is large because 3 scenarios collapse into 1 contract call.
4. [stores/gorm/deviceauth_test.go](https://github.com/panyam/oneauth/pull/285/files#diff-4015c51450c488995c58fabbee3353ada241796d5421714e085616276f8ad39c) — gorm `Backend` factory: same `*gorm.DB` shared between Store and Reopen so `RestartPersists` simulates a process restart over the same database.
5. [stores/gae/deviceauth_test.go](https://github.com/panyam/oneauth/pull/285/files#diff-fc18f2372ea98b0ba5254fac88f57d97a20d51eda9d36374093e63d556f65318) — gae `Backend` factory: same client + namespace; per-scenario cleanup happens via the existing `cleanup()` closure inside the factory so each sub-test sees an empty Datastore.
6. [core/device_authorization_test.go](https://github.com/panyam/oneauth/pull/285/files#diff-9ee0e34b48f7e3fe2e04d91db3c652f21f8ff8aac3c932f0e7d82c8c09c31397) — the surviving non-store tests (`IsExpired`, `UpperUserCode`). Drift catches that don't belong in the store contract suite stay here.
7. [stores/gae/go.mod](https://github.com/panyam/oneauth/pull/285/files#diff-adf2ca391d2138a87f247172a5bab71a142c6bd3da24fa8c2531b2b2974ad592), [stores/gorm/go.mod](https://github.com/panyam/oneauth/pull/285/files#diff-5f3293a20a6e06ca9a59b795494827b5bc07286fab32ed04e274ae36edb96122) — `testify` demoted from direct to indirect since the test files no longer import it directly (they go through `deviceauthtest`).

Skim or skip: the deletions in the per-backend test files — they're the scenarios being lifted into the suite, not new logic.

## Diff groups

- Production: `deviceauthtest/deviceauthtest.go` (new package).
- Test scaffolding (per backend): `core/device_authorization_contract_test.go`, `stores/fs/fsdeviceauth_store_test.go`, `stores/gorm/deviceauth_test.go`, `stores/gae/deviceauth_test.go`.
- Surviving non-store tests: `core/device_authorization_test.go`.
- Mechanical: `stores/gae/go.mod`, `stores/gorm/go.mod` (tidy after testify demotion).

## Decision log

- **Backend struct with Store + Reopen, not a Factory(reopen bool) shape.** The closure form (`factory(t, reopen=true)`) would have required each backend's factory to manage per-test state out-of-band; the struct shape keeps everything one call away and matches what the existing per-backend `RestartPersists` tests already do.
- **`RestartPersists` runs for the in-memory backend too.** Reopen returns the receiver, so the scenario degenerates to a same-handle round-trip. That's harmless and keeps the scenario set identical across all four backends — adding a fifth backend doesn't have to know which scenarios "don't apply."
- **Kept `IsExpired` and `UpperUserCode` tests in `core/device_authorization_test.go`.** Those test pure helpers (the `DeviceAuthorization` value type and the package-level normalization function), not the store interface. Folding them into the contract suite would have been a categorical mismatch.
- **GAE per-scenario cleanup runs inside the factory closure, not as a setup helper.** Matches the appstore_test.go pattern in the same package; each sub-test sees an empty namespace.

## Risk / blast radius

- Affects: test files only. No production behavior change.
- Tests covering this: the contract suite itself. Verified by deliberately breaking `core.UpperUserCode`'s call site in `InMemoryDeviceAuthorizationStore.GetByUserCode` and observing all four backends' `CreateAndGet` scenario fail (then reverted before commit).
- Be paranoid about: the GAE skip behavior. The `t.Skip("DATASTORE_PROJECT_ID not set, ...")` MUST fire before any `RunAll` call so `go test ./...` on a dev machine without the emulator stays green. Verified.
- `make test` (root module), `cd stores/gorm && GOWORK=off go test ./...` both pass locally. GAE builds clean; runtime needs the Datastore emulator.

## Before / after

```
Before:   ~525 lines of per-backend scenarios across 4 files
After:    deviceauthtest/ (260 LOC) + 4 thin Contract tests (~30 LOC each)
Diff:     8 files, +329 / -525
```

## Out of scope

- Migrating `appstoretest`'s factory pattern to the `Backend{Store, Reopen}` shape — out of scope; that's a separate consolidation if anyone wants it.
- Adding a fifth backend.

Closes 282.
