### PR TITLE
docs(stores/gae): doc comments on models.go exported helpers

### DIFF
--- a/stores/gae/models.go
+++ b/stores/gae/models.go
@@ -34,6 +34,11 @@ type IdentityEntity struct {
 	Version   int            `datastore:"version"`
 }
 
+// ToIdentity copies every IdentityEntity field into a new accounts.Identity.
+// The Datastore Key is NOT carried over — the returned domain object has no
+// pointer back to its storage row, so callers that still need the key must
+// hold the entity. Used by IdentityStore methods immediately after tx.Get
+// to hand domain objects back to the accounts layer.
 func (e *IdentityEntity) ToIdentity() *accounts.Identity {
 	return &accounts.Identity{
 		Type:      e.Type,
@@ -46,6 +51,11 @@ func (e *IdentityEntity) ToIdentity() *accounts.Identity {
 	}
 }
 
+// IdentityToEntity is the write-path counterpart of ToIdentity. The caller
+// supplies the namespaced datastore key — this helper does not derive it
+// because the store struct (IdentityStore) owns the namespace, not this
+// package-level function. The entity name follows the "<type>:<value>"
+// format documented on IdentityEntity.
 func IdentityToEntity(i *accounts.Identity, key *datastore.Key) *IdentityEntity {
 	return &IdentityEntity{
 		Key:       key,
@@ -83,6 +93,13 @@ type VerificationTokenEntity struct {
 	ExpiresAt time.Time                 `datastore:"expires_at"`
 }
 
+// ToVerificationToken reconstructs the plaintext Token from e.Key.Name.
+// Non-obvious invariant: the token string is the entity key name, not a
+// stored property — consumers must hold the entity (not just its
+// struct-tagged property bag) to recover the token. This is also why the
+// helper is a method on *VerificationTokenEntity rather than a free
+// function: it depends on the key, which lives on the entity, not on the
+// property struct.
 func (e *VerificationTokenEntity) ToVerificationToken() *localauth.VerificationToken {
 	return &localauth.VerificationToken{
 		Token:     e.Key.Name,
@@ -94,6 +111,11 @@ func (e *VerificationTokenEntity) ToVerificationToken() *localauth.VerificationT
 	}
 }
 
+// VerificationTokenToEntity is the write-path counterpart of
+// ToVerificationToken. Caller supplies the namespaced datastore key whose
+// name carries the token string; the t.Token field is NOT persisted as a
+// separate property — it lives only in the key, matching the
+// ToVerificationToken contract.
 func VerificationTokenToEntity(t *localauth.VerificationToken, key *datastore.Key) *VerificationTokenEntity {
 	return &VerificationTokenEntity{
 		Key:       key,


### PR DESCRIPTION
## What changes

Documents the four exported entity↔domain mapper helpers in `stores/gae/models.go` — the residual gap left by PR 287 (which closed #236 and scoped to `keystore.go` / `kidstore.go` / `stores.go`). Pure docs PR; no behavior change.

Closes #288.

## Reviewer's guide

Read in this order:

1. [stores/gae/models.go](https://github.com/panyam/oneauth/pull/289/files#diff-314fa9e23fb66d81ce06938b54e52973ad7d6c7d6b3e784aaa023f683f1ea943) — the only file. Four helpers (`IdentityEntity.ToIdentity`, `IdentityToEntity`, `VerificationTokenEntity.ToVerificationToken`, `VerificationTokenToEntity`). The interesting prose:
   - `ToIdentity` — the Datastore `Key` does NOT round-trip. Callers that still need the key must hold the entity, not the returned `accounts.Identity`.
   - `ToVerificationToken` — the token string is `e.Key.Name`, not a stored property. This is also why the helper is a method on `*VerificationTokenEntity`, not a free function — it needs the key, which lives on the entity, not on the property bag.
   - `IdentityToEntity` / `VerificationTokenToEntity` — write-path counterparts. Caller supplies the namespaced key because the store struct owns the namespace, not these package-level functions.

## Decision log

- **Did not touch the entity-level struct comments** (`UserEntity`, `ChannelEntity`, etc.). They're terse one-liners ("X is the Datastore entity for Y") but they exist. Out of scope for #288 — that's a separate discussion about whether to bring struct-level docs up to the polished bar.
- **Did not touch the unexported `entityToToken` / `entityToAPIKey` mappers in `stores.go`.** They're not exported, so they fall outside the "documented-contract for callers in another package" bar that this stack has been working from.

## Risk / blast radius

- **Affects**: nothing observable. Pure docs.
- **Tests**: `GOWORK=off go test ./stores/gae/...` passes locally.
- **Be paranoid about**: nothing.

## Out of scope (deliberately deferred)

- Polishing terse type-level struct comments — file separately if we want that pass.
