### PR TITLE
feat(apiauth): MountDeviceFlow + e2e RFC 8628 device flow (#276)

### DIFF
--- a/apiauth/device_flow_mount.go
+++ b/apiauth/device_flow_mount.go
@@ -1,0 +1,162 @@
+package apiauth
+
+import (
+	"net/http"
+	"time"
+)
+
+// DeviceFlowMountConfig configures MountDeviceFlow. Mirrors the
+// MountASMetadata pattern: the helper owns route placement and handler
+// construction; callers supply dependencies + the host-specific
+// integration points (session lookup, CSRF token source, optional
+// middleware wrapping the verifier routes).
+//
+// A minimal valid configuration sets APIAuth (with DeviceAuthStore
+// populated), VerificationURI, SubjectFromRequest, and
+// CSRFTokenFromRequest. Everything else has sensible defaults — the
+// helper deliberately keeps the knob count low so the reference server
+// and tests both reach for it instead of hand-wiring the four routes.
+type DeviceFlowMountConfig struct {
+	// APIAuth is the source of DeviceAuthStore (required for the
+	// device-grant handler and the verification UI), AppStore (used by
+	// the consent screen to render client_name and by the token
+	// endpoint to enforce RFC 8628 §3.4 confidential-client auth per
+	// issue 266), and the Approve / Deny helpers the verifier calls
+	// when the user decides. Required.
+	APIAuth *APIAuth
+
+	// VerificationURI is the absolute URL the device displays to the
+	// user — RFC 8628 §3.2 makes it REQUIRED on the /device/authorize
+	// response. Production: <public-base-url>/device. Tests: the
+	// httptest.Server URL + /device. The value is echoed verbatim to
+	// the device. Required.
+	VerificationURI string
+
+	// VerificationURICompleteTemplate, when set, generates the optional
+	// RFC 8628 §3.3.1 verification_uri_complete field. The user_code is
+	// substituted into "%s". Example: "https://auth.example/device?user_code=%s".
+	// Empty omits the field; the device falls back to verification_uri
+	// and prompts the user to type the code.
+	VerificationURICompleteTemplate string
+
+	// Expiry overrides the RFC 8628 §3.4 recommended 15-minute window.
+	// Zero keeps the default.
+	Expiry time.Duration
+
+	// Interval overrides the RFC 8628 §3.5 default 5-second polling
+	// interval. Zero keeps the default.
+	Interval int
+
+	// ClientAuthenticator authenticates clients at POST /device/authorize.
+	// Nil accepts any client_id (test-suitable). For deployments that
+	// register confidential clients, wire APIAuth's ClientAuthenticator
+	// here so the device-authorize call rejects unauthenticated
+	// confidential clients before a code is even minted. Confidential-
+	// client enforcement on the REDEMPTION path (POST /api/token) is
+	// independent and driven by APIAuth.AppStore (issue 266).
+	ClientAuthenticator ClientAuthenticator
+
+	// SubjectFromRequest returns the authenticated subject ("" if the
+	// user is unauthenticated). The verification UI uses this to decide
+	// whether to redirect to login before showing the consent screen.
+	// Wire `httpauth.Middleware.GetLoggedInSubject` or a cookie-reading
+	// equivalent. Required.
+	SubjectFromRequest func(r *http.Request) string
+
+	// CSRFTokenFromRequest returns the per-request CSRF token to embed
+	// in the rendered HTML forms (code-entry and consent). Wire
+	// `httpauth.CSRFToken`. Required — the consent forms are rendered
+	// with a hidden csrf_token input even when CSRF middleware is off
+	// at the route level.
+	CSRFTokenFromRequest func(r *http.Request) string
+
+	// LoginRedirectURL is where Submit redirects unauthenticated users.
+	// Empty defaults to "/auth/login" (the convention used elsewhere
+	// in the library).
+	LoginRedirectURL string
+
+	// LoginNextParam names the query parameter used to round-trip the
+	// post-login return URL. Empty defaults to "next".
+	LoginNextParam string
+
+	// Templates overrides the built-in HTML pages (form / consent /
+	// done). Nil uses the package defaults — fine for first-light
+	// deployments and tests.
+	Templates *DeviceTemplates
+
+	// VerifierMiddleware, when non-nil, wraps each of the four
+	// /device and /device/approve routes. Production wires
+	// `httpauth.CSRFMiddleware.Protect` here so POST submissions are
+	// CSRF-protected; tests pass nil because they drive the routes
+	// directly and skip CSRF validation. The /device/authorize route
+	// is NOT wrapped — it is a machine-to-machine endpoint called by
+	// the device, not a browser form, and CSRF does not apply.
+	VerifierMiddleware func(http.Handler) http.Handler
+}
+
+// MountDeviceFlow stamps the five RFC 8628 routes onto mux:
+//
+//	POST /device/authorize  — DeviceAuthorizationHandler (machine endpoint, no middleware)
+//	GET  /device            — DeviceVerificationHandler.Form    (browser form)
+//	POST /device            — DeviceVerificationHandler.Submit  (browser form)
+//	GET  /device/approve    — DeviceVerificationHandler.Consent (browser form)
+//	POST /device/approve    — DeviceVerificationHandler.Decide  (browser form)
+//
+// The four /device + /device/approve routes share the same backing
+// DeviceVerificationHandler and, when cfg.VerifierMiddleware is non-nil,
+// are wrapped with it. /device/authorize is intentionally unwrapped —
+// it is a device-driven JSON endpoint, not a browser form.
+//
+// Panics if cfg.APIAuth is nil, cfg.APIAuth.DeviceAuthStore is nil, or
+// cfg.VerificationURI is empty — those are programming errors the
+// caller cannot meaningfully recover from at request time.
+//
+// Does NOT advertise device_authorization_endpoint in AS metadata; the
+// caller is responsible for that on the ASServerMetadata struct passed
+// to MountASMetadata.
+func MountDeviceFlow(mux *http.ServeMux, cfg DeviceFlowMountConfig) {
+	if cfg.APIAuth == nil {
+		panic("apiauth: MountDeviceFlow: cfg.APIAuth is required")
+	}
+	if cfg.APIAuth.DeviceAuthStore == nil {
+		panic("apiauth: MountDeviceFlow: cfg.APIAuth.DeviceAuthStore is required (RFC 8628 needs persistence)")
+	}
+	if cfg.VerificationURI == "" {
+		panic("apiauth: MountDeviceFlow: cfg.VerificationURI is required (RFC 8628 §3.2)")
+	}
+
+	devAuth := &DeviceAuthorizationHandler{
+		Store:                           cfg.APIAuth.DeviceAuthStore,
+		VerificationURI:                 cfg.VerificationURI,
+		VerificationURICompleteTemplate: cfg.VerificationURICompleteTemplate,
+		Expiry:                          cfg.Expiry,
+		Interval:                        cfg.Interval,
+		ClientAuthenticator:             cfg.ClientAuthenticator,
+	}
+	mux.Handle("POST /device/authorize", devAuth)
+
+	verifier := &DeviceVerificationHandler{
+		Store:    cfg.APIAuth.DeviceAuthStore,
+		AppStore: cfg.APIAuth.AppStore,
+		Approve: func(r *http.Request, userCode, subject string, scopes []string) error {
+			return cfg.APIAuth.ApproveDeviceAuthorization(r, userCode, subject, scopes)
+		},
+		Deny: func(r *http.Request, userCode string) error {
+			return cfg.APIAuth.DenyDeviceAuthorization(r, userCode)
+		},
+		SubjectFromRequest:   cfg.SubjectFromRequest,
+		CSRFTokenFromRequest: cfg.CSRFTokenFromRequest,
+		LoginRedirectURL:     cfg.LoginRedirectURL,
+		LoginNextParam:       cfg.LoginNextParam,
+		Templates:            cfg.Templates,
+	}
+
+	wrap := cfg.VerifierMiddleware
+	if wrap == nil {
+		wrap = func(h http.Handler) http.Handler { return h }
+	}
+	mux.Handle("GET /device", wrap(http.HandlerFunc(verifier.Form)))
+	mux.Handle("POST /device", wrap(http.HandlerFunc(verifier.Submit)))
+	mux.Handle("GET /device/approve", wrap(http.HandlerFunc(verifier.Consent)))
+	mux.Handle("POST /device/approve", wrap(http.HandlerFunc(verifier.Decide)))
+}

--- a/apiauth/device_flow_mount_test.go
+++ b/apiauth/device_flow_mount_test.go
@@ -1,0 +1,159 @@
+package apiauth_test
+
+// Tests for apiauth.MountDeviceFlow — the helper that stamps the five
+// RFC 8628 routes onto an http.ServeMux. Behavioral coverage of the
+// device-grant arc itself lives in tests/e2e/device_flow_test.go (issue
+// 276); this file pins the helper's pre-conditions and route layout.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func defaultMountCfg() apiauth.DeviceFlowMountConfig {
+	return apiauth.DeviceFlowMountConfig{
+		APIAuth: &apiauth.APIAuth{
+			DeviceAuthStore: core.NewInMemoryDeviceAuthorizationStore(),
+		},
+		VerificationURI:      "https://auth.example/device",
+		SubjectFromRequest:   func(r *http.Request) string { return "" },
+		CSRFTokenFromRequest: func(r *http.Request) string { return "test-csrf" },
+	}
+}
+
+// TestMountDeviceFlow_PanicsOnMissingAPIAuth pins that a missing
+// APIAuth is rejected loudly at mount time. Required because nil
+// dereference at request time would surface a 500 with a stack trace,
+// not a usable diagnostic.
+func TestMountDeviceFlow_PanicsOnMissingAPIAuth(t *testing.T) {
+	cfg := defaultMountCfg()
+	cfg.APIAuth = nil
+	assert.PanicsWithValue(t, "apiauth: MountDeviceFlow: cfg.APIAuth is required", func() {
+		apiauth.MountDeviceFlow(http.NewServeMux(), cfg)
+	})
+}
+
+// TestMountDeviceFlow_PanicsOnMissingDeviceAuthStore pins that a
+// populated APIAuth with no DeviceAuthStore is rejected — every
+// /device/authorize call and every consent-UI lookup needs persistence
+// per RFC 8628.
+func TestMountDeviceFlow_PanicsOnMissingDeviceAuthStore(t *testing.T) {
+	cfg := defaultMountCfg()
+	cfg.APIAuth.DeviceAuthStore = nil
+	assert.PanicsWithValue(t, "apiauth: MountDeviceFlow: cfg.APIAuth.DeviceAuthStore is required (RFC 8628 needs persistence)", func() {
+		apiauth.MountDeviceFlow(http.NewServeMux(), cfg)
+	})
+}
+
+// TestMountDeviceFlow_PanicsOnMissingVerificationURI pins that the
+// RFC 8628 §3.2 required field is enforced. Empty would yield a
+// response with verification_uri="", which is a wire-format bug
+// disguised as a 200.
+func TestMountDeviceFlow_PanicsOnMissingVerificationURI(t *testing.T) {
+	cfg := defaultMountCfg()
+	cfg.VerificationURI = ""
+	assert.PanicsWithValue(t, "apiauth: MountDeviceFlow: cfg.VerificationURI is required (RFC 8628 §3.2)", func() {
+		apiauth.MountDeviceFlow(http.NewServeMux(), cfg)
+	})
+}
+
+// TestMountDeviceFlow_RegistersFiveRoutes pins the canonical route
+// layout. Hitting each route returns a non-404 — sufficient to prove
+// the handler is mounted; behavior is covered elsewhere.
+func TestMountDeviceFlow_RegistersFiveRoutes(t *testing.T) {
+	mux := http.NewServeMux()
+	apiauth.MountDeviceFlow(mux, defaultMountCfg())
+
+	cases := []struct {
+		method, path string
+	}{
+		{http.MethodPost, "/device/authorize"},
+		{http.MethodGet, "/device"},
+		{http.MethodPost, "/device"},
+		{http.MethodGet, "/device/approve"},
+		{http.MethodPost, "/device/approve"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(""))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			assert.NotEqual(t, http.StatusNotFound, rr.Code,
+				"%s %s MUST be registered by MountDeviceFlow", tc.method, tc.path)
+		})
+	}
+}
+
+// TestMountDeviceFlow_VerifierMiddlewareWrapsBrowserRoutesNotAuthorize
+// pins the deliberate asymmetry: the /device/authorize machine endpoint
+// is NOT wrapped by VerifierMiddleware (CSRF does not apply to a
+// device-driven JSON request), while the four browser-facing routes
+// ARE. A test middleware tags every wrapped response so we can read
+// which routes ran through it.
+func TestMountDeviceFlow_VerifierMiddlewareWrapsBrowserRoutesNotAuthorize(t *testing.T) {
+	cfg := defaultMountCfg()
+	cfg.VerifierMiddleware = func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Wrapped", "yes")
+			next.ServeHTTP(w, r)
+		})
+	}
+	mux := http.NewServeMux()
+	apiauth.MountDeviceFlow(mux, cfg)
+
+	// /device/authorize is the machine endpoint — must NOT be wrapped.
+	form := url.Values{"client_id": {"client-x"}}
+	req := httptest.NewRequest(http.MethodPost, "/device/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Empty(t, rr.Header().Get("X-Wrapped"),
+		"/device/authorize is a machine endpoint and MUST NOT be wrapped with the browser middleware")
+
+	// All four verifier routes MUST be wrapped.
+	browserRoutes := []struct{ method, path string }{
+		{http.MethodGet, "/device"},
+		{http.MethodPost, "/device"},
+		{http.MethodGet, "/device/approve"},
+		{http.MethodPost, "/device/approve"},
+	}
+	for _, route := range browserRoutes {
+		t.Run(route.method+"_"+route.path, func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.path, strings.NewReader(""))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			assert.Equal(t, "yes", rr.Header().Get("X-Wrapped"),
+				"%s %s MUST run through VerifierMiddleware", route.method, route.path)
+		})
+	}
+}
+
+// TestMountDeviceFlow_VerificationURIEchoedToDevice pins that the
+// configured VerificationURI flows through to the
+// DeviceAuthorizationHandler — a wire-format regression would surface
+// as a different URL on the response payload.
+func TestMountDeviceFlow_VerificationURIEchoedToDevice(t *testing.T) {
+	cfg := defaultMountCfg()
+	cfg.VerificationURI = "https://canary.example/device"
+	mux := http.NewServeMux()
+	apiauth.MountDeviceFlow(mux, cfg)
+
+	form := url.Values{"client_id": {"client-x"}}
+	req := httptest.NewRequest(http.MethodPost, "/device/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "https://canary.example/device",
+		"configured VerificationURI MUST appear on the /device/authorize response")
+}

--- a/cmd/oneauth-server/config.go
+++ b/cmd/oneauth-server/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,6 +19,53 @@ type Config struct {
 	JWT        JWTConfig        `yaml:"jwt"`
 	AdminAuth  AdminAuthConfig  `yaml:"admin_auth"`
 	TLS        TLSConfig        `yaml:"tls"`
+	DeviceFlow DeviceFlowConfig `yaml:"device_flow"`
+}
+
+// DeviceFlowConfig toggles and configures the RFC 8628 Device
+// Authorization Grant. When Enabled is false (default), the device-
+// flow routes are not mounted and the token endpoint refuses the
+// device_code grant. Setting Enabled wires:
+//
+//	POST /device/authorize  — the device-side wire endpoint
+//	GET  /device            — code entry form (CSRF-protected)
+//	POST /device            — submit code (CSRF-protected)
+//	GET  /device/approve    — consent screen (CSRF-protected)
+//	POST /device/approve    — approve / deny decision (CSRF-protected)
+//
+// AS metadata also advertises device_authorization_endpoint and the
+// grant_type so RFC 8414 discovery exposes the capability to clients.
+type DeviceFlowConfig struct {
+	// Enabled toggles the entire device-flow surface on. Default false
+	// — the routes are not mounted and AS metadata does not advertise
+	// the endpoint or grant type.
+	Enabled bool `yaml:"enabled"`
+
+	// Expiry overrides the RFC 8628 §3.4 recommended 15-minute
+	// authorization window. Format accepts Go duration syntax
+	// (e.g. "15m", "5m30s"). Zero/empty keeps the default.
+	Expiry time.Duration `yaml:"expiry"`
+
+	// Interval overrides the RFC 8628 §3.5 default 5-second polling
+	// interval the AS advertises to the device. Zero keeps the
+	// default.
+	Interval int `yaml:"interval"`
+
+	// Store backs the DeviceAuthorizationStore. memory (default) is
+	// fine for single-instance dev; production deployments choose
+	// fs / gorm / gae so authorizations survive restart. Mirrors the
+	// AppStoreConfig / KeyStoreConfig shape so operators see one
+	// pattern across all three.
+	Store DeviceAuthStoreConfig `yaml:"store"`
+}
+
+// DeviceAuthStoreConfig configures the DeviceAuthorizationStore
+// backend. Mirrors AppStoreConfig.
+type DeviceAuthStoreConfig struct {
+	Type string     `yaml:"type"` // memory (default), fs, gorm, gae
+	FS   FSConfig   `yaml:"fs"`
+	GORM GORMConfig `yaml:"gorm"`
+	GAE  GAEConfig  `yaml:"gae"`
 }
 
 // AppStoreConfig configures the AppRegistrationStore backing AppRegistrar
@@ -192,6 +240,9 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	if len(cfg.JWT.ClaimsSupported) == 0 {
 		cfg.JWT.ClaimsSupported = defaultClaimsSupported()
+	}
+	if cfg.DeviceFlow.Enabled && cfg.DeviceFlow.Store.Type == "" {
+		cfg.DeviceFlow.Store.Type = "memory"
 	}
 
 	return &cfg, nil

--- a/cmd/oneauth-server/main.go
+++ b/cmd/oneauth-server/main.go
@@ -317,14 +317,15 @@ func main() {
 		}
 		baseURL = fmt.Sprintf("%s://%s:%s", scheme, cfg.Server.Host, cfg.Server.Port)
 	}
-	apiauth.MountASMetadata(mux, &apiauth.ASServerMetadata{
+
+	grantTypes := []string{"password", "refresh_token", "client_credentials"}
+	asMeta := &apiauth.ASServerMetadata{
 		Issuer:                             baseURL,
 		TokenEndpoint:                      baseURL + "/api/token",
 		JWKSURI:                            baseURL + "/.well-known/jwks.json",
 		IntrospectionEndpoint:              baseURL + "/oauth/introspect",
 		RevocationEndpoint:                 baseURL + "/oauth/revoke",
 		RegistrationEndpoint:               baseURL + "/apps/dcr",
-		GrantTypesSupported:                        []string{"password", "refresh_token", "client_credentials"},
 		ResponseTypesSupported:                     []string{"token"},
 		TokenEndpointAuthMethods:                   []string{"client_secret_post", "client_secret_basic", "private_key_jwt"},
 		TokenEndpointAuthSigningAlgValuesSupported: []string{"RS256", "ES256"},
@@ -333,7 +334,42 @@ func main() {
 		ScopesSupported:                    cfg.JWT.ScopesSupported,
 		ClaimsSupported:                    cfg.JWT.ClaimsSupported,
 		AuthorizationDetailsTypesSupported: cfg.JWT.AuthorizationDetailsTypes,
-	})
+	}
+
+	// Device Authorization Grant (RFC 8628), opt-in via device_flow.enabled.
+	// Mount the routes, point APIAuth at the device store + app store
+	// (the latter drives RFC 8628 §3.4 confidential-client enforcement
+	// on redemption — issue 266), and advertise the endpoint + grant
+	// type in AS metadata so discovery surfaces the capability.
+	if cfg.DeviceFlow.Enabled {
+		deviceStore, err := buildDeviceAuthStore(cfg, db)
+		if err != nil {
+			log.Fatalf("Failed to create DeviceAuthStore: %v", err)
+		}
+		apiAuth.DeviceAuthStore = deviceStore
+		apiAuth.AppStore = appStore
+
+		apiauth.MountDeviceFlow(mux, apiauth.DeviceFlowMountConfig{
+			APIAuth:                         apiAuth,
+			VerificationURI:                 baseURL + "/device",
+			VerificationURICompleteTemplate: baseURL + "/device?user_code=%s",
+			Expiry:                          cfg.DeviceFlow.Expiry,
+			Interval:                        cfg.DeviceFlow.Interval,
+			SubjectFromRequest: func(r *http.Request) string {
+				return getUserIDFromCookie(r, cfg.JWT.SecretKey)
+			},
+			CSRFTokenFromRequest: httpauth.CSRFToken,
+			LoginRedirectURL:     "/auth/login",
+			VerifierMiddleware:   csrf.Protect,
+		})
+
+		asMeta.DeviceAuthorizationEndpoint = baseURL + "/device/authorize"
+		grantTypes = append(grantTypes, apiauth.DeviceCodeGrantType)
+		log.Println("RFC 8628 device flow enabled (/device/authorize + /device + /device/approve)")
+	}
+	asMeta.GrantTypesSupported = grantTypes
+
+	apiauth.MountASMetadata(mux, asMeta)
 
 	addr := cfg.Server.Host + ":" + cfg.Server.Port
 	log.Printf("oneauth-server listening on %s (keystore=%s, user_stores=%s, auth=%s)",
@@ -576,6 +612,50 @@ func buildAppStore(cfg *Config, sharedDB *gorm.DB) (core.AppRegistrationStore, e
 
 	default:
 		return nil, fmt.Errorf("unknown app_store type: %s", cfg.AppStore.Type)
+	}
+}
+
+// buildDeviceAuthStore constructs the DeviceAuthorizationStore backing
+// the RFC 8628 device-grant flow. Mirrors buildAppStore. Returns
+// (store, nil) on success; only invoked when cfg.DeviceFlow.Enabled is
+// true so callers can rely on a non-nil return.
+func buildDeviceAuthStore(cfg *Config, sharedDB *gorm.DB) (core.DeviceAuthorizationStore, error) {
+	sc := cfg.DeviceFlow.Store
+	switch sc.Type {
+	case "memory":
+		log.Println("Using in-memory DeviceAuthStore (device authorizations lost on restart)")
+		return core.NewInMemoryDeviceAuthorizationStore(), nil
+
+	case "fs":
+		log.Printf("Using filesystem DeviceAuthStore at %s", sc.FS.Path)
+		return fsstore.NewFSDeviceAuthorizationStore(sc.FS.Path), nil
+
+	case "gorm":
+		db := sharedDB
+		if db == nil || cfg.KeyStore.GORM.DSN != sc.GORM.DSN || cfg.KeyStore.GORM.Driver != sc.GORM.Driver {
+			fresh, err := openGORM(sc.GORM)
+			if err != nil {
+				return nil, err
+			}
+			db = fresh
+		}
+		if err := gormstore.AutoMigrate(db); err != nil {
+			return nil, err
+		}
+		log.Printf("Using GORM DeviceAuthStore (driver=%s)", sc.GORM.Driver)
+		return gormstore.NewDeviceAuthStore(db), nil
+
+	case "gae":
+		ctx := context.Background()
+		client, err := datastore.NewClient(ctx, sc.GAE.Project)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("Using GAE Datastore DeviceAuthStore (project=%s, namespace=%s)", sc.GAE.Project, sc.GAE.Namespace)
+		return gaestore.NewDeviceAuthStore(client, sc.GAE.Namespace), nil
+
+	default:
+		return nil, fmt.Errorf("unknown device_flow.store type: %s", sc.Type)
 	}
 }
 

--- a/cmd/oneauth-server/oneauth-server.yaml
+++ b/cmd/oneauth-server/oneauth-server.yaml
@@ -55,3 +55,18 @@ tls:
   enabled: false
   # cert: /etc/ssl/cert.pem
   # key: /etc/ssl/key.pem
+
+# RFC 8628 Device Authorization Grant (optional, off by default).
+# When enabled, mounts /device/authorize plus the /device + /device/approve
+# user-facing verification UI, and advertises device_authorization_endpoint
+# in AS metadata. CLI clients (oneauth token device, gcloud, GitHub CLI)
+# can then complete OAuth without a local browser.
+device_flow:
+  enabled: ${DEVICE_FLOW_ENABLED:-false}
+  # expiry: 15m   # RFC 8628 §3.4 default (15 minutes)
+  # interval: 5   # RFC 8628 §3.5 default (5 seconds)
+  store:
+    type: "${DEVICE_AUTH_STORE_TYPE:-memory}"   # memory (default), fs, gorm, gae
+    fs:
+      path: "${DEVICE_AUTH_STORE_PATH:-./data/device}"
+    # gorm and gae reuse the keystore.gorm / keystore.gae shape

--- a/tests/e2e/device_flow_test.go
+++ b/tests/e2e/device_flow_test.go
@@ -1,0 +1,383 @@
+package e2e_test
+
+// End-to-end RFC 8628 Device Authorization Grant test against an
+// in-process oneauth AS. Drives the full arc that #117, #266, #267, and
+// #268 ship across:
+//
+//	POST /device/authorize          — wire protocol (#117)
+//	GET  /device                    — code entry form (#267)
+//	POST /device                    — submit code, redirect to consent (#267)
+//	GET  /device/approve            — consent screen (#267)
+//	POST /device/approve            — approve / deny decision (#267)
+//	POST /api/token                 — grant_type=device_code + confidential-client auth (#117 / #266)
+//
+// Catches wire-format drift across all four PRs that the per-handler unit
+// tests cannot — those test each handler against synthetic stores; this
+// test drives one shared store through every handler the way a real
+// device-and-browser pair would.
+//
+// Why a hand-rolled fixture instead of TestEnv: TestEnv mounts the legacy
+// /api/token wired against a JSON request shape with no device-grant
+// branch; adding the device flow to it would mean threading new fields
+// through every other e2e test. A focused fixture keeps the device-flow
+// arc isolated and the failure mode narrow.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/panyam/oneauth/admin"
+	"github.com/panyam/oneauth/apiauth"
+	"github.com/panyam/oneauth/core"
+	"github.com/panyam/oneauth/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	deviceTestJWTSecret   = "device-e2e-jwt-secret-32chars!!!"
+	deviceTestJWTIssuer   = "oneauth-device-e2e"
+	deviceTestAdminKey    = "device-e2e-admin-key"
+	deviceTestCSRFToken   = "device-e2e-csrf-token" // fixed for the shim — real CSRF is exercised by httpauth_test
+	deviceTestSubjectHdr  = "X-Test-Subject"
+	deviceTestSlowDownGap = -time.Hour // backdate LastPolledAt past the polling interval
+)
+
+// deviceFlowEnv is the per-test fixture: a single in-process AS wired
+// with /device/authorize, the four /device + /device/approve verification
+// routes, and /api/token. Stores are in-memory and dedicated per test.
+type deviceFlowEnv struct {
+	t              *testing.T
+	server         *httptest.Server
+	apiAuth        *apiauth.APIAuth
+	appRegistrar   *admin.AppRegistrar
+	deviceStore    core.DeviceAuthorizationStore
+	appStore       core.AppRegistrationStore
+	keyStore       *keys.InMemoryKeyStore
+	expiry         time.Duration // applied to DeviceAuthorizationHandler.Expiry
+}
+
+func newDeviceFlowEnv(t *testing.T, expiry time.Duration) *deviceFlowEnv {
+	t.Helper()
+	env := &deviceFlowEnv{t: t, expiry: expiry}
+
+	env.deviceStore = core.NewInMemoryDeviceAuthorizationStore()
+	env.appStore = core.NewInMemoryAppStore()
+	env.keyStore = keys.NewInMemoryKeyStore()
+
+	env.appRegistrar = admin.NewAppRegistrarWithStore(env.keyStore, admin.NewAPIKeyAuth(deviceTestAdminKey), env.appStore)
+
+	env.apiAuth = &apiauth.APIAuth{
+		JWTSecretKey:    deviceTestJWTSecret,
+		JWTIssuer:       deviceTestJWTIssuer,
+		ClientKeyStore:  env.keyStore,
+		DeviceAuthStore: env.deviceStore,
+		AppStore:        env.appStore, // enables RFC 8628 §3.4 confidential-client enforcement
+	}
+
+	mux := http.NewServeMux()
+
+	devAuthHandler := &apiauth.DeviceAuthorizationHandler{
+		Store:               env.deviceStore,
+		VerificationURI:     "", // populated after server starts
+		Expiry:              env.expiry,
+		ClientAuthenticator: nil, // public + confidential clients both work; confidential auth happens on redemption per #266
+	}
+	mux.Handle("POST /device/authorize", devAuthHandler)
+
+	verifier := &apiauth.DeviceVerificationHandler{
+		Store:    env.deviceStore,
+		AppStore: env.appStore,
+		Approve: func(r *http.Request, userCode, subject string, scopes []string) error {
+			return env.apiAuth.ApproveDeviceAuthorization(r, userCode, subject, scopes)
+		},
+		Deny: func(r *http.Request, userCode string) error {
+			return env.apiAuth.DenyDeviceAuthorization(r, userCode)
+		},
+		// Option B (issue 276): the shim — login state lives in a request
+		// header so the test fixture stays free of localauth + session
+		// dependencies. Real-httpauth session and CSRF middleware are
+		// covered by httpauth_test and device_verification_handler_test
+		// respectively; this test's job is wire-format drift across the
+		// four shipped PRs (#117 / #266 / #267 / #268).
+		SubjectFromRequest:   func(r *http.Request) string { return r.Header.Get(deviceTestSubjectHdr) },
+		CSRFTokenFromRequest: func(*http.Request) string { return deviceTestCSRFToken },
+	}
+	mux.HandleFunc("GET /device", verifier.Form)
+	mux.HandleFunc("POST /device", verifier.Submit)
+	mux.HandleFunc("GET /device/approve", verifier.Consent)
+	mux.HandleFunc("POST /device/approve", verifier.Decide)
+
+	mux.Handle("POST /api/token", env.apiAuth)
+
+	env.server = httptest.NewServer(mux)
+	t.Cleanup(env.server.Close)
+
+	devAuthHandler.VerificationURI = env.server.URL + "/device"
+	return env
+}
+
+// registerClient drives AppRegistrar.Register directly (bypassing the
+// DCR HTTP wrapper) and returns the client_id + secret. authMethod is
+// "client_secret_post" / "client_secret_basic" / "none".
+func (e *deviceFlowEnv) registerClient(authMethod string) (clientID, secret string) {
+	e.t.Helper()
+	resp, err := e.appRegistrar.Register(context.Background(), &admin.RegisterRequest{
+		Metadata: &admin.DCRRequest{
+			ClientName:              "device-e2e-client",
+			TokenEndpointAuthMethod: authMethod,
+		},
+		IssuerBaseURL: e.server.URL,
+	})
+	require.NoError(e.t, err)
+	require.NotNil(e.t, resp)
+	require.NotNil(e.t, resp.Registration)
+	return resp.Registration.ClientID, resp.Registration.ClientSecret
+}
+
+// deviceAuthorize posts to /device/authorize and returns the parsed body.
+func (e *deviceFlowEnv) deviceAuthorize(clientID string) map[string]any {
+	e.t.Helper()
+	form := url.Values{"client_id": {clientID}, "scope": {"read"}}
+	resp, err := http.Post(e.server.URL+"/device/authorize", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(e.t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(e.t, http.StatusOK, resp.StatusCode, "device authorize failed: %s", body)
+	var parsed map[string]any
+	require.NoError(e.t, json.Unmarshal(body, &parsed))
+	return parsed
+}
+
+// browserClient is the user's browser that drives the consent UI. The
+// shim's subject header is set on every request so the verifier sees a
+// logged-in user; cookiejar is enabled so any future real-session work
+// migrates cleanly.
+func (e *deviceFlowEnv) browserClient(subject string) *http.Client {
+	jar, _ := cookiejar.New(nil)
+	return &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			req.Header.Set(deviceTestSubjectHdr, subject)
+			return nil
+		},
+		Transport: subjectHeaderTransport{subject: subject, base: http.DefaultTransport},
+	}
+}
+
+// subjectHeaderTransport stamps the test-subject header on every outbound
+// request the browser client makes. Lifts the shim into one place so each
+// scenario's HTTP calls stay readable.
+type subjectHeaderTransport struct {
+	subject string
+	base    http.RoundTripper
+}
+
+func (t subjectHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(deviceTestSubjectHdr, t.subject)
+	return t.base.RoundTrip(req)
+}
+
+// driveConsentUI walks GET /device → POST /device → GET /device/approve
+// → POST /device/approve. action is "approve" or "deny". Returns the
+// final response (the rendered "return to your device" page).
+func (e *deviceFlowEnv) driveConsentUI(client *http.Client, userCode, action string) *http.Response {
+	e.t.Helper()
+
+	// GET /device — sanity check the form renders.
+	resp, err := client.Get(e.server.URL + "/device")
+	require.NoError(e.t, err)
+	require.Equal(e.t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// POST /device — submit the user_code. Authenticated subject means
+	// the handler redirects to /device/approve, not the login page.
+	resp, err = client.PostForm(e.server.URL+"/device", url.Values{
+		"user_code":  {userCode},
+		"csrf_token": {deviceTestCSRFToken},
+	})
+	require.NoError(e.t, err)
+	require.Equal(e.t, http.StatusOK, resp.StatusCode, "post /device followed to %s", resp.Request.URL.Path)
+	// The post is followed through the redirect to /device/approve (GET).
+	require.Equal(e.t, "/device/approve", resp.Request.URL.Path)
+	resp.Body.Close()
+
+	// POST /device/approve — the user clicks Approve or Deny.
+	resp, err = client.PostForm(e.server.URL+"/device/approve", url.Values{
+		"user_code":  {userCode},
+		"action":     {action},
+		"csrf_token": {deviceTestCSRFToken},
+	})
+	require.NoError(e.t, err)
+	require.Equal(e.t, http.StatusOK, resp.StatusCode, "post /device/approve action=%s failed", action)
+	return resp
+}
+
+// pollToken posts grant_type=device_code with the supplied credentials.
+// Returns the HTTP status and the parsed body.
+func (e *deviceFlowEnv) pollToken(form url.Values) (int, map[string]any) {
+	e.t.Helper()
+	resp, err := http.Post(e.server.URL+"/api/token", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(e.t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var parsed map[string]any
+	if len(body) > 0 {
+		_ = json.Unmarshal(body, &parsed)
+	}
+	return resp.StatusCode, parsed
+}
+
+// resetPollClock backdates LastPolledAt so an immediate next poll is
+// allowed without slow_down. RFC 8628 §3.5 the AS rejects polls that
+// arrive faster than the advertised interval; tests cannot afford the
+// 5-second wait between polls so they manipulate the store directly.
+func (e *deviceFlowEnv) resetPollClock(deviceCode string) {
+	e.t.Helper()
+	_, err := e.deviceStore.UpdatePollingState(context.Background(), &core.UpdatePollingStateRequest{
+		DeviceCode: deviceCode,
+		PolledAt:   time.Now().Add(deviceTestSlowDownGap),
+		SlowDown:   false,
+	})
+	require.NoError(e.t, err)
+}
+
+// TestDeviceFlow_HappyPath_ConfidentialClient drives the full RFC 8628
+// arc end-to-end for a confidential client that authenticates on
+// redemption per RFC 8628 §3.4 + issue 266.
+func TestDeviceFlow_HappyPath_ConfidentialClient(t *testing.T) {
+	env := newDeviceFlowEnv(t, 0)
+	clientID, secret := env.registerClient("client_secret_post")
+	require.NotEmpty(t, secret, "confidential client MUST receive a secret")
+
+	auth := env.deviceAuthorize(clientID)
+	deviceCode := auth["device_code"].(string)
+	userCode := auth["user_code"].(string)
+
+	browser := env.browserClient("alice")
+	env.driveConsentUI(browser, userCode, "approve")
+
+	env.resetPollClock(deviceCode)
+	status, body := env.pollToken(url.Values{
+		"grant_type":    {apiauth.DeviceCodeGrantType},
+		"device_code":   {deviceCode},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+	})
+	require.Equal(t, http.StatusOK, status, "approved + authenticated poll MUST mint a token; got body=%v", body)
+	assert.NotEmpty(t, body["access_token"], "access_token issued")
+	assert.Equal(t, "Bearer", body["token_type"])
+}
+
+// TestDeviceFlow_Deny_ReturnsAccessDenied drives the explicit-deny
+// branch: the user clicks Deny, the next poll MUST surface
+// access_denied per RFC 8628 §3.5.
+func TestDeviceFlow_Deny_ReturnsAccessDenied(t *testing.T) {
+	env := newDeviceFlowEnv(t, 0)
+	clientID, secret := env.registerClient("client_secret_post")
+
+	auth := env.deviceAuthorize(clientID)
+	deviceCode := auth["device_code"].(string)
+	userCode := auth["user_code"].(string)
+
+	browser := env.browserClient("alice")
+	env.driveConsentUI(browser, userCode, "deny")
+
+	env.resetPollClock(deviceCode)
+	status, body := env.pollToken(url.Values{
+		"grant_type":    {apiauth.DeviceCodeGrantType},
+		"device_code":   {deviceCode},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+	})
+	require.Equal(t, http.StatusBadRequest, status, "denied auth MUST NOT mint a token")
+	assert.Equal(t, "access_denied", body["error"])
+}
+
+// TestDeviceFlow_NoClientCredentials_ReturnsInvalidClient pins the
+// issue-266 security review fix: a confidential client (anything other
+// than token_endpoint_auth_method=none) MUST authenticate on the
+// redemption call. Polling with the right device_code but no secret
+// returns invalid_client per RFC 6749 §5.2.
+func TestDeviceFlow_NoClientCredentials_ReturnsInvalidClient(t *testing.T) {
+	env := newDeviceFlowEnv(t, 0)
+	clientID, _ := env.registerClient("client_secret_post")
+
+	auth := env.deviceAuthorize(clientID)
+	deviceCode := auth["device_code"].(string)
+	userCode := auth["user_code"].(string)
+
+	browser := env.browserClient("alice")
+	env.driveConsentUI(browser, userCode, "approve")
+
+	env.resetPollClock(deviceCode)
+	status, body := env.pollToken(url.Values{
+		"grant_type":  {apiauth.DeviceCodeGrantType},
+		"device_code": {deviceCode},
+		"client_id":   {clientID},
+		// no client_secret — confidential client must NOT be redeemable
+	})
+	require.Equal(t, http.StatusUnauthorized, status,
+		"confidential client redemption without credentials MUST be rejected (RFC 8628 §3.4 / issue 266)")
+	assert.Equal(t, "invalid_client", body["error"], "got body=%v", body)
+}
+
+// TestDeviceFlow_ExpiredCode_ReturnsExpiredToken pins RFC 8628 §3.5
+// expired_token: once the authorization window passes, polling MUST
+// return expired_token even on otherwise-valid credentials.
+func TestDeviceFlow_ExpiredCode_ReturnsExpiredToken(t *testing.T) {
+	// Tight 100ms window — sleep past it before the first poll.
+	env := newDeviceFlowEnv(t, 100*time.Millisecond)
+	clientID, secret := env.registerClient("client_secret_post")
+
+	auth := env.deviceAuthorize(clientID)
+	deviceCode := auth["device_code"].(string)
+
+	time.Sleep(200 * time.Millisecond)
+
+	status, body := env.pollToken(url.Values{
+		"grant_type":    {apiauth.DeviceCodeGrantType},
+		"device_code":   {deviceCode},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+	})
+	require.Equal(t, http.StatusBadRequest, status, "expired authorization MUST NOT mint a token")
+	assert.Equal(t, "expired_token", body["error"], "got body=%v", body)
+}
+
+// TestDeviceFlow_PublicClient_NoAuthRequired pins the public-client
+// branch: a client registered with token_endpoint_auth_method=none MUST
+// redeem successfully without any client_secret. This is the path real
+// CLIs (oneauth token device, gcloud auth, GitHub CLI) take.
+func TestDeviceFlow_PublicClient_NoAuthRequired(t *testing.T) {
+	env := newDeviceFlowEnv(t, 0)
+	clientID, _ := env.registerClient("none")
+	// The registrar still issues a symmetric secret on the none path
+	// (#266 only governs token-endpoint enforcement, not registration).
+	// What we pin here is that the token endpoint does NOT require it.
+
+	auth := env.deviceAuthorize(clientID)
+	deviceCode := auth["device_code"].(string)
+	userCode := auth["user_code"].(string)
+
+	browser := env.browserClient("alice")
+	env.driveConsentUI(browser, userCode, "approve")
+
+	env.resetPollClock(deviceCode)
+	status, body := env.pollToken(url.Values{
+		"grant_type":  {apiauth.DeviceCodeGrantType},
+		"device_code": {deviceCode},
+		"client_id":   {clientID},
+	})
+	require.Equal(t, http.StatusOK, status, "public client poll MUST mint a token without credentials; body=%v", body)
+	assert.NotEmpty(t, body["access_token"], "access_token issued")
+}
+

--- a/tests/e2e/device_flow_test.go
+++ b/tests/e2e/device_flow_test.go
@@ -84,44 +84,34 @@ func newDeviceFlowEnv(t *testing.T, expiry time.Duration) *deviceFlowEnv {
 	}
 
 	mux := http.NewServeMux()
-
-	devAuthHandler := &apiauth.DeviceAuthorizationHandler{
-		Store:               env.deviceStore,
-		VerificationURI:     "", // populated after server starts
-		Expiry:              env.expiry,
-		ClientAuthenticator: nil, // public + confidential clients both work; confidential auth happens on redemption per #266
-	}
-	mux.Handle("POST /device/authorize", devAuthHandler)
-
-	verifier := &apiauth.DeviceVerificationHandler{
-		Store:    env.deviceStore,
-		AppStore: env.appStore,
-		Approve: func(r *http.Request, userCode, subject string, scopes []string) error {
-			return env.apiAuth.ApproveDeviceAuthorization(r, userCode, subject, scopes)
-		},
-		Deny: func(r *http.Request, userCode string) error {
-			return env.apiAuth.DenyDeviceAuthorization(r, userCode)
-		},
-		// Option B (issue 276): the shim — login state lives in a request
-		// header so the test fixture stays free of localauth + session
-		// dependencies. Real-httpauth session and CSRF middleware are
-		// covered by httpauth_test and device_verification_handler_test
-		// respectively; this test's job is wire-format drift across the
-		// four shipped PRs (#117 / #266 / #267 / #268).
-		SubjectFromRequest:   func(r *http.Request) string { return r.Header.Get(deviceTestSubjectHdr) },
-		CSRFTokenFromRequest: func(*http.Request) string { return deviceTestCSRFToken },
-	}
-	mux.HandleFunc("GET /device", verifier.Form)
-	mux.HandleFunc("POST /device", verifier.Submit)
-	mux.HandleFunc("GET /device/approve", verifier.Consent)
-	mux.HandleFunc("POST /device/approve", verifier.Decide)
-
 	mux.Handle("POST /api/token", env.apiAuth)
 
-	env.server = httptest.NewServer(mux)
+	// NewUnstartedServer so we know the server URL (and thus the
+	// VerificationURI) BEFORE the device-flow handlers are constructed.
+	// MountDeviceFlow takes the URI in its config and stamps it onto
+	// the DeviceAuthorizationHandler at mount time — no post-hoc
+	// mutation, no chicken-and-egg.
+	env.server = httptest.NewUnstartedServer(mux)
+	env.server.Start()
 	t.Cleanup(env.server.Close)
 
-	devAuthHandler.VerificationURI = env.server.URL + "/device"
+	apiauth.MountDeviceFlow(mux, apiauth.DeviceFlowMountConfig{
+		APIAuth:         env.apiAuth,
+		VerificationURI: env.server.URL + "/device",
+		Expiry:          env.expiry,
+		// Option B (issue 276): the shim — login state lives in a
+		// request header so the test fixture stays free of localauth +
+		// session dependencies. Real-httpauth session and CSRF
+		// middleware are covered by httpauth_test and
+		// device_verification_handler_test respectively; this test's
+		// job is wire-format drift across the four shipped device-flow
+		// PRs (#117 / #266 / #267 / #268).
+		SubjectFromRequest:   func(r *http.Request) string { return r.Header.Get(deviceTestSubjectHdr) },
+		CSRFTokenFromRequest: func(*http.Request) string { return deviceTestCSRFToken },
+		// VerifierMiddleware: nil — tests skip CSRF wrapping; the
+		// reference server wires httpauth.CSRFMiddleware.Protect here.
+	})
+
 	return env
 }
 


### PR DESCRIPTION
## What changes

Three connected pieces around the RFC 8628 device-grant arc:

1. **New library helper** `apiauth.MountDeviceFlow(mux, cfg)` — mirrors `apiauth.MountASMetadata` and stamps the canonical five device-flow routes (`POST /device/authorize` plus the four `/device` + `/device/approve` browser routes) onto an `http.ServeMux`. Callers supply dependencies + integration points (session lookup, CSRF token source, optional middleware); the helper owns route placement and handler construction. The four browser-facing routes run through the caller's `VerifierMiddleware`; `/device/authorize` is intentionally unwrapped because it is a machine endpoint and CSRF does not apply.

2. **End-to-end test** in `tests/e2e/device_flow_test.go` — drives the entire arc against a real `httptest.Server` with five scenarios: HappyPath_ConfidentialClient, Deny_ReturnsAccessDenied, NoClientCredentials_ReturnsInvalidClient (issue 266 pin), ExpiredCode_ReturnsExpiredToken, PublicClient_NoAuthRequired. Calls the new helper instead of hand-wiring routes, so the test now exercises the same wire-up production deployments use.

3. **Reference server wire-up** in `cmd/oneauth-server/` — a new `device_flow:` yaml block toggles the surface on; `buildDeviceAuthStore` mirrors `buildAppStore` with memory / fs / gorm / gae backends; the main server wires `SubjectFromRequest` via the existing `getUserIDFromCookie` helper, `CSRFTokenFromRequest` via `httpauth.CSRFToken`, and `csrf.Protect` as the verifier middleware; AS metadata advertises `device_authorization_endpoint` and the `device_code` grant when enabled.

The thread the third piece pulls on: production deployments shouldn't have to rediscover the device-flow wiring that the test fixture hand-rolled in the first commit. Folding the helper in gives it two real callers (test + reference server), validates the API, and closes a checkbox on the [#194](https://github.com/panyam/oneauth/issues/194) production-grade reference server tracker.

## Reviewer's guide
Read in this order:

1. [apiauth/device_flow_mount.go](https://github.com/panyam/oneauth/pull/286/files#diff-dfc829aa80a1392dd8d7b8294b06d9ee3ef83d695266f2900271801e1758ef3d) — the new helper. Start with `DeviceFlowMountConfig` for the contract surface, then `MountDeviceFlow` for the route layout. The asymmetric middleware handling (browser routes wrapped, machine route not) is the one non-obvious detail worth pausing on.
2. [apiauth/device_flow_mount_test.go](https://github.com/panyam/oneauth/pull/286/files#diff-466ccd74a7ccc256e3dd2bb385b3ea59549c0e4f5f8c99796085cbe74e23e0de) — pins the helper's pre-conditions and route layout. Five tests: three panic-on-missing-dep, one route-registration sweep, one middleware-asymmetry check.
3. [tests/e2e/device_flow_test.go](https://github.com/panyam/oneauth/pull/286/files#diff-e63218c2ab8c0635c45db930105e8f852c03a1830ab90ea0c357cabcc3ad4cc1) — the e2e fixture now calls `MountDeviceFlow` instead of hand-wiring. The five scenario tests are unchanged; what reviewers should focus on is `newDeviceFlowEnv`'s 30-line shrinkage and the `NewUnstartedServer` → `Start` → mount sequence (so the VerificationURI is known before mount).
4. [cmd/oneauth-server/config.go](https://github.com/panyam/oneauth/pull/286/files#diff-356728f980c9546d1ae9802ac863c4ccc97a7df25253e12e3ed019d559653f30) — the new `DeviceFlowConfig` struct (Enabled toggle, Expiry/Interval overrides, Store sub-config mirroring AppStoreConfig).
5. [cmd/oneauth-server/main.go](https://github.com/panyam/oneauth/pull/286/files#diff-e10cea20e37f1e5e5e61786642a3b5a2da9fa5b930d457555ca11400927e495a) — `buildDeviceAuthStore` follows the `buildAppStore` template; the wire-up block at the AS-metadata site conditionally mounts the flow and extends `grant_types_supported` + `device_authorization_endpoint`.
6. [cmd/oneauth-server/oneauth-server.yaml](https://github.com/panyam/oneauth/pull/286/files#diff-3715a5d22a9c64bd58d2eb8ce165095a77bdd04f7ba76c1a22f7d4f3b58944ec) — the new example block. Default `enabled: false` so existing deployments are unaffected.

Skim or skip: `subjectHeaderTransport` in the e2e file (mechanical: stamps the shim header on every browser request).

## Diff groups

- Production library: `apiauth/device_flow_mount.go`.
- Production reference server: `cmd/oneauth-server/config.go`, `cmd/oneauth-server/main.go`, `cmd/oneauth-server/oneauth-server.yaml`.
- Tests: `apiauth/device_flow_mount_test.go`, `tests/e2e/device_flow_test.go`.

## Decision log

- **Helper takes an APIAuth pointer, not separate stores.** APIAuth already owns DeviceAuthStore, AppStore, and the Approve/Deny helpers; passing it whole removes a parallel set of mutable fields and keeps the helper future-proof against APIAuth gaining new device-related state.
- **VerifierMiddleware is one function, not a per-route map.** All four browser routes share the same CSRF / session contract; differentiating them would invite mis-wiring. The reference server passes `csrf.Protect` once; the e2e passes nil.
- **`/device/authorize` is unwrapped.** It is a JSON endpoint called by the device, not a browser form — CSRF doesn't apply. The unit test pins this asymmetry so a future refactor that wraps everything uniformly fails loudly.
- **`NewUnstartedServer` → mount → `Start` in the e2e fixture.** The VerificationURI needs the server URL, which is only known after `httptest.NewUnstartedServer` allocates a listener. Mounting before `Start` avoids the previous code's post-hoc `devAuthHandler.VerificationURI = …` mutation.
- **AppStore wired in main only when device flow is enabled.** Setting `apiAuth.AppStore` outside the device flow path would change the introspection / revocation handler behavior unexpectedly. Keeping it scoped to the device flow means existing reference server deployments stay behaviorally identical when `device_flow.enabled: false`.
- **Option B (shim) survives in the e2e test.** Real `httpauth.Middleware` integration is now exercised by the reference server. The e2e's job is wire-format drift across the four shipped device-flow PRs (#117 / #266 / #267 / #268); session + CSRF middleware behavior is covered by their dedicated test files.

## Risk / blast radius

- Affects: new `apiauth/device_flow_mount.go` is purely additive. `cmd/oneauth-server` changes are additive and guarded by `cfg.DeviceFlow.Enabled` (default false) — existing deployments unchanged.
- Tests covering this: `make test` (root) runs both the new helper unit tests and the e2e flow. Verified red-before-green by deliberately flipping `if isConfidentialAuthMethod(...)` to `if false && ...` in `apiauth/device_auth_grant.go` and confirming `TestDeviceFlow_NoClientCredentials_ReturnsInvalidClient` fails (reverted before commit).
- Be paranoid about: the `Expiry: 100ms` scenario adds a 200ms sleep. Headroom for normal CI; if it ever flakes, bump the expiry + sleep proportionally rather than dropping the scenario.

## Before / after

```
Before: device-flow wiring lived only in test fixtures; cmd/oneauth-server
        had zero device-flow surface; consumers had to re-derive route
        layout and Approve/Deny lambdas.
After:  one canonical apiauth.MountDeviceFlow helper consumed by both
        the e2e fixture and the reference server. yaml-toggled.
```

## Out of scope

- Templating customization in the reference server (consent screen branding). Filed under #194.
- Localauth-integrated session for the e2e test (Option A from the original plan). The reference server now provides that integration; the e2e test retains the shim because its job is wire-format drift, not session behavior.

Closes 276.
