### PR TITLE
docs(stores/gae): backfill doc comments on public store methods

### DIFF
--- a/stores/gae/keystore.go
+++ b/stores/gae/keystore.go
@@ -42,6 +42,14 @@ func (s *GAEKeyStore) namespacedKey(name string) *datastore.Key {
 	return key
 }
 
+// PutKey upserts a per-client signing key. The record's Key field must be
+// []byte (HMAC secret or marshaled PEM); any other concrete type is rejected
+// with keys.ErrAlgorithmMismatch — KeyStorage callers serialize before
+// reaching the backend, and a wrong type here means the caller skipped that
+// step. Kid is filled in from utils.ComputeKid(KeyBytes, Algorithm) when the
+// caller leaves it empty so JWKS lookups stay deterministic across restarts.
+// Existing entries with the same ClientID are overwritten — KeyStorage has
+// no separate "create vs update" verb.
 func (s *GAEKeyStore) PutKey(ctx context.Context, req *keys.PutKeyRequest) (*keys.PutKeyResponse, error) {
 	if req == nil || req.Record == nil {
 		return nil, fmt.Errorf("PutKey: req.Record is required")
@@ -69,6 +77,13 @@ func (s *GAEKeyStore) PutKey(ctx context.Context, req *keys.PutKeyRequest) (*key
 	return &keys.PutKeyResponse{}, nil
 }
 
+// DeleteKey removes the signing-key entry for req.ClientID. Returns
+// keys.ErrKeyNotFound when the entry is absent — Datastore's bare Delete is
+// idempotent and silently succeeds on missing keys, so the implementation
+// does a Get-then-Delete to honor the KeyStorage contract (the conformance
+// suite asserts on this sentinel). Other Datastore errors (network, auth,
+// quota) surface unwrapped so callers can distinguish "no such key" from
+// "infrastructure problem."
 func (s *GAEKeyStore) DeleteKey(ctx context.Context, req *keys.DeleteKeyRequest) (*keys.DeleteKeyResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("DeleteKey: req is required")
@@ -99,6 +114,10 @@ func (s *GAEKeyStore) getEntity(ctx context.Context, clientID string) (*SigningK
 	return &entity, nil
 }
 
+// GetKey returns the signing-key record for req.ClientID, or
+// keys.ErrKeyNotFound when the entry is absent. KeyBytes are returned as
+// []byte (the same shape PutKey accepted) — callers are responsible for
+// parsing back to the algorithm-specific key type.
 func (s *GAEKeyStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetKey: req is required")
@@ -115,6 +134,12 @@ func (s *GAEKeyStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*key
 	}}, nil
 }
 
+// GetKeyByKid resolves a key by its kid (the JWT header identifier), used by
+// JWKS-driven validators that only know the kid, not the client_id. Returns
+// keys.ErrKidNotFound when no entry carries the requested kid. The query
+// runs against the "kid" property — the only indexed non-key field on
+// SigningKeyEntity — and reads at most one entity (Limit(1)) since kids are
+// unique per JWKS surface.
 func (s *GAEKeyStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetKeyByKid: req is required")
@@ -139,6 +164,12 @@ func (s *GAEKeyStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequ
 	}}, nil
 }
 
+// ListKeyIDs enumerates every client_id with a registered signing key in this
+// namespace. Returns an empty slice (not an error) for an empty namespace,
+// matching the other KeyStorage backends' "fresh store has no keys" shape.
+// Order is unspecified — Datastore key-only queries return results in
+// implementation-defined order; callers that need deterministic order must
+// sort.
 func (s *GAEKeyStore) ListKeyIDs(ctx context.Context, req *keys.ListKeyIDsRequest) (*keys.ListKeyIDsResponse, error) {
 	q := datastore.NewQuery(KindSigningKey).KeysOnly()
 	if s.namespace != "" {

--- a/stores/gae/kidstore.go
+++ b/stores/gae/kidstore.go
@@ -45,6 +45,12 @@ func (s *GAEKidStore) namespacedKey(name string) *datastore.Key {
 	return key
 }
 
+// Add registers a kid→key entry in the verification-only grace cache used
+// during key rotation. The Key field must be []byte (HMAC secret or marshaled
+// PEM); any other concrete type is rejected with keys.ErrAlgorithmMismatch.
+// ExpiresAt of the zero time means "never expires"; otherwise GetKeyByKid
+// treats now > ExpiresAt as not-found. Existing entries with the same kid
+// are overwritten — KidStorage has no separate "create vs update" verb.
 func (s *GAEKidStore) Add(ctx context.Context, req *keys.AddKidRequest) (*keys.AddKidResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("Add: req is required")
@@ -67,6 +73,10 @@ func (s *GAEKidStore) Add(ctx context.Context, req *keys.AddKidRequest) (*keys.A
 	return &keys.AddKidResponse{}, nil
 }
 
+// Remove is idempotent — Datastore's Delete silently succeeds on missing
+// keys, and KidStorage's contract permits that ("removing a kid that was
+// never added is not an error"). The verification-only nature of the grace
+// cache means a stale Remove during rotation is harmless.
 func (s *GAEKidStore) Remove(ctx context.Context, req *keys.RemoveKidRequest) (*keys.RemoveKidResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("Remove: req is required")
@@ -77,10 +87,22 @@ func (s *GAEKidStore) Remove(ctx context.Context, req *keys.RemoveKidRequest) (*
 	return &keys.RemoveKidResponse{}, nil
 }
 
+// GetKey always returns keys.ErrKeyNotFound. KidStorage is a verification-only
+// grace cache keyed by kid, not by client_id — there is no way to ask "give
+// me the rotation key for this client" because rotation entries are scoped
+// to a kid, not a subject. Callers should reach for GetKeyByKid instead.
+// The method exists only because keys.KidStorage embeds keys.KeyLookup
+// (which carries this verb); the not-found sentinel is the documented
+// behavior across all KidStorage backends, not a GAE-specific gap.
 func (s *GAEKidStore) GetKey(ctx context.Context, req *keys.GetKeyRequest) (*keys.GetKeyResponse, error) {
 	return nil, keys.ErrKeyNotFound
 }
 
+// GetKeyByKid resolves a kid to its grace-period key during rotation.
+// Returns keys.ErrKidNotFound when no entry exists or when ExpiresAt is
+// non-zero and already in the past. The expiry check runs on read so a
+// cleanup job that hasn't yet swept stale entries doesn't return them as
+// valid — CleanExpired's role is reclaiming storage, not gating reads.
 func (s *GAEKidStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequest) (*keys.GetKeyByKidResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetKeyByKid: req is required")
@@ -103,6 +125,13 @@ func (s *GAEKidStore) GetKeyByKid(ctx context.Context, req *keys.GetKeyByKidRequ
 	}}, nil
 }
 
+// CleanExpired sweeps the grace cache for entries whose ExpiresAt has passed
+// and returns the number removed. Implementation reads every entity in the
+// namespace and filters in process — Datastore doesn't expose a "delete
+// where" verb, and the grace cache is small (bounded by rotation cardinality
+// × grace period). Entries with zero ExpiresAt are immortal and skipped.
+// Safe to call concurrently with GetKeyByKid; reads filter on their own
+// independently.
 func (s *GAEKidStore) CleanExpired(ctx context.Context, req *keys.CleanExpiredRequest) (*keys.CleanExpiredResponse, error) {
 	q := datastore.NewQuery(KindKidKey)
 	if s.namespace != "" {

--- a/stores/gae/stores.go
+++ b/stores/gae/stores.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -69,6 +68,12 @@ func (s *UserStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
+// CreateUser inserts a new user keyed by req.UserID. The caller picks the
+// ID — this backend doesn't generate one — and re-creating the same ID
+// silently overwrites (Datastore's Put is upsert-shaped, not insert-only).
+// CreatedAt and UpdatedAt are stamped from time.Now() on the way in; the
+// returned GAEUser mirrors the persisted entity so callers don't have to
+// re-read.
 func (s *UserStore) CreateUser(ctx context.Context, req *accounts.CreateUserRequest) (*accounts.CreateUserResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("CreateUser: req is required")
@@ -102,12 +107,17 @@ func (s *UserStore) CreateUser(ctx context.Context, req *accounts.CreateUserRequ
 	}}, nil
 }
 
+// GetUserById returns the user for req.UserID. Absent users surface as
+// fmt.Errorf("user not found: %s", req.UserID) — not a sentinel — diverging
+// from the keys.ErrKeyNotFound / core.ErrAppNotFound pattern used elsewhere
+// in this package. Callers that need to distinguish "missing" from other
+// failures currently match on the string prefix; introducing a sentinel is
+// tracked separately (it's an interface change, not a doc fix).
 func (s *UserStore) GetUserById(ctx context.Context, req *accounts.GetUserByIDRequest) (*accounts.GetUserByIDResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetUserById: req is required")
 	}
 	key := s.namespacedKey(KindUser, req.UserID)
-	log.Println("UserStore Key: ", key, KindUser, req.UserID)
 	var entity UserEntity
 	if err := s.client.Get(ctx, key, &entity); err != nil {
 		if err == datastore.ErrNoSuchEntity {
@@ -130,6 +140,12 @@ func (s *UserStore) GetUserById(ctx context.Context, req *accounts.GetUserByIDRe
 	}}, nil
 }
 
+// SaveUser writes req.User, preserving CreatedAt across overwrites (re-saving
+// an existing user keeps the original create time and only bumps UpdatedAt).
+// IsActive defaults to true unless the concrete *GAEUser carries an explicit
+// false — the accounts.User interface has no Active() getter, so non-GAEUser
+// implementations always end up active. Callers that need a different
+// default should pass a *GAEUser.
 func (s *UserStore) SaveUser(ctx context.Context, req *accounts.SaveUserRequest) (*accounts.SaveUserResponse, error) {
 	if req == nil || req.User == nil {
 		return nil, fmt.Errorf("SaveUser: req.User is required")
@@ -197,6 +213,13 @@ func (s *IdentityStore) identityKeyName(idType, value string) string {
 	return idType + ":" + value
 }
 
+// GetIdentity returns the identity for (req.IdentityType, req.IdentityValue),
+// or fmt.Errorf("identity not found") when absent. With req.CreateIfMissing
+// set, an unbound identity (UserID="") is created in the same call and
+// NewCreated is set in the response — pairs with the signup flow's
+// "ensure-or-create" need without forcing two round trips. The entity key
+// derives from "<type>:<value>" so identities of different types with the
+// same value (e.g., email:foo@bar vs phone:foo@bar) are distinct rows.
 func (s *IdentityStore) GetIdentity(ctx context.Context, req *accounts.GetIdentityRequest) (*accounts.GetIdentityResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetIdentity: req is required")
@@ -232,6 +255,11 @@ func (s *IdentityStore) GetIdentity(ctx context.Context, req *accounts.GetIdenti
 	return &accounts.GetIdentityResponse{Identity: entity.ToIdentity()}, nil
 }
 
+// SaveIdentity writes req.Identity unconditionally — used after callers have
+// mutated fields not covered by the dedicated SetUserForIdentity /
+// MarkIdentityVerified helpers. Does NOT bump Version; the dedicated helpers
+// do that under transaction. Callers that need version increments should
+// reach for the appropriate helper instead.
 func (s *IdentityStore) SaveIdentity(ctx context.Context, req *accounts.SaveIdentityRequest) (*accounts.SaveIdentityResponse, error) {
 	if req == nil || req.Identity == nil {
 		return nil, fmt.Errorf("SaveIdentity: req.Identity is required")
@@ -245,6 +273,11 @@ func (s *IdentityStore) SaveIdentity(ctx context.Context, req *accounts.SaveIden
 	return &accounts.SaveIdentityResponse{}, nil
 }
 
+// SetUserForIdentity binds an identity to a user. Runs under a Datastore
+// transaction so two concurrent calls can't observe a stale UserID and race
+// each other; Version is incremented on every write for optimistic-lock
+// tooling downstream. Identity must already exist — there is no
+// CreateIfMissing here; pair with GetIdentity to provision first.
 func (s *IdentityStore) SetUserForIdentity(ctx context.Context, req *accounts.SetUserForIdentityRequest) (*accounts.SetUserForIdentityResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("SetUserForIdentity: req is required")
@@ -268,6 +301,10 @@ func (s *IdentityStore) SetUserForIdentity(ctx context.Context, req *accounts.Se
 	return &accounts.SetUserForIdentityResponse{}, nil
 }
 
+// MarkIdentityVerified flips Verified=true and bumps Version under a
+// transaction. Idempotent at the result level — re-marking an already-verified
+// identity still succeeds and still bumps Version (useful for audit trails
+// that want to count verification attempts).
 func (s *IdentityStore) MarkIdentityVerified(ctx context.Context, req *accounts.MarkIdentityVerifiedRequest) (*accounts.MarkIdentityVerifiedResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("MarkIdentityVerified: req is required")
@@ -291,6 +328,11 @@ func (s *IdentityStore) MarkIdentityVerified(ctx context.Context, req *accounts.
 	return &accounts.MarkIdentityVerifiedResponse{}, nil
 }
 
+// GetUserIdentities returns every identity bound to req.UserID. Backed by
+// an indexed query on the user_id property — unlike most properties in this
+// package, user_id is intentionally indexed because this lookup is on the
+// hot path of "show me all the ways this user can log in." Returns an empty
+// slice (not an error) for a user with no identities yet.
 func (s *IdentityStore) GetUserIdentities(ctx context.Context, req *accounts.GetUserIdentitiesRequest) (*accounts.GetUserIdentitiesResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetUserIdentities: req is required")
@@ -345,6 +387,13 @@ func (s *ChannelStore) channelKeyName(provider, identityKey string) string {
 	return provider + ":" + identityKey
 }
 
+// GetChannel returns the (provider, identity) channel, or fmt.Errorf("channel
+// not found") when absent. With req.CreateIfMissing set, an empty channel is
+// created in the same call and NewCreated is set — pairs with provider-bind
+// flows ("first time logging in with Google") that want a "fetch or
+// provision" step without a separate write. The entity key derives from
+// "<provider>:<identityKey>" so the same identity bound to two providers
+// (e.g., Google and GitHub) is two distinct rows.
 func (s *ChannelStore) GetChannel(ctx context.Context, req *accounts.GetChannelRequest) (*accounts.GetChannelResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetChannel: req is required")
@@ -405,6 +454,12 @@ func (s *ChannelStore) GetChannel(ctx context.Context, req *accounts.GetChannelR
 	}}, nil
 }
 
+// SaveChannel upserts req.Channel and increments Version each call.
+// CreatedAt is preserved across overwrites; on first write it's stamped from
+// time.Now() and Version starts at 1. Credentials and Profile maps are
+// JSON-encoded into noindex byte properties — Datastore's 1500-byte index
+// limit makes indexing them impractical, and nothing queries by their
+// contents anyway.
 func (s *ChannelStore) SaveChannel(ctx context.Context, req *accounts.SaveChannelRequest) (*accounts.SaveChannelResponse, error) {
 	if req == nil || req.Channel == nil {
 		return nil, fmt.Errorf("SaveChannel: req.Channel is required")
@@ -449,6 +504,10 @@ func (s *ChannelStore) SaveChannel(ctx context.Context, req *accounts.SaveChanne
 	return &accounts.SaveChannelResponse{}, nil
 }
 
+// GetChannelsByIdentity returns every channel for a given identity_key
+// across all providers — backed by an indexed query on the identity_key
+// property. Returns an empty slice (not an error) when nothing matches.
+// Order is unspecified.
 func (s *ChannelStore) GetChannelsByIdentity(ctx context.Context, req *accounts.GetChannelsByIdentityRequest) (*accounts.GetChannelsByIdentityResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetChannelsByIdentity: req is required")
@@ -517,6 +576,11 @@ func (s *TokenStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
+// CreateToken mints a fresh verification token via core.GenerateSecureToken
+// (the token is the entity key, so collisions would manifest as overwrites;
+// the secure-random width makes collision negligible). ExpiresAt is computed
+// from req.ExpiryDuration at insert time — the persisted absolute time, not
+// the relative duration, drives GetToken's expiry check.
 func (s *TokenStore) CreateToken(ctx context.Context, req *localauth.CreateVerificationTokenRequest) (*localauth.CreateVerificationTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("CreateToken: req is required")
@@ -551,6 +615,12 @@ func (s *TokenStore) CreateToken(ctx context.Context, req *localauth.CreateVerif
 	}}, nil
 }
 
+// GetToken returns the token or one of two error strings: "token not found"
+// when absent, "token expired" when the entity exists but its ExpiresAt has
+// passed. Expired entities are deleted on read — a single-shot self-clean so
+// stale rows don't pile up between explicit DeleteSubjectTokens sweeps.
+// Callers that need to distinguish the two failures match the error string
+// (a sentinel introduction is tracked separately).
 func (s *TokenStore) GetToken(ctx context.Context, req *localauth.GetVerificationTokenRequest) (*localauth.GetVerificationTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetToken: req is required")
@@ -573,6 +643,9 @@ func (s *TokenStore) GetToken(ctx context.Context, req *localauth.GetVerificatio
 	return &localauth.GetVerificationTokenResponse{Token: authToken}, nil
 }
 
+// DeleteToken is idempotent — Datastore's Delete silently succeeds on
+// missing keys, and verification tokens are single-use by design (delete
+// after the action they unlock fires). No "not found" error.
 func (s *TokenStore) DeleteToken(ctx context.Context, req *localauth.DeleteVerificationTokenRequest) (*localauth.DeleteVerificationTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("DeleteToken: req is required")
@@ -584,6 +657,11 @@ func (s *TokenStore) DeleteToken(ctx context.Context, req *localauth.DeleteVerif
 	return &localauth.DeleteVerificationTokenResponse{}, nil
 }
 
+// DeleteSubjectTokens removes every verification token of req.Type for
+// req.Subject. Used during password-reset / email-change cleanup to
+// invalidate every outstanding token a subject holds for the same action.
+// Returns success (not an error) when the subject has no matching tokens —
+// the no-op case is normal.
 func (s *TokenStore) DeleteSubjectTokens(ctx context.Context, req *localauth.DeleteSubjectVerificationTokensRequest) (*localauth.DeleteSubjectVerificationTokensResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("DeleteSubjectTokens: req is required")
@@ -640,6 +718,13 @@ func (s *RefreshTokenStore) hashToken(token string) string {
 	return hex.EncodeToString(hash[:])
 }
 
+// CreateRefreshToken mints a new refresh-token row with a fresh family id
+// (the first generation in its family). The token string itself is returned
+// to the caller; only its SHA-256 hash is persisted as the entity key — the
+// raw token must never round-trip through the database. Family is a
+// 16-character prefix of a secure random; rotation chains keep this Family
+// constant so RevokeTokenFamily can hit the whole lineage at once on reuse
+// detection.
 func (s *RefreshTokenStore) CreateRefreshToken(ctx context.Context, req *core.CreateRefreshTokenRequest) (*core.CreateRefreshTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("CreateRefreshToken: req is required")
@@ -734,6 +819,11 @@ func (s *RefreshTokenStore) entityToToken(entity *RefreshTokenEntity) *core.Refr
 	return rt
 }
 
+// GetRefreshToken returns the token row for req.Token (looked up by SHA-256
+// hash). Returns core.ErrTokenNotFound when absent. Does NOT validate
+// Revoked / ExpiresAt — callers that need that should use RotateRefreshToken
+// (which enforces both under transaction). This method exists for read-only
+// inspection paths (admin tooling, audit).
 func (s *RefreshTokenStore) GetRefreshToken(ctx context.Context, req *core.GetRefreshTokenRequest) (*core.GetRefreshTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetRefreshToken: req is required")
@@ -754,6 +844,20 @@ func (s *RefreshTokenStore) GetRefreshToken(ctx context.Context, req *core.GetRe
 	return &core.GetRefreshTokenResponse{Token: rt}, nil
 }
 
+// RotateRefreshToken implements OAuth refresh-token rotation with reuse
+// detection. Under transaction: revoke the old token, mint a new one in the
+// same Family (Generation+1), preserve Subject/ClientID/Scopes/DeviceInfo/
+// AuthorizationDetails. Three error sentinels:
+//
+//   - core.ErrTokenNotFound — old token doesn't exist
+//   - core.ErrTokenExpired — old token's ExpiresAt has passed
+//   - core.ErrTokenReused — old token was already revoked (reuse attack)
+//
+// On reuse, the entire family is revoked OUTSIDE the transaction (Datastore
+// transactions can touch at most 25 entity groups; a family can outgrow
+// that). The transaction itself is best-effort: if the family revoke fails,
+// the reuse is still reported to the caller, and a subsequent admin sweep
+// or RevokeSubjectTokens call can finish the cleanup.
 func (s *RefreshTokenStore) RotateRefreshToken(ctx context.Context, req *core.RotateRefreshTokenRequest) (*core.RotateRefreshTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("RotateRefreshToken: req is required")
@@ -867,6 +971,9 @@ func (s *RefreshTokenStore) RotateRefreshToken(ctx context.Context, req *core.Ro
 	return &core.RotateRefreshTokenResponse{Token: newRefreshToken}, nil
 }
 
+// RevokeRefreshToken flips Revoked=true under transaction. Idempotent: a
+// missing or already-revoked token returns success, not an error — explicit
+// logout / RFC 7009 revocation must be safe to call multiple times.
 func (s *RefreshTokenStore) RevokeRefreshToken(ctx context.Context, req *core.RevokeRefreshTokenRequest) (*core.RevokeRefreshTokenResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("RevokeRefreshToken: req is required")
@@ -898,6 +1005,13 @@ func (s *RefreshTokenStore) RevokeRefreshToken(ctx context.Context, req *core.Re
 	return &core.RevokeRefreshTokenResponse{}, nil
 }
 
+// RevokeSubjectTokens revokes every active (non-revoked) refresh token for
+// req.Subject — used by "log out everywhere" and admin force-revoke paths.
+// Iterates the indexed subject query and stamps Revoked/RevokedAt outside a
+// transaction (the working set can be larger than Datastore's per-tx limit);
+// callers tolerate a brief window where some tokens are revoked and others
+// aren't, since the worst case is a not-yet-revoked token getting one more
+// rotation that then fails reuse detection on the next try.
 func (s *RefreshTokenStore) RevokeSubjectTokens(ctx context.Context, req *core.RevokeSubjectTokensRequest) (*core.RevokeSubjectTokensResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("RevokeSubjectTokens: req is required")
@@ -931,6 +1045,10 @@ func (s *RefreshTokenStore) RevokeSubjectTokens(ctx context.Context, req *core.R
 	return &core.RevokeSubjectTokensResponse{}, nil
 }
 
+// RevokeTokenFamily revokes every active token in a rotation lineage. Called
+// by RotateRefreshToken's reuse-attack path (also addressable from admin
+// tooling). Like RevokeSubjectTokens, runs outside a transaction — the
+// family can have more entities than a single transaction permits.
 func (s *RefreshTokenStore) RevokeTokenFamily(ctx context.Context, req *core.RevokeTokenFamilyRequest) (*core.RevokeTokenFamilyResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("RevokeTokenFamily: req is required")
@@ -964,6 +1082,11 @@ func (s *RefreshTokenStore) RevokeTokenFamily(ctx context.Context, req *core.Rev
 	return &core.RevokeTokenFamilyResponse{}, nil
 }
 
+// GetSubjectTokens returns every active (non-revoked) refresh token for
+// req.Subject — backs the "list active sessions" admin / self-service flow.
+// The plaintext Token field is intentionally cleared from each result; only
+// the hash and metadata travel back to callers, since the store never holds
+// the raw token to begin with.
 func (s *RefreshTokenStore) GetSubjectTokens(ctx context.Context, req *core.GetSubjectTokensRequest) (*core.GetSubjectTokensResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetSubjectTokens: req is required")
@@ -995,6 +1118,11 @@ func (s *RefreshTokenStore) GetSubjectTokens(ctx context.Context, req *core.GetS
 	return &core.GetSubjectTokensResponse{Tokens: tokens}, nil
 }
 
+// CleanupExpiredTokens removes (a) every token whose ExpiresAt has passed
+// and (b) every revoked token whose RevokedAt is older than 24 hours. The
+// 24-hour grace on revoked rows lets ongoing rotation paths still detect
+// reuse against recently-revoked tokens before they vanish entirely.
+// Intended for a periodic background sweep, not per-request invocation.
 func (s *RefreshTokenStore) CleanupExpiredTokens(ctx context.Context, req *core.CleanupExpiredTokensRequest) (*core.CleanupExpiredTokensResponse, error) {
 	cutoff := time.Now().Add(-24 * time.Hour)
 
@@ -1062,6 +1190,14 @@ func (s *APIKeyStore) namespacedKey(kind, name string) *datastore.Key {
 	return key
 }
 
+// CreateAPIKey mints a new key. The KeyID (the entity key) is returned in
+// FullKey concatenated with the secret as "<keyID>_<secret>" — only the
+// bcrypt hash of the secret is persisted, so the raw secret can never be
+// retrieved again. Callers must surface FullKey to the end-user
+// immediately; losing it means rotating. HasExpiry tracks whether the
+// caller supplied an ExpiresAt — needed because Datastore stores a zero
+// time.Time identically to a not-set value, but the contract distinguishes
+// "never expires" from "set to 1970-01-01."
 func (s *APIKeyStore) CreateAPIKey(ctx context.Context, req *core.CreateAPIKeyRequest) (*core.CreateAPIKeyResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("CreateAPIKey: req is required")
@@ -1150,6 +1286,9 @@ func (s *APIKeyStore) entityToAPIKey(entity *APIKeyEntity) *core.APIKey {
 	return apiKey
 }
 
+// GetAPIKeyByID returns the metadata row for req.KeyID, or
+// core.ErrAPIKeyNotFound when absent. Does NOT validate secret, revocation,
+// or expiry — use ValidateAPIKey for the full check.
 func (s *APIKeyStore) GetAPIKeyByID(ctx context.Context, req *core.GetAPIKeyByIDRequest) (*core.GetAPIKeyByIDResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetAPIKeyByID: req is required")
@@ -1167,6 +1306,13 @@ func (s *APIKeyStore) GetAPIKeyByID(ctx context.Context, req *core.GetAPIKeyByID
 	return &core.GetAPIKeyByIDResponse{APIKey: s.entityToAPIKey(&entity)}, nil
 }
 
+// ValidateAPIKey performs the full check that GetAPIKeyByID skips. Three
+// error sentinels: core.ErrAPIKeyNotFound for "no such key, malformed input,
+// or wrong secret" (collapsed deliberately so a probe can't distinguish);
+// core.ErrTokenRevoked for revoked keys; core.ErrTokenExpired for expired
+// keys. The FullKey format is "oa_<idTail>_<secret>" — first segment fixed,
+// second the id tail, third the secret. Any deviation maps to
+// ErrAPIKeyNotFound.
 func (s *APIKeyStore) ValidateAPIKey(ctx context.Context, req *core.ValidateAPIKeyRequest) (*core.ValidateAPIKeyResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("ValidateAPIKey: req is required")
@@ -1200,6 +1346,9 @@ func (s *APIKeyStore) ValidateAPIKey(ctx context.Context, req *core.ValidateAPIK
 	return &core.ValidateAPIKeyResponse{APIKey: apiKey}, nil
 }
 
+// RevokeAPIKey flips Revoked=true under transaction. Returns
+// core.ErrAPIKeyNotFound when the key doesn't exist; already-revoked is a
+// no-op success (admin "revoke twice" calls must remain safe).
 func (s *APIKeyStore) RevokeAPIKey(ctx context.Context, req *core.RevokeAPIKeyRequest) (*core.RevokeAPIKeyResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("RevokeAPIKey: req is required")
@@ -1230,6 +1379,10 @@ func (s *APIKeyStore) RevokeAPIKey(ctx context.Context, req *core.RevokeAPIKeyRe
 	return &core.RevokeAPIKeyResponse{}, nil
 }
 
+// ListSubjectAPIKeys returns every API key (revoked or active) for
+// req.Subject. The KeyHash field is cleared from results — listing the
+// hash to an admin UI would leak bcrypt-protected material that's only
+// meant to live inside validation. Order is unspecified.
 func (s *APIKeyStore) ListSubjectAPIKeys(ctx context.Context, req *core.ListSubjectAPIKeysRequest) (*core.ListSubjectAPIKeysResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("ListSubjectAPIKeys: req is required")
@@ -1259,6 +1412,11 @@ func (s *APIKeyStore) ListSubjectAPIKeys(ctx context.Context, req *core.ListSubj
 	return &core.ListSubjectAPIKeysResponse{APIKeys: keys}, nil
 }
 
+// UpdateAPIKeyLastUsed bumps LastUsedAt to time.Now() under transaction.
+// Returns an unwrapped datastore.ErrNoSuchEntity (not core.ErrAPIKeyNotFound)
+// when the key is missing — this is on the validation hot path and a
+// missing key already implies an upstream lookup bug rather than user-facing
+// flow. Callers may swallow this error since the bump is advisory.
 func (s *APIKeyStore) UpdateAPIKeyLastUsed(ctx context.Context, req *core.UpdateAPIKeyLastUsedRequest) (*core.UpdateAPIKeyLastUsedResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("UpdateAPIKeyLastUsed: req is required")
@@ -1310,6 +1468,13 @@ func (s *UsernameStore) normalizeUsername(username string) string {
 	return strings.ToLower(username)
 }
 
+// ReserveUsername binds req.Username to req.UserID. The entity key is the
+// lowercased form (case-insensitive uniqueness); the Username field
+// preserves the original casing for display. Idempotent for the same
+// (username, user) pair — re-reserving by the owner refreshes the display
+// casing but doesn't error. A reservation owned by a different user returns
+// fmt.Errorf("username already taken"). Runs under transaction to close the
+// check-then-write race between two concurrent reservations.
 func (s *UsernameStore) ReserveUsername(ctx context.Context, req *accounts.ReserveUsernameRequest) (*accounts.ReserveUsernameResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("ReserveUsername: req is required")
@@ -1347,6 +1512,10 @@ func (s *UsernameStore) ReserveUsername(ctx context.Context, req *accounts.Reser
 	return &accounts.ReserveUsernameResponse{}, nil
 }
 
+// GetUserByUsername resolves a username (case-insensitively) to its UserID.
+// Returns fmt.Errorf("username not found") when absent — same string-error
+// pattern as the other accounts-package lookups; sentinel introduction is
+// tracked separately.
 func (s *UsernameStore) GetUserByUsername(ctx context.Context, req *accounts.GetUserByUsernameRequest) (*accounts.GetUserByUsernameResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("GetUserByUsername: req is required")
@@ -1364,6 +1533,11 @@ func (s *UsernameStore) GetUserByUsername(ctx context.Context, req *accounts.Get
 	return &accounts.GetUserByUsernameResponse{UserID: entity.UserID}, nil
 }
 
+// ReleaseUsername drops the reservation. Idempotent — Datastore's Delete
+// silently succeeds on missing keys, and account-cleanup paths must remain
+// safe to retry. Does NOT verify ownership; callers gating release on
+// "the right user is asking" must check upstream (account deletion, admin
+// release).
 func (s *UsernameStore) ReleaseUsername(ctx context.Context, req *accounts.ReleaseUsernameRequest) (*accounts.ReleaseUsernameResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("ReleaseUsername: req is required")
@@ -1376,6 +1550,20 @@ func (s *UsernameStore) ReleaseUsername(ctx context.Context, req *accounts.Relea
 	return &accounts.ReleaseUsernameResponse{}, nil
 }
 
+// ChangeUsername atomically moves a reservation from OldUsername to
+// NewUsername. Two paths:
+//
+//   - Case-only change (lowercased forms equal) — single-entity transaction
+//     that just updates the display Username; ownership is verified before
+//     write ("username not owned by user").
+//   - True rename — multi-entity transaction that asserts the new lowercased
+//     form is free, deletes the old entity, and inserts the new one in the
+//     same transaction so concurrent reservers can't win the race in the
+//     gap.
+//
+// Error strings: "old username not found", "old username not owned by
+// user", "new username already taken". CreatedAt resets to now on the new
+// row — the reservation is conceptually fresh for the new username.
 func (s *UsernameStore) ChangeUsername(ctx context.Context, req *accounts.ChangeUsernameRequest) (*accounts.ChangeUsernameResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("ChangeUsername: req is required")


### PR DESCRIPTION
## What changes

Documents the public contract of every store in `stores/gae/` that was previously shipping with sparse or absent method docs. Captures the *why* of each method: error-sentinel mapping, idempotency promises, transactional scope, and the deliberate-design quirks future readers would otherwise have to re-discover.

Drive-by: removes the stray `log.Println("UserStore Key: …")` left in `UserStore.GetUserById`, flagged in the issue body during the design-rebuild pass. The `log` import drops with it.

Closes #236.

## Reviewer's guide

Read in this order:

1. [stores/gae/keystore.go](https://github.com/panyam/oneauth/pull/287/files#diff-d30b2af53e25ebaaa7eec864c7736d804fbc3d82bc4e10e05a6ae4976fd29fef) — start here. 5 `KeyStorage` methods. Notes `keys.ErrAlgorithmMismatch` on non-`[]byte` keys, kid auto-derivation, the Get-then-Delete dance that satisfies `keys.ErrKeyNotFound`.
2. [stores/gae/kidstore.go](https://github.com/panyam/oneauth/pull/287/files#diff-243e141f1eed9c4b45505e5a2071e39920641deb5223632209ba000611d52ba9) — 5 `KidStorage` methods. Pins the deliberate "GetKey always returns ErrKeyNotFound" design (KidStorage embeds `KeyLookup` but is semantically kid-keyed, not client-keyed) and CleanExpired's expiry-on-read invariant.
3. [stores/gae/stores.go](https://github.com/panyam/oneauth/pull/287/files#diff-2c8530602a1cead3e8eb8b59c92358a081544846b91c040987fd6b658d773ba5) — 33 methods across 7 stores. The interesting prose:
   - `RotateRefreshToken` — three sentinels (`ErrTokenNotFound`, `ErrTokenExpired`, `ErrTokenReused`); family-revoke runs *outside* the transaction because a family can exceed Datastore's 25-entity-group transaction limit.
   - `ValidateAPIKey` — three sentinels collapsed into `ErrAPIKeyNotFound` for the "no such key / wrong secret / malformed" path so probes can't distinguish; rejection of revoked + expired keys separated as `ErrTokenRevoked` / `ErrTokenExpired`.
   - `ChangeUsername` — two-path transactional rename (case-only vs full); multi-entity transaction asserts the new normalized form is free before delete-then-insert so concurrent reservers can't win the gap.
   - `GetUserById`, `GetUserByUsername`, `GetToken` — string-based "X not found" errors rather than sentinels. Doc reflects current behavior; sentinel introduction is an interface change tracked separately, not in scope here.

Skim or skip: the trivial `GAEUser.Id()` / `Profile()` accessors stayed uncommented to match the FS precedent — the `GAEUser` type-level comment already names the interface they satisfy.

## Decision log

- **Polished bar over sparse bar.** Followed the contract-documenting style established by `stores/gae/appstore.go` (PR 234) and `stores/gorm/appstore.go`, not the one-liner style in `stores/fs/`. The issue body explicitly calls this out.
- **Documented divergence, didn't fix it.** `GetUserById` / `GetUserByUsername` / `GetToken` return string errors instead of sentinels — inconsistent with `core.ErrAppNotFound` / `keys.ErrKeyNotFound`. Surfaced in the doc so callers know what to match; sentinel introduction is an interface change for a separate PR.
- **Folded in the stray log line.** Issue body says "fix or file separately, caller's call" — fixing inline was cheaper than a follow-up PR. The `log` import got orphaned and was removed.
- **Did not expand to `models.go`.** Issue lists `keystore.go`, `kidstore.go`, `stores.go` only. Will file follow-up for `models.go` exported helpers.

## Risk / blast radius

- **Affects**: nothing observable. Pure docs + one stdout line gone.
- **Tests covering this**: `GOWORK=off go test ./stores/gae/...` — passes locally (`ok github.com/panyam/oneauth/stores/gae 0.827s`).
- **Be paranoid about**: nothing. The `log` import removal would have surfaced as a build break if anything else in the file relied on it; it didn't.

## Out of scope (deliberately deferred)

- `stores/gae/models.go` exported helpers (`IdentityEntity.ToIdentity`, `IdentityToEntity`, `VerificationTokenToEntity`) — out of issue scope, follow-up to file.
- Sentinel introduction for the three string-error lookups — interface change, separate PR.
